### PR TITLE
feat: add retry-failed command [P1.10]

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -eu
+
+bun run verify

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ Useful supporting docs:
 
 ## Local Development
 
+- `bun run hooks:install` once per clone to make `git push` run `bun run verify` locally
 - `bun test`
+- `bun run verify`
 - `bun run ci`
 - `./bin/media-sync run --config ./test/fixtures/valid-config.json`
 - `./bin/media-sync status`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Phase 01 ends at successful queueing in Transmission. It does not include a web 
 
 ## Status
 
-Tickets 01-09 are implemented:
+Tickets 01-10 are implemented:
 
 - minimal Bun + TypeScript CLI skeleton with JSON config loading and validation for `media-sync run`
 - RSS fetch-and-parse entrypoint that converts RSS items into a raw feed-item shape
@@ -26,6 +26,7 @@ Tickets 01-09 are implemented:
 - Transmission RPC adapter that negotiates session ids, submits torrent URLs, and returns structured queueing failures without wiring the full run pipeline yet
 - end-to-end `media-sync run` orchestration that fetches feeds, matches candidates, persists per-feed-item outcomes, submits winners, and prints a compact run summary
 - read-only `media-sync status` inspection that reports recent runs and current candidate state from SQLite without creating or migrating the database
+- `media-sync retry-failed` orchestration that re-submits only failed candidate-state rows from SQLite using stored torrent URLs and records a new run summary
 
 The project is being planned as a small-slice, review-friendly build:
 
@@ -57,6 +58,7 @@ Useful supporting docs:
 - `bun run ci`
 - `./bin/media-sync run --config ./test/fixtures/valid-config.json`
 - `./bin/media-sync status`
+- `./bin/media-sync retry-failed --config ./test/fixtures/valid-config.json`
 
 ## Proposed CLI Surface
 

--- a/docs/02-delivery/phase-01/ticket-10-rationale.md
+++ b/docs/02-delivery/phase-01/ticket-10-rationale.md
@@ -1,0 +1,6 @@
+# P1.10 Retry-Failed Command Rationale
+
+- `Red first:` CLI tests proved `media-sync retry-failed` must resubmit only failed candidate-state rows, leave queued rows untouched, and fail cleanly before the database exists.
+- `Why this path:` reusing the existing submission persistence path kept `run` and `retry-failed` aligned on how queued and failed outcomes are recorded while adding only one repository read query for retryable candidates.
+- `Alternative considered:` rebuilding retry work from historical `feed_items` and rematching was rejected because ticket 10 explicitly targets retrying stored candidates, not re-running feed ingestion logic.
+- `Deferred:` richer submission-attempt history, retry limits or backoff, and operator filters for retry subsets remain outside phase 01.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "ci": "bun run verify && bun run test",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "hooks:install": "git config core.hooksPath .githooks",
     "lint": "eslint .",
     "run": "bun run ./src/cli.ts",
     "test": "bun test",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 
 import { ConfigError, loadConfig, resolveConfigPath } from './config';
-import { runPipeline } from './pipeline';
+import { retryFailedCandidates, runPipeline } from './pipeline';
 import {
   createRepository,
   ensureSchema,
@@ -40,6 +40,26 @@ export async function runCli(argv: string[]): Promise<number> {
       return 0;
     }
 
+    if (command === 'retry-failed') {
+      const configPath = parseConfigPath(rest);
+      const resolvedConfigPath = resolveConfigPath(configPath);
+      const config = await loadConfig(resolvedConfigPath);
+      const database = openInitializedWritableDatabase();
+
+      try {
+        const result = await retryFailedCandidates({
+          repository: createRepository(database),
+          downloader: createTransmissionDownloader(config.transmission),
+        });
+
+        console.log(formatRunSummary(result));
+      } finally {
+        database.close();
+      }
+
+      return 0;
+    }
+
     if (command === 'status') {
       const database = openStatusDatabase();
 
@@ -58,7 +78,9 @@ export async function runCli(argv: string[]): Promise<number> {
       return 0;
     }
 
-    console.error('Unknown command. Available commands: "run", "status".');
+    console.error(
+      'Unknown command. Available commands: "run", "status", "retry-failed".',
+    );
     return 1;
   } catch (error) {
     const message =
@@ -68,6 +90,21 @@ export async function runCli(argv: string[]): Promise<number> {
     console.error(message);
     return 1;
   }
+}
+
+function openInitializedWritableDatabase() {
+  if (!existsSync(DEFAULT_DATABASE_PATH)) {
+    throw new Error(`Database not initialized. Run 'media-sync run' first.`);
+  }
+
+  const database = openDatabase();
+
+  if (!hasStatusSchema(database)) {
+    database.close();
+    throw new Error(`Database not initialized. Run 'media-sync run' first.`);
+  }
+
+  return database;
 }
 
 function openStatusDatabase() {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -102,6 +102,7 @@ export async function retryFailedCandidates(input: {
     for (const candidate of retryableCandidates) {
       await submitCandidate(input.repository, input.downloader, {
         runId: run.id,
+        feedItemId: candidate.lastFeedItemId,
         feedItem: createRawFeedItem(candidate),
         match: createCandidateMatchRecord(candidate),
       });

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -3,6 +3,7 @@ import { fetchFeed, type RawFeedItem } from './feed';
 import { matchMovieItem } from './movie-match';
 import { normalizeFeedItem } from './normalize';
 import type {
+  CandidateStateRecord,
   CandidateMatchRecord,
   FeedItemOutcomeRecord,
   FeedItemOutcomeStatus,
@@ -74,43 +75,35 @@ export async function runPipeline(input: {
         continue;
       }
 
-      const submission = await input.downloader.submit({
-        downloadUrl: winner.feedItem.downloadUrl,
-      });
-
-      if (submission.ok) {
-        input.repository.recordCandidateOutcome({
-          runId: run.id,
-          feedItemId: winner.feedItem.id,
-          feedItem: winner.feedItem,
-          match: winner.match,
-          status: 'queued',
-        });
-        input.repository.recordFeedItemOutcome({
-          runId: run.id,
-          feedItemId: winner.feedItem.id,
-          status: 'queued',
-          identityKey: winner.match.identityKey,
-          ruleName: winner.match.ruleName,
-          message: 'Queued in Transmission.',
-        });
-        continue;
-      }
-
-      input.repository.recordCandidateOutcome({
+      await submitCandidate(input.repository, input.downloader, {
         runId: run.id,
         feedItemId: winner.feedItem.id,
         feedItem: winner.feedItem,
         match: winner.match,
-        status: 'failed',
       });
-      input.repository.recordFeedItemOutcome({
+    }
+
+    return finalizeRun(input.repository, run);
+  } catch (error) {
+    input.repository.failRun(run.id);
+    throw error;
+  }
+}
+
+export async function retryFailedCandidates(input: {
+  repository: Repository;
+  downloader: Downloader;
+}): Promise<RunPipelineResult> {
+  const run = input.repository.startRun();
+
+  try {
+    const retryableCandidates = input.repository.listRetryableCandidates();
+
+    for (const candidate of retryableCandidates) {
+      await submitCandidate(input.repository, input.downloader, {
         runId: run.id,
-        feedItemId: winner.feedItem.id,
-        status: 'failed',
-        identityKey: winner.match.identityKey,
-        ruleName: winner.match.ruleName,
-        message: submission.message,
+        feedItem: createRawFeedItem(candidate),
+        match: createCandidateMatchRecord(candidate),
       });
     }
 
@@ -192,6 +185,56 @@ function recordDuplicateOutcome(
   });
 }
 
+export async function submitCandidate(
+  repository: Repository,
+  downloader: Downloader,
+  input: {
+    runId: number;
+    feedItemId?: number;
+    feedItem: RawFeedItem;
+    match: CandidateMatchRecord;
+  },
+): Promise<void> {
+  const submission = await downloader.submit({
+    downloadUrl: input.feedItem.downloadUrl,
+  });
+
+  if (submission.ok) {
+    repository.recordCandidateOutcome({
+      runId: input.runId,
+      feedItemId: input.feedItemId,
+      feedItem: input.feedItem,
+      match: input.match,
+      status: 'queued',
+    });
+    repository.recordFeedItemOutcome({
+      runId: input.runId,
+      feedItemId: input.feedItemId,
+      status: 'queued',
+      identityKey: input.match.identityKey,
+      ruleName: input.match.ruleName,
+      message: 'Queued in Transmission.',
+    });
+    return;
+  }
+
+  repository.recordCandidateOutcome({
+    runId: input.runId,
+    feedItemId: input.feedItemId,
+    feedItem: input.feedItem,
+    match: input.match,
+    status: 'failed',
+  });
+  repository.recordFeedItemOutcome({
+    runId: input.runId,
+    feedItemId: input.feedItemId,
+    status: 'failed',
+    identityKey: input.match.identityKey,
+    ruleName: input.match.ruleName,
+    message: submission.message,
+  });
+}
+
 function finalizeRun(
   repository: Repository,
   run: RunRecord,
@@ -219,6 +262,37 @@ function createEmptyCounts(): Record<FeedItemOutcomeStatus, number> {
     failed: 0,
     skipped_duplicate: 0,
     skipped_no_match: 0,
+  };
+}
+
+function createRawFeedItem(candidate: CandidateStateRecord): RawFeedItem {
+  return {
+    feedName: candidate.feedName,
+    guidOrLink: candidate.guidOrLink,
+    rawTitle: candidate.rawTitle,
+    publishedAt: candidate.publishedAt,
+    downloadUrl: candidate.downloadUrl,
+  };
+}
+
+function createCandidateMatchRecord(
+  candidate: CandidateStateRecord,
+): CandidateMatchRecord {
+  return {
+    ruleName: candidate.ruleName,
+    identityKey: candidate.identityKey,
+    score: candidate.score,
+    reasons: candidate.reasons,
+    item: {
+      mediaType: candidate.mediaType,
+      rawTitle: candidate.rawTitle,
+      normalizedTitle: candidate.normalizedTitle,
+      season: candidate.season,
+      episode: candidate.episode,
+      year: candidate.year,
+      resolution: candidate.resolution,
+      codec: candidate.codec,
+    },
   };
 }
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -108,6 +108,7 @@ export type Repository = {
   listFeedItemOutcomes(runId: number): FeedItemOutcomeRecord[];
   listRecentRunSummaries(limit?: number): RunSummaryRecord[];
   listCandidateStates(limit?: number): CandidateStateRecord[];
+  listRetryableCandidates(limit?: number): CandidateStateRecord[];
 };
 
 export const DEFAULT_DATABASE_PATH = 'media-sync.db';
@@ -418,6 +419,36 @@ export function createRepository(database: Database): Repository {
     ORDER BY updated_at DESC, identity_key ASC
     LIMIT ?1`,
   );
+  const listRetryableCandidatesStatement = database.query(
+    `SELECT
+      identity_key AS identityKey,
+      media_type AS mediaType,
+      status,
+      queued_at AS queuedAt,
+      rule_name AS ruleName,
+      score,
+      reasons_json AS reasonsJson,
+      raw_title AS rawTitle,
+      normalized_title AS normalizedTitle,
+      season,
+      episode,
+      year,
+      resolution,
+      codec,
+      feed_name AS feedName,
+      guid_or_link AS guidOrLink,
+      published_at AS publishedAt,
+      download_url AS downloadUrl,
+      first_seen_run_id AS firstSeenRunId,
+      last_seen_run_id AS lastSeenRunId,
+      last_feed_item_id AS lastFeedItemId,
+      updated_at AS updatedAt
+    FROM candidate_state
+    WHERE status = 'failed'
+      AND download_url <> ''
+    ORDER BY updated_at ASC, identity_key ASC
+    LIMIT ?1`,
+  );
 
   return {
     startRun(startedAt = new Date().toISOString()): RunRecord {
@@ -562,6 +593,12 @@ export function createRepository(database: Database): Repository {
     listCandidateStates(limit = 20): CandidateStateRecord[] {
       return (
         listCandidateStatesStatement.all(limit) as CandidateStateRow[]
+      ).map(mapCandidateStateRow);
+    },
+
+    listRetryableCandidates(limit = 1000): CandidateStateRecord[] {
+      return (
+        listRetryableCandidatesStatement.all(limit) as CandidateStateRow[]
       ).map(mapCandidateStateRow);
     },
   };

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -334,7 +334,10 @@ export function createRepository(database: Database): Repository {
       published_at = excluded.published_at,
       download_url = excluded.download_url,
       last_seen_run_id = excluded.last_seen_run_id,
-      last_feed_item_id = excluded.last_feed_item_id,
+      last_feed_item_id = COALESCE(
+        excluded.last_feed_item_id,
+        candidate_state.last_feed_item_id
+      ),
       updated_at = excluded.updated_at`,
   );
   const insertFeedItemOutcome = database.query(

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -436,6 +436,8 @@ describe('media-sync retry-failed', () => {
       status: 'failed',
     });
 
+    const retryMeBefore = repository.getCandidateState('movie:retry me|2024');
+
     const retry = await runSimpleCommand(
       directory,
       'retry-failed',
@@ -461,6 +463,7 @@ describe('media-sync retry-failed', () => {
     expect(repository.getCandidateState('movie:retry me|2024')).toMatchObject({
       status: 'queued',
       queuedAt: expect.any(String),
+      lastFeedItemId: retryMeBefore?.lastFeedItemId,
     });
     expect(
       repository.getCandidateState('movie:example movie|2024'),

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -375,6 +375,203 @@ describe('media-sync status', () => {
   });
 });
 
+describe('media-sync retry-failed', () => {
+  afterEach(async () => {
+    while (openDatabases.length > 0) {
+      openDatabases.pop()?.close();
+    }
+
+    while (servers.length > 0) {
+      servers.pop()?.stop(true);
+    }
+
+    while (tempDirs.length > 0) {
+      const directory = tempDirs.pop();
+
+      if (directory) {
+        await Bun.$`rm -rf ${directory}`;
+      }
+    }
+  });
+
+  it('retries only failed candidates from SQLite and updates successful retries to queued', async () => {
+    const directory = await mkdtemp();
+    const transmissionServer = startFlakyRetryTransmissionServer();
+    const configPath = join(directory, 'media-sync.config.json');
+    const repository = createTestRepository(join(directory, 'media-sync.db'));
+
+    await Bun.write(
+      configPath,
+      JSON.stringify({
+        feeds: [],
+        tv: [],
+        movies: {
+          years: [2024],
+          resolutions: ['2160p', '1080p'],
+          codecs: ['x265'],
+        },
+        transmission: {
+          url: `${transmissionServer.url}/transmission/rpc`,
+          username: 'user',
+          password: 'pass',
+        },
+      }),
+    );
+
+    seedQueuedMovieCandidate(repository, {
+      runId: repository.startRun('2026-03-30T00:00:00.000Z').id,
+      rawTitle: 'Example.Movie.2024.1080p.WEB.x265-GROUP',
+      guidOrLink: 'https://example.test/releases/example-movie-web',
+      downloadUrl: 'https://example.test/downloads/example-movie-web.torrent',
+      updatedAt: '2026-03-30T00:10:00.000Z',
+      status: 'queued',
+    });
+
+    seedQueuedMovieCandidate(repository, {
+      runId: repository.startRun('2026-03-30T01:00:00.000Z').id,
+      rawTitle: 'Retry.Me.2024.1080p.WEB.x265-GROUP',
+      guidOrLink: 'https://example.test/releases/retry-me-web',
+      downloadUrl: 'https://example.test/downloads/retry-me-web.torrent',
+      updatedAt: '2026-03-30T01:10:00.000Z',
+      status: 'failed',
+    });
+
+    const retry = await runSimpleCommand(
+      directory,
+      'retry-failed',
+      '--config',
+      './media-sync.config.json',
+    );
+
+    expect(retry.exitCode).toBe(0);
+    expect(retry.stderr).toBe('');
+    expect(retry.stdout).toContain('Run 3 completed.');
+    expect(retry.stdout).toContain('queued: 1');
+    expect(retry.stdout).toContain('failed: 0');
+    expect(retry.stdout).toContain('skipped_duplicate: 0');
+    expect(retry.stdout).toContain('skipped_no_match: 0');
+    expect(repository.listFeedItemOutcomes(3)).toMatchObject([
+      {
+        status: 'queued',
+        identityKey: 'movie:retry me|2024',
+        ruleName: 'movie-policy',
+        message: 'Queued in Transmission.',
+      },
+    ]);
+    expect(repository.getCandidateState('movie:retry me|2024')).toMatchObject({
+      status: 'queued',
+      queuedAt: expect.any(String),
+    });
+    expect(
+      repository.getCandidateState('movie:example movie|2024'),
+    ).toMatchObject({
+      status: 'queued',
+    });
+    expect(transmissionServer.requestedUrls).toEqual([
+      'https://example.test/downloads/retry-me-web.torrent',
+    ]);
+  });
+
+  it('keeps failed candidates failed when the retry attempt still fails', async () => {
+    const directory = await mkdtemp();
+    const transmissionServer = startTransmissionServer();
+    const configPath = join(directory, 'media-sync.config.json');
+    const repository = createTestRepository(join(directory, 'media-sync.db'));
+
+    await Bun.write(
+      configPath,
+      JSON.stringify({
+        feeds: [],
+        tv: [],
+        movies: {
+          years: [2024],
+          resolutions: ['2160p', '1080p'],
+          codecs: ['x265'],
+        },
+        transmission: {
+          url: `${transmissionServer.url}/transmission/rpc`,
+          username: 'user',
+          password: 'pass',
+        },
+      }),
+    );
+
+    seedQueuedMovieCandidate(repository, {
+      runId: repository.startRun('2026-03-30T00:00:00.000Z').id,
+      rawTitle: 'Retry.Me.2024.1080p.WEB.x265-GROUP',
+      guidOrLink: 'https://example.test/releases/retry-me-web',
+      downloadUrl: 'https://example.test/downloads/retry-me-web.torrent',
+      updatedAt: '2026-03-30T00:10:00.000Z',
+      status: 'failed',
+    });
+
+    const retry = await runSimpleCommand(
+      directory,
+      'retry-failed',
+      '--config',
+      './media-sync.config.json',
+    );
+
+    expect(retry.exitCode).toBe(0);
+    expect(retry.stderr).toBe('');
+    expect(retry.stdout).toContain('Run 2 completed.');
+    expect(retry.stdout).toContain('queued: 0');
+    expect(retry.stdout).toContain('failed: 1');
+    expect(repository.listFeedItemOutcomes(2)).toMatchObject([
+      {
+        status: 'failed',
+        identityKey: 'movie:retry me|2024',
+        ruleName: 'movie-policy',
+      },
+    ]);
+    expect(repository.getCandidateState('movie:retry me|2024')).toMatchObject({
+      status: 'failed',
+      queuedAt: undefined,
+    });
+    expect(transmissionServer.requestCount).toBe(2);
+  });
+
+  it('fails without creating a database when retry-failed is run before initialization', async () => {
+    const directory = await mkdtemp();
+    const databasePath = join(directory, 'media-sync.db');
+    const configPath = join(directory, 'media-sync.config.json');
+
+    await Bun.write(
+      configPath,
+      JSON.stringify({
+        feeds: [],
+        tv: [],
+        movies: {
+          years: [2024],
+          resolutions: ['2160p', '1080p'],
+          codecs: ['x265'],
+        },
+        transmission: {
+          url: 'http://127.0.0.1:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+        },
+      }),
+    );
+
+    expect(existsSync(databasePath)).toBe(false);
+
+    const retry = await runSimpleCommand(
+      directory,
+      'retry-failed',
+      '--config',
+      './media-sync.config.json',
+    );
+
+    expect(retry.exitCode).toBe(1);
+    expect(retry.stdout).toBe('');
+    expect(retry.stderr).toContain(
+      `Database not initialized. Run 'media-sync run' first.`,
+    );
+    expect(existsSync(databasePath)).toBe(false);
+  });
+});
+
 async function mkdtemp(): Promise<string> {
   const directory = await createTempDir(join(tmpdir(), 'media-sync-test-'));
 
@@ -413,6 +610,53 @@ function createTestRepository(path: string) {
   openDatabases.push(database);
   ensureSchema(database);
   return createRepository(database);
+}
+
+function seedQueuedMovieCandidate(
+  repository: ReturnType<typeof createRepository>,
+  input: {
+    runId: number;
+    rawTitle: string;
+    guidOrLink: string;
+    downloadUrl: string;
+    updatedAt: string;
+    status: 'queued' | 'failed';
+  },
+) {
+  const feedItem = repository.recordFeedItem(input.runId, {
+    feedName: 'Movie Feed',
+    guidOrLink: input.guidOrLink,
+    rawTitle: input.rawTitle,
+    publishedAt: input.updatedAt,
+    downloadUrl: input.downloadUrl,
+  });
+
+  repository.recordCandidateOutcome({
+    runId: input.runId,
+    feedItemId: feedItem.id,
+    feedItem,
+    match: {
+      ruleName: 'movie-policy',
+      identityKey:
+        input.rawTitle.includes('Retry')
+          ? 'movie:retry me|2024'
+          : 'movie:example movie|2024',
+      score: 10,
+      reasons: ['year matched'],
+      item: {
+        mediaType: 'movie',
+        rawTitle: feedItem.rawTitle,
+        normalizedTitle: input.rawTitle.includes('Retry')
+          ? 'retry me'
+          : 'example movie',
+        year: 2024,
+        resolution: '1080p',
+        codec: 'x265',
+      },
+    },
+    status: input.status,
+    updatedAt: input.updatedAt,
+  });
 }
 
 function startFeedServer(): { url: string } {
@@ -484,6 +728,75 @@ function startTransmissionServer(): { url: string; requestCount: number } {
     url: server.url.origin,
     get requestCount() {
       return state.requestCount;
+    },
+  };
+}
+
+function startFlakyRetryTransmissionServer(): {
+  url: string;
+  requestedUrls: string[];
+} {
+  const state = {
+    requestedUrls: [] as string[],
+    attemptsByUrl: new Map<string, number>(),
+  };
+  const server = Bun.serve({
+    port: 0,
+    hostname: '127.0.0.1',
+    routes: {
+      '/transmission/rpc': async (request: Request) => {
+        const sessionId = request.headers.get('x-transmission-session-id');
+
+        if (!sessionId) {
+          return new Response(null, {
+            status: 409,
+            headers: {
+              'x-transmission-session-id': 'session-123',
+            },
+          });
+        }
+
+        const body = (await request.json()) as {
+          arguments?: { filename?: string };
+        };
+        const filename = body.arguments?.filename ?? '';
+        state.requestedUrls.push(filename);
+        const nextAttempt = (state.attemptsByUrl.get(filename) ?? 0) + 1;
+
+        state.attemptsByUrl.set(filename, nextAttempt);
+
+        if (filename.includes('retry-me') && nextAttempt === 1) {
+          return Response.json({
+            result: 'success',
+            arguments: {
+              'torrent-added': {
+                id: 52,
+                hashString: 'hash-52',
+                name: 'Retried Torrent',
+              },
+            },
+          });
+        }
+
+        return Response.json({
+          result: 'success',
+          arguments: {
+            'torrent-added': {
+              id: 42,
+              hashString: 'hash-42',
+              name: 'Queued Torrent',
+            },
+          },
+        });
+      },
+    },
+  });
+
+  servers.push(server);
+  return {
+    url: server.url.origin,
+    get requestedUrls() {
+      return [...state.requestedUrls];
     },
   };
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -637,10 +637,9 @@ function seedQueuedMovieCandidate(
     feedItem,
     match: {
       ruleName: 'movie-policy',
-      identityKey:
-        input.rawTitle.includes('Retry')
-          ? 'movie:retry me|2024'
-          : 'movie:example movie|2024',
+      identityKey: input.rawTitle.includes('Retry')
+        ? 'movie:retry me|2024'
+        : 'movie:example movie|2024',
       score: 10,
       reasons: ['year matched'],
       item: {

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -274,6 +274,73 @@ describe('SQLite repository', () => {
       },
     ]);
   });
+
+  it('lists retryable candidates in updated order and excludes queued items', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+    const firstRun = repository.startRun('2026-03-30T00:00:00.000Z');
+    const queuedFeedItem = repository.recordFeedItem(firstRun.id, {
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/example-movie-web',
+      rawTitle: 'Example.Movie.2024.1080p.WEB.x265-GROUP',
+      publishedAt: '2026-03-30T00:05:00.000Z',
+      downloadUrl: 'https://example.test/downloads/example-movie-web.torrent',
+    });
+    repository.recordCandidateOutcome({
+      runId: firstRun.id,
+      feedItemId: queuedFeedItem.id,
+      feedItem: queuedFeedItem,
+      match: requireMovieMatch(queuedFeedItem.rawTitle),
+      status: 'queued',
+      updatedAt: '2026-03-30T00:10:00.000Z',
+    });
+
+    const secondRun = repository.startRun('2026-03-30T01:00:00.000Z');
+    const olderFailedFeedItem = repository.recordFeedItem(secondRun.id, {
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/retry-me-web',
+      rawTitle: 'Retry.Me.2024.1080p.WEB.x265-GROUP',
+      publishedAt: '2026-03-30T01:05:00.000Z',
+      downloadUrl: 'https://example.test/downloads/retry-me-web.torrent',
+    });
+    repository.recordCandidateOutcome({
+      runId: secondRun.id,
+      feedItemId: olderFailedFeedItem.id,
+      feedItem: olderFailedFeedItem,
+      match: requireMovieMatch(olderFailedFeedItem.rawTitle),
+      status: 'failed',
+      updatedAt: '2026-03-30T01:10:00.000Z',
+    });
+
+    const thirdRun = repository.startRun('2026-03-30T02:00:00.000Z');
+    const newerFailedFeedItem = repository.recordFeedItem(thirdRun.id, {
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/another-movie-web',
+      rawTitle: 'Another Movie 2024 2160p WEB x265 GROUP',
+      publishedAt: '2026-03-30T02:05:00.000Z',
+      downloadUrl: 'https://example.test/downloads/another-movie-web.torrent',
+    });
+    repository.recordCandidateOutcome({
+      runId: thirdRun.id,
+      feedItemId: newerFailedFeedItem.id,
+      feedItem: newerFailedFeedItem,
+      match: requireMovieMatch(newerFailedFeedItem.rawTitle),
+      status: 'failed',
+      updatedAt: '2026-03-30T02:10:00.000Z',
+    });
+
+    expect(repository.listRetryableCandidates()).toMatchObject([
+      {
+        identityKey: 'movie:retry me|2024',
+        status: 'failed',
+        updatedAt: '2026-03-30T01:10:00.000Z',
+      },
+      {
+        identityKey: 'movie:another movie|2024',
+        status: 'failed',
+        updatedAt: '2026-03-30T02:10:00.000Z',
+      },
+    ]);
+  });
 });
 
 function createTestRepository(path: string) {


### PR DESCRIPTION
## Summary
Add `media-sync retry-failed` to resubmit only failed candidate-state rows from SQLite using stored torrent URLs.
Reuse the existing submission persistence path so retry runs record `queued` and `failed` outcomes the same way as normal runs.

## Changes
- add CLI support for `retry-failed` with the same database initialization guard as `status`
- add repository query for retryable failed candidates ordered by `updatedAt` and `identityKey`
- extract shared submission handling and add retry-run orchestration without re-fetching feeds or rematching
- add CLI and repository tests covering successful retries, repeated failures, queued-item exclusion, and pre-init failure
- update README phase status and add the ticket rationale note
