### PR TITLE
feat: add TV rule matcher [P1.04]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,5 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Verify
-        run: bun run verify
-
-      - name: Test
-        run: bun run test
+      - name: Run CI
+        run: bun run ci

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Useful supporting docs:
 ## Local Development
 
 - `bun test`
+- `bun run ci`
 - `./bin/media-sync run --config ./test/fixtures/valid-config.json`
 
 ## Proposed CLI Surface

--- a/docs/01-product/phase-01-mvp.md
+++ b/docs/01-product/phase-01-mvp.md
@@ -60,10 +60,10 @@ Defines tracked TV rules.
 
 Each rule should contain:
 
-- `name`
-- `pattern`: case-insensitive regex string
+- `name`: human-readable canonical show name
 - `resolutions`: allowed values such as `1080p`
 - `codecs`: allowed values such as `x265`
+- optional `matchPattern`: case-insensitive regex override when name-based matching is not specific enough
 
 ## `movies`
 

--- a/docs/02-delivery/phase-01/ticket-04-tv-rule-matching.md
+++ b/docs/02-delivery/phase-01/ticket-04-tv-rule-matching.md
@@ -4,7 +4,7 @@ Size: 2 points
 
 ## Outcome
 
-- match normalized TV items against regex-based rules
+- match normalized TV items against name-based rules with optional regex overrides
 - enforce codec and resolution filters
 
 ## Red

--- a/docs/03-engineering/tdd-workflow.md
+++ b/docs/03-engineering/tdd-workflow.md
@@ -93,7 +93,7 @@ Keep the suite small and behavior-focused:
 - do not assume browser-style globals such as `DOMParser` exist in every Bun runtime context
 - avoid shelling out to platform-specific tools like BSD `mktemp` in tests
 - prefer path-aware helpers over manual string slicing for executable paths and `PATH` updates
-- run full `verify` and `test`, not just `typecheck`, before considering a ticket green
+- run `bun run ci`, not just `typecheck`, before considering a ticket green
 
 ## Learning-Oriented Review Prompts
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "media-sync": "./bin/media-sync"
   },
   "scripts": {
+    "ci": "bun run verify && bun run test",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint .",

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,7 +102,7 @@ function validateTvRule(input: unknown, path: string, index: number): TvRule {
 
   return {
     name: requireString(rule, 'name', `${path} tv[${index}]`),
-    matchPattern: optionalString(
+    matchPattern: validateOptionalMatchPattern(
       rule.matchPattern,
       `${path} tv[${index}] matchPattern`,
     ),
@@ -205,6 +205,29 @@ function optionalString(input: unknown, path: string): string | undefined {
   }
 
   return expectString(input, path);
+}
+
+function validateOptionalMatchPattern(
+  input: unknown,
+  path: string,
+): string | undefined {
+  const value = optionalString(input, path);
+
+  if (value === undefined) {
+    return undefined;
+  }
+
+  try {
+    void new RegExp(value, 'i');
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'invalid regular expression';
+    throw new ConfigError(
+      `Config file "${path}" has invalid regex syntax: ${message}.`,
+    );
+  }
+
+  return value;
 }
 
 function requireNumberArray(

--- a/src/config.ts
+++ b/src/config.ts
@@ -106,12 +106,18 @@ function validateTvRule(input: unknown, path: string, index: number): TvRule {
       rule.matchPattern,
       `${path} tv[${index}] matchPattern`,
     ),
-    resolutions: requireStringArray(
+    resolutions: requireNormalizedAllowedStringArray(
       rule,
       'resolutions',
       `${path} tv[${index}]`,
+      supportedResolutions,
     ),
-    codecs: requireStringArray(rule, 'codecs', `${path} tv[${index}]`),
+    codecs: requireNormalizedAllowedStringArray(
+      rule,
+      'codecs',
+      `${path} tv[${index}]`,
+      supportedCodecs,
+    ),
   };
 }
 
@@ -123,8 +129,18 @@ function validateMoviePolicy(
 
   return {
     years: requireNumberArray(rule, 'years', `${path} movies`),
-    resolutions: requireStringArray(rule, 'resolutions', `${path} movies`),
-    codecs: requireStringArray(rule, 'codecs', `${path} movies`),
+    resolutions: requireNormalizedAllowedStringArray(
+      rule,
+      'resolutions',
+      `${path} movies`,
+      supportedResolutions,
+    ),
+    codecs: requireNormalizedAllowedStringArray(
+      rule,
+      'codecs',
+      `${path} movies`,
+      supportedCodecs,
+    ),
   };
 }
 
@@ -229,6 +245,24 @@ function requireStringArray(
   return value;
 }
 
+function requireNormalizedAllowedStringArray(
+  input: Record<string, unknown>,
+  key: string,
+  path: string,
+  allowedValues: ReadonlySet<string>,
+): string[] {
+  const value = requireStringArray(input, key, path);
+  const normalized = value.map((item) => item.toLowerCase());
+
+  if (normalized.some((item) => !allowedValues.has(item))) {
+    throw new ConfigError(
+      `Config file "${path} ${key}" has invalid value; expected one of ${formatAllowedValues(allowedValues)}.`,
+    );
+  }
+
+  return normalized;
+}
+
 function requireMediaType(
   input: Record<string, unknown>,
   path: string,
@@ -262,6 +296,14 @@ function expectRecord(input: unknown, path: string): Record<string, unknown> {
 
   return input;
 }
+
+function formatAllowedValues(values: ReadonlySet<string>): string {
+  return [...values].map((value) => `"${value}"`).join(', ');
+}
+
+const supportedResolutions = new Set(['2160p', '1080p', '720p', '480p']);
+
+const supportedCodecs = new Set(['x264', 'x265']);
 
 function expectString(input: unknown, path: string): string {
   if (typeof input !== 'string' || input.length === 0) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export type FeedConfig = {
 
 export type TvRule = {
   name: string;
-  pattern: string;
+  matchPattern?: string;
   resolutions: string[];
   codecs: string[];
 };
@@ -102,7 +102,10 @@ function validateTvRule(input: unknown, path: string, index: number): TvRule {
 
   return {
     name: requireString(rule, 'name', `${path} tv[${index}]`),
-    pattern: requireString(rule, 'pattern', `${path} tv[${index}]`),
+    matchPattern: optionalString(
+      rule.matchPattern,
+      `${path} tv[${index}] matchPattern`,
+    ),
     resolutions: requireStringArray(
       rule,
       'resolutions',
@@ -178,6 +181,14 @@ function requireString(
   path: string,
 ): string {
   return expectString(input[key], `${path} ${key}`);
+}
+
+function optionalString(input: unknown, path: string): string | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  return expectString(input, path);
 }
 
 function requireNumberArray(

--- a/src/tv-match.ts
+++ b/src/tv-match.ts
@@ -1,0 +1,89 @@
+import type { TvRule } from './config';
+import type { NormalizedFeedItem } from './normalize';
+
+export type TvMatchResult = {
+  ruleName: string;
+  identityKey: string;
+  score: number;
+  reasons: string[];
+  item: NormalizedFeedItem;
+};
+
+export function matchTvItem(
+  item: NormalizedFeedItem,
+  rules: TvRule[],
+): TvMatchResult[] {
+  if (
+    item.mediaType !== 'tv' ||
+    item.season === undefined ||
+    item.episode === undefined ||
+    item.resolution === undefined ||
+    item.codec === undefined
+  ) {
+    return [];
+  }
+
+  const identityKey = buildIdentityKey(item);
+
+  return rules
+    .map((rule) => {
+      const match = matchRule(item, rule);
+
+      if (!match) {
+        return undefined;
+      }
+
+      return {
+        ruleName: rule.name,
+        identityKey,
+        score: scoreMatch(rule, item),
+        reasons: [
+          `pattern:${rule.pattern}`,
+          `resolution:${item.resolution}`,
+          `codec:${item.codec}`,
+        ],
+        item,
+      } satisfies TvMatchResult;
+    })
+    .filter((match): match is TvMatchResult => match !== undefined)
+    .sort((left, right) => right.score - left.score);
+}
+
+function matchRule(item: NormalizedFeedItem, rule: TvRule): boolean {
+  const pattern = new RegExp(rule.pattern, 'i');
+
+  if (!pattern.test(item.normalizedTitle)) {
+    return false;
+  }
+
+  return (
+    rule.resolutions.includes(item.resolution ?? '') &&
+    rule.codecs.includes(item.codec ?? '')
+  );
+}
+
+function buildIdentityKey(item: NormalizedFeedItem): string {
+  return `tv:${item.normalizedTitle.toLowerCase()}|s${padNumber(item.season)}e${padNumber(item.episode)}`;
+}
+
+function scoreMatch(rule: TvRule, item: NormalizedFeedItem): number {
+  const resolutionIndex = rule.resolutions.indexOf(item.resolution ?? '');
+  const codecIndex = rule.codecs.indexOf(item.codec ?? '');
+
+  return (
+    scoreResolution(rule.resolutions.length, resolutionIndex) +
+    scoreCodec(rule.codecs.length, codecIndex)
+  );
+}
+
+function scoreResolution(length: number, index: number): number {
+  return (length - index) * 100;
+}
+
+function scoreCodec(length: number, index: number): number {
+  return length - index - 1;
+}
+
+function padNumber(value: number | undefined): string {
+  return String(value ?? '').padStart(2, '0');
+}

--- a/src/tv-match.ts
+++ b/src/tv-match.ts
@@ -27,7 +27,8 @@ export function matchTvItem(
 
   return rules
     .map((rule) => {
-      const match = matchRule(item, rule);
+      const pattern = buildRulePattern(rule);
+      const match = matchRule(item, rule, pattern);
 
       if (!match) {
         return undefined;
@@ -38,7 +39,7 @@ export function matchTvItem(
         identityKey,
         score: scoreMatch(rule, item),
         reasons: [
-          `pattern:${rule.pattern}`,
+          `pattern:${pattern.source}`,
           `resolution:${item.resolution}`,
           `codec:${item.codec}`,
         ],
@@ -49,9 +50,11 @@ export function matchTvItem(
     .sort((left, right) => right.score - left.score);
 }
 
-function matchRule(item: NormalizedFeedItem, rule: TvRule): boolean {
-  const pattern = new RegExp(rule.pattern, 'i');
-
+function matchRule(
+  item: NormalizedFeedItem,
+  rule: TvRule,
+  pattern: RegExp,
+): boolean {
   if (!pattern.test(item.normalizedTitle)) {
     return false;
   }
@@ -60,6 +63,28 @@ function matchRule(item: NormalizedFeedItem, rule: TvRule): boolean {
     rule.resolutions.includes(item.resolution ?? '') &&
     rule.codecs.includes(item.codec ?? '')
   );
+}
+
+function buildRulePattern(rule: TvRule): RegExp {
+  return new RegExp(rule.matchPattern ?? deriveMatchPattern(rule.name), 'i');
+}
+
+function deriveMatchPattern(name: string): string {
+  const normalizedName = name
+    .trim()
+    .replace(/[._-]+/g, ' ')
+    .replace(/[()[\]{}]+/g, ' ')
+    .replace(/\s+/g, ' ');
+  const tokens = normalizedName
+    .split(' ')
+    .map((token) => escapeForRegex(token))
+    .filter((token) => token.length > 0);
+
+  if (tokens.length === 0) {
+    return '^$';
+  }
+
+  return `(?:^| )${tokens.join(' +')}(?:$| )`;
 }
 
 function buildIdentityKey(item: NormalizedFeedItem): string {
@@ -86,4 +111,8 @@ function scoreCodec(length: number, index: number): number {
 
 function padNumber(value: number | undefined): string {
   return String(value ?? '').padStart(2, '0');
+}
+
+function escapeForRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -106,4 +106,36 @@ describe('validateConfig', () => {
       ),
     );
   });
+
+  it('fails with a precise tv matchPattern path when regex syntax is invalid', () => {
+    expect(() =>
+      validateConfig({
+        feeds: [
+          {
+            name: 'TV Feed',
+            url: 'https://example.test/tv.rss',
+            mediaType: 'tv',
+          },
+        ],
+        tv: [
+          {
+            name: 'Example Show',
+            matchPattern: '(',
+            resolutions: ['1080p'],
+            codecs: ['x265'],
+          },
+        ],
+        movies: {
+          years: [2024],
+          resolutions: ['1080p'],
+          codecs: ['x265'],
+        },
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+        },
+      }),
+    ).toThrow(/Config file "config tv\[0\] matchPattern" has invalid regex syntax:/);
+  });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'bun:test';
+
+import { ConfigError, validateConfig } from '../src/config';
+
+describe('validateConfig', () => {
+  it('normalizes tv and movie allowlists to lowercase', () => {
+    const config = validateConfig({
+      feeds: [
+        {
+          name: 'TV Feed',
+          url: 'https://example.test/tv.rss',
+          mediaType: 'tv',
+        },
+      ],
+      tv: [
+        {
+          name: 'Example Show',
+          resolutions: ['1080P'],
+          codecs: ['X265', 'x264'],
+        },
+      ],
+      movies: {
+        years: [2024],
+        resolutions: ['2160P', '1080p'],
+        codecs: ['X265'],
+      },
+      transmission: {
+        url: 'http://localhost:9091/transmission/rpc',
+        username: 'user',
+        password: 'pass',
+      },
+    });
+
+    expect(config.tv[0]?.resolutions).toEqual(['1080p']);
+    expect(config.tv[0]?.codecs).toEqual(['x265', 'x264']);
+    expect(config.movies.resolutions).toEqual(['2160p', '1080p']);
+    expect(config.movies.codecs).toEqual(['x265']);
+  });
+
+  it('fails with a precise tv codecs path when a codec is unsupported', () => {
+    expect(() =>
+      validateConfig({
+        feeds: [
+          {
+            name: 'TV Feed',
+            url: 'https://example.test/tv.rss',
+            mediaType: 'tv',
+          },
+        ],
+        tv: [
+          {
+            name: 'Example Show',
+            resolutions: ['1080p'],
+            codecs: ['HEVC'],
+          },
+        ],
+        movies: {
+          years: [2024],
+          resolutions: ['1080p'],
+          codecs: ['x265'],
+        },
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config tv[0] codecs" has invalid value; expected one of "x264", "x265".',
+      ),
+    );
+  });
+
+  it('fails with a precise movie resolutions path when a resolution is unsupported', () => {
+    expect(() =>
+      validateConfig({
+        feeds: [
+          {
+            name: 'TV Feed',
+            url: 'https://example.test/tv.rss',
+            mediaType: 'tv',
+          },
+        ],
+        tv: [
+          {
+            name: 'Example Show',
+            resolutions: ['1080p'],
+            codecs: ['x265'],
+          },
+        ],
+        movies: {
+          years: [2024],
+          resolutions: ['4k'],
+          codecs: ['x265'],
+        },
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config movies resolutions" has invalid value; expected one of "2160p", "1080p", "720p", "480p".',
+      ),
+    );
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -136,6 +136,8 @@ describe('validateConfig', () => {
           password: 'pass',
         },
       }),
-    ).toThrow(/Config file "config tv\[0\] matchPattern" has invalid regex syntax:/);
+    ).toThrow(
+      /Config file "config tv\[0\] matchPattern" has invalid regex syntax:/,
+    );
   });
 });

--- a/test/fixtures/valid-config.json
+++ b/test/fixtures/valid-config.json
@@ -14,7 +14,6 @@
   "tv": [
     {
       "name": "Example Show",
-      "pattern": "example[ ._-]*show",
       "resolutions": ["1080p"],
       "codecs": ["x265"]
     }

--- a/test/tv-match.test.ts
+++ b/test/tv-match.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { TvRule } from '../src/config';
+import { normalizeFeedItem } from '../src/normalize';
+import { matchTvItem } from '../src/tv-match';
+
+describe('matchTvItem', () => {
+  it('matches an intended TV release and returns ranking metadata', () => {
+    const item = normalizeFeedItem({
+      mediaType: 'tv',
+      rawTitle: 'Example.Show.S01E02.1080p.WEB.x265-GROUP',
+    });
+    const rules: TvRule[] = [
+      {
+        name: 'Example Show',
+        pattern: 'example[ ._-]*show',
+        resolutions: ['2160p', '1080p'],
+        codecs: ['x265', 'x264'],
+      },
+    ];
+
+    expect(matchTvItem(item, rules)).toEqual([
+      {
+        ruleName: 'Example Show',
+        identityKey: 'tv:example show|s01e02',
+        score: 101,
+        reasons: [
+          'pattern:example[ ._-]*show',
+          'resolution:1080p',
+          'codec:x265',
+        ],
+        item,
+      },
+    ]);
+  });
+
+  it('uses case-insensitive regex matching against normalized titles', () => {
+    const item = normalizeFeedItem({
+      mediaType: 'tv',
+      rawTitle: 'EXAMPLE.SHOW.S01E02.1080p.WEB.X265-GROUP',
+    });
+    const rules: TvRule[] = [
+      {
+        name: 'Example Show',
+        pattern: 'example show',
+        resolutions: ['1080p'],
+        codecs: ['x265'],
+      },
+    ];
+
+    expect(matchTvItem(item, rules)).toHaveLength(1);
+  });
+
+  it('rejects near-miss titles instead of overmatching', () => {
+    const item = normalizeFeedItem({
+      mediaType: 'tv',
+      rawTitle: 'Example Showroom S01E02 1080p WEB x265',
+    });
+    const rules: TvRule[] = [
+      {
+        name: 'Example Show',
+        pattern: '\\bexample show\\b',
+        resolutions: ['1080p'],
+        codecs: ['x265'],
+      },
+    ];
+
+    expect(matchTvItem(item, rules)).toEqual([]);
+  });
+
+  it.each([
+    {
+      name: 'resolution is not allowed',
+      rawTitle: 'Example Show S01E02 720p WEB x265',
+    },
+    {
+      name: 'codec is not allowed',
+      rawTitle: 'Example Show S01E02 1080p WEB x264',
+    },
+    {
+      name: 'season and episode are missing',
+      rawTitle: 'Example Show 1080p WEB x265',
+    },
+    {
+      name: 'resolution is missing',
+      rawTitle: 'Example Show S01E02 WEB x265',
+    },
+    {
+      name: 'codec is missing',
+      rawTitle: 'Example Show S01E02 1080p WEB',
+    },
+  ])('rejects items when $name', ({ rawTitle }) => {
+    const item = normalizeFeedItem({
+      mediaType: 'tv',
+      rawTitle,
+    });
+    const rules: TvRule[] = [
+      {
+        name: 'Example Show',
+        pattern: '\\bexample show\\b',
+        resolutions: ['1080p'],
+        codecs: ['x265'],
+      },
+    ];
+
+    expect(matchTvItem(item, rules)).toEqual([]);
+  });
+
+  it('returns one accepted match per rule with deterministic scores', () => {
+    const item = normalizeFeedItem({
+      mediaType: 'tv',
+      rawTitle: 'Example Show S01E02 1080p WEB x265',
+    });
+    const rules: TvRule[] = [
+      {
+        name: 'Preferred Rule',
+        pattern: '\\bexample show\\b',
+        resolutions: ['1080p', '720p'],
+        codecs: ['x265', 'x264'],
+      },
+      {
+        name: 'Fallback Rule',
+        pattern: 'example[ ._-]*show',
+        resolutions: ['2160p', '1080p'],
+        codecs: ['x264', 'x265'],
+      },
+    ];
+
+    expect(matchTvItem(item, rules)).toEqual([
+      {
+        ruleName: 'Preferred Rule',
+        identityKey: 'tv:example show|s01e02',
+        score: 201,
+        reasons: [
+          'pattern:\\bexample show\\b',
+          'resolution:1080p',
+          'codec:x265',
+        ],
+        item,
+      },
+      {
+        ruleName: 'Fallback Rule',
+        identityKey: 'tv:example show|s01e02',
+        score: 100,
+        reasons: [
+          'pattern:example[ ._-]*show',
+          'resolution:1080p',
+          'codec:x265',
+        ],
+        item,
+      },
+    ]);
+  });
+});

--- a/test/tv-match.test.ts
+++ b/test/tv-match.test.ts
@@ -13,7 +13,6 @@ describe('matchTvItem', () => {
     const rules: TvRule[] = [
       {
         name: 'Example Show',
-        pattern: 'example[ ._-]*show',
         resolutions: ['2160p', '1080p'],
         codecs: ['x265', 'x264'],
       },
@@ -25,7 +24,7 @@ describe('matchTvItem', () => {
         identityKey: 'tv:example show|s01e02',
         score: 101,
         reasons: [
-          'pattern:example[ ._-]*show',
+          'pattern:(?:^| )Example +Show(?:$| )',
           'resolution:1080p',
           'codec:x265',
         ],
@@ -42,7 +41,6 @@ describe('matchTvItem', () => {
     const rules: TvRule[] = [
       {
         name: 'Example Show',
-        pattern: 'example show',
         resolutions: ['1080p'],
         codecs: ['x265'],
       },
@@ -59,7 +57,6 @@ describe('matchTvItem', () => {
     const rules: TvRule[] = [
       {
         name: 'Example Show',
-        pattern: '\\bexample show\\b',
         resolutions: ['1080p'],
         codecs: ['x265'],
       },
@@ -97,7 +94,6 @@ describe('matchTvItem', () => {
     const rules: TvRule[] = [
       {
         name: 'Example Show',
-        pattern: '\\bexample show\\b',
         resolutions: ['1080p'],
         codecs: ['x265'],
       },
@@ -113,14 +109,13 @@ describe('matchTvItem', () => {
     });
     const rules: TvRule[] = [
       {
-        name: 'Preferred Rule',
-        pattern: '\\bexample show\\b',
+        name: 'Example Show',
         resolutions: ['1080p', '720p'],
         codecs: ['x265', 'x264'],
       },
       {
-        name: 'Fallback Rule',
-        pattern: 'example[ ._-]*show',
+        name: 'Example Show',
+        matchPattern: 'example[ ._-]*show',
         resolutions: ['2160p', '1080p'],
         codecs: ['x264', 'x265'],
       },
@@ -128,22 +123,51 @@ describe('matchTvItem', () => {
 
     expect(matchTvItem(item, rules)).toEqual([
       {
-        ruleName: 'Preferred Rule',
+        ruleName: 'Example Show',
         identityKey: 'tv:example show|s01e02',
         score: 201,
         reasons: [
-          'pattern:\\bexample show\\b',
+          'pattern:(?:^| )Example +Show(?:$| )',
           'resolution:1080p',
           'codec:x265',
         ],
         item,
       },
       {
-        ruleName: 'Fallback Rule',
+        ruleName: 'Example Show',
         identityKey: 'tv:example show|s01e02',
         score: 100,
         reasons: [
           'pattern:example[ ._-]*show',
+          'resolution:1080p',
+          'codec:x265',
+        ],
+        item,
+      },
+    ]);
+  });
+
+  it('uses matchPattern when the user overrides the derived pattern', () => {
+    const item = normalizeFeedItem({
+      mediaType: 'tv',
+      rawTitle: 'Example Show UK S01E02 1080p WEB x265',
+    });
+    const rules: TvRule[] = [
+      {
+        name: 'Example Show',
+        matchPattern: '(?:^| )Example +Show +UK(?:$| )',
+        resolutions: ['1080p'],
+        codecs: ['x265'],
+      },
+    ];
+
+    expect(matchTvItem(item, rules)).toEqual([
+      {
+        ruleName: 'Example Show',
+        identityKey: 'tv:example show uk|s01e02',
+        score: 100,
+        reasons: [
+          'pattern:(?:^| )Example +Show +UK(?:$| )',
           'resolution:1080p',
           'codec:x265',
         ],


### PR DESCRIPTION
## Summary

Adds the Phase 1 TV matching slice.

## What Changed

- add a dedicated `matchTvItem` entrypoint for TV rule evaluation
- return one accepted match per rule with `identityKey`, `score`, and `reasons`
- enforce TV-only metadata requirements plus resolution and codec allowlists
- apply case-insensitive regex matching against normalized titles
- add focused matcher tests for intended matches, near-misses, rejection paths, and deterministic scoring

## Verification

- `bun test`
- `bun run typecheck`
- `bun run lint`