### PR TITLE
feat: add sqlite dedupe and run history [P1.06]

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ Phase 01 ends at successful queueing in Transmission. It does not include a web 
 
 ## Status
 
-Tickets 01-05 are implemented:
+Tickets 01-06 are implemented:
 
 - minimal Bun + TypeScript CLI skeleton with JSON config loading and validation for `media-sync run`
 - RSS fetch-and-parse entrypoint that converts RSS items into a raw feed-item shape
 - title-normalization module that extracts matching metadata for TV and movie releases
 - TV rule matcher that evaluates normalized items against name-based rules with optional regex overrides plus codec and resolution filters
 - movie policy matcher that accepts releases by global year and quality policy without per-title rules
+- SQLite-backed run history and candidate-state persistence that preserves dedupe and retryability
 
 The project is being planned as a small-slice, review-friendly build:
 

--- a/docs/02-delivery/phase-01/ticket-06-rationale.md
+++ b/docs/02-delivery/phase-01/ticket-06-rationale.md
@@ -3,4 +3,4 @@
 - `Red first:` repository tests proving a queued candidate blocks later duplicates while a failed candidate remains retryable.
 - `Why this path:` a single `candidate_state` row per identity with persistent `queued_at` gives later tickets one small place to check dedupe state without losing the latest outcome.
 - `Alternative considered:` a latest-status-only row was rejected because writing `skipped_duplicate` after a prior `queued` outcome would erase the fact that the candidate had already been queued successfully.
-- `Deferred:` submission-attempt history, CLI wiring, status rendering, and retry command orchestration remain in tickets 08-10.
+- `Deferred:` `skipped_no_match` persistence is intentionally not modeled in ticket 06 because unmatched feed items do not have a stable candidate identity. That outcome should land with the ticket 08 pipeline shape, likely as per-feed-item outcome history rather than `candidate_state`. Submission-attempt history, CLI wiring, status rendering, and retry command orchestration remain in tickets 08-10.

--- a/docs/02-delivery/phase-01/ticket-06-rationale.md
+++ b/docs/02-delivery/phase-01/ticket-06-rationale.md
@@ -1,0 +1,6 @@
+# P1.06 Rationale
+
+- `Red first:` repository tests proving a queued candidate blocks later duplicates while a failed candidate remains retryable.
+- `Why this path:` a single `candidate_state` row per identity with persistent `queued_at` gives later tickets one small place to check dedupe state without losing the latest outcome.
+- `Alternative considered:` a latest-status-only row was rejected because writing `skipped_duplicate` after a prior `queued` outcome would erase the fact that the candidate had already been queued successfully.
+- `Deferred:` submission-attempt history, CLI wiring, status rendering, and retry command orchestration remain in tickets 08-10.

--- a/docs/02-delivery/phase-01/ticket-08-end-to-end-run-pipeline.md
+++ b/docs/02-delivery/phase-01/ticket-08-end-to-end-run-pipeline.md
@@ -6,6 +6,7 @@ Size: 3 points
 
 - wire config, feed fetch, normalization, matching, dedupe, and Transmission together
 - choose one best candidate per identity and submit it
+- record `skipped_no_match` with a per-feed-item outcome shape instead of forcing it into `candidate_state`
 
 ## Red
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -3,11 +3,7 @@ import { Database } from 'bun:sqlite';
 import type { RawFeedItem } from './feed';
 import type { NormalizedFeedItem } from './normalize';
 
-export type CandidateStatus =
-  | 'queued'
-  | 'failed'
-  | 'skipped_duplicate'
-  | 'skipped_no_match';
+export type CandidateStatus = 'queued' | 'failed' | 'skipped_duplicate';
 
 export type CandidateMatchRecord = {
   ruleName: string;

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,0 +1,444 @@
+import { Database } from 'bun:sqlite';
+
+import type { RawFeedItem } from './feed';
+import type { NormalizedFeedItem } from './normalize';
+
+export type CandidateStatus =
+  | 'queued'
+  | 'failed'
+  | 'skipped_duplicate'
+  | 'skipped_no_match';
+
+export type CandidateMatchRecord = {
+  ruleName: string;
+  identityKey: string;
+  score: number;
+  reasons: string[];
+  item: NormalizedFeedItem;
+};
+
+export type RunRecord = {
+  id: number;
+  startedAt: string;
+  completedAt?: string;
+};
+
+export type FeedItemRecord = RawFeedItem & {
+  id: number;
+  runId: number;
+};
+
+export type CandidateStateRecord = {
+  identityKey: string;
+  mediaType: NormalizedFeedItem['mediaType'];
+  status: CandidateStatus;
+  queuedAt?: string;
+  ruleName: string;
+  score: number;
+  reasons: string[];
+  rawTitle: string;
+  normalizedTitle: string;
+  season?: number;
+  episode?: number;
+  year?: number;
+  resolution?: string;
+  codec?: NormalizedFeedItem['codec'];
+  feedName: string;
+  guidOrLink: string;
+  publishedAt: string;
+  downloadUrl: string;
+  firstSeenRunId: number;
+  lastSeenRunId: number;
+  lastFeedItemId?: number;
+  updatedAt: string;
+};
+
+export type RecordCandidateOutcomeInput = {
+  runId: number;
+  feedItemId?: number;
+  feedItem: RawFeedItem;
+  match: CandidateMatchRecord;
+  status: CandidateStatus;
+  updatedAt?: string;
+};
+
+export type Repository = {
+  startRun(startedAt?: string): RunRecord;
+  completeRun(runId: number, completedAt?: string): RunRecord;
+  recordFeedItem(runId: number, item: RawFeedItem): FeedItemRecord;
+  getCandidateState(identityKey: string): CandidateStateRecord | undefined;
+  isCandidateQueued(identityKey: string): boolean;
+  recordCandidateOutcome(
+    input: RecordCandidateOutcomeInput,
+  ): CandidateStateRecord;
+};
+
+export const DEFAULT_DATABASE_PATH = 'media-sync.db';
+
+export function openDatabase(path = DEFAULT_DATABASE_PATH): Database {
+  return new Database(path, { create: true, strict: true });
+}
+
+export function ensureSchema(database: Database): void {
+  database.exec(`
+    PRAGMA foreign_keys = ON;
+
+    CREATE TABLE IF NOT EXISTS runs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      started_at TEXT NOT NULL,
+      completed_at TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS feed_items (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      run_id INTEGER NOT NULL REFERENCES runs(id),
+      feed_name TEXT NOT NULL,
+      guid_or_link TEXT NOT NULL,
+      raw_title TEXT NOT NULL,
+      published_at TEXT NOT NULL,
+      download_url TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS candidate_state (
+      identity_key TEXT PRIMARY KEY,
+      media_type TEXT NOT NULL,
+      status TEXT NOT NULL,
+      queued_at TEXT,
+      rule_name TEXT NOT NULL,
+      score INTEGER NOT NULL,
+      reasons_json TEXT NOT NULL,
+      raw_title TEXT NOT NULL,
+      normalized_title TEXT NOT NULL,
+      season INTEGER,
+      episode INTEGER,
+      year INTEGER,
+      resolution TEXT,
+      codec TEXT,
+      feed_name TEXT NOT NULL,
+      guid_or_link TEXT NOT NULL,
+      published_at TEXT NOT NULL,
+      download_url TEXT NOT NULL,
+      first_seen_run_id INTEGER NOT NULL REFERENCES runs(id),
+      last_seen_run_id INTEGER NOT NULL REFERENCES runs(id),
+      last_feed_item_id INTEGER REFERENCES feed_items(id),
+      updated_at TEXT NOT NULL
+    );
+  `);
+}
+
+export function createRepository(database: Database): Repository {
+  const insertRun = database.query('INSERT INTO runs (started_at) VALUES (?1)');
+  const selectRun = database.query(
+    `SELECT
+      id,
+      started_at AS startedAt,
+      completed_at AS completedAt
+    FROM runs
+    WHERE id = ?1`,
+  );
+  const completeRunStatement = database.query(
+    'UPDATE runs SET completed_at = ?2 WHERE id = ?1',
+  );
+  const insertFeedItem = database.query(
+    `INSERT INTO feed_items (
+      run_id,
+      feed_name,
+      guid_or_link,
+      raw_title,
+      published_at,
+      download_url
+    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)`,
+  );
+  const selectFeedItem = database.query(
+    `SELECT
+      id,
+      run_id AS runId,
+      feed_name AS feedName,
+      guid_or_link AS guidOrLink,
+      raw_title AS rawTitle,
+      published_at AS publishedAt,
+      download_url AS downloadUrl
+    FROM feed_items
+    WHERE id = ?1`,
+  );
+  const selectCandidateState = database.query(
+    `SELECT
+      identity_key AS identityKey,
+      media_type AS mediaType,
+      status,
+      queued_at AS queuedAt,
+      rule_name AS ruleName,
+      score,
+      reasons_json AS reasonsJson,
+      raw_title AS rawTitle,
+      normalized_title AS normalizedTitle,
+      season,
+      episode,
+      year,
+      resolution,
+      codec,
+      feed_name AS feedName,
+      guid_or_link AS guidOrLink,
+      published_at AS publishedAt,
+      download_url AS downloadUrl,
+      first_seen_run_id AS firstSeenRunId,
+      last_seen_run_id AS lastSeenRunId,
+      last_feed_item_id AS lastFeedItemId,
+      updated_at AS updatedAt
+    FROM candidate_state
+    WHERE identity_key = ?1`,
+  );
+  const upsertCandidateState = database.query(
+    `INSERT INTO candidate_state (
+      identity_key,
+      media_type,
+      status,
+      queued_at,
+      rule_name,
+      score,
+      reasons_json,
+      raw_title,
+      normalized_title,
+      season,
+      episode,
+      year,
+      resolution,
+      codec,
+      feed_name,
+      guid_or_link,
+      published_at,
+      download_url,
+      first_seen_run_id,
+      last_seen_run_id,
+      last_feed_item_id,
+      updated_at
+    ) VALUES (
+      ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
+      ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22
+    )
+    ON CONFLICT(identity_key) DO UPDATE SET
+      media_type = excluded.media_type,
+      status = excluded.status,
+      queued_at = COALESCE(candidate_state.queued_at, excluded.queued_at),
+      rule_name = excluded.rule_name,
+      score = excluded.score,
+      reasons_json = excluded.reasons_json,
+      raw_title = excluded.raw_title,
+      normalized_title = excluded.normalized_title,
+      season = excluded.season,
+      episode = excluded.episode,
+      year = excluded.year,
+      resolution = excluded.resolution,
+      codec = excluded.codec,
+      feed_name = excluded.feed_name,
+      guid_or_link = excluded.guid_or_link,
+      published_at = excluded.published_at,
+      download_url = excluded.download_url,
+      last_seen_run_id = excluded.last_seen_run_id,
+      last_feed_item_id = excluded.last_feed_item_id,
+      updated_at = excluded.updated_at`,
+  );
+
+  return {
+    startRun(startedAt = new Date().toISOString()): RunRecord {
+      insertRun.run(startedAt);
+      const row = selectRun.get(lastInsertedRowId(database)) as
+        | RunRow
+        | null
+        | undefined;
+      return mapRunRow(requireRow(row, 'run'));
+    },
+
+    completeRun(
+      runId: number,
+      completedAt = new Date().toISOString(),
+    ): RunRecord {
+      completeRunStatement.run(runId, completedAt);
+      return mapRunRow(
+        requireRow(selectRun.get(runId) as RunRow | null | undefined, 'run'),
+      );
+    },
+
+    recordFeedItem(runId: number, item: RawFeedItem): FeedItemRecord {
+      insertFeedItem.run(
+        runId,
+        item.feedName,
+        item.guidOrLink,
+        item.rawTitle,
+        item.publishedAt,
+        item.downloadUrl,
+      );
+      const row = selectFeedItem.get(lastInsertedRowId(database)) as
+        | FeedItemRow
+        | null
+        | undefined;
+      return mapFeedItemRow(requireRow(row, 'feed item'));
+    },
+
+    getCandidateState(identityKey: string): CandidateStateRecord | undefined {
+      const row = selectCandidateState.get(identityKey) as
+        | CandidateStateRow
+        | null
+        | undefined;
+      return row ? mapCandidateStateRow(row) : undefined;
+    },
+
+    isCandidateQueued(identityKey: string): boolean {
+      return this.getCandidateState(identityKey)?.queuedAt !== undefined;
+    },
+
+    recordCandidateOutcome(
+      input: RecordCandidateOutcomeInput,
+    ): CandidateStateRecord {
+      const updatedAt = input.updatedAt ?? new Date().toISOString();
+      const queuedAt = input.status === 'queued' ? updatedAt : null;
+
+      upsertCandidateState.run(
+        input.match.identityKey,
+        input.match.item.mediaType,
+        input.status,
+        queuedAt,
+        input.match.ruleName,
+        input.match.score,
+        JSON.stringify(input.match.reasons),
+        input.feedItem.rawTitle,
+        input.match.item.normalizedTitle,
+        input.match.item.season ?? null,
+        input.match.item.episode ?? null,
+        input.match.item.year ?? null,
+        input.match.item.resolution ?? null,
+        input.match.item.codec ?? null,
+        input.feedItem.feedName,
+        input.feedItem.guidOrLink,
+        input.feedItem.publishedAt,
+        input.feedItem.downloadUrl,
+        input.runId,
+        input.runId,
+        input.feedItemId ?? null,
+        updatedAt,
+      );
+
+      return mapCandidateStateRow(
+        requireRow(
+          selectCandidateState.get(input.match.identityKey) as
+            | CandidateStateRow
+            | null
+            | undefined,
+          'candidate state',
+        ),
+      );
+    },
+  };
+}
+
+function lastInsertedRowId(database: Database): number {
+  return Number(
+    requireRow(
+      database.query('SELECT last_insert_rowid() AS id').get() as
+        | { id: number }
+        | null
+        | undefined,
+      'last insert row id',
+    ).id,
+  );
+}
+
+function requireRow<T>(row: T | null | undefined, label: string): T {
+  if (!row) {
+    throw new Error(`Failed to load ${label} row.`);
+  }
+
+  return row;
+}
+
+function mapRunRow(row: {
+  id: number;
+  startedAt: string;
+  completedAt: string | null;
+}): RunRecord {
+  return {
+    id: Number(row.id),
+    startedAt: row.startedAt,
+    completedAt: row.completedAt ?? undefined,
+  };
+}
+
+function mapFeedItemRow(row: FeedItemRow): FeedItemRecord {
+  return {
+    id: Number(row.id),
+    runId: Number(row.runId),
+    feedName: row.feedName,
+    guidOrLink: row.guidOrLink,
+    rawTitle: row.rawTitle,
+    publishedAt: row.publishedAt,
+    downloadUrl: row.downloadUrl,
+  };
+}
+
+function mapCandidateStateRow(row: CandidateStateRow): CandidateStateRecord {
+  return {
+    identityKey: row.identityKey,
+    mediaType: row.mediaType,
+    status: row.status,
+    queuedAt: row.queuedAt ?? undefined,
+    ruleName: row.ruleName,
+    score: Number(row.score),
+    reasons: JSON.parse(row.reasonsJson) as string[],
+    rawTitle: row.rawTitle,
+    normalizedTitle: row.normalizedTitle,
+    season: row.season ?? undefined,
+    episode: row.episode ?? undefined,
+    year: row.year ?? undefined,
+    resolution: row.resolution ?? undefined,
+    codec: row.codec ?? undefined,
+    feedName: row.feedName,
+    guidOrLink: row.guidOrLink,
+    publishedAt: row.publishedAt,
+    downloadUrl: row.downloadUrl,
+    firstSeenRunId: Number(row.firstSeenRunId),
+    lastSeenRunId: Number(row.lastSeenRunId),
+    lastFeedItemId: row.lastFeedItemId ?? undefined,
+    updatedAt: row.updatedAt,
+  };
+}
+
+type RunRow = {
+  id: number;
+  startedAt: string;
+  completedAt: string | null;
+};
+
+type FeedItemRow = {
+  id: number;
+  runId: number;
+  feedName: string;
+  guidOrLink: string;
+  rawTitle: string;
+  publishedAt: string;
+  downloadUrl: string;
+};
+
+type CandidateStateRow = {
+  identityKey: string;
+  mediaType: NormalizedFeedItem['mediaType'];
+  status: CandidateStatus;
+  queuedAt: string | null;
+  ruleName: string;
+  score: number;
+  reasonsJson: string;
+  rawTitle: string;
+  normalizedTitle: string;
+  season: number | null;
+  episode: number | null;
+  year: number | null;
+  resolution: string | null;
+  codec: NormalizedFeedItem['codec'] | null;
+  feedName: string;
+  guidOrLink: string;
+  publishedAt: string;
+  downloadUrl: string;
+  firstSeenRunId: number;
+  lastSeenRunId: number;
+  lastFeedItemId: number | null;
+  updatedAt: string;
+};

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -1,3 +1,4 @@
+import type { Database } from 'bun:sqlite';
 import { afterEach, describe, expect, it } from 'bun:test';
 import { mkdtemp as createTempDir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -12,9 +13,14 @@ import {
 } from '../src/repository';
 
 const tempDirs: string[] = [];
+const openDatabases: Database[] = [];
 
 describe('SQLite repository', () => {
   afterEach(async () => {
+    while (openDatabases.length > 0) {
+      openDatabases.pop()?.close();
+    }
+
     while (tempDirs.length > 0) {
       const directory = tempDirs.pop();
 
@@ -143,6 +149,8 @@ describe('SQLite repository', () => {
 
 function createTestRepository(path: string) {
   const database = openDatabase(path);
+
+  openDatabases.push(database);
   ensureSchema(database);
   return createRepository(database);
 }

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtemp as createTempDir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { matchMovieItem } from '../src/movie-match';
+import { normalizeFeedItem } from '../src/normalize';
+import {
+  createRepository,
+  ensureSchema,
+  openDatabase,
+} from '../src/repository';
+
+const tempDirs: string[] = [];
+
+describe('SQLite repository', () => {
+  afterEach(async () => {
+    while (tempDirs.length > 0) {
+      const directory = tempDirs.pop();
+
+      if (directory) {
+        await Bun.$`rm -rf ${directory}`;
+      }
+    }
+  });
+
+  it('marks later runs as duplicates after a candidate has already been queued', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+    const firstRun = repository.startRun('2026-03-30T00:00:00.000Z');
+    const firstFeedItem = repository.recordFeedItem(firstRun.id, {
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/example-movie-web',
+      rawTitle: 'Example.Movie.2024.1080p.WEB.x265-GROUP',
+      publishedAt: '2026-03-30T00:05:00.000Z',
+      downloadUrl: 'https://example.test/downloads/example-movie-web.torrent',
+    });
+    const firstMatch = requireMovieMatch(firstFeedItem.rawTitle);
+
+    repository.recordCandidateOutcome({
+      runId: firstRun.id,
+      feedItemId: firstFeedItem.id,
+      feedItem: firstFeedItem,
+      match: firstMatch,
+      status: 'queued',
+      updatedAt: '2026-03-30T00:10:00.000Z',
+    });
+
+    expect(repository.isCandidateQueued(firstMatch.identityKey)).toBe(true);
+
+    const secondRun = repository.startRun('2026-03-30T01:00:00.000Z');
+    const secondFeedItem = repository.recordFeedItem(secondRun.id, {
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/example-movie-bluray',
+      rawTitle: 'Example Movie 2024 2160p BluRay x265 OTHER',
+      publishedAt: '2026-03-30T01:05:00.000Z',
+      downloadUrl:
+        'https://example.test/downloads/example-movie-bluray.torrent',
+    });
+    const secondMatch = requireMovieMatch(secondFeedItem.rawTitle);
+
+    expect(secondMatch.identityKey).toBe(firstMatch.identityKey);
+    expect(repository.isCandidateQueued(secondMatch.identityKey)).toBe(true);
+
+    const state = repository.recordCandidateOutcome({
+      runId: secondRun.id,
+      feedItemId: secondFeedItem.id,
+      feedItem: secondFeedItem,
+      match: secondMatch,
+      status: 'skipped_duplicate',
+      updatedAt: '2026-03-30T01:10:00.000Z',
+    });
+
+    expect(state).toMatchObject({
+      identityKey: 'movie:example movie|2024',
+      status: 'skipped_duplicate',
+      queuedAt: '2026-03-30T00:10:00.000Z',
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/example-movie-bluray',
+      firstSeenRunId: firstRun.id,
+      lastSeenRunId: secondRun.id,
+      lastFeedItemId: secondFeedItem.id,
+    });
+  });
+
+  it('keeps failed candidates retryable until one is successfully queued', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+    const firstRun = repository.startRun('2026-03-30T02:00:00.000Z');
+    const firstFeedItem = repository.recordFeedItem(firstRun.id, {
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/retry-me-web',
+      rawTitle: 'Retry.Me.2024.1080p.WEB.x265-GROUP',
+      publishedAt: '2026-03-30T02:05:00.000Z',
+      downloadUrl: 'https://example.test/downloads/retry-me-web.torrent',
+    });
+    const match = requireMovieMatch(firstFeedItem.rawTitle);
+
+    const failedState = repository.recordCandidateOutcome({
+      runId: firstRun.id,
+      feedItemId: firstFeedItem.id,
+      feedItem: firstFeedItem,
+      match,
+      status: 'failed',
+      updatedAt: '2026-03-30T02:10:00.000Z',
+    });
+
+    expect(failedState.status).toBe('failed');
+    expect(failedState.queuedAt).toBeUndefined();
+    expect(repository.isCandidateQueued(match.identityKey)).toBe(false);
+
+    const secondRun = repository.startRun('2026-03-30T03:00:00.000Z');
+    const secondFeedItem = repository.recordFeedItem(secondRun.id, {
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/retry-me-bluray',
+      rawTitle: 'Retry Me 2024 2160p BluRay x265 OTHER',
+      publishedAt: '2026-03-30T03:05:00.000Z',
+      downloadUrl: 'https://example.test/downloads/retry-me-bluray.torrent',
+    });
+    const retryMatch = requireMovieMatch(secondFeedItem.rawTitle);
+
+    expect(retryMatch.identityKey).toBe(match.identityKey);
+    expect(repository.isCandidateQueued(retryMatch.identityKey)).toBe(false);
+
+    const queuedState = repository.recordCandidateOutcome({
+      runId: secondRun.id,
+      feedItemId: secondFeedItem.id,
+      feedItem: secondFeedItem,
+      match: retryMatch,
+      status: 'queued',
+      updatedAt: '2026-03-30T03:10:00.000Z',
+    });
+
+    expect(queuedState).toMatchObject({
+      identityKey: 'movie:retry me|2024',
+      status: 'queued',
+      queuedAt: '2026-03-30T03:10:00.000Z',
+      firstSeenRunId: firstRun.id,
+      lastSeenRunId: secondRun.id,
+      lastFeedItemId: secondFeedItem.id,
+    });
+    expect(repository.isCandidateQueued(retryMatch.identityKey)).toBe(true);
+  });
+});
+
+function createTestRepository(path: string) {
+  const database = openDatabase(path);
+  ensureSchema(database);
+  return createRepository(database);
+}
+
+async function createDatabasePath(): Promise<string> {
+  const directory = await createTempDir(join(tmpdir(), 'media-sync-db-test-'));
+
+  tempDirs.push(directory);
+  return join(directory, 'media-sync.db');
+}
+
+function requireMovieMatch(rawTitle: string) {
+  const match = matchMovieItem(
+    normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle,
+    }),
+    {
+      years: [2024],
+      resolutions: ['2160p', '1080p'],
+      codecs: ['x265'],
+    },
+  );
+
+  expect(match).toBeDefined();
+  return match!;
+}


### PR DESCRIPTION
## Summary

Implements ticket P1.06 by adding a SQLite-backed repository layer for run history and candidate state.

## What Changed

- add `runs`, `feed_items`, and `candidate_state` schema bootstrapping
- add repository operations for starting runs, recording feed items, reading candidate state, and recording outcomes
- preserve `queued_at` across later `skipped_duplicate` updates so dedupe remains correct
- keep failed candidates retryable until they are successfully queued
- add integration tests covering duplicate skipping and failed-item retryability
- update README status and add the ticket rationale note

## Verification

- `bun test`
- `bun run ci`
