### PR TITLE
feat: add media-sync status command [P1.09]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,6 @@
 # Repo Rules
 
 - `pr`: if a delivery ticket is clear from branch/docs/diff, use `type: summary [P1.01]`. Otherwise omit the suffix.
-- Squash merge titles: same rule and format as PR titles.
 
 ## Ticket Completion Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,11 @@
 
 - `pr`: if a delivery ticket is clear from branch/docs/diff, use `type: summary [P1.01]`. Otherwise omit the suffix.
 - Squash merge titles: same rule and format as PR titles.
+
+## Ticket Completion Checklist
+
+Before calling a delivery ticket complete:
+
+- update or add the ticket rationale note when the ticket introduces or changes behavior
+- update `README.md` when user-visible behavior, command surface, or project status changed
+- verify the relevant tests or checks for the completed work

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Phase 01 ends at successful queueing in Transmission. It does not include a web 
 
 ## Status
 
-Tickets 01-08 are implemented:
+Tickets 01-09 are implemented:
 
 - minimal Bun + TypeScript CLI skeleton with JSON config loading and validation for `media-sync run`
 - RSS fetch-and-parse entrypoint that converts RSS items into a raw feed-item shape
@@ -25,6 +25,7 @@ Tickets 01-08 are implemented:
 - SQLite-backed run history and candidate-state persistence that preserves dedupe and retryability
 - Transmission RPC adapter that negotiates session ids, submits torrent URLs, and returns structured queueing failures without wiring the full run pipeline yet
 - end-to-end `media-sync run` orchestration that fetches feeds, matches candidates, persists per-feed-item outcomes, submits winners, and prints a compact run summary
+- read-only `media-sync status` inspection that reports recent runs and current candidate state from SQLite without creating or migrating the database
 
 The project is being planned as a small-slice, review-friendly build:
 
@@ -55,6 +56,7 @@ Useful supporting docs:
 - `bun test`
 - `bun run ci`
 - `./bin/media-sync run --config ./test/fixtures/valid-config.json`
+- `./bin/media-sync status`
 
 ## Proposed CLI Surface
 

--- a/cspell.json
+++ b/cspell.json
@@ -3,7 +3,14 @@
   "ignorePaths": [],
   "dictionaryDefinitions": [],
   "dictionaries": [],
-  "words": ["eztv", "mktemp", "parsererror", "reparsing"],
+  "words": [
+    "AUTOINCREMENT",
+    "bluray",
+    "eztv",
+    "mktemp",
+    "parsererror",
+    "reparsing"
+  ],
   "ignoreWords": [],
   "import": []
 }

--- a/docs/02-delivery/phase-01/ticket-09-rationale.md
+++ b/docs/02-delivery/phase-01/ticket-09-rationale.md
@@ -1,0 +1,6 @@
+# P1.09 Rationale
+
+- `Red first:` a CLI-level test proving `media-sync status` shows recent runs and candidate states from SQLite, plus a follow-up test proving it fails cleanly without creating a database when none has been initialized.
+- `Why this path:` adding a read-only SQLite open path plus a schema-presence check was the smallest acceptable way to keep `status` truly inspect-only while reusing the existing repository queries and compact formatter.
+- `Alternative considered:` calling `ensureSchema()` from `status` or auto-creating an empty database was rejected because ticket 09 explicitly targets read-only operator inspection, and silent database creation would make misleading output look valid.
+- `Deferred:` richer troubleshooting output, dedicated status-only summary row types, and retry orchestration remain for later tickets if operator needs justify them.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,36 +1,61 @@
 import { ConfigError, loadConfig, resolveConfigPath } from './config';
 import { runPipeline } from './pipeline';
-import { createRepository, ensureSchema, openDatabase } from './repository';
+import {
+  createRepository,
+  ensureSchema,
+  openDatabase,
+  type CandidateStateRecord,
+  type RunSummaryRecord,
+} from './repository';
 import { createTransmissionDownloader } from './transmission';
 
 export async function runCli(argv: string[]): Promise<number> {
   const [command, ...rest] = argv;
 
-  if (command !== 'run') {
-    console.error('Unknown command. Available commands: "run".');
-    return 1;
-  }
-
   try {
-    const configPath = parseConfigPath(rest);
-    const resolvedConfigPath = resolveConfigPath(configPath);
-    const config = await loadConfig(resolvedConfigPath);
-    const database = openDatabase();
+    if (command === 'run') {
+      const configPath = parseConfigPath(rest);
+      const resolvedConfigPath = resolveConfigPath(configPath);
+      const config = await loadConfig(resolvedConfigPath);
+      const database = openDatabase();
 
-    try {
-      ensureSchema(database);
-      const result = await runPipeline({
-        config,
-        repository: createRepository(database),
-        downloader: createTransmissionDownloader(config.transmission),
-      });
+      try {
+        ensureSchema(database);
+        const result = await runPipeline({
+          config,
+          repository: createRepository(database),
+          downloader: createTransmissionDownloader(config.transmission),
+        });
 
-      console.log(formatRunSummary(result));
-    } finally {
-      database.close();
+        console.log(formatRunSummary(result));
+      } finally {
+        database.close();
+      }
+
+      return 0;
     }
 
-    return 0;
+    if (command === 'status') {
+      const database = openDatabase();
+
+      try {
+        ensureSchema(database);
+        const repository = createRepository(database);
+        console.log(
+          formatStatusReport({
+            runs: repository.listRecentRunSummaries(),
+            candidates: repository.listCandidateStates(),
+          }),
+        );
+      } finally {
+        database.close();
+      }
+
+      return 0;
+    }
+
+    console.error('Unknown command. Available commands: "run", "status".');
+    return 1;
   } catch (error) {
     const message =
       error instanceof ConfigError
@@ -57,6 +82,60 @@ function formatRunSummary(result: {
     `skipped_duplicate: ${result.counts.skipped_duplicate}`,
     `skipped_no_match: ${result.counts.skipped_no_match}`,
   ].join('\n');
+}
+
+function formatStatusReport(input: {
+  runs: RunSummaryRecord[];
+  candidates: CandidateStateRecord[];
+}): string {
+  return [
+    'Recent runs',
+    ...formatRecentRuns(input.runs),
+    '',
+    'Candidate states',
+    ...formatCandidateStates(input.candidates),
+  ].join('\n');
+}
+
+function formatRecentRuns(runs: RunSummaryRecord[]): string[] {
+  if (runs.length === 0) {
+    return ['No runs recorded.'];
+  }
+
+  return runs.map(
+    (run) =>
+      `Run ${run.id} | status=${run.status} | started=${run.startedAt} | completed=${run.completedAt ?? '-'} | queued=${run.counts.queued} failed=${run.counts.failed} skipped_duplicate=${run.counts.skipped_duplicate} skipped_no_match=${run.counts.skipped_no_match}`,
+  );
+}
+
+function formatCandidateStates(candidates: CandidateStateRecord[]): string[] {
+  if (candidates.length === 0) {
+    return ['No candidate states recorded.'];
+  }
+
+  return candidates.map((candidate) =>
+    [
+      `${candidate.identityKey} | status=${candidate.status} | rule=${candidate.ruleName} | title=${candidate.normalizedTitle}`,
+      formatCandidateMetadata(candidate),
+      `updated=${candidate.updatedAt} | queued=${candidate.queuedAt ?? '-'}`,
+    ].join('\n'),
+  );
+}
+
+function formatCandidateMetadata(candidate: CandidateStateRecord): string {
+  const details = [
+    `media=${candidate.mediaType}`,
+    candidate.season !== undefined ? `season=${candidate.season}` : undefined,
+    candidate.episode !== undefined
+      ? `episode=${candidate.episode}`
+      : undefined,
+    candidate.year !== undefined ? `year=${candidate.year}` : undefined,
+    candidate.resolution ? `resolution=${candidate.resolution}` : undefined,
+    candidate.codec ? `codec=${candidate.codec}` : undefined,
+    `feed=${candidate.feedName}`,
+  ].filter((value): value is string => value !== undefined);
+
+  return details.join(' | ');
 }
 
 function formatUnexpectedError(error: unknown): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,14 @@
+import { existsSync } from 'node:fs';
+
 import { ConfigError, loadConfig, resolveConfigPath } from './config';
 import { runPipeline } from './pipeline';
 import {
   createRepository,
   ensureSchema,
+  hasStatusSchema,
   openDatabase,
+  openDatabaseReadOnly,
+  DEFAULT_DATABASE_PATH,
   type CandidateStateRecord,
   type RunSummaryRecord,
 } from './repository';
@@ -36,10 +41,9 @@ export async function runCli(argv: string[]): Promise<number> {
     }
 
     if (command === 'status') {
-      const database = openDatabase();
+      const database = openStatusDatabase();
 
       try {
-        ensureSchema(database);
         const repository = createRepository(database);
         console.log(
           formatStatusReport({
@@ -64,6 +68,21 @@ export async function runCli(argv: string[]): Promise<number> {
     console.error(message);
     return 1;
   }
+}
+
+function openStatusDatabase() {
+  if (!existsSync(DEFAULT_DATABASE_PATH)) {
+    throw new Error(`Database not initialized. Run 'media-sync run' first.`);
+  }
+
+  const database = openDatabaseReadOnly();
+
+  if (!hasStatusSchema(database)) {
+    database.close();
+    throw new Error(`Database not initialized. Run 'media-sync run' first.`);
+  }
+
+  return database;
 }
 
 function formatRunSummary(result: {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -116,6 +116,10 @@ export function openDatabase(path = DEFAULT_DATABASE_PATH): Database {
   return new Database(path, { create: true, strict: true });
 }
 
+export function openDatabaseReadOnly(path = DEFAULT_DATABASE_PATH): Database {
+  return new Database(path, { readonly: true, strict: true });
+}
+
 export function ensureSchema(database: Database): void {
   database.run(`
     PRAGMA foreign_keys = ON;
@@ -184,6 +188,28 @@ export function ensureSchema(database: Database): void {
       `ALTER TABLE runs ADD COLUMN status TEXT NOT NULL DEFAULT 'running'`,
     );
   }
+}
+
+export function hasStatusSchema(database: Database): boolean {
+  const requiredTables = ['runs', 'candidate_state', 'feed_item_outcomes'];
+
+  for (const tableName of requiredTables) {
+    const hasTable =
+      (database
+        .query(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1`)
+        .get(tableName) as { 1: number } | null | undefined) !== null;
+
+    if (!hasTable) {
+      return false;
+    }
+  }
+
+  const hasRunStatusColumn =
+    (database
+      .query(`SELECT 1 FROM pragma_table_info('runs') WHERE name = 'status'`)
+      .get() as { 1: number } | null | undefined) !== null;
+
+  return hasRunStatusColumn;
 }
 
 export function createRepository(database: Database): Repository {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -27,6 +27,10 @@ export type RunRecord = {
   completedAt?: string;
 };
 
+export type RunSummaryRecord = RunRecord & {
+  counts: Record<FeedItemOutcomeStatus, number>;
+};
+
 export type FeedItemRecord = RawFeedItem & {
   id: number;
   runId: number;
@@ -102,6 +106,8 @@ export type Repository = {
     input: RecordFeedItemOutcomeInput,
   ): FeedItemOutcomeRecord;
   listFeedItemOutcomes(runId: number): FeedItemOutcomeRecord[];
+  listRecentRunSummaries(limit?: number): RunSummaryRecord[];
+  listCandidateStates(limit?: number): CandidateStateRecord[];
 };
 
 export const DEFAULT_DATABASE_PATH = 'media-sync.db';
@@ -342,6 +348,50 @@ export function createRepository(database: Database): Repository {
     WHERE run_id = ?1
     ORDER BY id ASC`,
   );
+  const listRecentRunSummariesStatement = database.query(
+    `SELECT
+      runs.id,
+      runs.started_at AS startedAt,
+      runs.status,
+      runs.completed_at AS completedAt,
+      COALESCE(SUM(CASE WHEN feed_item_outcomes.status = 'queued' THEN 1 ELSE 0 END), 0) AS queuedCount,
+      COALESCE(SUM(CASE WHEN feed_item_outcomes.status = 'failed' THEN 1 ELSE 0 END), 0) AS failedCount,
+      COALESCE(SUM(CASE WHEN feed_item_outcomes.status = 'skipped_duplicate' THEN 1 ELSE 0 END), 0) AS skippedDuplicateCount,
+      COALESCE(SUM(CASE WHEN feed_item_outcomes.status = 'skipped_no_match' THEN 1 ELSE 0 END), 0) AS skippedNoMatchCount
+    FROM runs
+    LEFT JOIN feed_item_outcomes ON feed_item_outcomes.run_id = runs.id
+    GROUP BY runs.id
+    ORDER BY runs.id DESC
+    LIMIT ?1`,
+  );
+  const listCandidateStatesStatement = database.query(
+    `SELECT
+      identity_key AS identityKey,
+      media_type AS mediaType,
+      status,
+      queued_at AS queuedAt,
+      rule_name AS ruleName,
+      score,
+      reasons_json AS reasonsJson,
+      raw_title AS rawTitle,
+      normalized_title AS normalizedTitle,
+      season,
+      episode,
+      year,
+      resolution,
+      codec,
+      feed_name AS feedName,
+      guid_or_link AS guidOrLink,
+      published_at AS publishedAt,
+      download_url AS downloadUrl,
+      first_seen_run_id AS firstSeenRunId,
+      last_seen_run_id AS lastSeenRunId,
+      last_feed_item_id AS lastFeedItemId,
+      updated_at AS updatedAt
+    FROM candidate_state
+    ORDER BY updated_at DESC, identity_key ASC
+    LIMIT ?1`,
+  );
 
   return {
     startRun(startedAt = new Date().toISOString()): RunRecord {
@@ -476,6 +526,18 @@ export function createRepository(database: Database): Repository {
         listFeedItemOutcomesStatement.all(runId) as FeedItemOutcomeRow[]
       ).map(mapFeedItemOutcomeRow);
     },
+
+    listRecentRunSummaries(limit = 5): RunSummaryRecord[] {
+      return (
+        listRecentRunSummariesStatement.all(limit) as RunSummaryRow[]
+      ).map(mapRunSummaryRow);
+    },
+
+    listCandidateStates(limit = 20): CandidateStateRecord[] {
+      return (
+        listCandidateStatesStatement.all(limit) as CandidateStateRow[]
+      ).map(mapCandidateStateRow);
+    },
   };
 }
 
@@ -510,6 +572,18 @@ function mapRunRow(row: {
     startedAt: row.startedAt,
     status: row.status,
     completedAt: row.completedAt ?? undefined,
+  };
+}
+
+function mapRunSummaryRow(row: RunSummaryRow): RunSummaryRecord {
+  return {
+    ...mapRunRow(row),
+    counts: {
+      queued: Number(row.queuedCount),
+      failed: Number(row.failedCount),
+      skipped_duplicate: Number(row.skippedDuplicateCount),
+      skipped_no_match: Number(row.skippedNoMatchCount),
+    },
   };
 }
 
@@ -580,6 +654,13 @@ type FeedItemRow = {
   rawTitle: string;
   publishedAt: string;
   downloadUrl: string;
+};
+
+type RunSummaryRow = RunRow & {
+  queuedCount: number;
+  failedCount: number;
+  skippedDuplicateCount: number;
+  skippedNoMatchCount: number;
 };
 
 type CandidateStateRow = {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -117,7 +117,7 @@ export function openDatabase(path = DEFAULT_DATABASE_PATH): Database {
 }
 
 export function ensureSchema(database: Database): void {
-  database.exec(`
+  database.run(`
     PRAGMA foreign_keys = ON;
 
     CREATE TABLE IF NOT EXISTS runs (
@@ -180,7 +180,7 @@ export function ensureSchema(database: Database): void {
       .get() as { 1: number } | null | undefined) !== null;
 
   if (!hasRunStatusColumn) {
-    database.exec(
+    database.run(
       `ALTER TABLE runs ADD COLUMN status TEXT NOT NULL DEFAULT 'running'`,
     );
   }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -229,6 +229,135 @@ describe('media-sync run', () => {
   });
 });
 
+describe('media-sync status', () => {
+  afterEach(async () => {
+    while (openDatabases.length > 0) {
+      openDatabases.pop()?.close();
+    }
+
+    while (servers.length > 0) {
+      servers.pop()?.stop(true);
+    }
+
+    while (tempDirs.length > 0) {
+      const directory = tempDirs.pop();
+
+      if (directory) {
+        await Bun.$`rm -rf ${directory}`;
+      }
+    }
+  });
+
+  it('prints recent run summaries and current candidate states without mutating the database', async () => {
+    const directory = await mkdtemp();
+    const repository = createTestRepository(join(directory, 'media-sync.db'));
+
+    const firstRun = repository.startRun('2026-03-30T00:00:00.000Z');
+    repository.recordFeedItemOutcome({
+      runId: firstRun.id,
+      status: 'queued',
+      createdAt: '2026-03-30T00:10:00.000Z',
+    });
+    repository.completeRun(firstRun.id, '2026-03-30T00:12:00.000Z');
+
+    const secondRun = repository.startRun('2026-03-30T01:00:00.000Z');
+    repository.recordFeedItemOutcome({
+      runId: secondRun.id,
+      status: 'failed',
+      createdAt: '2026-03-30T01:10:00.000Z',
+    });
+    repository.recordFeedItemOutcome({
+      runId: secondRun.id,
+      status: 'skipped_duplicate',
+      createdAt: '2026-03-30T01:11:00.000Z',
+    });
+    repository.completeRun(secondRun.id, '2026-03-30T01:12:00.000Z');
+
+    const queuedFeedItem = repository.recordFeedItem(firstRun.id, {
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/example-movie-web',
+      rawTitle: 'Example.Movie.2024.1080p.WEB.x265-GROUP',
+      publishedAt: '2026-03-30T00:05:00.000Z',
+      downloadUrl: 'https://example.test/downloads/example-movie-web.torrent',
+    });
+    repository.recordCandidateOutcome({
+      runId: firstRun.id,
+      feedItemId: queuedFeedItem.id,
+      feedItem: queuedFeedItem,
+      match: {
+        ruleName: 'movie-policy',
+        identityKey: 'movie:example movie|2024',
+        score: 10,
+        reasons: ['year matched'],
+        item: {
+          mediaType: 'movie',
+          rawTitle: queuedFeedItem.rawTitle,
+          normalizedTitle: 'example movie',
+          year: 2024,
+          resolution: '1080p',
+          codec: 'x265',
+        },
+      },
+      status: 'queued',
+      updatedAt: '2026-03-30T00:10:00.000Z',
+    });
+
+    const failedFeedItem = repository.recordFeedItem(secondRun.id, {
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/retry-me-web',
+      rawTitle: 'Retry.Me.2024.1080p.WEB.x265-GROUP',
+      publishedAt: '2026-03-30T01:05:00.000Z',
+      downloadUrl: 'https://example.test/downloads/retry-me-web.torrent',
+    });
+    repository.recordCandidateOutcome({
+      runId: secondRun.id,
+      feedItemId: failedFeedItem.id,
+      feedItem: failedFeedItem,
+      match: {
+        ruleName: 'movie-policy',
+        identityKey: 'movie:retry me|2024',
+        score: 10,
+        reasons: ['year matched'],
+        item: {
+          mediaType: 'movie',
+          rawTitle: failedFeedItem.rawTitle,
+          normalizedTitle: 'retry me',
+          year: 2024,
+          resolution: '1080p',
+          codec: 'x265',
+        },
+      },
+      status: 'failed',
+      updatedAt: '2026-03-30T01:10:00.000Z',
+    });
+
+    const runsBefore = repository.listRecentRunSummaries();
+    const candidatesBefore = repository.listCandidateStates();
+
+    const status = await runSimpleCommand(directory, 'status');
+
+    expect(status.exitCode).toBe(0);
+    expect(status.stderr).toBe('');
+    expect(status.stdout).toContain('Recent runs');
+    expect(status.stdout).toContain(
+      'Run 2 | status=completed | started=2026-03-30T01:00:00.000Z | completed=2026-03-30T01:12:00.000Z | queued=0 failed=1 skipped_duplicate=1 skipped_no_match=0',
+    );
+    expect(status.stdout).toContain(
+      'Run 1 | status=completed | started=2026-03-30T00:00:00.000Z | completed=2026-03-30T00:12:00.000Z | queued=1 failed=0 skipped_duplicate=0 skipped_no_match=0',
+    );
+    expect(status.stdout).toContain('Candidate states');
+    expect(status.stdout).toContain(
+      'movie:retry me|2024 | status=failed | rule=movie-policy | title=retry me',
+    );
+    expect(status.stdout).toContain(
+      'movie:example movie|2024 | status=queued | rule=movie-policy | title=example movie',
+    );
+
+    expect(repository.listRecentRunSummaries()).toEqual(runsBefore);
+    expect(repository.listCandidateStates()).toEqual(candidatesBefore);
+  });
+});
+
 async function mkdtemp(): Promise<string> {
   const directory = await createTempDir(join(tmpdir(), 'media-sync-test-'));
 
@@ -240,7 +369,14 @@ async function runCliCommand(
   commandCwd: string,
   configPath: string,
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  const child = Bun.spawn([cliExecutable, 'run', '--config', configPath], {
+  return runSimpleCommand(commandCwd, 'run', '--config', configPath);
+}
+
+async function runSimpleCommand(
+  commandCwd: string,
+  ...args: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const child = Bun.spawn([cliExecutable, ...args], {
     cwd: commandCwd,
     env,
     stderr: 'pipe',

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,5 +1,6 @@
 import type { Database } from 'bun:sqlite';
 import { afterEach, describe, expect, it } from 'bun:test';
+import { existsSync } from 'node:fs';
 import { mkdtemp as createTempDir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { delimiter, dirname, join } from 'node:path';
@@ -355,6 +356,22 @@ describe('media-sync status', () => {
 
     expect(repository.listRecentRunSummaries()).toEqual(runsBefore);
     expect(repository.listCandidateStates()).toEqual(candidatesBefore);
+  });
+
+  it('fails without creating a database when status is run before initialization', async () => {
+    const directory = await mkdtemp();
+    const databasePath = join(directory, 'media-sync.db');
+
+    expect(existsSync(databasePath)).toBe(false);
+
+    const status = await runSimpleCommand(directory, 'status');
+
+    expect(status.exitCode).toBe(1);
+    expect(status.stdout).toBe('');
+    expect(status.stderr).toContain(
+      `Database not initialized. Run 'media-sync run' first.`,
+    );
+    expect(existsSync(databasePath)).toBe(false);
   });
 });
 

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -166,6 +166,114 @@ describe('SQLite repository', () => {
       completedAt: '2026-03-30T04:05:00.000Z',
     });
   });
+
+  it('lists recent run summaries with aggregated outcome counts', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+    const firstRun = repository.startRun('2026-03-30T00:00:00.000Z');
+    repository.recordFeedItemOutcome({
+      runId: firstRun.id,
+      status: 'queued',
+      createdAt: '2026-03-30T00:10:00.000Z',
+    });
+    repository.recordFeedItemOutcome({
+      runId: firstRun.id,
+      status: 'failed',
+      createdAt: '2026-03-30T00:11:00.000Z',
+    });
+    repository.completeRun(firstRun.id, '2026-03-30T00:12:00.000Z');
+
+    const secondRun = repository.startRun('2026-03-30T01:00:00.000Z');
+    repository.recordFeedItemOutcome({
+      runId: secondRun.id,
+      status: 'skipped_duplicate',
+      createdAt: '2026-03-30T01:10:00.000Z',
+    });
+    repository.recordFeedItemOutcome({
+      runId: secondRun.id,
+      status: 'skipped_no_match',
+      createdAt: '2026-03-30T01:11:00.000Z',
+    });
+    repository.completeRun(secondRun.id, '2026-03-30T01:12:00.000Z');
+
+    expect(repository.listRecentRunSummaries()).toEqual([
+      {
+        id: secondRun.id,
+        startedAt: '2026-03-30T01:00:00.000Z',
+        status: 'completed',
+        completedAt: '2026-03-30T01:12:00.000Z',
+        counts: {
+          queued: 0,
+          failed: 0,
+          skipped_duplicate: 1,
+          skipped_no_match: 1,
+        },
+      },
+      {
+        id: firstRun.id,
+        startedAt: '2026-03-30T00:00:00.000Z',
+        status: 'completed',
+        completedAt: '2026-03-30T00:12:00.000Z',
+        counts: {
+          queued: 1,
+          failed: 1,
+          skipped_duplicate: 0,
+          skipped_no_match: 0,
+        },
+      },
+    ]);
+  });
+
+  it('lists candidate states newest first', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+    const firstRun = repository.startRun('2026-03-30T02:00:00.000Z');
+    const firstFeedItem = repository.recordFeedItem(firstRun.id, {
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/example-movie-web',
+      rawTitle: 'Example.Movie.2024.1080p.WEB.x265-GROUP',
+      publishedAt: '2026-03-30T02:05:00.000Z',
+      downloadUrl: 'https://example.test/downloads/example-movie-web.torrent',
+    });
+    const firstMatch = requireMovieMatch(firstFeedItem.rawTitle);
+    repository.recordCandidateOutcome({
+      runId: firstRun.id,
+      feedItemId: firstFeedItem.id,
+      feedItem: firstFeedItem,
+      match: firstMatch,
+      status: 'queued',
+      updatedAt: '2026-03-30T02:10:00.000Z',
+    });
+
+    const secondRun = repository.startRun('2026-03-30T03:00:00.000Z');
+    const secondFeedItem = repository.recordFeedItem(secondRun.id, {
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/retry-me-web',
+      rawTitle: 'Retry.Me.2024.1080p.WEB.x265-GROUP',
+      publishedAt: '2026-03-30T03:05:00.000Z',
+      downloadUrl: 'https://example.test/downloads/retry-me-web.torrent',
+    });
+    const secondMatch = requireMovieMatch(secondFeedItem.rawTitle);
+    repository.recordCandidateOutcome({
+      runId: secondRun.id,
+      feedItemId: secondFeedItem.id,
+      feedItem: secondFeedItem,
+      match: secondMatch,
+      status: 'failed',
+      updatedAt: '2026-03-30T03:10:00.000Z',
+    });
+
+    expect(repository.listCandidateStates()).toMatchObject([
+      {
+        identityKey: 'movie:retry me|2024',
+        status: 'failed',
+        updatedAt: '2026-03-30T03:10:00.000Z',
+      },
+      {
+        identityKey: 'movie:example movie|2024',
+        status: 'queued',
+        updatedAt: '2026-03-30T02:10:00.000Z',
+      },
+    ]);
+  });
 });
 
 function createTestRepository(path: string) {


### PR DESCRIPTION
## Summary

Adds a read-only `media-sync status` command backed by SQLite so operators can quickly inspect recent runs and current candidate state without loading config.

## Changes

- add `status` command handling to the CLI alongside `run`
- add repository queries for recent run summaries and current candidate states
- render compact status output with newest runs first and current candidate metadata
- add repository and CLI integration coverage for aggregation, ordering, and no-mutation behavior
- replace deprecated SQLite `exec` calls with `run`
- extend `cspell.json` for new SQLite/media terms used in this ticket