### PR TITLE
feat: add Transmission adapter [P1.07]

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Phase 01 ends at successful queueing in Transmission. It does not include a web 
 
 ## Status
 
-Tickets 01-06 are implemented:
+Tickets 01-07 are implemented:
 
 - minimal Bun + TypeScript CLI skeleton with JSON config loading and validation for `media-sync run`
 - RSS fetch-and-parse entrypoint that converts RSS items into a raw feed-item shape
@@ -23,6 +23,7 @@ Tickets 01-06 are implemented:
 - TV rule matcher that evaluates normalized items against name-based rules with optional regex overrides plus codec and resolution filters
 - movie policy matcher that accepts releases by global year and quality policy without per-title rules
 - SQLite-backed run history and candidate-state persistence that preserves dedupe and retryability
+- Transmission RPC adapter that negotiates session ids, submits torrent URLs, and returns structured queueing failures without wiring the full run pipeline yet
 
 The project is being planned as a small-slice, review-friendly build:
 

--- a/docs/02-delivery/phase-01/ticket-07-rationale.md
+++ b/docs/02-delivery/phase-01/ticket-07-rationale.md
@@ -1,0 +1,6 @@
+# P1.07 Rationale
+
+- `Red first:` adapter tests proving Transmission session negotiation succeeds on `409` plus `X-Transmission-Session-Id`, and that RPC, HTTP, malformed-response, and network failures are surfaced as structured results.
+- `Why this path:` a narrow downloader boundary with one `submit` operation was the smallest acceptable slice that adds real Transmission integration without pulling pipeline orchestration or persistence concerns into the adapter.
+- `Alternative considered:` exposing raw Transmission RPC request and response shapes to the rest of the app was rejected because later tickets only need queueing semantics, not protocol details.
+- `Deferred:` run-pipeline wiring, persistence of submission outcomes, duplicate handling across prior candidate state, status rendering, and retry command orchestration remain in tickets 08-10.

--- a/src/transmission.ts
+++ b/src/transmission.ts
@@ -1,0 +1,243 @@
+import type { TransmissionConfig } from './config';
+
+export type SubmitDownloadInput = {
+  downloadUrl: string;
+};
+
+export type SubmissionSuccess = {
+  ok: true;
+  status: 'queued';
+  torrentId?: number;
+  torrentName?: string;
+  torrentHash?: string;
+};
+
+export type SubmissionFailureCode =
+  | 'network_error'
+  | 'session_error'
+  | 'http_error'
+  | 'invalid_response'
+  | 'rpc_error';
+
+export type SubmissionFailure = {
+  ok: false;
+  code: SubmissionFailureCode;
+  message: string;
+};
+
+export type SubmissionResult = SubmissionSuccess | SubmissionFailure;
+
+export type Downloader = {
+  submit(input: SubmitDownloadInput): Promise<SubmissionResult>;
+};
+
+export function createTransmissionDownloader(
+  config: TransmissionConfig,
+): Downloader {
+  return {
+    submit(input) {
+      return submitToTransmission(config, input);
+    },
+  };
+}
+
+async function submitToTransmission(
+  config: TransmissionConfig,
+  input: SubmitDownloadInput,
+): Promise<SubmissionResult> {
+  const firstResponse = await sendRpcRequest(config, input);
+
+  if (!firstResponse.ok) {
+    return firstResponse.error;
+  }
+
+  let response = firstResponse.response;
+
+  if (response.status === 409) {
+    const sessionId = response.headers.get('x-transmission-session-id');
+
+    if (!sessionId) {
+      return {
+        ok: false,
+        code: 'session_error',
+        message:
+          'Transmission session negotiation failed: missing X-Transmission-Session-Id header.',
+      };
+    }
+
+    const retryResponse = await sendRpcRequest(config, input, sessionId);
+
+    if (!retryResponse.ok) {
+      return retryResponse.error;
+    }
+
+    response = retryResponse.response;
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      code: 'http_error',
+      message: `Transmission RPC request failed with HTTP ${response.status}.`,
+    };
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = await response.json();
+  } catch {
+    return {
+      ok: false,
+      code: 'invalid_response',
+      message: 'Transmission RPC response was not valid JSON.',
+    };
+  }
+
+  return parseSubmissionResult(parsed);
+}
+
+async function sendRpcRequest(
+  config: TransmissionConfig,
+  input: SubmitDownloadInput,
+  sessionId?: string,
+): Promise<
+  | {
+      ok: true;
+      response: Response;
+    }
+  | {
+      ok: false;
+      error: SubmissionFailure;
+    }
+> {
+  try {
+    const response = await fetch(config.url, {
+      method: 'POST',
+      headers: buildHeaders(config, sessionId),
+      body: JSON.stringify(buildRequestBody(config, input)),
+    });
+
+    return {
+      ok: true,
+      response,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: {
+        ok: false,
+        code: 'network_error',
+        message: `Transmission RPC request failed: ${formatErrorMessage(error)}.`,
+      },
+    };
+  }
+}
+
+function buildHeaders(
+  config: TransmissionConfig,
+  sessionId?: string,
+): HeadersInit {
+  const headers: Record<string, string> = {
+    authorization: `Basic ${Buffer.from(`${config.username}:${config.password}`).toString('base64')}`,
+    'content-type': 'application/json',
+  };
+
+  if (sessionId) {
+    headers['x-transmission-session-id'] = sessionId;
+  }
+
+  return headers;
+}
+
+function buildRequestBody(
+  config: TransmissionConfig,
+  input: SubmitDownloadInput,
+): {
+  method: 'torrent-add';
+  arguments: {
+    filename: string;
+    'download-dir'?: string;
+  };
+} {
+  return {
+    method: 'torrent-add',
+    arguments: {
+      filename: input.downloadUrl,
+      ...(config.downloadDir ? { 'download-dir': config.downloadDir } : {}),
+    },
+  };
+}
+
+function parseSubmissionResult(parsed: unknown): SubmissionResult {
+  if (!isTransmissionResponse(parsed)) {
+    return {
+      ok: false,
+      code: 'invalid_response',
+      message: 'Transmission RPC response was missing required fields.',
+    };
+  }
+
+  if (parsed.result !== 'success') {
+    return {
+      ok: false,
+      code: 'rpc_error',
+      message: `Transmission rejected torrent submission: ${parsed.result}.`,
+    };
+  }
+
+  const addedTorrent = parsed.arguments['torrent-added'];
+  const duplicateTorrent = parsed.arguments['torrent-duplicate'];
+  const torrent = addedTorrent ?? duplicateTorrent;
+
+  return {
+    ok: true,
+    status: 'queued',
+    torrentId: typeof torrent?.id === 'number' ? torrent.id : undefined,
+    torrentName: typeof torrent?.name === 'string' ? torrent.name : undefined,
+    torrentHash:
+      typeof torrent?.hashString === 'string' ? torrent.hashString : undefined,
+  };
+}
+
+function isTransmissionResponse(value: unknown): value is TransmissionResponse {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  if (!('result' in value) || typeof value.result !== 'string') {
+    return false;
+  }
+
+  if (
+    !('arguments' in value) ||
+    !value.arguments ||
+    typeof value.arguments !== 'object'
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function formatErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+type TransmissionTorrent = {
+  id?: number;
+  name?: string;
+  hashString?: string;
+};
+
+type TransmissionResponse = {
+  result: string;
+  arguments: {
+    'torrent-added'?: TransmissionTorrent;
+    'torrent-duplicate'?: TransmissionTorrent;
+  };
+};

--- a/src/transmission.ts
+++ b/src/transmission.ts
@@ -190,6 +190,14 @@ function parseSubmissionResult(parsed: unknown): SubmissionResult {
   const duplicateTorrent = parsed.arguments['torrent-duplicate'];
   const torrent = addedTorrent ?? duplicateTorrent;
 
+  if (!torrent || typeof torrent !== 'object') {
+    return {
+      ok: false,
+      code: 'invalid_response',
+      message: 'Transmission RPC success response was missing torrent details.',
+    };
+  }
+
   return {
     ok: true,
     status: 'queued',

--- a/test/transmission.test.ts
+++ b/test/transmission.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import type { TransmissionConfig } from '../src/config';
+import {
+  createTransmissionDownloader,
+  type SubmissionFailure,
+  type SubmissionFailureCode,
+} from '../src/transmission';
+
+const servers: Array<ReturnType<typeof Bun.serve>> = [];
+const originalFetch = globalThis.fetch;
+
+describe('Transmission adapter', () => {
+  afterEach(() => {
+    while (servers.length > 0) {
+      const server = servers.pop();
+
+      if (server) {
+        server.stop(true);
+      }
+    }
+
+    globalThis.fetch = originalFetch;
+  });
+
+  it('submits a torrent after negotiating a session id', async () => {
+    const requests: CapturedRequest[] = [];
+    let requestCount = 0;
+    const server = startTransmissionServer(async (request) => {
+      requests.push(await captureRequest(request));
+      requestCount += 1;
+
+      if (requestCount === 1) {
+        return new Response(null, {
+          status: 409,
+          headers: {
+            'x-transmission-session-id': 'session-123',
+          },
+        });
+      }
+
+      return Response.json({
+        result: 'success',
+        arguments: {
+          'torrent-added': {
+            id: 7,
+            hashString: 'abcdef123456',
+            name: 'Example Movie',
+          },
+        },
+      });
+    });
+    const downloader = createTransmissionDownloader(
+      createTransmissionConfig(server.url.origin, '/downloads/movies'),
+    );
+
+    const result = await downloader.submit({
+      downloadUrl: 'https://download.example.test/movie/example.torrent',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: 'queued',
+      torrentId: 7,
+      torrentName: 'Example Movie',
+      torrentHash: 'abcdef123456',
+    });
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.authorization).toBe(basicAuthHeader('pirate', 'claw'));
+    expect(requests[0]?.sessionId).toBeNull();
+    expect(requests[1]?.sessionId).toBe('session-123');
+    expect(requests[1]?.contentType).toBe('application/json');
+
+    expect(requests[1]!.json).toEqual({
+      method: 'torrent-add',
+      arguments: {
+        filename: 'https://download.example.test/movie/example.torrent',
+        'download-dir': '/downloads/movies',
+      },
+    });
+  });
+
+  it('returns a structured failure when Transmission rejects the RPC call', async () => {
+    const server = startTransmissionServer((request) => {
+      const sessionId = request.headers.get('x-transmission-session-id');
+
+      if (!sessionId) {
+        return new Response(null, {
+          status: 409,
+          headers: {
+            'x-transmission-session-id': 'session-123',
+          },
+        });
+      }
+
+      return Response.json({
+        result: 'duplicate torrent',
+        arguments: {},
+      });
+    });
+    const downloader = createTransmissionDownloader(
+      createTransmissionConfig(server.url.origin),
+    );
+
+    const result = await downloader.submit({
+      downloadUrl: 'https://download.example.test/movie/example.torrent',
+    });
+
+    expectFailure(
+      result,
+      'rpc_error',
+      'Transmission rejected torrent submission: duplicate torrent.',
+    );
+  });
+
+  it('returns a structured failure when the server responds with a non-OK status after negotiation', async () => {
+    const server = startTransmissionServer((request) => {
+      const sessionId = request.headers.get('x-transmission-session-id');
+
+      if (!sessionId) {
+        return new Response(null, {
+          status: 409,
+          headers: {
+            'x-transmission-session-id': 'session-123',
+          },
+        });
+      }
+
+      return new Response('upstream unavailable', {
+        status: 503,
+      });
+    });
+    const downloader = createTransmissionDownloader(
+      createTransmissionConfig(server.url.origin),
+    );
+
+    const result = await downloader.submit({
+      downloadUrl: 'https://download.example.test/movie/example.torrent',
+    });
+
+    expectFailure(
+      result,
+      'http_error',
+      'Transmission RPC request failed with HTTP 503.',
+    );
+  });
+
+  it('returns a structured failure when session negotiation omits the session id header', async () => {
+    const server = startTransmissionServer(
+      () =>
+        new Response(null, {
+          status: 409,
+        }),
+    );
+    const downloader = createTransmissionDownloader(
+      createTransmissionConfig(server.url.origin),
+    );
+
+    const result = await downloader.submit({
+      downloadUrl: 'https://download.example.test/movie/example.torrent',
+    });
+
+    expectFailure(
+      result,
+      'session_error',
+      'Transmission session negotiation failed: missing X-Transmission-Session-Id header.',
+    );
+  });
+
+  it('returns a structured failure when the response body is not valid JSON', async () => {
+    const server = startTransmissionServer((request) => {
+      const sessionId = request.headers.get('x-transmission-session-id');
+
+      if (!sessionId) {
+        return new Response(null, {
+          status: 409,
+          headers: {
+            'x-transmission-session-id': 'session-123',
+          },
+        });
+      }
+
+      return new Response('not-json', {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+    });
+    const downloader = createTransmissionDownloader(
+      createTransmissionConfig(server.url.origin),
+    );
+
+    const result = await downloader.submit({
+      downloadUrl: 'https://download.example.test/movie/example.torrent',
+    });
+
+    expectFailure(
+      result,
+      'invalid_response',
+      'Transmission RPC response was not valid JSON.',
+    );
+  });
+
+  it('returns a structured failure when fetch throws before any response is returned', async () => {
+    globalThis.fetch = Object.assign(
+      async () => {
+        throw new Error('connect ECONNREFUSED');
+      },
+      {
+        preconnect: originalFetch.preconnect.bind(originalFetch),
+      },
+    );
+
+    const downloader = createTransmissionDownloader(
+      createTransmissionConfig('http://127.0.0.1:65535'),
+    );
+
+    const result = await downloader.submit({
+      downloadUrl: 'https://download.example.test/movie/example.torrent',
+    });
+
+    expectFailure(
+      result,
+      'network_error',
+      'Transmission RPC request failed: connect ECONNREFUSED.',
+    );
+  });
+});
+
+function startTransmissionServer(
+  handler: (request: Request) => Response | Promise<Response>,
+) {
+  const server = Bun.serve({
+    port: 0,
+    hostname: '127.0.0.1',
+    routes: {
+      '/transmission/rpc': handler,
+    },
+  });
+
+  servers.push(server);
+  return server;
+}
+
+function createTransmissionConfig(
+  origin: string,
+  downloadDir?: string,
+): TransmissionConfig {
+  return {
+    url: `${origin}/transmission/rpc`,
+    username: 'pirate',
+    password: 'claw',
+    downloadDir,
+  };
+}
+
+function basicAuthHeader(username: string, password: string): string {
+  return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+}
+
+async function captureRequest(request: Request): Promise<CapturedRequest> {
+  const text = await request.text();
+
+  return {
+    authorization: request.headers.get('authorization'),
+    sessionId: request.headers.get('x-transmission-session-id'),
+    contentType: request.headers.get('content-type'),
+    json: text.length > 0 ? JSON.parse(text) : undefined,
+  };
+}
+
+type CapturedRequest = {
+  authorization: string | null;
+  sessionId: string | null;
+  contentType: string | null;
+  json: unknown;
+};
+
+function expectFailure(
+  result: unknown,
+  code: SubmissionFailureCode,
+  message: string,
+): asserts result is SubmissionFailure {
+  expect(result).toEqual({
+    ok: false,
+    code,
+    message,
+  });
+}

--- a/test/transmission.test.ts
+++ b/test/transmission.test.ts
@@ -202,6 +202,39 @@ describe('Transmission adapter', () => {
     );
   });
 
+  it('returns a structured failure when a success response omits torrent details', async () => {
+    const server = startTransmissionServer((request) => {
+      const sessionId = request.headers.get('x-transmission-session-id');
+
+      if (!sessionId) {
+        return new Response(null, {
+          status: 409,
+          headers: {
+            'x-transmission-session-id': 'session-123',
+          },
+        });
+      }
+
+      return Response.json({
+        result: 'success',
+        arguments: {},
+      });
+    });
+    const downloader = createTransmissionDownloader(
+      createTransmissionConfig(server.url.origin),
+    );
+
+    const result = await downloader.submit({
+      downloadUrl: 'https://download.example.test/movie/example.torrent',
+    });
+
+    expectFailure(
+      result,
+      'invalid_response',
+      'Transmission RPC success response was missing torrent details.',
+    );
+  });
+
   it('returns a structured failure when fetch throws before any response is returned', async () => {
     globalThis.fetch = Object.assign(
       async () => {


### PR DESCRIPTION
## Summary

Add a narrow Transmission RPC adapter that submits torrent URLs behind a downloader boundary with structured success and failure results.

## What Changed

- add `src/transmission.ts` with one-shot session-id negotiation and `torrent-add` submission
- return typed adapter results for queued, RPC error, HTTP error, invalid response, session negotiation failure, and network failure cases
- add fake-server integration tests covering handshake, auth, request payload, and failure behavior
- add the missing `P1.07` rationale doc and update the README status to mark tickets `01-07` as implemented

## Rationale

This keeps Transmission protocol details isolated so ticket `P1.08` can wire orchestration to a small queueing interface instead of raw RPC calls.
