### PR TITLE
feat: add movie policy filtering [P1.05]

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ Phase 01 ends at successful queueing in Transmission. It does not include a web 
 
 ## Status
 
-Tickets 01-04 are implemented: the repository now has a minimal Bun + TypeScript CLI skeleton with JSON config loading and validation for `media-sync run`, an RSS fetch-and-parse entrypoint that converts RSS items into a raw feed-item shape, a title-normalization module that extracts matching metadata for TV and movie releases, and a TV rule matcher that evaluates normalized items against name-based rules with optional regex overrides plus codec and resolution filters.
+Tickets 01-05 are implemented:
+
+- minimal Bun + TypeScript CLI skeleton with JSON config loading and validation for `media-sync run`
+- RSS fetch-and-parse entrypoint that converts RSS items into a raw feed-item shape
+- title-normalization module that extracts matching metadata for TV and movie releases
+- TV rule matcher that evaluates normalized items against name-based rules with optional regex overrides plus codec and resolution filters
+- movie policy matcher that accepts releases by global year and quality policy without per-title rules
 
 The project is being planned as a small-slice, review-friendly build:
 

--- a/docs/02-delivery/phase-01/ticket-05-rationale.md
+++ b/docs/02-delivery/phase-01/ticket-05-rationale.md
@@ -1,0 +1,6 @@
+# Ticket 05 Rationale
+
+- Red first: matching representative normalized movie releases should accept allowed year-and-quality combinations and reject releases that fail year, resolution, or codec policy without relying on title intent.
+- Why this path: one policy matcher that reuses the existing quality-preference semantics was the smallest acceptable slice that proves movie intake behavior is global-policy filtering rather than per-title rule matching.
+- Alternative considered: adding movie title rules alongside TV rules was rejected because Phase 01 defines movies as one global intake policy and does not track specific movie names.
+- Deferred: feed `guidOrLink` identity, torrent-level identity, and any pipeline or dedupe integration beyond this standalone matcher boundary.

--- a/src/match-policy.ts
+++ b/src/match-policy.ts
@@ -1,0 +1,36 @@
+export function matchesAllowedQuality(
+  resolution: string | undefined,
+  codec: string | undefined,
+  resolutions: string[],
+  codecs: string[],
+): boolean {
+  return (
+    resolution !== undefined &&
+    codec !== undefined &&
+    resolutions.includes(resolution) &&
+    codecs.includes(codec)
+  );
+}
+
+export function scoreQualityPreference(
+  resolution: string,
+  codec: string,
+  resolutions: string[],
+  codecs: string[],
+): number {
+  const resolutionIndex = resolutions.indexOf(resolution);
+  const codecIndex = codecs.indexOf(codec);
+
+  return (
+    scoreResolution(resolutions.length, resolutionIndex) +
+    scoreCodec(codecs.length, codecIndex)
+  );
+}
+
+function scoreResolution(length: number, index: number): number {
+  return (length - index) * 100;
+}
+
+function scoreCodec(length: number, index: number): number {
+  return length - index - 1;
+}

--- a/src/movie-match.ts
+++ b/src/movie-match.ts
@@ -1,0 +1,48 @@
+import type { MoviePolicy } from './config';
+import { matchesAllowedQuality, scoreQualityPreference } from './match-policy';
+import type { NormalizedFeedItem } from './normalize';
+
+export type MovieMatchResult = {
+  ruleName: string;
+  identityKey: string;
+  score: number;
+  reasons: string[];
+  item: NormalizedFeedItem;
+};
+
+const MOVIE_POLICY_RULE_NAME = 'movies';
+
+export function matchMovieItem(
+  item: NormalizedFeedItem,
+  policy: MoviePolicy,
+): MovieMatchResult | undefined {
+  const { year, resolution, codec } = item;
+
+  if (
+    item.mediaType !== 'movie' ||
+    year === undefined ||
+    resolution === undefined ||
+    codec === undefined ||
+    !policy.years.includes(year) ||
+    !matchesAllowedQuality(resolution, codec, policy.resolutions, policy.codecs)
+  ) {
+    return undefined;
+  }
+
+  return {
+    ruleName: MOVIE_POLICY_RULE_NAME,
+    identityKey: buildIdentityKey(item),
+    score: scoreQualityPreference(
+      resolution,
+      codec,
+      policy.resolutions,
+      policy.codecs,
+    ),
+    reasons: [`year:${year}`, `resolution:${resolution}`, `codec:${codec}`],
+    item,
+  };
+}
+
+function buildIdentityKey(item: NormalizedFeedItem): string {
+  return `movie:${item.normalizedTitle.trim().toLowerCase()}|${item.year ?? ''}`;
+}

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -23,7 +23,7 @@ export function normalizeFeedItem(input: {
   const normalizedTitle =
     input.mediaType === 'tv'
       ? extractNormalizedTitle(input.rawTitle, seasonEpisode?.index)
-      : extractNormalizedTitle(input.rawTitle, year?.index);
+      : extractMovieNormalizedTitle(input.rawTitle, year, resolution, codec);
 
   return {
     mediaType: input.mediaType,
@@ -32,8 +32,8 @@ export function normalizeFeedItem(input: {
     season: seasonEpisode?.season,
     episode: seasonEpisode?.episode,
     year: year?.value,
-    resolution,
-    codec,
+    resolution: resolution?.value,
+    codec: codec?.value,
   };
 }
 
@@ -62,7 +62,7 @@ function extractSeasonEpisode(
 
 function extractYear(
   value: string,
-): { value: number; index: number } | undefined {
+): { value: number; index: number; endIndex: number } | undefined {
   const match = yearPattern.exec(value);
 
   if (!match) {
@@ -72,28 +72,72 @@ function extractYear(
   return {
     value: Number(match[0]),
     index: match.index,
+    endIndex: match.index + match[0].length,
   };
 }
 
-function extractResolution(value: string): string | undefined {
+function extractResolution(
+  value: string,
+): { value: string; index: number } | undefined {
   const match = resolutionPattern.exec(value);
-  return match?.[1]?.toLowerCase();
+
+  if (!match || !match[1]) {
+    return undefined;
+  }
+
+  return {
+    value: match[1].toLowerCase(),
+    index: match.index,
+  };
 }
 
-function extractCodec(value: string): 'x264' | 'x265' | undefined {
+function extractCodec(
+  value: string,
+): { value: 'x264' | 'x265'; index: number } | undefined {
   const match = codecPattern.exec(value);
 
   if (!match) {
     return undefined;
   }
 
-  return x265CodecTokens.has(match[1].toLowerCase()) ? 'x265' : 'x264';
+  return {
+    value: x265CodecTokens.has(match[1].toLowerCase()) ? 'x265' : 'x264',
+    index: match.index,
+  };
 }
 
 function extractNormalizedTitle(value: string, cutoff?: number): string {
   const titleSegment = cutoff === undefined ? value : value.slice(0, cutoff);
 
   return normalizeTitleWhitespace(titleSegment);
+}
+
+function extractMovieNormalizedTitle(
+  value: string,
+  year?: { index: number; endIndex: number },
+  resolution?: { index: number },
+  codec?: { index: number },
+): string {
+  if (year === undefined) {
+    return extractNormalizedTitle(value);
+  }
+
+  if (year.index > 0) {
+    return extractNormalizedTitle(value, year.index);
+  }
+
+  const rawSuffix = value.slice(year.endIndex);
+  const suffix = rawSuffix.replace(leadingSeparatorPattern, '');
+  const trimmedOffset = rawSuffix.length - suffix.length;
+  const cutoff = [resolution?.index, codec?.index]
+    .filter(
+      (index): index is number => index !== undefined && index > year.endIndex,
+    )
+    .map((index) => index - year.endIndex - trimmedOffset)
+    .filter((index) => index > 0)
+    .sort((left, right) => left - right)[0];
+
+  return extractNormalizedTitle(suffix, cutoff);
 }
 
 function normalizeTitleWhitespace(value: string): string {
@@ -114,6 +158,7 @@ const resolutionPattern = /\b(2160p|1080p|720p|480p)\b/i;
 const codecPattern = /\b(x265|h265|hevc|x264|h264|avc)\b/i;
 
 const separatorPattern = /[._-]+/g;
+const leadingSeparatorPattern = /^[._\-\s]+/;
 
 const extraSymbolPattern = /[()[\]{}]+/g;
 

--- a/src/tv-match.ts
+++ b/src/tv-match.ts
@@ -1,4 +1,5 @@
 import type { TvRule } from './config';
+import { matchesAllowedQuality, scoreQualityPreference } from './match-policy';
 import type { NormalizedFeedItem } from './normalize';
 
 export type TvMatchResult = {
@@ -59,9 +60,11 @@ function matchRule(
     return false;
   }
 
-  return (
-    rule.resolutions.includes(item.resolution ?? '') &&
-    rule.codecs.includes(item.codec ?? '')
+  return matchesAllowedQuality(
+    item.resolution,
+    item.codec,
+    rule.resolutions,
+    rule.codecs,
   );
 }
 
@@ -92,21 +95,12 @@ function buildIdentityKey(item: NormalizedFeedItem): string {
 }
 
 function scoreMatch(rule: TvRule, item: NormalizedFeedItem): number {
-  const resolutionIndex = rule.resolutions.indexOf(item.resolution ?? '');
-  const codecIndex = rule.codecs.indexOf(item.codec ?? '');
-
-  return (
-    scoreResolution(rule.resolutions.length, resolutionIndex) +
-    scoreCodec(rule.codecs.length, codecIndex)
+  return scoreQualityPreference(
+    item.resolution ?? '',
+    item.codec ?? '',
+    rule.resolutions,
+    rule.codecs,
   );
-}
-
-function scoreResolution(length: number, index: number): number {
-  return (length - index) * 100;
-}
-
-function scoreCodec(length: number, index: number): number {
-  return length - index - 1;
 }
 
 function padNumber(value: number | undefined): string {

--- a/test/movie-match.test.ts
+++ b/test/movie-match.test.ts
@@ -68,6 +68,22 @@ describe('matchMovieItem', () => {
     );
   });
 
+  it('does not emit an empty identity key when a release title starts with the year', () => {
+    const item = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: '2024.Example.Movie.1080p.WEB.x265-GROUP',
+    });
+    const policy: MoviePolicy = {
+      years: [2024],
+      resolutions: ['1080p'],
+      codecs: ['x265'],
+    };
+
+    expect(matchMovieItem(item, policy)?.identityKey).toBe(
+      'movie:example movie|2024',
+    );
+  });
+
   it.each([
     {
       name: 'year is not allowed',

--- a/test/movie-match.test.ts
+++ b/test/movie-match.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { MoviePolicy } from '../src/config';
+import { matchMovieItem } from '../src/movie-match';
+import { normalizeFeedItem } from '../src/normalize';
+
+describe('matchMovieItem', () => {
+  it('accepts a movie release when year and quality are allowed', () => {
+    const item = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: 'Example.Movie.2024.1080p.WEB.x265-GROUP',
+    });
+    const policy: MoviePolicy = {
+      years: [2025, 2024],
+      resolutions: ['2160p', '1080p'],
+      codecs: ['x265', 'x264'],
+    };
+
+    expect(matchMovieItem(item, policy)).toEqual({
+      ruleName: 'movies',
+      identityKey: 'movie:example movie|2024',
+      score: 101,
+      reasons: ['year:2024', 'resolution:1080p', 'codec:x265'],
+      item,
+    });
+  });
+
+  it('matches by policy without requiring any title-pattern semantics', () => {
+    const item = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: 'Totally.Different.Release.Name.2024.1080p.WEB.x265-GROUP',
+    });
+    const policy: MoviePolicy = {
+      years: [2024],
+      resolutions: ['1080p'],
+      codecs: ['x265'],
+    };
+
+    expect(matchMovieItem(item, policy)).toEqual({
+      ruleName: 'movies',
+      identityKey: 'movie:totally different release name|2024',
+      score: 100,
+      reasons: ['year:2024', 'resolution:1080p', 'codec:x265'],
+      item,
+    });
+  });
+
+  it('uses normalized title and year so release variants collapse to one identity', () => {
+    const webRelease = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: 'Example.Movie.2024.1080p.WEB.x265-GROUP',
+    });
+    const blurayRelease = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: 'Example Movie 2024 2160p BluRay x265 OTHER',
+    });
+    const policy: MoviePolicy = {
+      years: [2024],
+      resolutions: ['2160p', '1080p'],
+      codecs: ['x265'],
+    };
+
+    expect(matchMovieItem(webRelease, policy)?.identityKey).toBe(
+      'movie:example movie|2024',
+    );
+    expect(matchMovieItem(blurayRelease, policy)?.identityKey).toBe(
+      'movie:example movie|2024',
+    );
+  });
+
+  it.each([
+    {
+      name: 'year is not allowed',
+      rawTitle: 'Example Movie 2023 1080p WEB x265',
+    },
+    {
+      name: 'resolution is not allowed',
+      rawTitle: 'Example Movie 2024 720p WEB x265',
+    },
+    {
+      name: 'codec is not allowed',
+      rawTitle: 'Example Movie 2024 1080p WEB x264',
+    },
+    {
+      name: 'year is missing',
+      rawTitle: 'Example Movie 1080p WEB x265',
+    },
+    {
+      name: 'resolution is missing',
+      rawTitle: 'Example Movie 2024 WEB x265',
+    },
+    {
+      name: 'codec is missing',
+      rawTitle: 'Example Movie 2024 1080p WEB',
+    },
+    {
+      name: 'item is not a movie',
+      rawTitle: 'Example Show S01E02 2024 1080p WEB x265',
+      mediaType: 'tv' as const,
+    },
+  ] satisfies Array<{
+    name: string;
+    rawTitle: string;
+    mediaType?: 'tv' | 'movie';
+  }>)(
+    'rejects items when $name',
+    ({
+      rawTitle,
+      mediaType = 'movie',
+    }: {
+      rawTitle: string;
+      mediaType?: 'tv' | 'movie';
+    }) => {
+      const item = normalizeFeedItem({
+        mediaType,
+        rawTitle,
+      });
+      const policy: MoviePolicy = {
+        years: [2024],
+        resolutions: ['1080p'],
+        codecs: ['x265'],
+      };
+
+      expect(matchMovieItem(item, policy)).toBeUndefined();
+    },
+  );
+});

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -80,6 +80,21 @@ describe('normalizeFeedItem', () => {
       },
     },
     {
+      name: 'extracts movie titles when the raw title starts with the year',
+      mediaType: 'movie' as const,
+      rawTitle: '2024.Example.Movie.1080p.WEB.x265-GROUP',
+      expected: {
+        mediaType: 'movie',
+        rawTitle: '2024.Example.Movie.1080p.WEB.x265-GROUP',
+        normalizedTitle: 'Example Movie',
+        season: undefined,
+        episode: undefined,
+        year: 2024,
+        resolution: '1080p',
+        codec: 'x265',
+      },
+    },
+    {
       name: 'returns undefined metadata when only a title is available',
       mediaType: 'tv' as const,
       rawTitle: 'Plain Title Release',


### PR DESCRIPTION
feat: add movie policy filtering [P1.05]

## Summary

Add a standalone movie matcher that applies the global movie policy by year, resolution, and codec without requiring per-title rules.

## Changes

- add `matchMovieItem` and a shared quality-policy helper used by both movie and TV matchers
- dedupe movie matches by normalized title plus year so release variants collapse to one identity
- add focused movie matcher coverage for acceptance, rejection, and identity behavior
- add the Ticket 05 rationale note and rewrite the README status summary as bullets

## Verification

- `bun run ci`
