### PR TITLE
refactor: phase 01 polish and hardening

### DIFF
--- a/docs/02-delivery/issue-tracking.md
+++ b/docs/02-delivery/issue-tracking.md
@@ -47,6 +47,16 @@ For each ticket:
 4. capture a short rationale note for reviewers and future threads
 5. stop for review before the next ticket
 
+After a phase or epic is functionally complete, run one bounded polish pass before starting the next phase.
+
+Use that pass to:
+
+- simplify architecture around the completed scope
+- strengthen behavior-level tests around the completed scope
+- update docs for any newly stable interfaces
+
+Do not add next-phase features during this pass.
+
 ## Learning Artifact
 
 Each ticket or PR should include a short rationale section with these prompts:

--- a/docs/02-delivery/phase-01/polish-rationale.md
+++ b/docs/02-delivery/phase-01/polish-rationale.md
@@ -1,0 +1,6 @@
+# Phase 01 Polish And Hardening Rationale
+
+- `Red first:` pipeline behavior coverage now includes duplicate winner selection within one identity and retry-run failure handling when submission throws.
+- `Why this path:` extracting a dedicated pipeline coordinator was the smallest acceptable refactor that reduced orchestration complexity in the run path without changing the CLI surface, config shape, repository schema, or downloader contract.
+- `Alternative considered:` broader cleanup across the CLI and repository layers was rejected because the highest-friction seam was already concentrated in pipeline orchestration, and widening the scope would blur phase-01 hardening with phase-02 design work.
+- `Deferred:` PR creation and the closing `qodo-code-review` pass remain separate follow-up steps once this branch is pushed and opened for review.

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ Execution plans, issue conventions, and ticket breakdowns.
 - `issue-tracking.md`: naming, sizing, and issue hierarchy
 - `phase-01/implementation-plan.md`: ordered delivery plan for phase 01
 - `phase-01/ticket-*.md`: one file per ticket
+- `phase-01/*-rationale.md`: rationale notes for tickets and the post-phase polish pass
 
 ### `03-engineering`
 

--- a/src/pipeline-runner.ts
+++ b/src/pipeline-runner.ts
@@ -60,7 +60,11 @@ export function createPipelineCoordinator(input: {
         }
 
         if (input.repository.isCandidateQueued(winner.match.identityKey)) {
-          recordDuplicateOutcome(input.repository, input.run, winner, {
+          recordFeedItemOutcome(input.repository, {
+            runId: input.run.id,
+            feedItemId: winner.feedItem.id,
+            status: 'skipped_duplicate',
+            match: winner.match,
             message: 'Candidate already queued in a previous run.',
           });
           continue;
@@ -170,6 +174,26 @@ function recordDuplicateOutcome(
   });
 }
 
+function recordFeedItemOutcome(
+  repository: Repository,
+  input: {
+    runId: number;
+    feedItemId?: number;
+    status: FeedItemOutcomeStatus;
+    match: CandidateMatchRecord;
+    message: string;
+  },
+): void {
+  repository.recordFeedItemOutcome({
+    runId: input.runId,
+    feedItemId: input.feedItemId,
+    status: input.status,
+    identityKey: input.match.identityKey,
+    ruleName: input.match.ruleName,
+    message: input.message,
+  });
+}
+
 function recordCandidateResult(
   repository: Repository,
   input: SubmissionInput & {
@@ -184,12 +208,11 @@ function recordCandidateResult(
     match: input.match,
     status: input.status,
   });
-  repository.recordFeedItemOutcome({
+  recordFeedItemOutcome(repository, {
     runId: input.runId,
     feedItemId: input.feedItemId,
     status: input.status,
-    identityKey: input.match.identityKey,
-    ruleName: input.match.ruleName,
+    match: input.match,
     message: input.message,
   });
 }

--- a/src/pipeline-runner.ts
+++ b/src/pipeline-runner.ts
@@ -1,0 +1,256 @@
+import type { RawFeedItem } from './feed';
+import type {
+  CandidateMatchRecord,
+  CandidateStateRecord,
+  FeedItemOutcomeRecord,
+  FeedItemOutcomeStatus,
+  FeedItemRecord,
+  Repository,
+  RunRecord,
+} from './repository';
+import type { Downloader } from './transmission';
+
+export type RunPipelineResult = {
+  runId: number;
+  startedAt: string;
+  completedAt: string;
+  counts: Record<FeedItemOutcomeStatus, number>;
+  outcomes: FeedItemOutcomeRecord[];
+};
+
+export type MatchedFeedItem = {
+  feedItem: FeedItemRecord;
+  match: CandidateMatchRecord;
+};
+
+type SubmissionInput = {
+  runId: number;
+  feedItemId?: number;
+  feedItem: RawFeedItem;
+  match: CandidateMatchRecord;
+};
+
+export function createPipelineCoordinator(input: {
+  run: RunRecord;
+  repository: Repository;
+  downloader: Downloader;
+}) {
+  return {
+    recordNoMatch(feedItemId: number): void {
+      input.repository.recordFeedItemOutcome({
+        runId: input.run.id,
+        feedItemId,
+        status: 'skipped_no_match',
+        message: 'No matching rule or policy.',
+      });
+    },
+
+    async submitMatchedCandidates(
+      candidates: MatchedFeedItem[],
+    ): Promise<void> {
+      for (const group of groupByIdentity(candidates).values()) {
+        const winner = selectWinningCandidate(group);
+
+        for (const candidate of group) {
+          if (candidate !== winner) {
+            recordDuplicateOutcome(input.repository, input.run, candidate, {
+              message: 'Higher-ranked candidate selected for this identity.',
+            });
+          }
+        }
+
+        if (input.repository.isCandidateQueued(winner.match.identityKey)) {
+          recordDuplicateOutcome(input.repository, input.run, winner, {
+            message: 'Candidate already queued in a previous run.',
+          });
+          continue;
+        }
+
+        await submitCandidate(input.repository, input.downloader, {
+          runId: input.run.id,
+          feedItemId: winner.feedItem.id,
+          feedItem: winner.feedItem,
+          match: winner.match,
+        });
+      }
+    },
+
+    async retryFailedCandidates(
+      candidates: CandidateStateRecord[],
+    ): Promise<void> {
+      for (const candidate of candidates) {
+        await submitCandidate(input.repository, input.downloader, {
+          runId: input.run.id,
+          feedItemId: candidate.lastFeedItemId,
+          feedItem: createRawFeedItem(candidate),
+          match: createCandidateMatchRecord(candidate),
+        });
+      }
+    },
+
+    finalize(): RunPipelineResult {
+      return finalizeRun(input.repository, input.run);
+    },
+
+    fail(): void {
+      input.repository.failRun(input.run.id);
+    },
+  };
+}
+
+export async function submitCandidate(
+  repository: Repository,
+  downloader: Downloader,
+  input: SubmissionInput,
+): Promise<void> {
+  const submission = await downloader.submit({
+    downloadUrl: input.feedItem.downloadUrl,
+  });
+
+  if (submission.ok) {
+    recordCandidateResult(repository, {
+      ...input,
+      status: 'queued',
+      message: 'Queued in Transmission.',
+    });
+    return;
+  }
+
+  recordCandidateResult(repository, {
+    ...input,
+    status: 'failed',
+    message: submission.message,
+  });
+}
+
+function groupByIdentity(
+  candidates: MatchedFeedItem[],
+): Map<string, MatchedFeedItem[]> {
+  const groups = new Map<string, MatchedFeedItem[]>();
+
+  for (const candidate of candidates) {
+    const group = groups.get(candidate.match.identityKey);
+
+    if (group) {
+      group.push(candidate);
+      continue;
+    }
+
+    groups.set(candidate.match.identityKey, [candidate]);
+  }
+
+  return groups;
+}
+
+function selectWinningCandidate(group: MatchedFeedItem[]): MatchedFeedItem {
+  let winner = group[0];
+
+  for (const candidate of group.slice(1)) {
+    if (candidate.match.score > winner.match.score) {
+      winner = candidate;
+    }
+  }
+
+  return winner;
+}
+
+function recordDuplicateOutcome(
+  repository: Repository,
+  run: RunRecord,
+  candidate: MatchedFeedItem,
+  input: { message: string },
+): void {
+  recordCandidateResult(repository, {
+    runId: run.id,
+    feedItemId: candidate.feedItem.id,
+    feedItem: candidate.feedItem,
+    match: candidate.match,
+    status: 'skipped_duplicate',
+    message: input.message,
+  });
+}
+
+function recordCandidateResult(
+  repository: Repository,
+  input: SubmissionInput & {
+    status: 'queued' | 'failed' | 'skipped_duplicate';
+    message: string;
+  },
+): void {
+  repository.recordCandidateOutcome({
+    runId: input.runId,
+    feedItemId: input.feedItemId,
+    feedItem: input.feedItem,
+    match: input.match,
+    status: input.status,
+  });
+  repository.recordFeedItemOutcome({
+    runId: input.runId,
+    feedItemId: input.feedItemId,
+    status: input.status,
+    identityKey: input.match.identityKey,
+    ruleName: input.match.ruleName,
+    message: input.message,
+  });
+}
+
+function finalizeRun(
+  repository: Repository,
+  run: RunRecord,
+): RunPipelineResult {
+  const completedRun = repository.completeRun(run.id);
+  const outcomes = repository.listFeedItemOutcomes(run.id);
+  const counts = createEmptyCounts();
+
+  for (const outcome of outcomes) {
+    counts[outcome.status] += 1;
+  }
+
+  return {
+    runId: completedRun.id,
+    startedAt: completedRun.startedAt,
+    completedAt: completedRun.completedAt ?? completedRun.startedAt,
+    counts,
+    outcomes,
+  };
+}
+
+function createEmptyCounts(): Record<FeedItemOutcomeStatus, number> {
+  return {
+    queued: 0,
+    failed: 0,
+    skipped_duplicate: 0,
+    skipped_no_match: 0,
+  };
+}
+
+function createRawFeedItem(candidate: CandidateStateRecord): RawFeedItem {
+  return {
+    feedName: candidate.feedName,
+    guidOrLink: candidate.guidOrLink,
+    rawTitle: candidate.rawTitle,
+    publishedAt: candidate.publishedAt,
+    downloadUrl: candidate.downloadUrl,
+  };
+}
+
+function createCandidateMatchRecord(
+  candidate: CandidateStateRecord,
+): CandidateMatchRecord {
+  return {
+    ruleName: candidate.ruleName,
+    identityKey: candidate.identityKey,
+    score: candidate.score,
+    reasons: candidate.reasons,
+    item: {
+      mediaType: candidate.mediaType,
+      rawTitle: candidate.rawTitle,
+      normalizedTitle: candidate.normalizedTitle,
+      season: candidate.season,
+      episode: candidate.episode,
+      year: candidate.year,
+      resolution: candidate.resolution,
+      codec: candidate.codec,
+    },
+  };
+}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -2,25 +2,21 @@ import type { AppConfig, FeedConfig } from './config';
 import { fetchFeed, type RawFeedItem } from './feed';
 import { matchMovieItem } from './movie-match';
 import { normalizeFeedItem } from './normalize';
+import {
+  createPipelineCoordinator,
+  type MatchedFeedItem,
+  type RunPipelineResult,
+} from './pipeline-runner';
 import type {
-  CandidateStateRecord,
   CandidateMatchRecord,
-  FeedItemOutcomeRecord,
-  FeedItemOutcomeStatus,
   FeedItemRecord,
   Repository,
-  RunRecord,
 } from './repository';
 import type { Downloader } from './transmission';
 import { matchTvItem } from './tv-match';
 
-export type RunPipelineResult = {
-  runId: number;
-  startedAt: string;
-  completedAt: string;
-  counts: Record<FeedItemOutcomeStatus, number>;
-  outcomes: FeedItemOutcomeRecord[];
-};
+export type { RunPipelineResult } from './pipeline-runner';
+export { submitCandidate } from './pipeline-runner';
 
 export type FetchFeedFn = (feed: FeedConfig) => Promise<RawFeedItem[]>;
 
@@ -32,6 +28,11 @@ export async function runPipeline(input: {
 }): Promise<RunPipelineResult> {
   const fetchFeedImpl = input.fetchFeed ?? fetchFeed;
   const run = input.repository.startRun();
+  const coordinator = createPipelineCoordinator({
+    run,
+    repository: input.repository,
+    downloader: input.downloader,
+  });
 
   try {
     const candidates: MatchedFeedItem[] = [];
@@ -44,12 +45,7 @@ export async function runPipeline(input: {
         const match = matchFeedItem(feedItem, input.config, feed);
 
         if (!match) {
-          input.repository.recordFeedItemOutcome({
-            runId: run.id,
-            feedItemId: feedItem.id,
-            status: 'skipped_no_match',
-            message: 'No matching rule or policy.',
-          });
+          coordinator.recordNoMatch(feedItem.id);
           continue;
         }
 
@@ -57,35 +53,10 @@ export async function runPipeline(input: {
       }
     }
 
-    for (const group of groupByIdentity(candidates).values()) {
-      const winner = selectWinningCandidate(group);
-
-      for (const candidate of group) {
-        if (candidate !== winner) {
-          recordDuplicateOutcome(input.repository, run, candidate, {
-            message: 'Higher-ranked candidate selected for this identity.',
-          });
-        }
-      }
-
-      if (input.repository.isCandidateQueued(winner.match.identityKey)) {
-        recordDuplicateOutcome(input.repository, run, winner, {
-          message: 'Candidate already queued in a previous run.',
-        });
-        continue;
-      }
-
-      await submitCandidate(input.repository, input.downloader, {
-        runId: run.id,
-        feedItemId: winner.feedItem.id,
-        feedItem: winner.feedItem,
-        match: winner.match,
-      });
-    }
-
-    return finalizeRun(input.repository, run);
+    await coordinator.submitMatchedCandidates(candidates);
+    return coordinator.finalize();
   } catch (error) {
-    input.repository.failRun(run.id);
+    coordinator.fail();
     throw error;
   }
 }
@@ -95,22 +66,19 @@ export async function retryFailedCandidates(input: {
   downloader: Downloader;
 }): Promise<RunPipelineResult> {
   const run = input.repository.startRun();
+  const coordinator = createPipelineCoordinator({
+    run,
+    repository: input.repository,
+    downloader: input.downloader,
+  });
 
   try {
-    const retryableCandidates = input.repository.listRetryableCandidates();
-
-    for (const candidate of retryableCandidates) {
-      await submitCandidate(input.repository, input.downloader, {
-        runId: run.id,
-        feedItemId: candidate.lastFeedItemId,
-        feedItem: createRawFeedItem(candidate),
-        match: createCandidateMatchRecord(candidate),
-      });
-    }
-
-    return finalizeRun(input.repository, run);
+    await coordinator.retryFailedCandidates(
+      input.repository.listRetryableCandidates(),
+    );
+    return coordinator.finalize();
   } catch (error) {
-    input.repository.failRun(run.id);
+    coordinator.fail();
     throw error;
   }
 }
@@ -131,173 +99,3 @@ function matchFeedItem(
 
   return matchMovieItem(normalized, config.movies);
 }
-
-function groupByIdentity(
-  candidates: MatchedFeedItem[],
-): Map<string, MatchedFeedItem[]> {
-  const groups = new Map<string, MatchedFeedItem[]>();
-
-  for (const candidate of candidates) {
-    const group = groups.get(candidate.match.identityKey);
-
-    if (group) {
-      group.push(candidate);
-      continue;
-    }
-
-    groups.set(candidate.match.identityKey, [candidate]);
-  }
-
-  return groups;
-}
-
-function selectWinningCandidate(group: MatchedFeedItem[]): MatchedFeedItem {
-  let winner = group[0];
-
-  for (const candidate of group.slice(1)) {
-    if (candidate.match.score > winner.match.score) {
-      winner = candidate;
-    }
-  }
-
-  return winner;
-}
-
-function recordDuplicateOutcome(
-  repository: Repository,
-  run: RunRecord,
-  candidate: MatchedFeedItem,
-  input: { message: string },
-): void {
-  repository.recordCandidateOutcome({
-    runId: run.id,
-    feedItemId: candidate.feedItem.id,
-    feedItem: candidate.feedItem,
-    match: candidate.match,
-    status: 'skipped_duplicate',
-  });
-  repository.recordFeedItemOutcome({
-    runId: run.id,
-    feedItemId: candidate.feedItem.id,
-    status: 'skipped_duplicate',
-    identityKey: candidate.match.identityKey,
-    ruleName: candidate.match.ruleName,
-    message: input.message,
-  });
-}
-
-export async function submitCandidate(
-  repository: Repository,
-  downloader: Downloader,
-  input: {
-    runId: number;
-    feedItemId?: number;
-    feedItem: RawFeedItem;
-    match: CandidateMatchRecord;
-  },
-): Promise<void> {
-  const submission = await downloader.submit({
-    downloadUrl: input.feedItem.downloadUrl,
-  });
-
-  if (submission.ok) {
-    repository.recordCandidateOutcome({
-      runId: input.runId,
-      feedItemId: input.feedItemId,
-      feedItem: input.feedItem,
-      match: input.match,
-      status: 'queued',
-    });
-    repository.recordFeedItemOutcome({
-      runId: input.runId,
-      feedItemId: input.feedItemId,
-      status: 'queued',
-      identityKey: input.match.identityKey,
-      ruleName: input.match.ruleName,
-      message: 'Queued in Transmission.',
-    });
-    return;
-  }
-
-  repository.recordCandidateOutcome({
-    runId: input.runId,
-    feedItemId: input.feedItemId,
-    feedItem: input.feedItem,
-    match: input.match,
-    status: 'failed',
-  });
-  repository.recordFeedItemOutcome({
-    runId: input.runId,
-    feedItemId: input.feedItemId,
-    status: 'failed',
-    identityKey: input.match.identityKey,
-    ruleName: input.match.ruleName,
-    message: submission.message,
-  });
-}
-
-function finalizeRun(
-  repository: Repository,
-  run: RunRecord,
-): RunPipelineResult {
-  const completedRun = repository.completeRun(run.id);
-  const outcomes = repository.listFeedItemOutcomes(run.id);
-  const counts = createEmptyCounts();
-
-  for (const outcome of outcomes) {
-    counts[outcome.status] += 1;
-  }
-
-  return {
-    runId: completedRun.id,
-    startedAt: completedRun.startedAt,
-    completedAt: completedRun.completedAt ?? completedRun.startedAt,
-    counts,
-    outcomes,
-  };
-}
-
-function createEmptyCounts(): Record<FeedItemOutcomeStatus, number> {
-  return {
-    queued: 0,
-    failed: 0,
-    skipped_duplicate: 0,
-    skipped_no_match: 0,
-  };
-}
-
-function createRawFeedItem(candidate: CandidateStateRecord): RawFeedItem {
-  return {
-    feedName: candidate.feedName,
-    guidOrLink: candidate.guidOrLink,
-    rawTitle: candidate.rawTitle,
-    publishedAt: candidate.publishedAt,
-    downloadUrl: candidate.downloadUrl,
-  };
-}
-
-function createCandidateMatchRecord(
-  candidate: CandidateStateRecord,
-): CandidateMatchRecord {
-  return {
-    ruleName: candidate.ruleName,
-    identityKey: candidate.identityKey,
-    score: candidate.score,
-    reasons: candidate.reasons,
-    item: {
-      mediaType: candidate.mediaType,
-      rawTitle: candidate.rawTitle,
-      normalizedTitle: candidate.normalizedTitle,
-      season: candidate.season,
-      episode: candidate.episode,
-      year: candidate.year,
-      resolution: candidate.resolution,
-      codec: candidate.codec,
-    },
-  };
-}
-
-type MatchedFeedItem = {
-  feedItem: FeedItemRecord;
-  match: CandidateMatchRecord;
-};

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -6,11 +6,12 @@ import { join } from 'node:path';
 
 import type { AppConfig } from '../src/config';
 import { FeedError } from '../src/feed';
-import { runPipeline } from '../src/pipeline';
+import { retryFailedCandidates, runPipeline } from '../src/pipeline';
 import {
   createRepository,
   ensureSchema,
   openDatabase,
+  type Repository,
 } from '../src/repository';
 
 const tempDirs: string[] = [];
@@ -56,6 +57,111 @@ describe('runPipeline', () => {
       completedAt: expect.any(String),
     });
   });
+
+  it('queues only the highest-ranked candidate for an identity and records the rest as duplicates', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+
+    const result = await runPipeline({
+      config: createConfig({
+        tv: [
+          {
+            name: 'Example Show',
+            resolutions: ['2160p', '1080p'],
+            codecs: ['x265'],
+          },
+        ],
+      }),
+      repository,
+      downloader: {
+        submit: async () => ({
+          ok: true as const,
+          status: 'queued' as const,
+        }),
+      },
+      fetchFeed: async () => [
+        {
+          feedName: 'TV Feed',
+          guidOrLink: 'https://example.test/releases/example-show-1080p',
+          rawTitle: 'Example.Show.S01E02.1080p.WEB.x265-GROUP',
+          publishedAt: '2026-03-30T00:00:00.000Z',
+          downloadUrl:
+            'https://example.test/downloads/example-show-1080p.torrent',
+        },
+        {
+          feedName: 'TV Feed',
+          guidOrLink: 'https://example.test/releases/example-show-2160p',
+          rawTitle: 'Example.Show.S01E02.2160p.WEB.x265-GROUP',
+          publishedAt: '2026-03-30T00:01:00.000Z',
+          downloadUrl:
+            'https://example.test/downloads/example-show-2160p.torrent',
+        },
+      ],
+    });
+
+    expect(result.counts).toEqual({
+      queued: 1,
+      failed: 0,
+      skipped_duplicate: 1,
+      skipped_no_match: 0,
+    });
+    expect(repository.listFeedItemOutcomes(result.runId)).toMatchObject([
+      {
+        status: 'skipped_duplicate',
+        identityKey: 'tv:example show|s01e02',
+        message: 'Higher-ranked candidate selected for this identity.',
+      },
+      {
+        status: 'queued',
+        identityKey: 'tv:example show|s01e02',
+        message: 'Queued in Transmission.',
+      },
+    ]);
+    expect(
+      repository.getCandidateState('tv:example show|s01e02'),
+    ).toMatchObject({
+      status: 'queued',
+      rawTitle: 'Example.Show.S01E02.2160p.WEB.x265-GROUP',
+      resolution: '2160p',
+    });
+  });
+});
+
+describe('retryFailedCandidates', () => {
+  afterEach(async () => {
+    while (openDatabases.length > 0) {
+      openDatabases.pop()?.close();
+    }
+
+    while (tempDirs.length > 0) {
+      const directory = tempDirs.pop();
+
+      if (directory) {
+        await Bun.$`rm -rf ${directory}`;
+      }
+    }
+  });
+
+  it('marks the retry run as failed when submission throws', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+    seedFailedMovieCandidate(repository);
+
+    await expect(
+      retryFailedCandidates({
+        repository,
+        downloader: {
+          submit: async () => {
+            throw new Error('transient downloader failure');
+          },
+        },
+      }),
+    ).rejects.toThrow('transient downloader failure');
+
+    expect(repository.getRun(2)).toMatchObject({
+      id: 2,
+      status: 'failed',
+      completedAt: expect.any(String),
+    });
+  });
 });
 
 function createTestRepository(path: string) {
@@ -66,6 +172,40 @@ function createTestRepository(path: string) {
   return createRepository(database);
 }
 
+function seedFailedMovieCandidate(repository: Repository): void {
+  const run = repository.startRun('2026-03-30T00:00:00.000Z');
+  const feedItem = repository.recordFeedItem(run.id, {
+    feedName: 'Movie Feed',
+    guidOrLink: 'https://example.test/releases/retry-me',
+    rawTitle: 'Retry.Me.2024.1080p.WEB.x265-GROUP',
+    publishedAt: '2026-03-30T00:05:00.000Z',
+    downloadUrl: 'https://example.test/downloads/retry-me.torrent',
+  });
+
+  repository.recordCandidateOutcome({
+    runId: run.id,
+    feedItemId: feedItem.id,
+    feedItem,
+    match: {
+      ruleName: 'movie-policy',
+      identityKey: 'movie:retry me|2024',
+      score: 10,
+      reasons: ['year matched'],
+      item: {
+        mediaType: 'movie',
+        rawTitle: feedItem.rawTitle,
+        normalizedTitle: 'retry me',
+        year: 2024,
+        resolution: '1080p',
+        codec: 'x265',
+      },
+    },
+    status: 'failed',
+    updatedAt: '2026-03-30T00:10:00.000Z',
+  });
+  repository.completeRun(run.id, '2026-03-30T00:12:00.000Z');
+}
+
 async function createDatabasePath(): Promise<string> {
   const directory = await createTempDir(join(tmpdir(), 'media-sync-pipeline-'));
 
@@ -73,7 +213,7 @@ async function createDatabasePath(): Promise<string> {
   return join(directory, 'media-sync.db');
 }
 
-function createConfig(): AppConfig {
+function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
   return {
     feeds: [
       {
@@ -99,5 +239,6 @@ function createConfig(): AppConfig {
       username: 'user',
       password: 'pass',
     },
+    ...overrides,
   };
 }

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -124,6 +124,53 @@ describe('runPipeline', () => {
       resolution: '2160p',
     });
   });
+
+  it('records a duplicate outcome for previously queued identities without overwriting candidate state', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+    seedQueuedTvCandidate(repository);
+
+    const result = await runPipeline({
+      config: createConfig(),
+      repository,
+      downloader: {
+        submit: async () => ({
+          ok: true as const,
+          status: 'queued' as const,
+        }),
+      },
+      fetchFeed: async () => [
+        {
+          feedName: 'TV Feed',
+          guidOrLink: 'https://example.test/releases/example-show-rerun',
+          rawTitle: 'Example.Show.S01E02.1080p.WEB.x265-NEWGROUP',
+          publishedAt: '2026-03-30T01:00:00.000Z',
+          downloadUrl:
+            'https://example.test/downloads/example-show-rerun.torrent',
+        },
+      ],
+    });
+
+    expect(result.counts).toEqual({
+      queued: 0,
+      failed: 0,
+      skipped_duplicate: 1,
+      skipped_no_match: 0,
+    });
+    expect(repository.listFeedItemOutcomes(result.runId)).toMatchObject([
+      {
+        status: 'skipped_duplicate',
+        identityKey: 'tv:example show|s01e02',
+        message: 'Candidate already queued in a previous run.',
+      },
+    ]);
+    expect(
+      repository.getCandidateState('tv:example show|s01e02'),
+    ).toMatchObject({
+      status: 'queued',
+      rawTitle: 'Example.Show.S01E02.1080p.WEB.x265-GROUP',
+      queuedAt: '2026-03-30T00:10:00.000Z',
+    });
+  });
 });
 
 describe('retryFailedCandidates', () => {
@@ -201,6 +248,41 @@ function seedFailedMovieCandidate(repository: Repository): void {
       },
     },
     status: 'failed',
+    updatedAt: '2026-03-30T00:10:00.000Z',
+  });
+  repository.completeRun(run.id, '2026-03-30T00:12:00.000Z');
+}
+
+function seedQueuedTvCandidate(repository: Repository): void {
+  const run = repository.startRun('2026-03-30T00:00:00.000Z');
+  const feedItem = repository.recordFeedItem(run.id, {
+    feedName: 'TV Feed',
+    guidOrLink: 'https://example.test/releases/example-show-original',
+    rawTitle: 'Example.Show.S01E02.1080p.WEB.x265-GROUP',
+    publishedAt: '2026-03-30T00:05:00.000Z',
+    downloadUrl: 'https://example.test/downloads/example-show-original.torrent',
+  });
+
+  repository.recordCandidateOutcome({
+    runId: run.id,
+    feedItemId: feedItem.id,
+    feedItem,
+    match: {
+      ruleName: 'Example Show',
+      identityKey: 'tv:example show|s01e02',
+      score: 10,
+      reasons: ['title matched'],
+      item: {
+        mediaType: 'tv',
+        rawTitle: feedItem.rawTitle,
+        normalizedTitle: 'example show',
+        season: 1,
+        episode: 2,
+        resolution: '1080p',
+        codec: 'x265',
+      },
+    },
+    status: 'queued',
     updatedAt: '2026-03-30T00:10:00.000Z',
   });
   repository.completeRun(run.id, '2026-03-30T00:12:00.000Z');


### PR DESCRIPTION
## Summary

- extract a dedicated pipeline coordinator to own candidate grouping, duplicate handling, retry submission, and run finalization
- keep `runPipeline` and `retryFailedCandidates` as the public pipeline entrypoints while reducing orchestration complexity in `pipeline.ts`
- add behavior coverage for duplicate winner selection and retry-run failure handling
- add a phase-level polish rationale note and document the new post-phase polish workflow

## Notes

- this is phase-level hardening work, not a new `P1.xx` delivery ticket
- the CLI surface, config shape, repository schema, and downloader contract remain unchanged
