### PR TITLE
feat: add CLI config loading and project hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.vscode/settings.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules/
+.vscode/
+bun.lock

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The phase 01 MVP is intentionally narrow:
 
 - read configured RSS feeds
 - normalize release titles into media metadata
-- match TV and movie items against JSON rules
+- match TV items against JSON rules and movie items against JSON intake policies
 - deduplicate previously handled items with SQLite
 - submit approved candidates to Transmission
 - record outcomes for review and retry

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Useful supporting docs:
 ## Local Development
 
 - `bun test`
-- `bun run ./src/cli.ts run --config ./test/fixtures/valid-config.json`
+- `./bin/media-sync run --config ./test/fixtures/valid-config.json`
 
 ## Proposed CLI Surface
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Phase 01 ends at successful queueing in Transmission. It does not include a web 
 
 ## Status
 
-This repository is currently documentation-first. There is no implementation yet.
+Ticket 01 is implemented: the repository now has a minimal Bun + TypeScript CLI skeleton with JSON config loading and validation for `media-sync run`.
 
 The project is being planned as a small-slice, review-friendly build:
 
@@ -40,6 +40,11 @@ Useful supporting docs:
 - `docs/00-overview/roadmap.md`
 - `docs/02-delivery/issue-tracking.md`
 - `docs/04-decisions/adr-001-use-bun.md`
+
+## Local Development
+
+- `bun test`
+- `bun run ./src/cli.ts run --config ./test/fixtures/valid-config.json`
 
 ## Proposed CLI Surface
 

--- a/bin/media-sync
+++ b/bin/media-sync
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+CLI_PATH="$SCRIPT_DIR/../src/cli.ts"
+
+if command -v bun >/dev/null 2>&1; then
+  exec bun run "$CLI_PATH" "$@"
+fi
+
+if [ -x "${HOME}/.bun/bin/bun" ]; then
+  exec "${HOME}/.bun/bin/bun" run "$CLI_PATH" "$@"
+fi
+
+echo "bun executable not found in PATH or ~/.bun/bin/bun" >&2
+exit 127

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,245 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "pirate-claw",
+      "devDependencies": {
+        "@eslint/js": "^9.24.0",
+        "@types/bun": "^1.2.13",
+        "eslint": "^9.24.0",
+        "globals": "^16.0.0",
+        "prettier": "^3.5.3",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.29.1",
+      },
+    },
+  },
+  "packages": {
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+
+    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+
+    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
+
+    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
+
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.57.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.57.2", "@typescript-eslint/type-utils": "8.57.2", "@typescript-eslint/utils": "8.57.2", "@typescript-eslint/visitor-keys": "8.57.2", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.57.2", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w=="],
+
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.57.2", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.57.2", "@typescript-eslint/types": "8.57.2", "@typescript-eslint/typescript-estree": "8.57.2", "@typescript-eslint/visitor-keys": "8.57.2", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA=="],
+
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.57.2", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.57.2", "@typescript-eslint/types": "^8.57.2", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw=="],
+
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.57.2", "", { "dependencies": { "@typescript-eslint/types": "8.57.2", "@typescript-eslint/visitor-keys": "8.57.2" } }, "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw=="],
+
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.57.2", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw=="],
+
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.57.2", "", { "dependencies": { "@typescript-eslint/types": "8.57.2", "@typescript-eslint/typescript-estree": "8.57.2", "@typescript-eslint/utils": "8.57.2", "debug": "^4.4.3", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.57.2", "", {}, "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA=="],
+
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.57.2", "", { "dependencies": { "@typescript-eslint/project-service": "8.57.2", "@typescript-eslint/tsconfig-utils": "8.57.2", "@typescript-eslint/types": "8.57.2", "@typescript-eslint/visitor-keys": "8.57.2", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.4.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA=="],
+
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.57.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.57.2", "@typescript-eslint/types": "8.57.2", "@typescript-eslint/typescript-estree": "8.57.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg=="],
+
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.57.2", "", { "dependencies": { "@typescript-eslint/types": "8.57.2", "eslint-visitor-keys": "^5.0.0" } }, "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
+
+    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+
+    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.57.2", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.57.2", "@typescript-eslint/parser": "8.57.2", "@typescript-eslint/typescript-estree": "8.57.2", "@typescript-eslint/utils": "8.57.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+
+    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -5,13 +5,13 @@
     "": {
       "name": "pirate-claw",
       "devDependencies": {
-        "@eslint/js": "^9.24.0",
-        "@types/bun": "^1.2.13",
-        "eslint": "^9.24.0",
-        "globals": "^16.0.0",
-        "prettier": "^3.5.3",
+        "@eslint/js": "^10.0.1",
+        "@types/bun": "^1.3.11",
+        "eslint": "^10.1.0",
+        "globals": "^17.4.0",
+        "prettier": "^3.8.1",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.29.1",
+        "typescript-eslint": "^8.57.2",
       },
     },
   },
@@ -20,19 +20,17 @@
 
     "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
 
-    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
+    "@eslint/config-array": ["@eslint/config-array@0.23.3", "", { "dependencies": { "@eslint/object-schema": "^3.0.3", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw=="],
 
-    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.5.3", "", { "dependencies": { "@eslint/core": "^1.1.1" } }, "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw=="],
 
-    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
+    "@eslint/core": ["@eslint/core@1.1.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ=="],
 
-    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
+    "@eslint/js": ["@eslint/js@10.0.1", "", { "peerDependencies": { "eslint": "^10.0.0" }, "optionalPeers": ["eslint"] }, "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA=="],
 
-    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
+    "@eslint/object-schema": ["@eslint/object-schema@3.0.3", "", {}, "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ=="],
 
-    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
-
-    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.6.1", "", { "dependencies": { "@eslint/core": "^1.1.1", "levn": "^0.4.1" } }, "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -43,6 +41,8 @@
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -76,25 +76,11 @@
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
-
-    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
+    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
-
-    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
-
-    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
-
-    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
-    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -104,13 +90,13 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
+    "eslint": ["eslint@10.1.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.3", "@eslint/config-helpers": "^0.5.3", "@eslint/core": "^1.1.1", "@eslint/plugin-kit": "^0.6.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA=="],
 
-    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
+    "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
 
-    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
+    "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
-    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
+    "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
 
     "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
 
@@ -138,13 +124,9 @@
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
-    "globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
-
-    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+    "globals": ["globals@17.4.0", "", {}, "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
-    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
@@ -153,8 +135,6 @@
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
-
-    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -168,9 +148,7 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
-    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
-
-    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+    "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -181,8 +159,6 @@
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
-
-    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
@@ -196,17 +172,11 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
-
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
-
-    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
-
-    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
@@ -230,16 +200,6 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
-    "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
-
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
-
-    "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
-
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
-
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
   }
 }

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.2",
+  "ignorePaths": [],
+  "dictionaryDefinitions": [],
+  "dictionaries": [],
+  "words": ["mktemp"],
+  "ignoreWords": [],
+  "import": []
+}

--- a/docs/01-product/phase-01-mvp.md
+++ b/docs/01-product/phase-01-mvp.md
@@ -6,7 +6,7 @@ Build a local CLI that:
 
 - fetches configured RSS feeds
 - normalizes feed items into a common media shape
-- matches items against TV and movie rules from JSON config
+- matches TV items against rules and movie items against intake policies from JSON config
 - deduplicates items using SQLite
 - submits the best match to Transmission
 - records outcomes so later runs can skip duplicates and retry failures
@@ -67,15 +67,15 @@ Each rule should contain:
 
 ## `movies`
 
-Defines tracked movie rules.
+Defines movie intake policies, not per-title tracking rules.
 
-Each rule should contain:
+Each policy should contain:
 
-- `name`
-- `year`
-- optional `pattern`
+- `years`: one or more allowed release years
 - `resolutions`
 - `codecs`
+
+Movie feeds should be curated enough that year + quality policy is meaningful. The config does not target specific movie names in phase 01.
 
 ## `transmission`
 
@@ -95,7 +95,7 @@ Each run should follow the same pipeline:
 3. Fetch each RSS feed.
 4. Parse entries into a common raw feed-item shape.
 5. Normalize titles into structured metadata.
-6. Match each normalized item against TV or movie rules.
+6. Match each normalized item against TV rules or movie intake policies.
 7. Group competing matches by media identity.
 8. Select the best candidate using configured quality preferences.
 9. Skip anything already queued successfully.
@@ -140,11 +140,11 @@ TV identity:
 
 Movie identity:
 
-- normalized title + year
+- stable external release identity such as RSS `guidOrLink`, and later torrent-level identity such as infohash when available
 
 ## Match Result
 
-Represents a rule hit plus ranking metadata.
+Represents a rule or policy hit plus ranking metadata.
 
 Suggested fields:
 

--- a/docs/01-product/phase-01-mvp.md
+++ b/docs/01-product/phase-01-mvp.md
@@ -67,15 +67,15 @@ Each rule should contain:
 
 ## `movies`
 
-Defines movie intake policies, not per-title tracking rules.
+Defines the global movie intake policy, not per-title tracking rules.
 
-Each policy should contain:
+The policy should contain:
 
 - `years`: one or more allowed release years
 - `resolutions`
 - `codecs`
 
-Movie feeds should be curated enough that year + quality policy is meaningful. The config does not target specific movie names in phase 01.
+Movie feeds should be curated enough that year + quality policy is meaningful. The config does not target specific movie names in phase 01, and `movies` is a single object because movie intake policy is global for the app.
 
 ## `transmission`
 

--- a/docs/02-delivery/phase-01/ticket-01-rationale.md
+++ b/docs/02-delivery/phase-01/ticket-01-rationale.md
@@ -1,0 +1,6 @@
+# Ticket 01 Rationale
+
+- Red first: `media-sync run --config ...` should load a valid JSON config and exit successfully, while missing or malformed config should fail with a readable message.
+- Why this path: a single `run` command with one config module is the minimum public surface needed to prove the CLI can start, read config, and reject bad input.
+- Alternative considered: adding a full command parser with placeholder `status` and `retry-failed` handlers was rejected because it adds CLI structure that Ticket 01 does not need yet.
+- Deferred: default-command ergonomics beyond `run`, richer schema validation, environment-based config discovery, and all feed/database/downloader behavior.

--- a/docs/02-delivery/phase-01/ticket-05-movie-rule-matching.md
+++ b/docs/02-delivery/phase-01/ticket-05-movie-rule-matching.md
@@ -1,20 +1,22 @@
-# P1.05 Movie Rule Matching
+# P1.05 Movie Policy Filtering
 
 Size: 2 points
 
 ## Outcome
 
-- match movie items by year and optional regex pattern
+- match movie items by allowed release year policy
 - enforce codec and resolution filters
+- rely on release identity, not movie name intent, for duplicate prevention assumptions
 
 ## Red
 
-- write tests for year-only matching
-- write tests for year + pattern matching
+- write tests for year-policy acceptance
+- write tests for codec and resolution rejection
+- write tests that movie matching does not require a title pattern
 
 ## Green
 
-- implement the movie matcher
+- implement the movie policy filter
 
 ## Refactor
 
@@ -22,4 +24,4 @@ Size: 2 points
 
 ## Review Focus
 
-- clear difference between TV and movie rule semantics
+- clear difference between TV rule semantics and movie policy semantics

--- a/docs/02-delivery/phase-01/ticket-05-movie-rule-matching.md
+++ b/docs/02-delivery/phase-01/ticket-05-movie-rule-matching.md
@@ -4,7 +4,7 @@ Size: 2 points
 
 ## Outcome
 
-- match movie items by allowed release year policy
+- match movie items by the global allowed release year policy
 - enforce codec and resolution filters
 - rely on release identity, not movie name intent, for duplicate prevention assumptions
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,25 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: ['node_modules/', '.vscode/', 'test/fixtures/'],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      globals: {
+        ...globals.node,
+        ...globals.es2024,
+        Bun: 'readonly',
+      },
+    },
+    rules: {
+      'no-console': 'off',
+    },
+  },
+);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "bin": {
-    "media-sync": "./src/cli.ts"
+    "media-sync": "./bin/media-sync"
   },
   "scripts": {
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "pirate-claw",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "media-sync": "./src/cli.ts"
+  },
+  "scripts": {
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "eslint .",
+    "run": "bun run ./src/cli.ts",
+    "test": "bun test"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.13",
+    "@eslint/js": "^9.24.0",
+    "eslint": "^9.24.0",
+    "globals": "^16.0.0",
+    "prettier": "^3.5.3",
+    "typescript-eslint": "^8.29.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     "test": "bun test"
   },
   "devDependencies": {
-    "@types/bun": "^1.2.13",
-    "@eslint/js": "^9.24.0",
-    "eslint": "^9.24.0",
-    "globals": "^16.0.0",
-    "prettier": "^3.5.3",
-    "typescript-eslint": "^8.29.1",
+    "@types/bun": "^1.3.11",
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.1.0",
+    "globals": "^17.4.0",
+    "prettier": "^3.8.1",
+    "typescript-eslint": "^8.57.2",
     "typescript": "^5.9.3"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,44 @@
+import { ConfigError, loadConfig, resolveConfigPath } from './config';
+
+export async function runCli(argv: string[]): Promise<number> {
+  const [command, ...rest] = argv;
+
+  if (command !== 'run') {
+    console.error('Unknown command. Available commands: "run".');
+    return 1;
+  }
+
+  const configPath = parseConfigPath(rest);
+
+  try {
+    await loadConfig(resolveConfigPath(configPath));
+    console.log(`Config loaded from ${resolveConfigPath(configPath)}.`);
+    return 0;
+  } catch (error) {
+    const message =
+      error instanceof ConfigError ? error.message : 'Unexpected error.';
+    console.error(message);
+    return 1;
+  }
+}
+
+function parseConfigPath(argv: string[]): string | undefined {
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === '--config') {
+      const value = argv[index + 1];
+
+      if (!value) {
+        throw new ConfigError('Missing value for --config.');
+      }
+
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+if (import.meta.main) {
+  const exitCode = await runCli(Bun.argv.slice(2));
+  process.exit(exitCode);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,9 +8,8 @@ export async function runCli(argv: string[]): Promise<number> {
     return 1;
   }
 
-  const configPath = parseConfigPath(rest);
-
   try {
+    const configPath = parseConfigPath(rest);
     await loadConfig(resolveConfigPath(configPath));
     console.log(`Config loaded from ${resolveConfigPath(configPath)}.`);
     return 0;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,10 +15,20 @@ export async function runCli(argv: string[]): Promise<number> {
     return 0;
   } catch (error) {
     const message =
-      error instanceof ConfigError ? error.message : 'Unexpected error.';
+      error instanceof ConfigError
+        ? error.message
+        : formatUnexpectedError(error);
     console.error(message);
     return 1;
   }
+}
+
+function formatUnexpectedError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+
+  return String(error);
 }
 
 function parseConfigPath(argv: string[]): string | undefined {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,272 @@
+export type FeedConfig = {
+  name: string;
+  url: string;
+  mediaType: 'tv' | 'movie';
+  parserHints?: Record<string, unknown>;
+};
+
+export type TvRule = {
+  name: string;
+  pattern: string;
+  resolutions: string[];
+  codecs: string[];
+};
+
+export type MovieRule = {
+  name: string;
+  year: number;
+  pattern?: string;
+  resolutions: string[];
+  codecs: string[];
+};
+
+export type TransmissionConfig = {
+  url: string;
+  username: string;
+  password: string;
+  downloadDir?: string;
+};
+
+export type AppConfig = {
+  feeds: FeedConfig[];
+  tv: TvRule[];
+  movies: MovieRule[];
+  transmission: TransmissionConfig;
+};
+
+const DEFAULT_CONFIG_PATH = 'media-sync.config.json';
+
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConfigError';
+  }
+}
+
+export function resolveConfigPath(cliPath?: string): string {
+  return cliPath ?? DEFAULT_CONFIG_PATH;
+}
+
+export async function loadConfig(path: string): Promise<AppConfig> {
+  const file = Bun.file(path);
+
+  if (!(await file.exists())) {
+    throw new ConfigError(
+      `Config file not found at "${path}". Pass --config <path> or create ${DEFAULT_CONFIG_PATH}.`,
+    );
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(await file.text());
+  } catch {
+    throw new ConfigError(`Config file "${path}" contains invalid JSON.`);
+  }
+
+  return validateConfig(parsed, path);
+}
+
+export function validateConfig(input: unknown, path = 'config'): AppConfig {
+  if (!isRecord(input)) {
+    throw new ConfigError(`Config file "${path}" must contain a JSON object.`);
+  }
+
+  const feeds = requireArray(input, 'feeds', path);
+  const tv = requireArray(input, 'tv', path);
+  const movies = requireArray(input, 'movies', path);
+  const transmission = requireRecord(input, 'transmission', path);
+
+  return {
+    feeds: feeds.map((entry, index) => validateFeed(entry, path, index)),
+    tv: tv.map((entry, index) => validateTvRule(entry, path, index)),
+    movies: movies.map((entry, index) => validateMovieRule(entry, path, index)),
+    transmission: validateTransmission(transmission, path),
+  };
+}
+
+function validateFeed(input: unknown, path: string, index: number): FeedConfig {
+  const feed = expectRecord(input, `${path} feeds[${index}]`);
+
+  return {
+    name: requireString(feed, 'name', `${path} feeds[${index}]`),
+    url: requireString(feed, 'url', `${path} feeds[${index}]`),
+    mediaType: requireMediaType(feed, `${path} feeds[${index}]`),
+    parserHints: optionalRecord(
+      feed.parserHints,
+      `${path} feeds[${index}] parserHints`,
+    ),
+  };
+}
+
+function validateTvRule(input: unknown, path: string, index: number): TvRule {
+  const rule = expectRecord(input, `${path} tv[${index}]`);
+
+  return {
+    name: requireString(rule, 'name', `${path} tv[${index}]`),
+    pattern: requireString(rule, 'pattern', `${path} tv[${index}]`),
+    resolutions: requireStringArray(
+      rule,
+      'resolutions',
+      `${path} tv[${index}]`,
+    ),
+    codecs: requireStringArray(rule, 'codecs', `${path} tv[${index}]`),
+  };
+}
+
+function validateMovieRule(
+  input: unknown,
+  path: string,
+  index: number,
+): MovieRule {
+  const rule = expectRecord(input, `${path} movies[${index}]`);
+  const pattern = rule.pattern;
+
+  return {
+    name: requireString(rule, 'name', `${path} movies[${index}]`),
+    year: requireNumber(rule, 'year', `${path} movies[${index}]`),
+    pattern:
+      pattern === undefined
+        ? undefined
+        : expectString(pattern, `${path} movies[${index}] pattern`),
+    resolutions: requireStringArray(
+      rule,
+      'resolutions',
+      `${path} movies[${index}]`,
+    ),
+    codecs: requireStringArray(rule, 'codecs', `${path} movies[${index}]`),
+  };
+}
+
+function validateTransmission(
+  input: Record<string, unknown>,
+  path: string,
+): TransmissionConfig {
+  return {
+    url: requireString(input, 'url', `${path} transmission`),
+    username: requireString(input, 'username', `${path} transmission`),
+    password: requireString(input, 'password', `${path} transmission`),
+    downloadDir:
+      input.downloadDir === undefined
+        ? undefined
+        : expectString(input.downloadDir, `${path} transmission downloadDir`),
+  };
+}
+
+function requireArray(
+  input: Record<string, unknown>,
+  key: string,
+  path: string,
+): unknown[] {
+  const value = input[key];
+
+  if (!Array.isArray(value)) {
+    throw new ConfigError(
+      `Config file "${path}" is missing required array section "${key}".`,
+    );
+  }
+
+  return value;
+}
+
+function requireRecord(
+  input: Record<string, unknown>,
+  key: string,
+  path: string,
+): Record<string, unknown> {
+  const value = input[key];
+
+  if (!isRecord(value)) {
+    throw new ConfigError(
+      `Config file "${path}" is missing required object section "${key}".`,
+    );
+  }
+
+  return value;
+}
+
+function requireString(
+  input: Record<string, unknown>,
+  key: string,
+  path: string,
+): string {
+  return expectString(input[key], `${path} ${key}`);
+}
+
+function requireNumber(
+  input: Record<string, unknown>,
+  key: string,
+  path: string,
+): number {
+  const value = input[key];
+
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    throw new ConfigError(
+      `Config file "${path}" has invalid "${key}"; expected a number.`,
+    );
+  }
+
+  return value;
+}
+
+function requireStringArray(
+  input: Record<string, unknown>,
+  key: string,
+  path: string,
+): string[] {
+  const value = input[key];
+
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new ConfigError(
+      `Config file "${path}" has invalid "${key}"; expected an array of strings.`,
+    );
+  }
+
+  return value;
+}
+
+function requireMediaType(
+  input: Record<string, unknown>,
+  path: string,
+): 'tv' | 'movie' {
+  const value = input.mediaType;
+
+  if (value !== 'tv' && value !== 'movie') {
+    throw new ConfigError(
+      `Config file "${path}" has invalid "mediaType"; expected "tv" or "movie".`,
+    );
+  }
+
+  return value;
+}
+
+function optionalRecord(
+  input: unknown,
+  path: string,
+): Record<string, unknown> | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  return expectRecord(input, path);
+}
+
+function expectRecord(input: unknown, path: string): Record<string, unknown> {
+  if (!isRecord(input)) {
+    throw new ConfigError(`Config file "${path}" must be an object.`);
+  }
+
+  return input;
+}
+
+function expectString(input: unknown, path: string): string {
+  if (typeof input !== 'string' || input.length === 0) {
+    throw new ConfigError(`Config file "${path}" must be a non-empty string.`);
+  }
+
+  return input;
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === 'object' && input !== null && !Array.isArray(input);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,7 +28,7 @@ export type TransmissionConfig = {
 export type AppConfig = {
   feeds: FeedConfig[];
   tv: TvRule[];
-  movies: MoviePolicy[];
+  movies: MoviePolicy;
   transmission: TransmissionConfig;
 };
 
@@ -72,15 +72,13 @@ export function validateConfig(input: unknown, path = 'config'): AppConfig {
 
   const feeds = requireArray(input, 'feeds', path);
   const tv = requireArray(input, 'tv', path);
-  const movies = requireArray(input, 'movies', path);
+  const movies = requireRecord(input, 'movies', path);
   const transmission = requireRecord(input, 'transmission', path);
 
   return {
     feeds: feeds.map((entry, index) => validateFeed(entry, path, index)),
     tv: tv.map((entry, index) => validateTvRule(entry, path, index)),
-    movies: movies.map((entry, index) =>
-      validateMoviePolicy(entry, path, index),
-    ),
+    movies: validateMoviePolicy(movies, path),
     transmission: validateTransmission(transmission, path),
   };
 }
@@ -115,20 +113,15 @@ function validateTvRule(input: unknown, path: string, index: number): TvRule {
 }
 
 function validateMoviePolicy(
-  input: unknown,
+  input: Record<string, unknown>,
   path: string,
-  index: number,
 ): MoviePolicy {
-  const rule = expectRecord(input, `${path} movies[${index}]`);
+  const rule = input;
 
   return {
-    years: requireNumberArray(rule, 'years', `${path} movies[${index}]`),
-    resolutions: requireStringArray(
-      rule,
-      'resolutions',
-      `${path} movies[${index}]`,
-    ),
-    codecs: requireStringArray(rule, 'codecs', `${path} movies[${index}]`),
+    years: requireNumberArray(rule, 'years', `${path} movies`),
+    resolutions: requireStringArray(rule, 'resolutions', `${path} movies`),
+    codecs: requireStringArray(rule, 'codecs', `${path} movies`),
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,10 +12,8 @@ export type TvRule = {
   codecs: string[];
 };
 
-export type MovieRule = {
-  name: string;
-  year: number;
-  pattern?: string;
+export type MoviePolicy = {
+  years: number[];
   resolutions: string[];
   codecs: string[];
 };
@@ -30,7 +28,7 @@ export type TransmissionConfig = {
 export type AppConfig = {
   feeds: FeedConfig[];
   tv: TvRule[];
-  movies: MovieRule[];
+  movies: MoviePolicy[];
   transmission: TransmissionConfig;
 };
 
@@ -80,7 +78,9 @@ export function validateConfig(input: unknown, path = 'config'): AppConfig {
   return {
     feeds: feeds.map((entry, index) => validateFeed(entry, path, index)),
     tv: tv.map((entry, index) => validateTvRule(entry, path, index)),
-    movies: movies.map((entry, index) => validateMovieRule(entry, path, index)),
+    movies: movies.map((entry, index) =>
+      validateMoviePolicy(entry, path, index),
+    ),
     transmission: validateTransmission(transmission, path),
   };
 }
@@ -114,21 +114,15 @@ function validateTvRule(input: unknown, path: string, index: number): TvRule {
   };
 }
 
-function validateMovieRule(
+function validateMoviePolicy(
   input: unknown,
   path: string,
   index: number,
-): MovieRule {
+): MoviePolicy {
   const rule = expectRecord(input, `${path} movies[${index}]`);
-  const pattern = rule.pattern;
 
   return {
-    name: requireString(rule, 'name', `${path} movies[${index}]`),
-    year: requireNumber(rule, 'year', `${path} movies[${index}]`),
-    pattern:
-      pattern === undefined
-        ? undefined
-        : expectString(pattern, `${path} movies[${index}] pattern`),
+    years: requireNumberArray(rule, 'years', `${path} movies[${index}]`),
     resolutions: requireStringArray(
       rule,
       'resolutions',
@@ -193,16 +187,22 @@ function requireString(
   return expectString(input[key], `${path} ${key}`);
 }
 
-function requireNumber(
+function requireNumberArray(
   input: Record<string, unknown>,
   key: string,
   path: string,
-): number {
+): number[] {
   const value = input[key];
 
-  if (typeof value !== 'number' || Number.isNaN(value)) {
+  if (!Array.isArray(value) || value.length === 0) {
     throw new ConfigError(
-      `Config file "${path}" has invalid "${key}"; expected a number.`,
+      `Config file "${path}" has invalid "${key}"; expected a non-empty array of numbers.`,
+    );
+  }
+
+  if (value.some((item) => typeof item !== 'number' || Number.isNaN(item))) {
+    throw new ConfigError(
+      `Config file "${path}" has invalid "${key}"; expected a non-empty array of numbers.`,
     );
   }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -52,7 +52,11 @@ describe('media-sync run', () => {
       JSON.stringify({
         feeds: [],
         tv: [],
-        movies: [],
+        movies: {
+          years: [2024],
+          resolutions: ['1080p'],
+          codecs: ['x265'],
+        },
       }),
     );
 
@@ -98,6 +102,25 @@ describe('media-sync run', () => {
     expect(stderr).toContain('contains invalid JSON');
   });
 
+  it('fails fast when --config is passed without a value', async () => {
+    const child = Bun.spawn(
+      [bunExecutable, 'run', './src/cli.ts', 'run', '--config'],
+      {
+        cwd,
+        stderr: 'pipe',
+        stdout: 'pipe',
+      },
+    );
+
+    const stdout = await new Response(child.stdout).text();
+    const stderr = await new Response(child.stderr).text();
+    const exitCode = await child.exited;
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('Missing value for --config.');
+  });
+
   it('fails fast when movie policy uses the legacy title-based shape', async () => {
     const directory = await mkdtemp();
     const configPath = `${directory}/legacy-movie-shape.json`;
@@ -107,10 +130,52 @@ describe('media-sync run', () => {
       JSON.stringify({
         feeds: [],
         tv: [],
+        movies: {
+          name: 'Example Movie',
+          year: 2024,
+          resolutions: ['1080p'],
+          codecs: ['x265'],
+        },
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+        },
+      }),
+    );
+
+    const child = Bun.spawn(
+      [bunExecutable, 'run', './src/cli.ts', 'run', '--config', configPath],
+      {
+        cwd,
+        stderr: 'pipe',
+        stdout: 'pipe',
+      },
+    );
+
+    const stdout = await new Response(child.stdout).text();
+    const stderr = await new Response(child.stderr).text();
+    const exitCode = await child.exited;
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe('');
+    expect(stderr).toContain(
+      'has invalid "years"; expected a non-empty array of numbers',
+    );
+  });
+
+  it('fails fast when movie policy is configured as an array instead of an object', async () => {
+    const directory = await mkdtemp();
+    const configPath = `${directory}/movie-policy-array.json`;
+
+    await Bun.write(
+      configPath,
+      JSON.stringify({
+        feeds: [],
+        tv: [],
         movies: [
           {
-            name: 'Example Movie',
-            year: 2024,
+            years: [2024],
             resolutions: ['1080p'],
             codecs: ['x265'],
           },
@@ -138,9 +203,7 @@ describe('media-sync run', () => {
 
     expect(exitCode).toBe(1);
     expect(stdout).toBe('');
-    expect(stderr).toContain(
-      'has invalid "years"; expected a non-empty array of numbers',
-    );
+    expect(stderr).toContain('missing required object section "movies"');
   });
 });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -43,7 +43,7 @@ describe('media-sync run', () => {
     expect(stderr).toBe('');
   });
 
-  it('fails fast when config is missing a required section', async () => {
+  it('exits with a readable error when config is missing a required section', async () => {
     const directory = await mkdtemp();
     const configPath = `${directory}/missing-sections.json`;
 
@@ -78,7 +78,7 @@ describe('media-sync run', () => {
     expect(stderr).toContain('missing required object section "transmission"');
   });
 
-  it('fails fast when config JSON is malformed', async () => {
+  it('exits with a readable error when config JSON is malformed', async () => {
     const directory = await mkdtemp();
     const configPath = `${directory}/broken.json`;
 
@@ -102,7 +102,7 @@ describe('media-sync run', () => {
     expect(stderr).toContain('contains invalid JSON');
   });
 
-  it('fails fast when --config is passed without a value', async () => {
+  it('exits with a readable error when --config is passed without a value', async () => {
     const child = Bun.spawn(
       [bunExecutable, 'run', './src/cli.ts', 'run', '--config'],
       {
@@ -121,90 +121,6 @@ describe('media-sync run', () => {
     expect(stderr).toContain('Missing value for --config.');
   });
 
-  it('fails fast when movie policy uses the legacy title-based shape', async () => {
-    const directory = await mkdtemp();
-    const configPath = `${directory}/legacy-movie-shape.json`;
-
-    await Bun.write(
-      configPath,
-      JSON.stringify({
-        feeds: [],
-        tv: [],
-        movies: {
-          name: 'Example Movie',
-          year: 2024,
-          resolutions: ['1080p'],
-          codecs: ['x265'],
-        },
-        transmission: {
-          url: 'http://localhost:9091/transmission/rpc',
-          username: 'user',
-          password: 'pass',
-        },
-      }),
-    );
-
-    const child = Bun.spawn(
-      [bunExecutable, 'run', './src/cli.ts', 'run', '--config', configPath],
-      {
-        cwd,
-        stderr: 'pipe',
-        stdout: 'pipe',
-      },
-    );
-
-    const stdout = await new Response(child.stdout).text();
-    const stderr = await new Response(child.stderr).text();
-    const exitCode = await child.exited;
-
-    expect(exitCode).toBe(1);
-    expect(stdout).toBe('');
-    expect(stderr).toContain(
-      'has invalid "years"; expected a non-empty array of numbers',
-    );
-  });
-
-  it('fails fast when movie policy is configured as an array instead of an object', async () => {
-    const directory = await mkdtemp();
-    const configPath = `${directory}/movie-policy-array.json`;
-
-    await Bun.write(
-      configPath,
-      JSON.stringify({
-        feeds: [],
-        tv: [],
-        movies: [
-          {
-            years: [2024],
-            resolutions: ['1080p'],
-            codecs: ['x265'],
-          },
-        ],
-        transmission: {
-          url: 'http://localhost:9091/transmission/rpc',
-          username: 'user',
-          password: 'pass',
-        },
-      }),
-    );
-
-    const child = Bun.spawn(
-      [bunExecutable, 'run', './src/cli.ts', 'run', '--config', configPath],
-      {
-        cwd,
-        stderr: 'pipe',
-        stdout: 'pipe',
-      },
-    );
-
-    const stdout = await new Response(child.stdout).text();
-    const stderr = await new Response(child.stderr).text();
-    const exitCode = await child.exited;
-
-    expect(exitCode).toBe(1);
-    expect(stdout).toBe('');
-    expect(stderr).toContain('missing required object section "movies"');
-  });
 });
 
 async function mkdtemp(): Promise<string> {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+
+const tempDirs: string[] = [];
+const cwd = process.cwd();
+const bunExecutable = process.execPath;
+
+describe('media-sync run', () => {
+  afterEach(async () => {
+    while (tempDirs.length > 0) {
+      const directory = tempDirs.pop();
+
+      if (directory) {
+        await Bun.$`rm -rf ${directory}`;
+      }
+    }
+  });
+
+  it('loads config passed with --config', async () => {
+    const child = Bun.spawn(
+      [
+        bunExecutable,
+        'run',
+        './src/cli.ts',
+        'run',
+        '--config',
+        './test/fixtures/valid-config.json',
+      ],
+      {
+        cwd,
+        stderr: 'pipe',
+        stdout: 'pipe',
+      },
+    );
+
+    const stdout = await new Response(child.stdout).text();
+    const stderr = await new Response(child.stderr).text();
+    const exitCode = await child.exited;
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(
+      'Config loaded from ./test/fixtures/valid-config.json.',
+    );
+    expect(stderr).toBe('');
+  });
+
+  it('fails fast when config is missing a required section', async () => {
+    const directory = await mkdtemp();
+    const configPath = `${directory}/missing-sections.json`;
+
+    await Bun.write(
+      configPath,
+      JSON.stringify({
+        feeds: [],
+        tv: [],
+        movies: [],
+      }),
+    );
+
+    const child = Bun.spawn(
+      [bunExecutable, 'run', './src/cli.ts', 'run', '--config', configPath],
+      {
+        cwd,
+        stderr: 'pipe',
+        stdout: 'pipe',
+      },
+    );
+
+    const stdout = await new Response(child.stdout).text();
+    const stderr = await new Response(child.stderr).text();
+    const exitCode = await child.exited;
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('missing required object section "transmission"');
+  });
+
+  it('fails fast when config JSON is malformed', async () => {
+    const directory = await mkdtemp();
+    const configPath = `${directory}/broken.json`;
+
+    await Bun.write(configPath, '{not-json');
+
+    const child = Bun.spawn(
+      [bunExecutable, 'run', './src/cli.ts', 'run', '--config', configPath],
+      {
+        cwd,
+        stderr: 'pipe',
+        stdout: 'pipe',
+      },
+    );
+
+    const stdout = await new Response(child.stdout).text();
+    const stderr = await new Response(child.stderr).text();
+    const exitCode = await child.exited;
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('contains invalid JSON');
+  });
+});
+
+async function mkdtemp(): Promise<string> {
+  const child = Bun.spawn(['mktemp', '-d', '-t', 'media-sync-test'], {
+    cwd,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+  const directory = (await new Response(child.stdout).text()).trim();
+
+  if ((await child.exited) !== 0 || directory.length === 0) {
+    throw new Error('Failed to create temporary directory for test.');
+  }
+
+  tempDirs.push(directory);
+  return directory;
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, describe, expect, it } from 'bun:test';
+import { dirname } from 'node:path';
 
 const tempDirs: string[] = [];
 const cwd = process.cwd();
 const bunExecutable = process.execPath;
+const cliExecutable = './bin/media-sync';
+const binPath = dirname(bunExecutable);
+const env = {
+  ...process.env,
+  PATH: `${binPath}:${process.env.PATH ?? ''}`,
+};
 
 describe('media-sync run', () => {
   afterEach(async () => {
@@ -17,16 +24,10 @@ describe('media-sync run', () => {
 
   it('loads config passed with --config', async () => {
     const child = Bun.spawn(
-      [
-        bunExecutable,
-        'run',
-        './src/cli.ts',
-        'run',
-        '--config',
-        './test/fixtures/valid-config.json',
-      ],
+      [cliExecutable, 'run', '--config', './test/fixtures/valid-config.json'],
       {
         cwd,
+        env,
         stderr: 'pipe',
         stdout: 'pipe',
       },
@@ -64,6 +65,7 @@ describe('media-sync run', () => {
       [bunExecutable, 'run', './src/cli.ts', 'run', '--config', configPath],
       {
         cwd,
+        env,
         stderr: 'pipe',
         stdout: 'pipe',
       },
@@ -88,6 +90,7 @@ describe('media-sync run', () => {
       [bunExecutable, 'run', './src/cli.ts', 'run', '--config', configPath],
       {
         cwd,
+        env,
         stderr: 'pipe',
         stdout: 'pipe',
       },
@@ -107,6 +110,7 @@ describe('media-sync run', () => {
       [bunExecutable, 'run', './src/cli.ts', 'run', '--config'],
       {
         cwd,
+        env,
         stderr: 'pipe',
         stdout: 'pipe',
       },
@@ -120,12 +124,12 @@ describe('media-sync run', () => {
     expect(stdout).toBe('');
     expect(stderr).toContain('Missing value for --config.');
   });
-
 });
 
 async function mkdtemp(): Promise<string> {
   const child = Bun.spawn(['mktemp', '-d', '-t', 'media-sync-test'], {
     cwd,
+    env,
     stderr: 'pipe',
     stdout: 'pipe',
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -97,6 +97,51 @@ describe('media-sync run', () => {
     expect(stdout).toBe('');
     expect(stderr).toContain('contains invalid JSON');
   });
+
+  it('fails fast when movie policy uses the legacy title-based shape', async () => {
+    const directory = await mkdtemp();
+    const configPath = `${directory}/legacy-movie-shape.json`;
+
+    await Bun.write(
+      configPath,
+      JSON.stringify({
+        feeds: [],
+        tv: [],
+        movies: [
+          {
+            name: 'Example Movie',
+            year: 2024,
+            resolutions: ['1080p'],
+            codecs: ['x265'],
+          },
+        ],
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+        },
+      }),
+    );
+
+    const child = Bun.spawn(
+      [bunExecutable, 'run', './src/cli.ts', 'run', '--config', configPath],
+      {
+        cwd,
+        stderr: 'pipe',
+        stdout: 'pipe',
+      },
+    );
+
+    const stdout = await new Response(child.stdout).text();
+    const stderr = await new Response(child.stderr).text();
+    const exitCode = await child.exited;
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe('');
+    expect(stderr).toContain(
+      'has invalid "years"; expected a non-empty array of numbers',
+    );
+  });
 });
 
 async function mkdtemp(): Promise<string> {

--- a/test/fixtures/valid-config.json
+++ b/test/fixtures/valid-config.json
@@ -19,13 +19,11 @@
       "codecs": ["x265"]
     }
   ],
-  "movies": [
-    {
-      "years": [2024],
-      "resolutions": ["1080p"],
-      "codecs": ["x265"]
-    }
-  ],
+  "movies": {
+    "years": [2024],
+    "resolutions": ["1080p"],
+    "codecs": ["x265"]
+  },
   "transmission": {
     "url": "http://localhost:9091/transmission/rpc",
     "username": "user",

--- a/test/fixtures/valid-config.json
+++ b/test/fixtures/valid-config.json
@@ -1,0 +1,30 @@
+{
+  "feeds": [
+    {
+      "name": "TV Feed",
+      "url": "https://example.com/tv.rss",
+      "mediaType": "tv"
+    }
+  ],
+  "tv": [
+    {
+      "name": "Example Show",
+      "pattern": "example[ ._-]*show",
+      "resolutions": ["1080p"],
+      "codecs": ["x265"]
+    }
+  ],
+  "movies": [
+    {
+      "name": "Example Movie",
+      "year": 2024,
+      "resolutions": ["1080p"],
+      "codecs": ["x265"]
+    }
+  ],
+  "transmission": {
+    "url": "http://localhost:9091/transmission/rpc",
+    "username": "user",
+    "password": "pass"
+  }
+}

--- a/test/fixtures/valid-config.json
+++ b/test/fixtures/valid-config.json
@@ -4,6 +4,11 @@
       "name": "TV Feed",
       "url": "https://example.com/tv.rss",
       "mediaType": "tv"
+    },
+    {
+      "name": "Movie Feed",
+      "url": "https://example.com/movies.rss",
+      "mediaType": "movie"
     }
   ],
   "tv": [
@@ -16,8 +21,7 @@
   ],
   "movies": [
     {
-      "name": "Example Movie",
-      "year": 2024,
+      "years": [2024],
       "resolutions": ["1080p"],
       "codecs": ["x265"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "types": ["bun"],
+    "allowJs": false
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- implement Ticket 01 with a minimal Bun + TypeScript CLI scaffold
- add `media-sync run` config loading from `--config` or the default config path
- validate required config sections and fail fast on missing or malformed JSON
- add integration-style CLI tests and a Ticket 01 rationale note
- add ESLint and Prettier with minimal repo configuration
- upgrade tooling to the latest compatible package versions

## Testing

- `bun run lint`
- `bun test`

## Notes

- `typescript` remains on `5.9.3` because the current `typescript-eslint` release does not support TypeScript 6 yet
- local VS Code user settings are ignored without ignoring the full `.vscode/` directory

## Deferred

- additional CLI commands beyond `run`
- richer config schema validation and all feed, database, and Transmission behavior from later tickets

