### PR TITLE
feat: add end-to-end run pipeline [P1.08]

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Phase 01 ends at successful queueing in Transmission. It does not include a web 
 
 ## Status
 
-Tickets 01-07 are implemented:
+Tickets 01-08 are implemented:
 
 - minimal Bun + TypeScript CLI skeleton with JSON config loading and validation for `media-sync run`
 - RSS fetch-and-parse entrypoint that converts RSS items into a raw feed-item shape
@@ -24,6 +24,7 @@ Tickets 01-07 are implemented:
 - movie policy matcher that accepts releases by global year and quality policy without per-title rules
 - SQLite-backed run history and candidate-state persistence that preserves dedupe and retryability
 - Transmission RPC adapter that negotiates session ids, submits torrent URLs, and returns structured queueing failures without wiring the full run pipeline yet
+- end-to-end `media-sync run` orchestration that fetches feeds, matches candidates, persists per-feed-item outcomes, submits winners, and prints a compact run summary
 
 The project is being planned as a small-slice, review-friendly build:
 

--- a/docs/02-delivery/phase-01/ticket-08-rationale.md
+++ b/docs/02-delivery/phase-01/ticket-08-rationale.md
@@ -1,0 +1,6 @@
+# P1.08 Rationale
+
+- `Red first:` an end-to-end CLI test proving one run can queue the best candidate, persist `failed`, `skipped_duplicate`, and `skipped_no_match` outcomes, and keep queued identities deduped on a later run.
+- `Why this path:` a small pipeline entrypoint plus a minimal `feed_item_outcomes` table was the smallest acceptable slice that made `media-sync run` real without pulling status rendering or retry orchestration forward.
+- `Alternative considered:` storing `skipped_no_match` indirectly in `candidate_state` or jumping straight to a full submission-attempt history model was rejected because unmatched feed items do not have stable candidate identities and ticket 08 only needs one per-item outcome record.
+- `Deferred:` dedicated status command output, retry-failed orchestration, richer submission-attempt history, and any verbose operator UI remain in tickets 09-10.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,7 @@
 import { ConfigError, loadConfig, resolveConfigPath } from './config';
+import { runPipeline } from './pipeline';
+import { createRepository, ensureSchema, openDatabase } from './repository';
+import { createTransmissionDownloader } from './transmission';
 
 export async function runCli(argv: string[]): Promise<number> {
   const [command, ...rest] = argv;
@@ -10,8 +13,23 @@ export async function runCli(argv: string[]): Promise<number> {
 
   try {
     const configPath = parseConfigPath(rest);
-    await loadConfig(resolveConfigPath(configPath));
-    console.log(`Config loaded from ${resolveConfigPath(configPath)}.`);
+    const resolvedConfigPath = resolveConfigPath(configPath);
+    const config = await loadConfig(resolvedConfigPath);
+    const database = openDatabase();
+
+    try {
+      ensureSchema(database);
+      const result = await runPipeline({
+        config,
+        repository: createRepository(database),
+        downloader: createTransmissionDownloader(config.transmission),
+      });
+
+      console.log(formatRunSummary(result));
+    } finally {
+      database.close();
+    }
+
     return 0;
   } catch (error) {
     const message =
@@ -21,6 +39,24 @@ export async function runCli(argv: string[]): Promise<number> {
     console.error(message);
     return 1;
   }
+}
+
+function formatRunSummary(result: {
+  runId: number;
+  counts: {
+    queued: number;
+    failed: number;
+    skipped_duplicate: number;
+    skipped_no_match: number;
+  };
+}): string {
+  return [
+    `Run ${result.runId} completed.`,
+    `queued: ${result.counts.queued}`,
+    `failed: ${result.counts.failed}`,
+    `skipped_duplicate: ${result.counts.skipped_duplicate}`,
+    `skipped_no_match: ${result.counts.skipped_no_match}`,
+  ].join('\n');
 }
 
 function formatUnexpectedError(error: unknown): string {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,0 +1,228 @@
+import type { AppConfig, FeedConfig } from './config';
+import { fetchFeed, type RawFeedItem } from './feed';
+import { matchMovieItem } from './movie-match';
+import { normalizeFeedItem } from './normalize';
+import type {
+  CandidateMatchRecord,
+  FeedItemOutcomeRecord,
+  FeedItemOutcomeStatus,
+  FeedItemRecord,
+  Repository,
+  RunRecord,
+} from './repository';
+import type { Downloader } from './transmission';
+import { matchTvItem } from './tv-match';
+
+export type RunPipelineResult = {
+  runId: number;
+  startedAt: string;
+  completedAt: string;
+  counts: Record<FeedItemOutcomeStatus, number>;
+  outcomes: FeedItemOutcomeRecord[];
+};
+
+export type FetchFeedFn = (feed: FeedConfig) => Promise<RawFeedItem[]>;
+
+export async function runPipeline(input: {
+  config: AppConfig;
+  repository: Repository;
+  downloader: Downloader;
+  fetchFeed?: FetchFeedFn;
+}): Promise<RunPipelineResult> {
+  const fetchFeedImpl = input.fetchFeed ?? fetchFeed;
+  const run = input.repository.startRun();
+
+  try {
+    const candidates: MatchedFeedItem[] = [];
+
+    for (const feed of input.config.feeds) {
+      const items = await fetchFeedImpl(feed);
+
+      for (const item of items) {
+        const feedItem = input.repository.recordFeedItem(run.id, item);
+        const match = matchFeedItem(feedItem, input.config, feed);
+
+        if (!match) {
+          input.repository.recordFeedItemOutcome({
+            runId: run.id,
+            feedItemId: feedItem.id,
+            status: 'skipped_no_match',
+            message: 'No matching rule or policy.',
+          });
+          continue;
+        }
+
+        candidates.push({ feedItem, match });
+      }
+    }
+
+    for (const group of groupByIdentity(candidates).values()) {
+      const winner = selectWinningCandidate(group);
+
+      for (const candidate of group) {
+        if (candidate !== winner) {
+          recordDuplicateOutcome(input.repository, run, candidate, {
+            message: 'Higher-ranked candidate selected for this identity.',
+          });
+        }
+      }
+
+      if (input.repository.isCandidateQueued(winner.match.identityKey)) {
+        recordDuplicateOutcome(input.repository, run, winner, {
+          message: 'Candidate already queued in a previous run.',
+        });
+        continue;
+      }
+
+      const submission = await input.downloader.submit({
+        downloadUrl: winner.feedItem.downloadUrl,
+      });
+
+      if (submission.ok) {
+        input.repository.recordCandidateOutcome({
+          runId: run.id,
+          feedItemId: winner.feedItem.id,
+          feedItem: winner.feedItem,
+          match: winner.match,
+          status: 'queued',
+        });
+        input.repository.recordFeedItemOutcome({
+          runId: run.id,
+          feedItemId: winner.feedItem.id,
+          status: 'queued',
+          identityKey: winner.match.identityKey,
+          ruleName: winner.match.ruleName,
+          message: 'Queued in Transmission.',
+        });
+        continue;
+      }
+
+      input.repository.recordCandidateOutcome({
+        runId: run.id,
+        feedItemId: winner.feedItem.id,
+        feedItem: winner.feedItem,
+        match: winner.match,
+        status: 'failed',
+      });
+      input.repository.recordFeedItemOutcome({
+        runId: run.id,
+        feedItemId: winner.feedItem.id,
+        status: 'failed',
+        identityKey: winner.match.identityKey,
+        ruleName: winner.match.ruleName,
+        message: submission.message,
+      });
+    }
+
+    return finalizeRun(input.repository, run);
+  } catch (error) {
+    input.repository.completeRun(run.id);
+    throw error;
+  }
+}
+
+function matchFeedItem(
+  feedItem: FeedItemRecord,
+  config: AppConfig,
+  feed: FeedConfig,
+): CandidateMatchRecord | undefined {
+  const normalized = normalizeFeedItem({
+    mediaType: feed.mediaType,
+    rawTitle: feedItem.rawTitle,
+  });
+
+  if (normalized.mediaType === 'tv') {
+    return matchTvItem(normalized, config.tv)[0];
+  }
+
+  return matchMovieItem(normalized, config.movies);
+}
+
+function groupByIdentity(
+  candidates: MatchedFeedItem[],
+): Map<string, MatchedFeedItem[]> {
+  const groups = new Map<string, MatchedFeedItem[]>();
+
+  for (const candidate of candidates) {
+    const group = groups.get(candidate.match.identityKey);
+
+    if (group) {
+      group.push(candidate);
+      continue;
+    }
+
+    groups.set(candidate.match.identityKey, [candidate]);
+  }
+
+  return groups;
+}
+
+function selectWinningCandidate(group: MatchedFeedItem[]): MatchedFeedItem {
+  let winner = group[0];
+
+  for (const candidate of group.slice(1)) {
+    if (candidate.match.score > winner.match.score) {
+      winner = candidate;
+    }
+  }
+
+  return winner;
+}
+
+function recordDuplicateOutcome(
+  repository: Repository,
+  run: RunRecord,
+  candidate: MatchedFeedItem,
+  input: { message: string },
+): void {
+  repository.recordCandidateOutcome({
+    runId: run.id,
+    feedItemId: candidate.feedItem.id,
+    feedItem: candidate.feedItem,
+    match: candidate.match,
+    status: 'skipped_duplicate',
+  });
+  repository.recordFeedItemOutcome({
+    runId: run.id,
+    feedItemId: candidate.feedItem.id,
+    status: 'skipped_duplicate',
+    identityKey: candidate.match.identityKey,
+    ruleName: candidate.match.ruleName,
+    message: input.message,
+  });
+}
+
+function finalizeRun(
+  repository: Repository,
+  run: RunRecord,
+): RunPipelineResult {
+  const completedRun = repository.completeRun(run.id);
+  const outcomes = repository.listFeedItemOutcomes(run.id);
+  const counts = createEmptyCounts();
+
+  for (const outcome of outcomes) {
+    counts[outcome.status] += 1;
+  }
+
+  return {
+    runId: completedRun.id,
+    startedAt: completedRun.startedAt,
+    completedAt: completedRun.completedAt ?? completedRun.startedAt,
+    counts,
+    outcomes,
+  };
+}
+
+function createEmptyCounts(): Record<FeedItemOutcomeStatus, number> {
+  return {
+    queued: 0,
+    failed: 0,
+    skipped_duplicate: 0,
+    skipped_no_match: 0,
+  };
+}
+
+type MatchedFeedItem = {
+  feedItem: FeedItemRecord;
+  match: CandidateMatchRecord;
+};

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -116,7 +116,7 @@ export async function runPipeline(input: {
 
     return finalizeRun(input.repository, run);
   } catch (error) {
-    input.repository.completeRun(run.id);
+    input.repository.failRun(run.id);
     throw error;
   }
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -5,6 +5,12 @@ import type { NormalizedFeedItem } from './normalize';
 
 export type CandidateStatus = 'queued' | 'failed' | 'skipped_duplicate';
 
+export type FeedItemOutcomeStatus =
+  | 'queued'
+  | 'failed'
+  | 'skipped_duplicate'
+  | 'skipped_no_match';
+
 export type CandidateMatchRecord = {
   ruleName: string;
   identityKey: string;
@@ -22,6 +28,17 @@ export type RunRecord = {
 export type FeedItemRecord = RawFeedItem & {
   id: number;
   runId: number;
+};
+
+export type FeedItemOutcomeRecord = {
+  id: number;
+  runId: number;
+  feedItemId?: number;
+  status: FeedItemOutcomeStatus;
+  identityKey?: string;
+  ruleName?: string;
+  message?: string;
+  createdAt: string;
 };
 
 export type CandidateStateRecord = {
@@ -58,6 +75,16 @@ export type RecordCandidateOutcomeInput = {
   updatedAt?: string;
 };
 
+export type RecordFeedItemOutcomeInput = {
+  runId: number;
+  feedItemId?: number;
+  status: FeedItemOutcomeStatus;
+  identityKey?: string;
+  ruleName?: string;
+  message?: string;
+  createdAt?: string;
+};
+
 export type Repository = {
   startRun(startedAt?: string): RunRecord;
   completeRun(runId: number, completedAt?: string): RunRecord;
@@ -67,6 +94,10 @@ export type Repository = {
   recordCandidateOutcome(
     input: RecordCandidateOutcomeInput,
   ): CandidateStateRecord;
+  recordFeedItemOutcome(
+    input: RecordFeedItemOutcomeInput,
+  ): FeedItemOutcomeRecord;
+  listFeedItemOutcomes(runId: number): FeedItemOutcomeRecord[];
 };
 
 export const DEFAULT_DATABASE_PATH = 'media-sync.db';
@@ -118,6 +149,17 @@ export function ensureSchema(database: Database): void {
       last_seen_run_id INTEGER NOT NULL REFERENCES runs(id),
       last_feed_item_id INTEGER REFERENCES feed_items(id),
       updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS feed_item_outcomes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      run_id INTEGER NOT NULL REFERENCES runs(id),
+      feed_item_id INTEGER REFERENCES feed_items(id),
+      status TEXT NOT NULL,
+      identity_key TEXT,
+      rule_name TEXT,
+      message TEXT,
+      created_at TEXT NOT NULL
     );
   `);
 }
@@ -234,6 +276,44 @@ export function createRepository(database: Database): Repository {
       last_feed_item_id = excluded.last_feed_item_id,
       updated_at = excluded.updated_at`,
   );
+  const insertFeedItemOutcome = database.query(
+    `INSERT INTO feed_item_outcomes (
+      run_id,
+      feed_item_id,
+      status,
+      identity_key,
+      rule_name,
+      message,
+      created_at
+    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)`,
+  );
+  const selectFeedItemOutcome = database.query(
+    `SELECT
+      id,
+      run_id AS runId,
+      feed_item_id AS feedItemId,
+      status,
+      identity_key AS identityKey,
+      rule_name AS ruleName,
+      message,
+      created_at AS createdAt
+    FROM feed_item_outcomes
+    WHERE id = ?1`,
+  );
+  const listFeedItemOutcomesStatement = database.query(
+    `SELECT
+      id,
+      run_id AS runId,
+      feed_item_id AS feedItemId,
+      status,
+      identity_key AS identityKey,
+      rule_name AS ruleName,
+      message,
+      created_at AS createdAt
+    FROM feed_item_outcomes
+    WHERE run_id = ?1
+    ORDER BY id ASC`,
+  );
 
   return {
     startRun(startedAt = new Date().toISOString()): RunRecord {
@@ -324,6 +404,38 @@ export function createRepository(database: Database): Repository {
         ),
       );
     },
+
+    recordFeedItemOutcome(
+      input: RecordFeedItemOutcomeInput,
+    ): FeedItemOutcomeRecord {
+      const createdAt = input.createdAt ?? new Date().toISOString();
+
+      insertFeedItemOutcome.run(
+        input.runId,
+        input.feedItemId ?? null,
+        input.status,
+        input.identityKey ?? null,
+        input.ruleName ?? null,
+        input.message ?? null,
+        createdAt,
+      );
+
+      return mapFeedItemOutcomeRow(
+        requireRow(
+          selectFeedItemOutcome.get(lastInsertedRowId(database)) as
+            | FeedItemOutcomeRow
+            | null
+            | undefined,
+          'feed item outcome',
+        ),
+      );
+    },
+
+    listFeedItemOutcomes(runId: number): FeedItemOutcomeRecord[] {
+      return (
+        listFeedItemOutcomesStatement.all(runId) as FeedItemOutcomeRow[]
+      ).map(mapFeedItemOutcomeRow);
+    },
   };
 }
 
@@ -398,6 +510,19 @@ function mapCandidateStateRow(row: CandidateStateRow): CandidateStateRecord {
   };
 }
 
+function mapFeedItemOutcomeRow(row: FeedItemOutcomeRow): FeedItemOutcomeRecord {
+  return {
+    id: Number(row.id),
+    runId: Number(row.runId),
+    feedItemId: row.feedItemId ?? undefined,
+    status: row.status,
+    identityKey: row.identityKey ?? undefined,
+    ruleName: row.ruleName ?? undefined,
+    message: row.message ?? undefined,
+    createdAt: row.createdAt,
+  };
+}
+
 type RunRow = {
   id: number;
   startedAt: string;
@@ -437,4 +562,15 @@ type CandidateStateRow = {
   lastSeenRunId: number;
   lastFeedItemId: number | null;
   updatedAt: string;
+};
+
+type FeedItemOutcomeRow = {
+  id: number;
+  runId: number;
+  feedItemId: number | null;
+  status: FeedItemOutcomeStatus;
+  identityKey: string | null;
+  ruleName: string | null;
+  message: string | null;
+  createdAt: string;
 };

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -4,6 +4,7 @@ import type { RawFeedItem } from './feed';
 import type { NormalizedFeedItem } from './normalize';
 
 export type CandidateStatus = 'queued' | 'failed' | 'skipped_duplicate';
+export type RunStatus = 'running' | 'completed' | 'failed';
 
 export type FeedItemOutcomeStatus =
   | 'queued'
@@ -22,6 +23,7 @@ export type CandidateMatchRecord = {
 export type RunRecord = {
   id: number;
   startedAt: string;
+  status: RunStatus;
   completedAt?: string;
 };
 
@@ -87,7 +89,9 @@ export type RecordFeedItemOutcomeInput = {
 
 export type Repository = {
   startRun(startedAt?: string): RunRecord;
+  getRun(runId: number): RunRecord | undefined;
   completeRun(runId: number, completedAt?: string): RunRecord;
+  failRun(runId: number, failedAt?: string): RunRecord;
   recordFeedItem(runId: number, item: RawFeedItem): FeedItemRecord;
   getCandidateState(identityKey: string): CandidateStateRecord | undefined;
   isCandidateQueued(identityKey: string): boolean;
@@ -113,6 +117,7 @@ export function ensureSchema(database: Database): void {
     CREATE TABLE IF NOT EXISTS runs (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       started_at TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'running',
       completed_at TEXT
     );
 
@@ -162,20 +167,43 @@ export function ensureSchema(database: Database): void {
       created_at TEXT NOT NULL
     );
   `);
+
+  const hasRunStatusColumn =
+    (database
+      .query(`SELECT 1 FROM pragma_table_info('runs') WHERE name = 'status'`)
+      .get() as { 1: number } | null | undefined) !== null;
+
+  if (!hasRunStatusColumn) {
+    database.exec(
+      `ALTER TABLE runs ADD COLUMN status TEXT NOT NULL DEFAULT 'running'`,
+    );
+  }
 }
 
 export function createRepository(database: Database): Repository {
-  const insertRun = database.query('INSERT INTO runs (started_at) VALUES (?1)');
+  const insertRun = database.query(
+    `INSERT INTO runs (started_at, status) VALUES (?1, 'running')`,
+  );
   const selectRun = database.query(
     `SELECT
       id,
       started_at AS startedAt,
+      status,
       completed_at AS completedAt
     FROM runs
     WHERE id = ?1`,
   );
   const completeRunStatement = database.query(
-    'UPDATE runs SET completed_at = ?2 WHERE id = ?1',
+    `UPDATE runs
+    SET completed_at = ?2,
+        status = 'completed'
+    WHERE id = ?1`,
+  );
+  const failRunStatement = database.query(
+    `UPDATE runs
+    SET completed_at = ?2,
+        status = 'failed'
+    WHERE id = ?1`,
   );
   const insertFeedItem = database.query(
     `INSERT INTO feed_items (
@@ -325,11 +353,23 @@ export function createRepository(database: Database): Repository {
       return mapRunRow(requireRow(row, 'run'));
     },
 
+    getRun(runId: number): RunRecord | undefined {
+      const row = selectRun.get(runId) as RunRow | null | undefined;
+      return row ? mapRunRow(row) : undefined;
+    },
+
     completeRun(
       runId: number,
       completedAt = new Date().toISOString(),
     ): RunRecord {
       completeRunStatement.run(runId, completedAt);
+      return mapRunRow(
+        requireRow(selectRun.get(runId) as RunRow | null | undefined, 'run'),
+      );
+    },
+
+    failRun(runId: number, failedAt = new Date().toISOString()): RunRecord {
+      failRunStatement.run(runId, failedAt);
       return mapRunRow(
         requireRow(selectRun.get(runId) as RunRow | null | undefined, 'run'),
       );
@@ -462,11 +502,13 @@ function requireRow<T>(row: T | null | undefined, label: string): T {
 function mapRunRow(row: {
   id: number;
   startedAt: string;
+  status: RunStatus;
   completedAt: string | null;
 }): RunRecord {
   return {
     id: Number(row.id),
     startedAt: row.startedAt,
+    status: row.status,
     completedAt: row.completedAt ?? undefined,
   };
 }
@@ -526,6 +568,7 @@ function mapFeedItemOutcomeRow(row: FeedItemOutcomeRow): FeedItemOutcomeRecord {
 type RunRow = {
   id: number;
   startedAt: string;
+  status: RunStatus;
   completedAt: string | null;
 };
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,12 +1,21 @@
+import type { Database } from 'bun:sqlite';
 import { afterEach, describe, expect, it } from 'bun:test';
 import { mkdtemp as createTempDir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { delimiter, dirname, join } from 'node:path';
 
+import {
+  createRepository,
+  ensureSchema,
+  openDatabase,
+} from '../src/repository';
+
 const tempDirs: string[] = [];
+const openDatabases: Database[] = [];
+const servers: Array<ReturnType<typeof Bun.serve>> = [];
 const cwd = process.cwd();
 const bunExecutable = process.execPath;
-const cliExecutable = './bin/media-sync';
+const cliExecutable = join(cwd, 'bin/media-sync');
 const binPath = dirname(bunExecutable);
 const env = {
   ...process.env,
@@ -15,6 +24,14 @@ const env = {
 
 describe('media-sync run', () => {
   afterEach(async () => {
+    while (openDatabases.length > 0) {
+      openDatabases.pop()?.close();
+    }
+
+    while (servers.length > 0) {
+      servers.pop()?.stop(true);
+    }
+
     while (tempDirs.length > 0) {
       const directory = tempDirs.pop();
 
@@ -24,26 +41,110 @@ describe('media-sync run', () => {
     }
   });
 
-  it('loads config passed with --config', async () => {
-    const child = Bun.spawn(
-      [cliExecutable, 'run', '--config', './test/fixtures/valid-config.json'],
-      {
-        cwd,
-        env,
-        stderr: 'pipe',
-        stdout: 'pipe',
-      },
+  it('runs the end-to-end pipeline and persists per-feed-item outcomes', async () => {
+    const directory = await mkdtemp();
+    const feedServer = startFeedServer();
+    const transmissionServer = startTransmissionServer();
+    const configPath = join(directory, 'media-sync.config.json');
+
+    await Bun.write(
+      configPath,
+      JSON.stringify(
+        {
+          feeds: [
+            {
+              name: 'TV Feed',
+              url: `${feedServer.url}/tv.rss`,
+              mediaType: 'tv',
+            },
+            {
+              name: 'Movie Feed',
+              url: `${feedServer.url}/movie.rss`,
+              mediaType: 'movie',
+            },
+          ],
+          tv: [
+            {
+              name: 'Example Show',
+              resolutions: ['1080p'],
+              codecs: ['x265'],
+            },
+          ],
+          movies: {
+            years: [2024],
+            resolutions: ['2160p', '1080p'],
+            codecs: ['x265'],
+          },
+          transmission: {
+            url: `${transmissionServer.url}/transmission/rpc`,
+            username: 'user',
+            password: 'pass',
+          },
+        },
+        null,
+        2,
+      ),
     );
 
-    const stdout = await new Response(child.stdout).text();
-    const stderr = await new Response(child.stderr).text();
-    const exitCode = await child.exited;
+    const firstRun = await runCliCommand(directory, './media-sync.config.json');
 
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain(
-      'Config loaded from ./test/fixtures/valid-config.json.',
+    expect(firstRun.exitCode).toBe(0);
+    expect(firstRun.stderr).toBe('');
+    expect(firstRun.stdout).toContain('Run 1 completed.');
+    expect(firstRun.stdout).toContain('queued: 1');
+    expect(firstRun.stdout).toContain('failed: 1');
+    expect(firstRun.stdout).toContain('skipped_duplicate: 1');
+    expect(firstRun.stdout).toContain('skipped_no_match: 1');
+
+    const secondRun = await runCliCommand(
+      directory,
+      './media-sync.config.json',
     );
-    expect(stderr).toBe('');
+
+    expect(secondRun.exitCode).toBe(0);
+    expect(secondRun.stderr).toBe('');
+    expect(secondRun.stdout).toContain('Run 2 completed.');
+    expect(secondRun.stdout).toContain('queued: 0');
+    expect(secondRun.stdout).toContain('failed: 1');
+    expect(secondRun.stdout).toContain('skipped_duplicate: 2');
+    expect(secondRun.stdout).toContain('skipped_no_match: 1');
+
+    const repository = createTestRepository(join(directory, 'media-sync.db'));
+    const firstRunOutcomes = repository.listFeedItemOutcomes(1);
+    const secondRunOutcomes = repository.listFeedItemOutcomes(2);
+
+    expect(firstRunOutcomes.map((outcome) => outcome.status)).toEqual([
+      'skipped_no_match',
+      'skipped_duplicate',
+      'queued',
+      'failed',
+    ]);
+    expect(secondRunOutcomes.map((outcome) => outcome.status)).toEqual([
+      'skipped_no_match',
+      'skipped_duplicate',
+      'skipped_duplicate',
+      'failed',
+    ]);
+    expect(
+      firstRunOutcomes.find((outcome) => outcome.status === 'failed')?.message,
+    ).toContain('torrent rejected by policy');
+    expect(
+      secondRunOutcomes.find(
+        (outcome) =>
+          outcome.status === 'skipped_duplicate' &&
+          outcome.message?.includes('previous run'),
+      ),
+    ).toBeDefined();
+    expect(
+      repository.getCandidateState('movie:example movie|2024'),
+    ).toMatchObject({
+      queuedAt: expect.any(String),
+    });
+    expect(repository.getCandidateState('movie:retry me|2024')).toMatchObject({
+      status: 'failed',
+      queuedAt: undefined,
+    });
+    expect(transmissionServer.requestCount).toBe(6);
   });
 
   it('exits with a readable error when config is missing a required section', async () => {
@@ -134,3 +235,140 @@ async function mkdtemp(): Promise<string> {
   tempDirs.push(directory);
   return directory;
 }
+
+async function runCliCommand(
+  commandCwd: string,
+  configPath: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const child = Bun.spawn([cliExecutable, 'run', '--config', configPath], {
+    cwd: commandCwd,
+    env,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  return {
+    stdout: await new Response(child.stdout).text(),
+    stderr: await new Response(child.stderr).text(),
+    exitCode: await child.exited,
+  };
+}
+
+function createTestRepository(path: string) {
+  const database = openDatabase(path);
+
+  openDatabases.push(database);
+  ensureSchema(database);
+  return createRepository(database);
+}
+
+function startFeedServer(): { url: string } {
+  const server = Bun.serve({
+    port: 0,
+    hostname: '127.0.0.1',
+    routes: {
+      '/tv.rss': new Response(tvFeedFixture, {
+        headers: { 'content-type': 'application/rss+xml; charset=utf-8' },
+      }),
+      '/movie.rss': new Response(movieFeedFixture, {
+        headers: { 'content-type': 'application/rss+xml; charset=utf-8' },
+      }),
+    },
+  });
+
+  servers.push(server);
+  return { url: server.url.origin };
+}
+
+function startTransmissionServer(): { url: string; requestCount: number } {
+  const state = { requestCount: 0 };
+  const server = Bun.serve({
+    port: 0,
+    hostname: '127.0.0.1',
+    routes: {
+      '/transmission/rpc': async (request: Request) => {
+        state.requestCount += 1;
+
+        const sessionId = request.headers.get('x-transmission-session-id');
+
+        if (!sessionId) {
+          return new Response(null, {
+            status: 409,
+            headers: {
+              'x-transmission-session-id': 'session-123',
+            },
+          });
+        }
+
+        const body = (await request.json()) as {
+          arguments?: { filename?: string };
+        };
+        const filename = body.arguments?.filename ?? '';
+
+        if (filename.includes('retry-me')) {
+          return Response.json({
+            result: 'torrent rejected by policy',
+            arguments: {},
+          });
+        }
+
+        return Response.json({
+          result: 'success',
+          arguments: {
+            'torrent-added': {
+              id: 42,
+              hashString: 'hash-42',
+              name: 'Queued Torrent',
+            },
+          },
+        });
+      },
+    },
+  });
+
+  servers.push(server);
+  return {
+    url: server.url.origin,
+    get requestCount() {
+      return state.requestCount;
+    },
+  };
+}
+
+const tvFeedFixture = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>TV Feed</title>
+    <item>
+      <title>Other Show S01E01 1080p WEB x265</title>
+      <link>https://download.example.test/tv/other-show</link>
+      <guid isPermaLink="false">tv-other-show</guid>
+      <pubDate>Sun, 30 Mar 2026 08:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+const movieFeedFixture = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Movie Feed</title>
+    <item>
+      <title>Example Movie 2024 1080p WEB x265 GROUP</title>
+      <link>https://download.example.test/movie/example-movie-1080.torrent</link>
+      <guid isPermaLink="false">movie-example-1080</guid>
+      <pubDate>Sun, 30 Mar 2026 08:05:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Example Movie 2024 2160p WEB x265 GROUP</title>
+      <link>https://download.example.test/movie/example-movie-2160.torrent</link>
+      <guid isPermaLink="false">movie-example-2160</guid>
+      <pubDate>Sun, 30 Mar 2026 08:10:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Retry Me 2024 1080p WEB x265 GROUP</title>
+      <link>https://download.example.test/movie/retry-me-1080.torrent</link>
+      <guid isPermaLink="false">movie-retry-1080</guid>
+      <pubDate>Sun, 30 Mar 2026 08:15:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -1,0 +1,103 @@
+import type { Database } from 'bun:sqlite';
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtemp as createTempDir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { AppConfig } from '../src/config';
+import { FeedError } from '../src/feed';
+import { runPipeline } from '../src/pipeline';
+import {
+  createRepository,
+  ensureSchema,
+  openDatabase,
+} from '../src/repository';
+
+const tempDirs: string[] = [];
+const openDatabases: Database[] = [];
+
+describe('runPipeline', () => {
+  afterEach(async () => {
+    while (openDatabases.length > 0) {
+      openDatabases.pop()?.close();
+    }
+
+    while (tempDirs.length > 0) {
+      const directory = tempDirs.pop();
+
+      if (directory) {
+        await Bun.$`rm -rf ${directory}`;
+      }
+    }
+  });
+
+  it('marks a run as failed when feed fetching throws', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+
+    await expect(
+      runPipeline({
+        config: createConfig(),
+        repository,
+        downloader: {
+          submit: async () => ({
+            ok: true as const,
+            status: 'queued' as const,
+          }),
+        },
+        fetchFeed: async () => {
+          throw new FeedError('boom');
+        },
+      }),
+    ).rejects.toThrow(new FeedError('boom'));
+
+    expect(repository.getRun(1)).toMatchObject({
+      id: 1,
+      status: 'failed',
+      completedAt: expect.any(String),
+    });
+  });
+});
+
+function createTestRepository(path: string) {
+  const database = openDatabase(path);
+
+  openDatabases.push(database);
+  ensureSchema(database);
+  return createRepository(database);
+}
+
+async function createDatabasePath(): Promise<string> {
+  const directory = await createTempDir(join(tmpdir(), 'media-sync-pipeline-'));
+
+  tempDirs.push(directory);
+  return join(directory, 'media-sync.db');
+}
+
+function createConfig(): AppConfig {
+  return {
+    feeds: [
+      {
+        name: 'TV Feed',
+        url: 'https://example.test/tv.rss',
+        mediaType: 'tv',
+      },
+    ],
+    tv: [
+      {
+        name: 'Example Show',
+        resolutions: ['1080p'],
+        codecs: ['x265'],
+      },
+    ],
+    movies: {
+      years: [2024],
+      resolutions: ['1080p'],
+      codecs: ['x265'],
+    },
+    transmission: {
+      url: 'http://localhost:9091/transmission/rpc',
+      username: 'user',
+      password: 'pass',
+    },
+  };
+}

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -145,6 +145,27 @@ describe('SQLite repository', () => {
     });
     expect(repository.isCandidateQueued(retryMatch.identityKey)).toBe(true);
   });
+
+  it('distinguishes failed runs from completed runs', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+    const startedRun = repository.startRun('2026-03-30T04:00:00.000Z');
+
+    expect(startedRun).toMatchObject({
+      status: 'running',
+      completedAt: undefined,
+    });
+
+    const failedRun = repository.failRun(
+      startedRun.id,
+      '2026-03-30T04:05:00.000Z',
+    );
+
+    expect(failedRun).toMatchObject({
+      id: startedRun.id,
+      status: 'failed',
+      completedAt: '2026-03-30T04:05:00.000Z',
+    });
+  });
 });
 
 function createTestRepository(path: string) {


### PR DESCRIPTION
## Summary

Implement the first real `media-sync run` pipeline so the CLI fetches feeds, matches candidates, submits winners to Transmission, persists per-feed-item outcomes, and prints a compact run summary.

## What Changed

- add pipeline orchestration for config loading, feed fetch, normalization, matching, identity grouping, dedupe, Transmission submission, and run completion
- extend SQLite persistence with `feed_item_outcomes` so `queued`, `failed`, `skipped_duplicate`, and `skipped_no_match` are stored per feed item
- update the CLI to execute the pipeline and render stable summary counts instead of only confirming config load
- replace the old config-only CLI happy path with a two-run integration test using fake RSS and Transmission servers to prove queueing, duplicate skipping, unmatched items, and retryable failures
- add the `P1.08` rationale doc and update the README status to mark tickets `01-08` as implemented

## Rationale

This is the smallest slice that makes `run` real while still deferring richer status views and retry orchestration to tickets `09` and `10`.