### PR TITLE
feat: add title normalization [P1.03]

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Phase 01 ends at successful queueing in Transmission. It does not include a web 
 
 ## Status
 
-Tickets 01-02 are implemented: the repository now has a minimal Bun + TypeScript CLI skeleton with JSON config loading and validation for `media-sync run`, plus an RSS fetch-and-parse entrypoint that converts RSS items into a raw feed-item shape.
+Tickets 01-03 are implemented: the repository now has a minimal Bun + TypeScript CLI skeleton with JSON config loading and validation for `media-sync run`, an RSS fetch-and-parse entrypoint that converts RSS items into a raw feed-item shape, and a title-normalization module that extracts matching metadata for TV and movie releases.
 
 The project is being planned as a small-slice, review-friendly build:
 

--- a/cspell.json
+++ b/cspell.json
@@ -3,7 +3,7 @@
   "ignorePaths": [],
   "dictionaryDefinitions": [],
   "dictionaries": [],
-  "words": ["eztv", "mktemp", "parsererror"],
+  "words": ["eztv", "mktemp", "parsererror", "reparsing"],
   "ignoreWords": [],
   "import": []
 }

--- a/docs/02-delivery/phase-01/ticket-03-rationale.md
+++ b/docs/02-delivery/phase-01/ticket-03-rationale.md
@@ -1,0 +1,6 @@
+# Ticket 03 Rationale
+
+- Red first: normalizing representative TV and movie release titles should extract the matching metadata shape, while still returning a usable normalized title when some metadata is missing.
+- Why this path: one normalization entrypoint with table-driven examples is the smallest acceptable slice that proves downstream matchers can depend on a stable media shape instead of reparsing raw titles.
+- Alternative considered: building normalization directly into the future TV and movie matchers was rejected because it would duplicate parsing rules and make matcher tests carry unrelated title-cleanup behavior.
+- Deferred: feed-specific parser hints, broader quality/source token cleanup, multi-episode parsing, and any scoring or rule-matching logic.

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,0 +1,138 @@
+import type { FeedConfig } from './config';
+
+export type NormalizedFeedItem = {
+  mediaType: FeedConfig['mediaType'];
+  rawTitle: string;
+  normalizedTitle: string;
+  season?: number;
+  episode?: number;
+  year?: number;
+  resolution?: string;
+  codec?: 'x264' | 'x265';
+};
+
+export function normalizeFeedItem(input: {
+  mediaType: FeedConfig['mediaType'];
+  rawTitle: string;
+}): NormalizedFeedItem {
+  const seasonEpisode = extractSeasonEpisode(input.rawTitle);
+  const year = extractYear(input.rawTitle);
+  const resolution = extractResolution(input.rawTitle);
+  const codec = extractCodec(input.rawTitle);
+
+  return {
+    mediaType: input.mediaType,
+    rawTitle: input.rawTitle,
+    normalizedTitle: extractNormalizedTitle(
+      input.rawTitle,
+      seasonEpisode?.index,
+      year?.index,
+    ),
+    season: seasonEpisode?.season,
+    episode: seasonEpisode?.episode,
+    year: year?.value,
+    resolution,
+    codec,
+  };
+}
+
+function extractSeasonEpisode(
+  value: string,
+): { season: number; episode: number; index: number } | undefined {
+  const match = tvEpisodePattern.exec(value);
+
+  if (!match) {
+    return undefined;
+  }
+
+  const season = Number(match.groups?.season ?? match.groups?.seasonAlt);
+  const episode = Number(match.groups?.episode ?? match.groups?.episodeAlt);
+
+  if (Number.isNaN(season) || Number.isNaN(episode)) {
+    return undefined;
+  }
+
+  return {
+    season,
+    episode,
+    index: match.index,
+  };
+}
+
+function extractYear(
+  value: string,
+): { value: number; index: number } | undefined {
+  const match = yearPattern.exec(value);
+
+  if (!match) {
+    return undefined;
+  }
+
+  return {
+    value: Number(match[0]),
+    index: match.index,
+  };
+}
+
+function extractResolution(value: string): string | undefined {
+  const match = resolutionPattern.exec(value);
+  return match?.[1]?.toLowerCase();
+}
+
+function extractCodec(value: string): 'x264' | 'x265' | undefined {
+  const match = codecPattern.exec(value);
+
+  if (!match) {
+    return undefined;
+  }
+
+  return x265CodecTokens.has(match[1].toLowerCase()) ? 'x265' : 'x264';
+}
+
+function extractNormalizedTitle(
+  value: string,
+  seasonEpisodeIndex?: number,
+  yearIndex?: number,
+): string {
+  const cutoff = firstDefinedIndex(seasonEpisodeIndex, yearIndex);
+  const titleSegment = cutoff === undefined ? value : value.slice(0, cutoff);
+
+  return normalizeTitleWhitespace(titleSegment);
+}
+
+function firstDefinedIndex(
+  ...indexes: Array<number | undefined>
+): number | undefined {
+  const defined = indexes.filter(
+    (value): value is number => value !== undefined,
+  );
+
+  if (defined.length === 0) {
+    return undefined;
+  }
+
+  return Math.min(...defined);
+}
+
+function normalizeTitleWhitespace(value: string): string {
+  return value
+    .replace(separatorPattern, ' ')
+    .replace(extraSymbolPattern, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const tvEpisodePattern =
+  /\b(?:s(?<season>\d{1,2})e(?<episode>\d{1,2})|(?<seasonAlt>\d{1,2})x(?<episodeAlt>\d{1,2}))\b/i;
+
+const yearPattern = /\b(?:19|20)\d{2}\b/;
+
+const resolutionPattern = /\b(2160p|1080p|720p|480p)\b/i;
+
+const codecPattern = /\b(x265|h265|hevc|x264|h264|avc)\b/i;
+
+const separatorPattern = /[._-]+/g;
+
+const extraSymbolPattern = /[()[\]{}]+/g;
+
+const x265CodecTokens = new Set(['x265', 'h265', 'hevc']);

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -15,19 +15,20 @@ export function normalizeFeedItem(input: {
   mediaType: FeedConfig['mediaType'];
   rawTitle: string;
 }): NormalizedFeedItem {
-  const seasonEpisode = extractSeasonEpisode(input.rawTitle);
+  const seasonEpisode =
+    input.mediaType === 'tv' ? extractSeasonEpisode(input.rawTitle) : undefined;
   const year = extractYear(input.rawTitle);
   const resolution = extractResolution(input.rawTitle);
   const codec = extractCodec(input.rawTitle);
+  const normalizedTitle =
+    input.mediaType === 'tv'
+      ? extractNormalizedTitle(input.rawTitle, seasonEpisode?.index)
+      : extractNormalizedTitle(input.rawTitle, year?.index);
 
   return {
     mediaType: input.mediaType,
     rawTitle: input.rawTitle,
-    normalizedTitle: extractNormalizedTitle(
-      input.rawTitle,
-      seasonEpisode?.index,
-      year?.index,
-    ),
+    normalizedTitle,
     season: seasonEpisode?.season,
     episode: seasonEpisode?.episode,
     year: year?.value,
@@ -89,29 +90,10 @@ function extractCodec(value: string): 'x264' | 'x265' | undefined {
   return x265CodecTokens.has(match[1].toLowerCase()) ? 'x265' : 'x264';
 }
 
-function extractNormalizedTitle(
-  value: string,
-  seasonEpisodeIndex?: number,
-  yearIndex?: number,
-): string {
-  const cutoff = firstDefinedIndex(seasonEpisodeIndex, yearIndex);
+function extractNormalizedTitle(value: string, cutoff?: number): string {
   const titleSegment = cutoff === undefined ? value : value.slice(0, cutoff);
 
   return normalizeTitleWhitespace(titleSegment);
-}
-
-function firstDefinedIndex(
-  ...indexes: Array<number | undefined>
-): number | undefined {
-  const defined = indexes.filter(
-    (value): value is number => value !== undefined,
-  );
-
-  if (defined.length === 0) {
-    return undefined;
-  }
-
-  return Math.min(...defined);
 }
 
 function normalizeTitleWhitespace(value: string): string {

--- a/test/feed.test.ts
+++ b/test/feed.test.ts
@@ -4,6 +4,7 @@ import type { FeedConfig } from '../src/config';
 import { FeedError, fetchFeed } from '../src/feed';
 
 const servers: Array<ReturnType<typeof Bun.serve>> = [];
+const originalFetch = globalThis.fetch;
 
 describe('fetchFeed', () => {
   afterEach(() => {
@@ -14,6 +15,8 @@ describe('fetchFeed', () => {
         server.stop(true);
       }
     }
+
+    globalThis.fetch = originalFetch;
   });
 
   it('parses multiple TV-style RSS items and prefers guid over link', async () => {
@@ -71,6 +74,29 @@ describe('fetchFeed', () => {
     await expect(fetchFeed(feed)).rejects.toThrow(
       new FeedError(
         `Failed to fetch feed "TV Feed" from ${server.url}/eztv: HTTP 503.`,
+      ),
+    );
+  });
+
+  it('fails with a readable error when fetch throws before a response is returned', async () => {
+    globalThis.fetch = Object.assign(
+      async () => {
+        throw new Error('connect ECONNREFUSED');
+      },
+      {
+        preconnect: originalFetch.preconnect.bind(originalFetch),
+      },
+    );
+
+    const feed = createFeedConfig(
+      'TV Feed',
+      'https://user:secret@example.test/eztv?token=abc123',
+      'tv',
+    );
+
+    await expect(fetchFeed(feed)).rejects.toThrow(
+      new FeedError(
+        'Failed to fetch feed "TV Feed" from https://example.test/eztv: connect ECONNREFUSED.',
       ),
     );
   });

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'bun:test';
+
+import { normalizeFeedItem, type NormalizedFeedItem } from '../src/normalize';
+
+describe('normalizeFeedItem', () => {
+  it.each([
+    {
+      name: 'extracts TV metadata from dotted release titles',
+      mediaType: 'tv' as const,
+      rawTitle: 'Example.Show.S01E02.1080p.WEB.H264-GROUP',
+      expected: {
+        mediaType: 'tv',
+        rawTitle: 'Example.Show.S01E02.1080p.WEB.H264-GROUP',
+        normalizedTitle: 'Example Show',
+        season: 1,
+        episode: 2,
+        year: undefined,
+        resolution: '1080p',
+        codec: 'x264',
+      },
+    },
+    {
+      name: 'extracts TV metadata from x-based episode notation',
+      mediaType: 'tv' as const,
+      rawTitle: 'Another Show - 2x03 - 720p WEB x265',
+      expected: {
+        mediaType: 'tv',
+        rawTitle: 'Another Show - 2x03 - 720p WEB x265',
+        normalizedTitle: 'Another Show',
+        season: 2,
+        episode: 3,
+        year: undefined,
+        resolution: '720p',
+        codec: 'x265',
+      },
+    },
+    {
+      name: 'extracts movie metadata from noisy release titles',
+      mediaType: 'movie' as const,
+      rawTitle: 'Example.Movie.2024.2160p.WEB-DL.HEVC-GROUP',
+      expected: {
+        mediaType: 'movie',
+        rawTitle: 'Example.Movie.2024.2160p.WEB-DL.HEVC-GROUP',
+        normalizedTitle: 'Example Movie',
+        season: undefined,
+        episode: undefined,
+        year: 2024,
+        resolution: '2160p',
+        codec: 'x265',
+      },
+    },
+    {
+      name: 'keeps partial metadata when season and episode are absent',
+      mediaType: 'movie' as const,
+      rawTitle: 'Catalog Title 2023 BluRay',
+      expected: {
+        mediaType: 'movie',
+        rawTitle: 'Catalog Title 2023 BluRay',
+        normalizedTitle: 'Catalog Title',
+        season: undefined,
+        episode: undefined,
+        year: 2023,
+        resolution: undefined,
+        codec: undefined,
+      },
+    },
+    {
+      name: 'returns undefined metadata when only a title is available',
+      mediaType: 'tv' as const,
+      rawTitle: 'Plain Title Release',
+      expected: {
+        mediaType: 'tv',
+        rawTitle: 'Plain Title Release',
+        normalizedTitle: 'Plain Title Release',
+        season: undefined,
+        episode: undefined,
+        year: undefined,
+        resolution: undefined,
+        codec: undefined,
+      },
+    },
+  ])('$name', ({ mediaType, rawTitle, expected }) => {
+    expect(normalizeFeedItem({ mediaType, rawTitle })).toEqual(expected);
+  });
+
+  it('normalizes multiple feed items into a consistent shape', () => {
+    const items = [
+      normalizeFeedItem({
+        mediaType: 'tv',
+        rawTitle: 'Example.Show.S01E02.1080p.WEB.H264-GROUP',
+      }),
+      normalizeFeedItem({
+        mediaType: 'movie',
+        rawTitle: 'Example.Movie.2024.2160p.WEB-DL.HEVC-GROUP',
+      }),
+    ];
+
+    expect(items).toEqual<NormalizedFeedItem[]>([
+      {
+        mediaType: 'tv',
+        rawTitle: 'Example.Show.S01E02.1080p.WEB.H264-GROUP',
+        normalizedTitle: 'Example Show',
+        season: 1,
+        episode: 2,
+        year: undefined,
+        resolution: '1080p',
+        codec: 'x264',
+      },
+      {
+        mediaType: 'movie',
+        rawTitle: 'Example.Movie.2024.2160p.WEB-DL.HEVC-GROUP',
+        normalizedTitle: 'Example Movie',
+        season: undefined,
+        episode: undefined,
+        year: 2024,
+        resolution: '2160p',
+        codec: 'x265',
+      },
+    ]);
+  });
+});

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -50,6 +50,21 @@ describe('normalizeFeedItem', () => {
       },
     },
     {
+      name: 'ignores TV episode tokens when normalizing movie titles',
+      mediaType: 'movie' as const,
+      rawTitle: 'Studio 54 S01E02 2024 1080p WEB x265',
+      expected: {
+        mediaType: 'movie',
+        rawTitle: 'Studio 54 S01E02 2024 1080p WEB x265',
+        normalizedTitle: 'Studio 54 S01E02',
+        season: undefined,
+        episode: undefined,
+        year: 2024,
+        resolution: '1080p',
+        codec: 'x265',
+      },
+    },
+    {
       name: 'keeps partial metadata when season and episode are absent',
       mediaType: 'movie' as const,
       rawTitle: 'Catalog Title 2023 BluRay',


### PR DESCRIPTION
## Summary

Implements `P1.03` by adding a title-normalization module for TV and movie releases.
The new parser extracts normalized title, season, episode, year, resolution, and codec metadata from noisy feed titles.

## Testing

- adds table-driven normalization coverage for representative TV and movie titles
- adds coverage for partial metadata cases
- adds a fetch failure test for the branch where no `Response` is returned

## Docs

- adds the `P1.03` rationale note
- updates the README status to reflect ticket 03 completion

