### PR TITLE
chore: bootstrap phase 02 delivery docs and spellcheck workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Useful supporting docs:
 ## Local Development
 
 - `bun run hooks:install` once per clone to make `git push` run `bun run verify` locally
+- `bun run spellcheck`
+- `bun run spellcheck:words` to review unknown-word candidates before adding stable jargon to `cspell.json`
 - `bun test`
 - `bun run test:coverage` for local coverage checks when changing or refactoring tested behavior
 - `bun run verify`

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/bun": "^1.3.11",
+        "cspell": "^9.7.0",
         "eslint": "^10.1.0",
         "globals": "^17.4.0",
         "prettier": "^3.8.1",
@@ -19,6 +20,150 @@
     },
   },
   "packages": {
+    "@cspell/cspell-bundled-dicts": ["@cspell/cspell-bundled-dicts@9.7.0", "", { "dependencies": { "@cspell/dict-ada": "^4.1.1", "@cspell/dict-al": "^1.1.1", "@cspell/dict-aws": "^4.0.17", "@cspell/dict-bash": "^4.2.2", "@cspell/dict-companies": "^3.2.10", "@cspell/dict-cpp": "^7.0.2", "@cspell/dict-cryptocurrencies": "^5.0.5", "@cspell/dict-csharp": "^4.0.8", "@cspell/dict-css": "^4.0.19", "@cspell/dict-dart": "^2.3.2", "@cspell/dict-data-science": "^2.0.13", "@cspell/dict-django": "^4.1.6", "@cspell/dict-docker": "^1.1.17", "@cspell/dict-dotnet": "^5.0.12", "@cspell/dict-elixir": "^4.0.8", "@cspell/dict-en-common-misspellings": "^2.1.12", "@cspell/dict-en-gb-mit": "^3.1.18", "@cspell/dict-en_us": "^4.4.29", "@cspell/dict-filetypes": "^3.0.15", "@cspell/dict-flutter": "^1.1.1", "@cspell/dict-fonts": "^4.0.5", "@cspell/dict-fsharp": "^1.1.1", "@cspell/dict-fullstack": "^3.2.8", "@cspell/dict-gaming-terms": "^1.1.2", "@cspell/dict-git": "^3.1.0", "@cspell/dict-golang": "^6.0.26", "@cspell/dict-google": "^1.0.9", "@cspell/dict-haskell": "^4.0.6", "@cspell/dict-html": "^4.0.14", "@cspell/dict-html-symbol-entities": "^4.0.5", "@cspell/dict-java": "^5.0.12", "@cspell/dict-julia": "^1.1.1", "@cspell/dict-k8s": "^1.0.12", "@cspell/dict-kotlin": "^1.1.1", "@cspell/dict-latex": "^5.0.0", "@cspell/dict-lorem-ipsum": "^4.0.5", "@cspell/dict-lua": "^4.0.8", "@cspell/dict-makefile": "^1.0.5", "@cspell/dict-markdown": "^2.0.14", "@cspell/dict-monkeyc": "^1.0.12", "@cspell/dict-node": "^5.0.9", "@cspell/dict-npm": "^5.2.34", "@cspell/dict-php": "^4.1.1", "@cspell/dict-powershell": "^5.0.15", "@cspell/dict-public-licenses": "^2.0.15", "@cspell/dict-python": "^4.2.25", "@cspell/dict-r": "^2.1.1", "@cspell/dict-ruby": "^5.1.0", "@cspell/dict-rust": "^4.1.2", "@cspell/dict-scala": "^5.0.9", "@cspell/dict-shell": "^1.1.2", "@cspell/dict-software-terms": "^5.1.21", "@cspell/dict-sql": "^2.2.1", "@cspell/dict-svelte": "^1.0.7", "@cspell/dict-swift": "^2.0.6", "@cspell/dict-terraform": "^1.1.3", "@cspell/dict-typescript": "^3.2.3", "@cspell/dict-vue": "^3.0.5", "@cspell/dict-zig": "^1.0.0" } }, "sha512-s7h1vo++Q3AsfQa3cs0u/KGwm3SYInuIlC4kjlCBWjQmb4KddiZB5O1u0+3TlA7GycHb5M4CR7MDfHUICgJf+w=="],
+
+    "@cspell/cspell-json-reporter": ["@cspell/cspell-json-reporter@9.7.0", "", { "dependencies": { "@cspell/cspell-types": "9.7.0" } }, "sha512-6xpGXlMtQA3hV2BCAQcPkpx9eI12I0o01i9eRqSSEDKtxuAnnrejbcCpL+5OboAjTp3/BSeNYSnhuWYLkSITWQ=="],
+
+    "@cspell/cspell-performance-monitor": ["@cspell/cspell-performance-monitor@9.7.0", "", {}, "sha512-w1PZIFXuvjnC6mQHyYAFnrsn5MzKnEcEkcK1bj4OG00bAt7WX2VUA/eNNt9c1iHozCQ+FcRYlfbGxuBmNyzSgw=="],
+
+    "@cspell/cspell-pipe": ["@cspell/cspell-pipe@9.7.0", "", {}, "sha512-iiisyRpJciU9SOHNSi0ZEK0pqbEMFRatI/R4O+trVKb+W44p4MNGClLVRWPGUmsFbZKPJL3jDtz0wPlG0/JCZA=="],
+
+    "@cspell/cspell-resolver": ["@cspell/cspell-resolver@9.7.0", "", { "dependencies": { "global-directory": "^5.0.0" } }, "sha512-uiEgS238mdabDnwavo6HXt8K98jlh/jpm7NONroM9NTr9rzck2VZKD2kXEj85wDNMtRsRXNoywTjwQ8WTB6/+w=="],
+
+    "@cspell/cspell-service-bus": ["@cspell/cspell-service-bus@9.7.0", "", {}, "sha512-fkqtaCkg4jY/FotmzjhIavbXuH0AgUJxZk78Ktf4XlhqOZ4wDeUWrCf220bva4mh3TWiLx/ae9lIlpl59Vx6hA=="],
+
+    "@cspell/cspell-types": ["@cspell/cspell-types@9.7.0", "", {}, "sha512-Tdfx4eH2uS+gv9V9NCr3Rz+c7RSS6ntXp3Blliud18ibRUlRxO9dTaOjG4iv4x0nAmMeedP1ORkEpeXSkh2QiQ=="],
+
+    "@cspell/cspell-worker": ["@cspell/cspell-worker@9.7.0", "", { "dependencies": { "cspell-lib": "9.7.0" } }, "sha512-cjEApFF0aOAa1vTUk+e7xP8ofK7iC7hsRzj1FmvvVQz8PoLWPRaq+1bT89ypPsZQvavqm5sIgb97S60/aW4TVg=="],
+
+    "@cspell/dict-ada": ["@cspell/dict-ada@4.1.1", "", {}, "sha512-E+0YW9RhZod/9Qy2gxfNZiHJjCYFlCdI69br1eviQQWB8yOTJX0JHXLs79kOYhSW0kINPVUdvddEBe6Lu6CjGQ=="],
+
+    "@cspell/dict-al": ["@cspell/dict-al@1.1.1", "", {}, "sha512-sD8GCaZetgQL4+MaJLXqbzWcRjfKVp8x+px3HuCaaiATAAtvjwUQ5/Iubiqwfd1boIh2Y1/3EgM3TLQ7Q8e0wQ=="],
+
+    "@cspell/dict-aws": ["@cspell/dict-aws@4.0.17", "", {}, "sha512-ORcblTWcdlGjIbWrgKF+8CNEBQiLVKdUOFoTn0KPNkAYnFcdPP0muT4892h7H4Xafh3j72wqB4/loQ6Nti9E/w=="],
+
+    "@cspell/dict-bash": ["@cspell/dict-bash@4.2.2", "", { "dependencies": { "@cspell/dict-shell": "1.1.2" } }, "sha512-kyWbwtX3TsCf5l49gGQIZkRLaB/P8g73GDRm41Zu8Mv51kjl2H7Au0TsEvHv7jzcsRLS6aUYaZv6Zsvk1fOz+Q=="],
+
+    "@cspell/dict-companies": ["@cspell/dict-companies@3.2.11", "", {}, "sha512-0cmafbcz2pTHXLd59eLR1gvDvN6aWAOM0+cIL4LLF9GX9yB2iKDNrKsvs4tJRqutoaTdwNFBbV0FYv+6iCtebQ=="],
+
+    "@cspell/dict-cpp": ["@cspell/dict-cpp@7.0.2", "", {}, "sha512-dfbeERiVNeqmo/npivdR6rDiBCqZi3QtjH2Z0HFcXwpdj6i97dX1xaKyK2GUsO/p4u1TOv63Dmj5Vm48haDpuA=="],
+
+    "@cspell/dict-cryptocurrencies": ["@cspell/dict-cryptocurrencies@5.0.5", "", {}, "sha512-R68hYYF/rtlE6T/dsObStzN5QZw+0aQBinAXuWCVqwdS7YZo0X33vGMfChkHaiCo3Z2+bkegqHlqxZF4TD3rUA=="],
+
+    "@cspell/dict-csharp": ["@cspell/dict-csharp@4.0.8", "", {}, "sha512-qmk45pKFHSxckl5mSlbHxmDitSsGMlk/XzFgt7emeTJWLNSTUK//MbYAkBNRtfzB4uD7pAFiKgpKgtJrTMRnrQ=="],
+
+    "@cspell/dict-css": ["@cspell/dict-css@4.1.1", "", {}, "sha512-y/Vgo6qY08e1t9OqR56qjoFLBCpi4QfWMf2qzD1l9omRZwvSMQGRPz4x0bxkkkU4oocMAeztjzCsmLew//c/8w=="],
+
+    "@cspell/dict-dart": ["@cspell/dict-dart@2.3.2", "", {}, "sha512-sUiLW56t9gfZcu8iR/5EUg+KYyRD83Cjl3yjDEA2ApVuJvK1HhX+vn4e4k4YfjpUQMag8XO2AaRhARE09+/rqw=="],
+
+    "@cspell/dict-data-science": ["@cspell/dict-data-science@2.0.13", "", {}, "sha512-l1HMEhBJkPmw4I2YGVu2eBSKM89K9pVF+N6qIr5Uo5H3O979jVodtuwP8I7LyPrJnC6nz28oxeGRCLh9xC5CVA=="],
+
+    "@cspell/dict-django": ["@cspell/dict-django@4.1.6", "", {}, "sha512-SdbSFDGy9ulETqNz15oWv2+kpWLlk8DJYd573xhIkeRdcXOjskRuxjSZPKfW7O3NxN/KEf3gm3IevVOiNuFS+w=="],
+
+    "@cspell/dict-docker": ["@cspell/dict-docker@1.1.17", "", {}, "sha512-OcnVTIpHIYYKhztNTyK8ShAnXTfnqs43hVH6p0py0wlcwRIXe5uj4f12n7zPf2CeBI7JAlPjEsV0Rlf4hbz/xQ=="],
+
+    "@cspell/dict-dotnet": ["@cspell/dict-dotnet@5.0.13", "", {}, "sha512-xPp7jMnFpOri7tzmqmm/dXMolXz1t2bhNqxYkOyMqXhvs08oc7BFs+EsbDY0X7hqiISgeFZGNqn0dOCr+ncPYw=="],
+
+    "@cspell/dict-elixir": ["@cspell/dict-elixir@4.0.8", "", {}, "sha512-CyfphrbMyl4Ms55Vzuj+mNmd693HjBFr9hvU+B2YbFEZprE5AG+EXLYTMRWrXbpds4AuZcvN3deM2XVB80BN/Q=="],
+
+    "@cspell/dict-en-common-misspellings": ["@cspell/dict-en-common-misspellings@2.1.12", "", {}, "sha512-14Eu6QGqyksqOd4fYPuRb58lK1Va7FQK9XxFsRKnZU8LhL3N+kj7YKDW+7aIaAN/0WGEqslGP6lGbQzNti8Akw=="],
+
+    "@cspell/dict-en-gb-mit": ["@cspell/dict-en-gb-mit@3.1.22", "", {}, "sha512-xE5Vg6gGdMkZ1Ep6z9SJMMioGkkT1GbxS5Mm0U3Ey1/H68P0G7cJcyiVr1CARxFbLqKE4QUpoV1o6jz1Z5Yl9Q=="],
+
+    "@cspell/dict-en_us": ["@cspell/dict-en_us@4.4.33", "", {}, "sha512-zWftVqfUStDA37wO1ZNDN1qMJOfcxELa8ucHW8W8wBAZY3TK5Nb6deLogCK/IJi/Qljf30dwwuqqv84Qqle9Tw=="],
+
+    "@cspell/dict-filetypes": ["@cspell/dict-filetypes@3.0.18", "", {}, "sha512-yU7RKD/x1IWmDLzWeiItMwgV+6bUcU/af23uS0+uGiFUbsY1qWV/D4rxlAAO6Z7no3J2z8aZOkYIOvUrJq0Rcw=="],
+
+    "@cspell/dict-flutter": ["@cspell/dict-flutter@1.1.1", "", {}, "sha512-UlOzRcH2tNbFhZmHJN48Za/2/MEdRHl2BMkCWZBYs+30b91mWvBfzaN4IJQU7dUZtowKayVIF9FzvLZtZokc5A=="],
+
+    "@cspell/dict-fonts": ["@cspell/dict-fonts@4.0.6", "", {}, "sha512-aR/0csY01dNb0A1tw/UmN9rKgHruUxsYsvXu6YlSBJFu60s26SKr/k1o4LavpHTQ+lznlYMqAvuxGkE4Flliqw=="],
+
+    "@cspell/dict-fsharp": ["@cspell/dict-fsharp@1.1.1", "", {}, "sha512-imhs0u87wEA4/cYjgzS0tAyaJpwG7vwtC8UyMFbwpmtw+/bgss+osNfyqhYRyS/ehVCWL17Ewx2UPkexjKyaBA=="],
+
+    "@cspell/dict-fullstack": ["@cspell/dict-fullstack@3.2.9", "", {}, "sha512-diZX+usW5aZ4/b2T0QM/H/Wl9aNMbdODa1Jq0ReBr/jazmNeWjd+PyqeVgzd1joEaHY+SAnjrf/i9CwKd2ZtWQ=="],
+
+    "@cspell/dict-gaming-terms": ["@cspell/dict-gaming-terms@1.1.2", "", {}, "sha512-9XnOvaoTBscq0xuD6KTEIkk9hhdfBkkvJAIsvw3JMcnp1214OCGW8+kako5RqQ2vTZR3Tnf3pc57o7VgkM0q1Q=="],
+
+    "@cspell/dict-git": ["@cspell/dict-git@3.1.0", "", {}, "sha512-KEt9zGkxqGy2q1nwH4CbyqTSv5nadpn8BAlDnzlRcnL0Xb3LX9xTgSGShKvzb0bw35lHoYyLWN2ZKAqbC4pgGQ=="],
+
+    "@cspell/dict-golang": ["@cspell/dict-golang@6.0.26", "", {}, "sha512-YKA7Xm5KeOd14v5SQ4ll6afe9VSy3a2DWM7L9uBq4u3lXToRBQ1W5PRa+/Q9udd+DTURyVVnQ+7b9cnOlNxaRg=="],
+
+    "@cspell/dict-google": ["@cspell/dict-google@1.0.9", "", {}, "sha512-biL65POqialY0i4g6crj7pR6JnBkbsPovB2WDYkj3H4TuC/QXv7Pu5pdPxeUJA6TSCHI7T5twsO4VSVyRxD9CA=="],
+
+    "@cspell/dict-haskell": ["@cspell/dict-haskell@4.0.6", "", {}, "sha512-ib8SA5qgftExpYNjWhpYIgvDsZ/0wvKKxSP+kuSkkak520iPvTJumEpIE+qPcmJQo4NzdKMN8nEfaeci4OcFAQ=="],
+
+    "@cspell/dict-html": ["@cspell/dict-html@4.0.15", "", {}, "sha512-GJYnYKoD9fmo2OI0aySEGZOjThnx3upSUvV7mmqUu8oG+mGgzqm82P/f7OqsuvTaInZZwZbo+PwJQd/yHcyFIw=="],
+
+    "@cspell/dict-html-symbol-entities": ["@cspell/dict-html-symbol-entities@4.0.5", "", {}, "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA=="],
+
+    "@cspell/dict-java": ["@cspell/dict-java@5.0.12", "", {}, "sha512-qPSNhTcl7LGJ5Qp6VN71H8zqvRQK04S08T67knMq9hTA8U7G1sTKzLmBaDOFhq17vNX/+rT+rbRYp+B5Nwza1A=="],
+
+    "@cspell/dict-julia": ["@cspell/dict-julia@1.1.1", "", {}, "sha512-WylJR9TQ2cgwd5BWEOfdO3zvDB+L7kYFm0I9u0s9jKHWQ6yKmfKeMjU9oXxTBxIufhCXm92SKwwVNAC7gjv+yA=="],
+
+    "@cspell/dict-k8s": ["@cspell/dict-k8s@1.0.12", "", {}, "sha512-2LcllTWgaTfYC7DmkMPOn9GsBWsA4DZdlun4po8s2ysTP7CPEnZc1ZfK6pZ2eI4TsZemlUQQ+NZxMe9/QutQxg=="],
+
+    "@cspell/dict-kotlin": ["@cspell/dict-kotlin@1.1.1", "", {}, "sha512-J3NzzfgmxRvEeOe3qUXnSJQCd38i/dpF9/t3quuWh6gXM+krsAXP75dY1CzDmS8mrJAlBdVBeAW5eAZTD8g86Q=="],
+
+    "@cspell/dict-latex": ["@cspell/dict-latex@5.1.0", "", {}, "sha512-qxT4guhysyBt0gzoliXYEBYinkAdEtR2M7goRaUH0a7ltCsoqqAeEV8aXYRIdZGcV77gYSobvu3jJL038tlPAw=="],
+
+    "@cspell/dict-lorem-ipsum": ["@cspell/dict-lorem-ipsum@4.0.5", "", {}, "sha512-9a4TJYRcPWPBKkQAJ/whCu4uCAEgv/O2xAaZEI0n4y1/l18Yyx8pBKoIX5QuVXjjmKEkK7hi5SxyIsH7pFEK9Q=="],
+
+    "@cspell/dict-lua": ["@cspell/dict-lua@4.0.8", "", {}, "sha512-N4PkgNDMu9JVsRu7JBS/3E/dvfItRgk9w5ga2dKq+JupP2Y3lojNaAVFhXISh4Y0a6qXDn2clA6nvnavQ/jjLA=="],
+
+    "@cspell/dict-makefile": ["@cspell/dict-makefile@1.0.5", "", {}, "sha512-4vrVt7bGiK8Rx98tfRbYo42Xo2IstJkAF4tLLDMNQLkQ86msDlYSKG1ZCk8Abg+EdNcFAjNhXIiNO+w4KflGAQ=="],
+
+    "@cspell/dict-markdown": ["@cspell/dict-markdown@2.0.16", "", { "peerDependencies": { "@cspell/dict-css": "^4.1.1", "@cspell/dict-html": "^4.0.15", "@cspell/dict-html-symbol-entities": "^4.0.5", "@cspell/dict-typescript": "^3.2.3" } }, "sha512-976RRqKv6cwhrxdFCQP2DdnBVB86BF57oQtPHy4Zbf4jF/i2Oy29MCrxirnOBalS1W6KQeto7NdfDXRAwkK4PQ=="],
+
+    "@cspell/dict-monkeyc": ["@cspell/dict-monkeyc@1.0.12", "", {}, "sha512-MN7Vs11TdP5mbdNFQP5x2Ac8zOBm97ARg6zM5Sb53YQt/eMvXOMvrep7+/+8NJXs0jkp70bBzjqU4APcqBFNAw=="],
+
+    "@cspell/dict-node": ["@cspell/dict-node@5.0.9", "", {}, "sha512-hO+ga+uYZ/WA4OtiMEyKt5rDUlUyu3nXMf8KVEeqq2msYvAPdldKBGH7lGONg6R/rPhv53Rb+0Y1SLdoK1+7wQ=="],
+
+    "@cspell/dict-npm": ["@cspell/dict-npm@5.2.38", "", {}, "sha512-21ucGRPYYhr91C2cDBoMPTrcIOStQv33xOqJB0JLoC5LAs2Sfj9EoPGhGb+gIFVHz6Ia7JQWE2SJsOVFJD1wmg=="],
+
+    "@cspell/dict-php": ["@cspell/dict-php@4.1.1", "", {}, "sha512-EXelI+4AftmdIGtA8HL8kr4WlUE11OqCSVlnIgZekmTkEGSZdYnkFdiJ5IANSALtlQ1mghKjz+OFqVs6yowgWA=="],
+
+    "@cspell/dict-powershell": ["@cspell/dict-powershell@5.0.15", "", {}, "sha512-l4S5PAcvCFcVDMJShrYD0X6Huv9dcsQPlsVsBGbH38wvuN7gS7+GxZFAjTNxDmTY1wrNi1cCatSg6Pu2BW4rgg=="],
+
+    "@cspell/dict-public-licenses": ["@cspell/dict-public-licenses@2.0.16", "", {}, "sha512-EQRrPvEOmwhwWezV+W7LjXbIBjiy6y/shrET6Qcpnk3XANTzfvWflf9PnJ5kId/oKWvihFy0za0AV1JHd03pSQ=="],
+
+    "@cspell/dict-python": ["@cspell/dict-python@4.2.26", "", { "dependencies": { "@cspell/dict-data-science": "^2.0.13" } }, "sha512-hbjN6BjlSgZOG2dA2DtvYNGBM5Aq0i0dHaZjMOI9K/9vRicVvKbcCiBSSrR3b+jwjhQL5ff7HwG5xFaaci0GQA=="],
+
+    "@cspell/dict-r": ["@cspell/dict-r@2.1.1", "", {}, "sha512-71Ka+yKfG4ZHEMEmDxc6+blFkeTTvgKbKAbwiwQAuKl3zpqs1Y0vUtwW2N4b3LgmSPhV3ODVY0y4m5ofqDuKMw=="],
+
+    "@cspell/dict-ruby": ["@cspell/dict-ruby@5.1.1", "", {}, "sha512-LHrp84oEV6q1ZxPPyj4z+FdKyq1XAKYPtmGptrd+uwHbrF/Ns5+fy6gtSi7pS+uc0zk3JdO9w/tPK+8N1/7WUA=="],
+
+    "@cspell/dict-rust": ["@cspell/dict-rust@4.1.2", "", {}, "sha512-O1FHrumYcO+HZti3dHfBPUdnDFkI+nbYK3pxYmiM1sr+G0ebOd6qchmswS0Wsc6ZdEVNiPYJY/gZQR6jfW3uOg=="],
+
+    "@cspell/dict-scala": ["@cspell/dict-scala@5.0.9", "", {}, "sha512-AjVcVAELgllybr1zk93CJ5wSUNu/Zb5kIubymR/GAYkMyBdYFCZ3Zbwn4Zz8GJlFFAbazABGOu0JPVbeY59vGg=="],
+
+    "@cspell/dict-shell": ["@cspell/dict-shell@1.1.2", "", {}, "sha512-WqOUvnwcHK1X61wAfwyXq04cn7KYyskg90j4lLg3sGGKMW9Sq13hs91pqrjC44Q+lQLgCobrTkMDw9Wyl9nRFA=="],
+
+    "@cspell/dict-software-terms": ["@cspell/dict-software-terms@5.2.2", "", {}, "sha512-0CaYd6TAsKtEoA7tNswm1iptEblTzEe3UG8beG2cpSTHk7afWIVMtJLgXDv0f/Li67Lf3Z1Jf3JeXR7GsJ2TRw=="],
+
+    "@cspell/dict-sql": ["@cspell/dict-sql@2.2.1", "", {}, "sha512-qDHF8MpAYCf4pWU8NKbnVGzkoxMNrFqBHyG/dgrlic5EQiKANCLELYtGlX5auIMDLmTf1inA0eNtv74tyRJ/vg=="],
+
+    "@cspell/dict-svelte": ["@cspell/dict-svelte@1.0.7", "", {}, "sha512-hGZsGqP0WdzKkdpeVLBivRuSNzOTvN036EBmpOwxH+FTY2DuUH7ecW+cSaMwOgmq5JFSdTcbTNFlNC8HN8lhaQ=="],
+
+    "@cspell/dict-swift": ["@cspell/dict-swift@2.0.6", "", {}, "sha512-PnpNbrIbex2aqU1kMgwEKvCzgbkHtj3dlFLPMqW1vSniop7YxaDTtvTUO4zA++ugYAEL+UK8vYrBwDPTjjvSnA=="],
+
+    "@cspell/dict-terraform": ["@cspell/dict-terraform@1.1.3", "", {}, "sha512-gr6wxCydwSFyyBKhBA2xkENXtVFToheqYYGFvlMZXWjviynXmh+NK/JTvTCk/VHk3+lzbO9EEQKee6VjrAUSbA=="],
+
+    "@cspell/dict-typescript": ["@cspell/dict-typescript@3.2.3", "", {}, "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg=="],
+
+    "@cspell/dict-vue": ["@cspell/dict-vue@3.0.5", "", {}, "sha512-Mqutb8jbM+kIcywuPQCCaK5qQHTdaByoEO2J9LKFy3sqAdiBogNkrplqUK0HyyRFgCfbJUgjz3N85iCMcWH0JA=="],
+
+    "@cspell/dict-zig": ["@cspell/dict-zig@1.0.0", "", {}, "sha512-XibBIxBlVosU06+M6uHWkFeT0/pW5WajDRYdXG2CgHnq85b0TI/Ks0FuBJykmsgi2CAD3Qtx8UHFEtl/DSFnAQ=="],
+
+    "@cspell/dynamic-import": ["@cspell/dynamic-import@9.7.0", "", { "dependencies": { "@cspell/url": "9.7.0", "import-meta-resolve": "^4.2.0" } }, "sha512-Ws36IYvtS/8IN3x6K9dPLvTmaArodRJmzTn2Rkf2NaTnIYWhRuFzsP3SVVO59NN3fXswAEbmz5DSbVUe8bPZHg=="],
+
+    "@cspell/filetypes": ["@cspell/filetypes@9.7.0", "", {}, "sha512-Ln9e/8wGOyTeL3DCCs6kwd18TSpTw3kxsANjTrzLDASrX4cNmAdvc9J5dcIuBHPaqOAnRQxuZbzUlpRh73Y24w=="],
+
+    "@cspell/rpc": ["@cspell/rpc@9.7.0", "", {}, "sha512-VnZ4ABgQeoS4RwofcePkDP7L6tf3Kh5D7LQKoyRM4R6XtfSsYefym6XKaRl3saGtthH5YyjgNJ0Tgdjen4wAAw=="],
+
+    "@cspell/strong-weak-map": ["@cspell/strong-weak-map@9.7.0", "", {}, "sha512-5xbvDASjklrmy88O6gmGXgYhpByCXqOj5wIgyvwZe2l83T1bE+iOfGI4pGzZJ/mN+qTn1DNKq8BPBPtDgb7Q2Q=="],
+
+    "@cspell/url": ["@cspell/url@9.7.0", "", {}, "sha512-ZaaBr0pTvNxmyUbIn+nVPXPr383VqJzfUDMWicgTjJIeo2+T2hOq2kNpgpvTIrWtZrsZnSP8oXms1+sKTjcvkw=="],
+
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
     "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
@@ -79,17 +224,53 @@
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "array-timsort": ["array-timsort@1.0.3", "", {}, "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ=="],
+
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "chalk-template": ["chalk-template@1.1.2", "", { "dependencies": { "chalk": "^5.2.0" } }, "sha512-2bxTP2yUH7AJj/VAXfcA+4IcWGdQ87HwBANLt5XxGTeomo8yG0y95N1um9i5StvhT/Bl0/2cARA5v1PpPXUxUA=="],
+
+    "clear-module": ["clear-module@4.1.2", "", { "dependencies": { "parent-module": "^2.0.0", "resolve-from": "^5.0.0" } }, "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw=="],
+
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "comment-json": ["comment-json@4.6.2", "", { "dependencies": { "array-timsort": "^1.0.3", "esprima": "^4.0.1" } }, "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "cspell": ["cspell@9.7.0", "", { "dependencies": { "@cspell/cspell-json-reporter": "9.7.0", "@cspell/cspell-performance-monitor": "9.7.0", "@cspell/cspell-pipe": "9.7.0", "@cspell/cspell-types": "9.7.0", "@cspell/cspell-worker": "9.7.0", "@cspell/dynamic-import": "9.7.0", "@cspell/url": "9.7.0", "ansi-regex": "^6.2.2", "chalk": "^5.6.2", "chalk-template": "^1.1.2", "commander": "^14.0.3", "cspell-config-lib": "9.7.0", "cspell-dictionary": "9.7.0", "cspell-gitignore": "9.7.0", "cspell-glob": "9.7.0", "cspell-io": "9.7.0", "cspell-lib": "9.7.0", "fast-json-stable-stringify": "^2.1.0", "flatted": "^3.3.3", "semver": "^7.7.4", "tinyglobby": "^0.2.15" }, "bin": { "cspell": "bin.mjs", "cspell-esm": "bin.mjs" } }, "sha512-ftxOnkd+scAI7RZ1/ksgBZRr0ouC7QRKtPQhD/PbLTKwAM62sSvRhE1bFsuW3VKBn/GilWzTjkJ40WmnDqH5iQ=="],
+
+    "cspell-config-lib": ["cspell-config-lib@9.7.0", "", { "dependencies": { "@cspell/cspell-types": "9.7.0", "comment-json": "^4.5.1", "smol-toml": "^1.6.0", "yaml": "^2.8.2" } }, "sha512-pguh8A3+bSJ1OOrKCiQan8bvaaY125de76OEFz7q1Pq309lIcDrkoL/W4aYbso/NjrXaIw6OjkgPMGRBI/IgGg=="],
+
+    "cspell-dictionary": ["cspell-dictionary@9.7.0", "", { "dependencies": { "@cspell/cspell-performance-monitor": "9.7.0", "@cspell/cspell-pipe": "9.7.0", "@cspell/cspell-types": "9.7.0", "cspell-trie-lib": "9.7.0", "fast-equals": "^6.0.0" } }, "sha512-k/Wz0so32+0QEqQe21V9m4BNXM5ZN6lz3Ix/jLCbMxFIPl6wT711ftjOWIEMFhvUOP0TWXsbzcuE9mKtS5mTig=="],
+
+    "cspell-gitignore": ["cspell-gitignore@9.7.0", "", { "dependencies": { "@cspell/url": "9.7.0", "cspell-glob": "9.7.0", "cspell-io": "9.7.0" }, "bin": { "cspell-gitignore": "bin.mjs" } }, "sha512-MtoYuH4ah4K6RrmaF834npMcRsTKw0658mC6yvmBacUQOmwB/olqyuxF3fxtbb55HDb7cXDQ35t1XuwwGEQeZw=="],
+
+    "cspell-glob": ["cspell-glob@9.7.0", "", { "dependencies": { "@cspell/url": "9.7.0", "picomatch": "^4.0.3" } }, "sha512-LUeAoEsoCJ+7E3TnUmWBscpVQOmdwBejMlFn0JkXy6LQzxrybxXBKf65RSdIv1o5QtrhQIMa358xXYQG0sv/tA=="],
+
+    "cspell-grammar": ["cspell-grammar@9.7.0", "", { "dependencies": { "@cspell/cspell-pipe": "9.7.0", "@cspell/cspell-types": "9.7.0" }, "bin": { "cspell-grammar": "bin.mjs" } }, "sha512-oEYME+7MJztfVY1C06aGcJgEYyqBS/v/ETkQGPzf/c6ObSAPRcUbVtsXZgnR72Gru9aBckc70xJcD6bELdoWCA=="],
+
+    "cspell-io": ["cspell-io@9.7.0", "", { "dependencies": { "@cspell/cspell-service-bus": "9.7.0", "@cspell/url": "9.7.0" } }, "sha512-V7x0JHAUCcJPRCH8c0MQkkaKmZD2yotxVyrNEx2SZTpvnKrYscLEnUUTWnGJIIf9znzISqw116PLnYu2c+zd6Q=="],
+
+    "cspell-lib": ["cspell-lib@9.7.0", "", { "dependencies": { "@cspell/cspell-bundled-dicts": "9.7.0", "@cspell/cspell-performance-monitor": "9.7.0", "@cspell/cspell-pipe": "9.7.0", "@cspell/cspell-resolver": "9.7.0", "@cspell/cspell-types": "9.7.0", "@cspell/dynamic-import": "9.7.0", "@cspell/filetypes": "9.7.0", "@cspell/rpc": "9.7.0", "@cspell/strong-weak-map": "9.7.0", "@cspell/url": "9.7.0", "clear-module": "^4.1.2", "cspell-config-lib": "9.7.0", "cspell-dictionary": "9.7.0", "cspell-glob": "9.7.0", "cspell-grammar": "9.7.0", "cspell-io": "9.7.0", "cspell-trie-lib": "9.7.0", "env-paths": "^4.0.0", "gensequence": "^8.0.8", "import-fresh": "^3.3.1", "resolve-from": "^5.0.0", "vscode-languageserver-textdocument": "^1.0.12", "vscode-uri": "^3.1.0", "xdg-basedir": "^5.1.0" } }, "sha512-aTx/aLRpnuY1RJnYAu+A8PXfm1oIUdvAQ4W9E66bTgp1LWI+2G2++UtaPxRIgI0olxE9vcXqUnKpjOpO+5W9bQ=="],
+
+    "cspell-trie-lib": ["cspell-trie-lib@9.7.0", "", { "peerDependencies": { "@cspell/cspell-types": "9.7.0" } }, "sha512-a2YqmcraL3g6I/4gY7SYWEZfP73oLluUtxO7wxompk/kOG2K1FUXyQfZXaaR7HxVv10axT1+NrjhOmXpfbI6LA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
+
+    "env-paths": ["env-paths@4.0.0", "", { "dependencies": { "is-safe-filename": "^0.1.0" } }, "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -101,6 +282,8 @@
 
     "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
 
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
     "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
 
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
@@ -110,6 +293,8 @@
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-equals": ["fast-equals@6.0.0", "", {}, "sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
@@ -129,17 +314,29 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
+    "gensequence": ["gensequence@8.0.8", "", {}, "sha512-omMVniXEXpdx/vKxGnPRoO2394Otlze28TyxECbFVyoSpZ9H3EO7lemjcB12OpQJzRW4e5tt/dL1rOxry6aMHg=="],
+
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "global-directory": ["global-directory@5.0.0", "", { "dependencies": { "ini": "6.0.0" } }, "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w=="],
 
     "globals": ["globals@17.4.0", "", {}, "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-safe-filename": ["is-safe-filename@0.1.1", "", {}, "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -167,6 +364,8 @@
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
+    "parent-module": ["parent-module@2.0.0", "", { "dependencies": { "callsites": "^3.1.0" } }, "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.2.0", "", {}, "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ=="],
@@ -181,11 +380,15 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
     "strnum": ["strnum@2.2.2", "", {}, "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA=="],
 
@@ -203,14 +406,26 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
+
+    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "import-fresh/parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
   }
 }

--- a/cspell.json
+++ b/cspell.json
@@ -5,11 +5,23 @@
   "dictionaries": [],
   "words": [
     "AUTOINCREMENT",
+    "CDPATH",
     "bluray",
     "eztv",
+    "infohash",
     "mktemp",
+    "NEWGROUP",
+    "overengineering",
     "parsererror",
-    "reparsing"
+    "queueable",
+    "qodo",
+    "Qube",
+    "reparsing",
+    "retryability",
+    "SARIF",
+    "Turso",
+    "upserted",
+    "upserts"
   ],
   "ignoreWords": [],
   "import": []

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -17,25 +17,27 @@ Exit condition:
 
 - `media-sync run` can successfully queue a matched item in Transmission
 
-## Phase 02: Automation And Operator Ergonomics
+## Phase 02: Real-World Feed Compatibility
 
-Likely scope:
+Goal:
 
-- scheduling
-- safer dry-run and preview modes
-- richer run summaries
-- config ergonomics
-- operational logging improvements
-- durable ticket tracking with issue workflow states and deferred-work capture
-- issue-tracker integration such as Linear when it improves delivery signal
-- AI-readable project management context through MCP-backed tooling
+- make `media-sync run` work end-to-end against real target feeds
+- use RSS `enclosure.url` as the queueable torrent payload when present
+- keep movie items eligible when year and resolution match but codec is absent
+- preserve the current manual local workflow
 
-Not committed yet:
+Committed scope:
 
-- exact scheduler mechanism
-- notification model
-- config editing workflow
-- exact issue tracker choice and workflow depth
+- real-world compatibility fixes for `https://myrss.org/eztv`
+- real-world compatibility fixes for `https://atlas.rssly.org/feed`
+- documentation and manual verification guidance for a valid local config
+
+Explicitly deferred:
+
+- scheduling or polling
+- remote feed capture
+- Turso or other hosted persistence
+- persistence redesign beyond local SQLite
 
 Working notes:
 

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -21,7 +21,7 @@ Exit condition:
 
 Goal:
 
-- make `media-sync run` work end-to-end against real target feeds
+- make the branded CLI work end-to-end against real target feeds
 - use RSS `enclosure.url` as the queueable torrent payload when present
 - keep movie items eligible when year and resolution match but codec is absent
 - preserve the current manual local workflow
@@ -30,6 +30,7 @@ Committed scope:
 
 - real-world compatibility fixes for `https://myrss.org/eztv`
 - real-world compatibility fixes for `https://atlas.rssly.org/feed`
+- rename the operator surface to `pirate-claw` and `pirate-claw.config.json`
 - documentation and manual verification guidance for a valid local config
 
 Explicitly deferred:

--- a/docs/01-product/phase-02-preliminary-notes.md
+++ b/docs/01-product/phase-02-preliminary-notes.md
@@ -4,7 +4,7 @@ These notes started as a holding area for real-world feed findings before Phase 
 
 ## Current Phase 02 Scope
 
-Phase 02 should deliver a minimal real-world working app for local manual invocation of `media-sync run` against:
+Phase 02 should deliver a minimal real-world working app for local manual invocation of the branded CLI against:
 
 - `https://myrss.org/eztv`
 - `https://atlas.rssly.org/feed`
@@ -14,6 +14,7 @@ The current Phase 02 implementation target is:
 - prefer RSS `enclosure.url` over `<link>` for queueable download URLs
 - keep `<link>` as fallback when no enclosure URL exists
 - allow movie items to match when year and resolution are valid even if codec is absent
+- rename the operator surface to `pirate-claw` and `pirate-claw.config.json` as the final Phase 02 ticket
 - keep the app manually invoked and locally persisted using the existing SQLite model
 
 ## Explicit Phase 03 Deferrals

--- a/docs/01-product/phase-02-preliminary-notes.md
+++ b/docs/01-product/phase-02-preliminary-notes.md
@@ -1,10 +1,34 @@
 # Phase 02 Preliminary Notes
 
-These notes are intentionally provisional. They capture real-world findings and likely design directions without committing Phase 02 to a full scope or implementation plan yet.
+These notes started as a holding area for real-world feed findings before Phase 02 scope was clear. Phase 02 is now narrowed to a smaller compatibility goal; the older polling and remote-capture ideas remain useful background, but they are not the implementation target for this phase.
+
+## Current Phase 02 Scope
+
+Phase 02 should deliver a minimal real-world working app for local manual invocation of `media-sync run` against:
+
+- `https://myrss.org/eztv`
+- `https://atlas.rssly.org/feed`
+
+The current Phase 02 implementation target is:
+
+- prefer RSS `enclosure.url` over `<link>` for queueable download URLs
+- keep `<link>` as fallback when no enclosure URL exists
+- allow movie items to match when year and resolution are valid even if codec is absent
+- keep the app manually invoked and locally persisted using the existing SQLite model
+
+## Explicit Phase 03 Deferrals
+
+The following ideas are deferred out of Phase 02:
+
+- polling or scheduling to avoid short feed-retention windows
+- remote feed capture
+- Turso or any other hosted persistence layer
+- importing buffered feed items into local SQLite
+- persistence redesign beyond the current local SQLite behavior
 
 ## Why This Note Exists
 
-Phase 01 is complete, but the exact objectives for Phase 02 are still in flux. A few important findings came out of manual review of a live movie RSS feed and should not be lost in chat history.
+Phase 01 is complete, and a few important findings came out of manual review of live RSS feeds. Those findings still matter because they explain why Phase 02 needs compatibility work before it needs automation.
 
 Reference feed discussed:
 
@@ -37,18 +61,17 @@ Observed on sampled live feed content:
 - For movie feeds like this one, codec omission appears to mean "not explicitly x265" rather than "metadata unavailable at random."
 - A hard codec filter causes Pirate Claw to reject releases that are likely acceptable candidates once year and resolution match.
 - Once-daily direct polling against live feeds is not reliable enough for the target sources.
-- Feed capture should be decoupled from queueing so RSS collection can run frequently while `run` remains manual or less frequent.
+- For Phase 02, this remains a known limitation rather than an implementation target.
+- Any future feed-capture layer should be treated as a later ingestion solution, not bundled into the compatibility slice.
 
-## Likely Phase 02 Direction
+## Earlier Ideas Now Deferred
 
 - Keep movie `years` as a hard filter.
 - Keep movie `resolutions` as a hard filter.
-- Move movie codec handling from a hard rejection rule to a scoring preference.
+- Move movie codec handling from a hard rejection rule to a scoring preference when codec is absent.
 - Prefer explicit preferred-codec hits over unknown codec.
-- Continue to rank among duplicate movie candidates using the scoring rubric so explicit `x265` wins when both candidates are otherwise acceptable.
-- Add a lightweight capture path that records raw feed items frequently for later local processing.
-- If the local machine cannot be relied on to stay online, use a remote poller to collect feed data on a short interval.
-- Prefer a separate data repo as the cheapest hosted persistence layer for captured feed data rather than appending operational snapshots into the application repo.
+- Continue to rank among duplicate movie candidates using the scoring rubric so explicit codec beats unknown codec when both candidates are otherwise acceptable.
+- Defer any capture path, remote poller, or hosted persistence design to Phase 03.
 
 ## Open Questions
 
@@ -114,5 +137,5 @@ Why this is attractive:
 - Prefer enclosure-based download URLs over link-based submission URLs.
 - Treat explicit codec hits as a ranking advantage, not necessarily a mandatory filter, for movie feeds with incomplete codec labeling.
 - Treat short-lived RSS windows as an ingestion problem, not a reason to abandon RSS for source-specific APIs yet.
-- If remote polling is needed because the local machine is not always on, prefer a separate data repo over writing captured feed snapshots into the application repo.
-- Avoid locking this into a full Phase 02 plan until the operator ergonomics and automation goals are clearer.
+- Defer polling, remote capture, Turso, and any ingestion redesign to Phase 03.
+- Treat Phase 02 as a compatibility slice, not an automation phase.

--- a/docs/02-delivery/issue-tracking.md
+++ b/docs/02-delivery/issue-tracking.md
@@ -24,7 +24,7 @@ Examples:
 Recommended epic names:
 
 - `Phase 01 MVP`
-- `Phase 02 Automation And Operator Ergonomics`
+- `Phase 02 Real-World Feed Compatibility`
 - `Phase 03 Post-Queue Lifecycle`
 
 ## Point System

--- a/docs/02-delivery/phase-02/implementation-plan.md
+++ b/docs/02-delivery/phase-02/implementation-plan.md
@@ -1,0 +1,60 @@
+# Phase 02 Implementation Plan
+
+Phase 02 is intentionally narrow. The goal is to make Pirate Claw work end-to-end against two real RSS feeds through local manual invocation before adding any automation or persistence redesign.
+
+## Epic
+
+- `Phase 02 Real-World Feed Compatibility`
+
+## Ticket Order
+
+1. `P2.01 Enclosure-First Feed Parsing`
+2. `P2.02 Movie Matcher Allows Missing Codec`
+3. `P2.03 README, Config Example, And Manual Live Verification`
+
+## Ticket Files
+
+- `ticket-01-enclosure-first-feed-parsing.md`
+- `ticket-02-movie-matcher-allows-missing-codec.md`
+- `ticket-03-readme-config-example-and-manual-live-verification.md`
+
+## Exit Condition
+
+`media-sync run` can be manually exercised against these target feeds using a valid local `media-sync.config.json` and a real Transmission instance:
+
+- `https://myrss.org/eztv`
+- `https://atlas.rssly.org/feed`
+
+The expected Phase 02 behavior is:
+
+- queueable torrent payloads are taken from RSS `enclosure.url` when present
+- `<link>` remains a fallback when no enclosure URL is present
+- movie releases remain eligible when year and resolution match policy even if codec is absent from the title
+
+## Review Rules
+
+Review and merge in ticket order.
+
+Do not start the next ticket until:
+
+- the previous tests are green
+- the behavior change is explained in the ticket and rationale
+- the deferred Phase 03 ingestion work remains deferred
+
+## Explicit Deferrals
+
+These are intentionally out of scope for Phase 02:
+
+- polling or scheduling
+- remote capture of feeds
+- Turso or any other hosted persistence layer
+- importing buffered feed items into local SQLite
+- persistence redesign beyond the current local SQLite model
+
+## Stop Conditions
+
+Pause for review if:
+
+- enclosure parsing requires feed-specific config instead of a generic fallback rule
+- movie matching needs a config redesign rather than a local matching-policy adjustment
+- manual verification against the live feeds reveals additional source-specific behavior outside the planned ticket scope

--- a/docs/02-delivery/phase-02/implementation-plan.md
+++ b/docs/02-delivery/phase-02/implementation-plan.md
@@ -10,17 +10,19 @@ Phase 02 is intentionally narrow. The goal is to make Pirate Claw work end-to-en
 
 1. `P2.01 Enclosure-First Feed Parsing`
 2. `P2.02 Movie Matcher Allows Missing Codec`
-3. `P2.03 README, Config Example, And Manual Live Verification`
+3. `P2.03 README And Real-World Config Example`
+4. `P2.04 Rename CLI And Config To Pirate Claw`
 
 ## Ticket Files
 
 - `ticket-01-enclosure-first-feed-parsing.md`
 - `ticket-02-movie-matcher-allows-missing-codec.md`
 - `ticket-03-readme-config-example-and-manual-live-verification.md`
+- `ticket-04-rename-cli-and-config-to-pirate-claw.md`
 
 ## Exit Condition
 
-`media-sync run` can be manually exercised against these target feeds using a valid local `media-sync.config.json` and a real Transmission instance:
+`pirate-claw run` can be manually exercised against these target feeds using a valid local `pirate-claw.config.json` and a real Transmission instance:
 
 - `https://myrss.org/eztv`
 - `https://atlas.rssly.org/feed`
@@ -30,6 +32,7 @@ The expected Phase 02 behavior is:
 - queueable torrent payloads are taken from RSS `enclosure.url` when present
 - `<link>` remains a fallback when no enclosure URL is present
 - movie releases remain eligible when year and resolution match policy even if codec is absent from the title
+- the branded operator surface is `pirate-claw` with `pirate-claw.config.json`
 
 ## Review Rules
 

--- a/docs/02-delivery/phase-02/ticket-01-enclosure-first-feed-parsing.md
+++ b/docs/02-delivery/phase-02/ticket-01-enclosure-first-feed-parsing.md
@@ -1,0 +1,29 @@
+# P2.01 Enclosure-First Feed Parsing
+
+Size: 2 points
+
+## Outcome
+
+- parse RSS items so `downloadUrl` prefers `enclosure.url`
+- keep `<link>` as the fallback when no enclosure URL exists
+- preserve current `guidOrLink`, `rawTitle`, and `publishedAt` behavior
+
+## Red
+
+- add parser tests for RSS items that include both `<link>` and `<enclosure url="...">`
+- prove the queueable download URL comes from `enclosure.url` for EZTV-style and YTS-style items
+- prove feeds without enclosure still fall back to `<link>`
+
+## Green
+
+- update feed parsing to read enclosure attributes without introducing feed-specific config
+
+## Refactor
+
+- keep XML extraction helpers small and source-agnostic
+- avoid widening the feed config surface for a generic RSS behavior
+
+## Review Focus
+
+- correct fallback order between `enclosure.url` and `<link>`
+- confidence that Transmission will receive queueable torrent URLs instead of details-page links

--- a/docs/02-delivery/phase-02/ticket-02-movie-matcher-allows-missing-codec.md
+++ b/docs/02-delivery/phase-02/ticket-02-movie-matcher-allows-missing-codec.md
@@ -1,0 +1,29 @@
+# P2.02 Movie Matcher Allows Missing Codec
+
+Size: 2 points
+
+## Outcome
+
+- allow movie items to match when year and resolution are valid even if codec is absent
+- keep explicit disallowed codecs rejected
+- rank explicit allowed codec hits above otherwise equivalent unknown-codec candidates
+
+## Red
+
+- add movie matcher tests for YTS-style titles that include year and resolution but no codec token
+- prove explicit allowed codec beats missing codec when duplicate movie candidates compete for the same identity
+- prove explicit disallowed codec still rejects the item
+
+## Green
+
+- adjust movie matching so codec is optional only when it is absent from the parsed title
+
+## Refactor
+
+- keep the config schema unchanged for this ticket
+- isolate any scoring change so TV matching semantics do not drift
+
+## Review Focus
+
+- minimal change to movie policy semantics
+- duplicate ranking remains predictable when metadata richness differs between candidates

--- a/docs/02-delivery/phase-02/ticket-03-readme-config-example-and-manual-live-verification.md
+++ b/docs/02-delivery/phase-02/ticket-03-readme-config-example-and-manual-live-verification.md
@@ -1,0 +1,31 @@
+# P2.03 README, Config Example, And Manual Live Verification
+
+Size: 2 points
+
+## Outcome
+
+- document the Phase 02 real-world target feeds and expected behavior
+- provide a concrete local `media-sync.config.json` example for manual testing
+- verify the live end-to-end path against real feeds and a local Transmission instance
+
+## Red
+
+- identify missing or misleading docs around queueable URLs and movie codec handling
+- identify any gaps that prevent a local operator from preparing a valid real-world config
+
+## Green
+
+- update `README.md` with the Phase 02 real-world compatibility notes
+- add a concrete config example using:
+  - `https://myrss.org/eztv`
+  - `https://atlas.rssly.org/feed`
+- capture the manual live-verification command and success criteria
+
+## Refactor
+
+- keep the README focused on current behavior rather than future polling or ingestion plans
+
+## Review Focus
+
+- operator can configure and exercise the app without consulting chat history
+- docs clearly separate the working Phase 02 path from deferred Phase 03 ingestion work

--- a/docs/02-delivery/phase-02/ticket-03-readme-config-example-and-manual-live-verification.md
+++ b/docs/02-delivery/phase-02/ticket-03-readme-config-example-and-manual-live-verification.md
@@ -1,12 +1,11 @@
-# P2.03 README, Config Example, And Manual Live Verification
+# P2.03 README And Real-World Config Example
 
 Size: 2 points
 
 ## Outcome
 
 - document the Phase 02 real-world target feeds and expected behavior
-- provide a concrete local `media-sync.config.json` example for manual testing
-- verify the live end-to-end path against real feeds and a local Transmission instance
+- provide a concrete local config example for manual testing before the branding rename lands
 
 ## Red
 
@@ -19,11 +18,12 @@ Size: 2 points
 - add a concrete config example using:
   - `https://myrss.org/eztv`
   - `https://atlas.rssly.org/feed`
-- capture the manual live-verification command and success criteria
+- capture the planned manual verification prerequisites while deferring the final branded command to the rename ticket
 
 ## Refactor
 
 - keep the README focused on current behavior rather than future polling or ingestion plans
+- avoid documenting a temporary operator surface as the final branded workflow
 
 ## Review Focus
 

--- a/docs/02-delivery/phase-02/ticket-04-rename-cli-and-config-to-pirate-claw.md
+++ b/docs/02-delivery/phase-02/ticket-04-rename-cli-and-config-to-pirate-claw.md
@@ -1,0 +1,32 @@
+# P2.04 Rename CLI And Config To Pirate Claw
+
+Size: 2 points
+
+## Outcome
+
+- rename the executable from `media-sync` to `pirate-claw`
+- rename the default config path from `media-sync.config.json` to `pirate-claw.config.json`
+- update docs, examples, and manual verification to use the branded names only
+- treat this as a clean break with no backward-compatibility aliases
+
+## Red
+
+- add or update CLI tests proving the branded command and default config name are the only supported interface
+- prove outdated docs or examples still reference the old names until this ticket is implemented
+
+## Green
+
+- update the bin entrypoint, package metadata, default config constant, CLI-facing messages, and tests
+- update README and Phase 02 docs to use `pirate-claw` and `pirate-claw.config.json`
+- perform the final real-world manual verification with:
+  - `./bin/pirate-claw run --config ./pirate-claw.config.json`
+
+## Refactor
+
+- remove the old names rather than carrying compatibility paths
+- keep the rename scoped to the branded operator surface without changing unrelated internals
+
+## Review Focus
+
+- branded interface is consistent across executable, config file, docs, and tests
+- no stale `media-sync` naming remains in the intended current-user workflow

--- a/docs/03-engineering/sqlite-schema.md
+++ b/docs/03-engineering/sqlite-schema.md
@@ -1,0 +1,166 @@
+# Current SQLite Schema
+
+This note documents the current local SQLite model used by Pirate Claw. It is intentionally behavior-oriented: the goal is to explain what is persisted, how the tables relate, and which invariants matter for review and future tickets.
+
+For the exact DDL and repository queries, see [src/repository.ts](/Users/cesar/.codex/worktrees/ac10/pirate_claw/src/repository.ts).
+
+## Scope
+
+The current schema supports these behaviors:
+
+- record each CLI run
+- record raw feed items seen during a run
+- preserve the latest known state for each matched media identity
+- record per-item outcomes for status reporting and debugging
+- support duplicate suppression and retry of failed submissions
+
+This schema is local-only. It does not attempt to capture polling history, remote ingestion, or any cross-machine state.
+
+## Tables
+
+## `runs`
+
+One row per `media-sync run` or `media-sync retry-failed` invocation.
+
+Important fields:
+
+- `id`: surrogate primary key
+- `started_at`
+- `status`: `running`, `completed`, or `failed`
+- `completed_at`
+
+Behavioral role:
+
+- provides the top-level audit trail for each invocation
+- anchors `feed_items`, `candidate_state.first_seen_run_id`, `candidate_state.last_seen_run_id`, and `feed_item_outcomes.run_id`
+
+## `feed_items`
+
+One row per raw RSS item observed during a specific run.
+
+Important fields:
+
+- `id`: surrogate primary key
+- `run_id`: references `runs(id)`
+- `feed_name`
+- `guid_or_link`
+- `raw_title`
+- `published_at`
+- `download_url`
+
+Behavioral role:
+
+- preserves the source payload used for matching and queueing during that run
+- captures the queueable URL passed downstream at the time the item was seen
+- gives `feed_item_outcomes` and `candidate_state.last_feed_item_id` a stable pointer back to the specific observed item
+
+## `candidate_state`
+
+One row per matched media identity. This is the durable dedupe and retry table.
+
+Primary key:
+
+- `identity_key`
+
+Important fields:
+
+- `media_type`
+- `status`: `queued`, `failed`, or `skipped_duplicate`
+- `queued_at`
+- `rule_name`
+- `score`
+- `reasons_json`
+- normalized media fields such as `normalized_title`, `season`, `episode`, `year`, `resolution`, and `codec`
+- last-seen source fields such as `feed_name`, `guid_or_link`, `published_at`, and `download_url`
+- provenance fields: `first_seen_run_id`, `last_seen_run_id`, `last_feed_item_id`
+- `updated_at`
+
+Behavioral role:
+
+- collapses competing releases onto one durable identity
+- records the current best-known state for that identity
+- blocks requeueing when a prior candidate was already queued
+- powers `retry-failed` by storing the last retryable failed candidate with its `download_url`
+
+## `feed_item_outcomes`
+
+One row per disposition decision made during a run.
+
+Important fields:
+
+- `id`: surrogate primary key
+- `run_id`: references `runs(id)`
+- `feed_item_id`: optional reference to `feed_items(id)`
+- `status`: `queued`, `failed`, `skipped_duplicate`, or `skipped_no_match`
+- `identity_key`
+- `rule_name`
+- `message`
+- `created_at`
+
+Behavioral role:
+
+- records what happened to each processed feed item during that run
+- supports run summaries and operator debugging
+- preserves decisions even when there is no durable `candidate_state` row, such as `skipped_no_match`
+
+## Identity And Relationships
+
+The schema intentionally separates three layers of identity:
+
+- run identity: `runs.id`
+- observed feed item identity: `feed_items.id`
+- media candidate identity: `candidate_state.identity_key`
+
+Key relationships:
+
+- one `run` has many `feed_items`
+- one `run` has many `feed_item_outcomes`
+- one `feed_item` may produce zero or one durable `candidate_state` update
+- many observed `feed_items` across multiple runs can collapse onto one `candidate_state.identity_key`
+
+This separation matters because dedupe happens at the media identity level, not at the raw RSS item level.
+
+## State Model
+
+## Run states
+
+`runs.status` transitions are:
+
+- `running` when the invocation starts
+- `completed` when orchestration finishes successfully
+- `failed` when orchestration aborts due to an error
+
+## Candidate states
+
+`candidate_state.status` reflects the latest durable state for an identity:
+
+- `queued`: the identity has been successfully sent to Transmission
+- `failed`: the latest submission attempt failed and remains retryable
+- `skipped_duplicate`: the identity lost to a higher-ranked candidate or was seen again after being effectively handled elsewhere
+
+Important nuance:
+
+- `skipped_no_match` is not a `candidate_state` value because unmatched feed items do not create a durable candidate identity
+- `queued_at` is preserved once set, even if later upserts touch the same identity
+
+## Current Invariants
+
+- `candidate_state.identity_key` is the dedupe boundary for queueing behavior.
+- `candidate_state.first_seen_run_id` never changes after the first insert.
+- `candidate_state.last_seen_run_id` moves forward as later runs encounter the same identity.
+- `candidate_state.queued_at` is sticky once a candidate has been queued.
+- `feed_item_outcomes` is append-only from the application point of view; it records each run decision rather than overwriting history.
+- `listRetryableCandidates` only returns `candidate_state` rows with `status = 'failed'` and a non-empty `download_url`.
+
+## What This Doc Intentionally Does Not Freeze
+
+This note describes the current Phase 01 and early Phase 02 local model. It does not promise that the schema is final for later ingestion work.
+
+Likely future pressure points:
+
+- remote feed capture
+- import or buffering layers for short-lived feeds
+- richer submission-attempt history
+- migrations beyond the current lightweight `runs.status` compatibility check
+
+If later phases change the persistence boundary materially, update this doc alongside the schema changes instead of relying on chat history.

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ Execution plans, issue conventions, and ticket breakdowns.
 
 Cross-cutting engineering rules that apply beyond a single phase.
 
+- `sqlite-schema.md`: current local SQLite tables, identities, and persistence invariants
 - `snyk-workflow-rationale.md`: rationale for adding Snyk-based security scanning to CI
 - `tdd-workflow.md`: red-green-refactor workflow for this repo
 

--- a/package.json
+++ b/package.json
@@ -13,19 +13,22 @@
     "hooks:install": "git config core.hooksPath .githooks",
     "lint": "eslint .",
     "run": "bun run ./src/cli.ts",
+    "spellcheck": "cspell lint . --gitignore --no-progress",
+    "spellcheck:words": "cspell lint . --gitignore --no-progress --no-summary --no-exit-code --words-only | bun run ./scripts/spellcheck-words.ts",
     "test": "bun test",
     "test:coverage": "bun test --coverage",
     "typecheck": "tsc --noEmit",
-    "verify": "bun run format:check && bun run typecheck && bun run lint"
+    "verify": "bun run format:check && bun run typecheck && bun run lint && bun run spellcheck"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.11",
     "@eslint/js": "^10.0.1",
+    "@types/bun": "^1.3.11",
+    "cspell": "^9.7.0",
     "eslint": "^10.1.0",
     "globals": "^17.4.0",
     "prettier": "^3.8.1",
-    "typescript-eslint": "^8.57.2",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.57.2"
   },
   "dependencies": {
     "fast-xml-parser": "^5.5.9"

--- a/scripts/spellcheck-words.ts
+++ b/scripts/spellcheck-words.ts
@@ -1,3 +1,5 @@
+export {};
+
 const input = await Bun.stdin.text();
 
 const counts = new Map<string, number>();

--- a/scripts/spellcheck-words.ts
+++ b/scripts/spellcheck-words.ts
@@ -1,0 +1,32 @@
+const input = await Bun.stdin.text();
+
+const counts = new Map<string, number>();
+
+for (const line of input.split(/\r?\n/)) {
+  const word = line.trim();
+
+  if (!word) {
+    continue;
+  }
+
+  counts.set(word, (counts.get(word) ?? 0) + 1);
+}
+
+const entries = [...counts.entries()].sort((left, right) => {
+  if (right[1] !== left[1]) {
+    return right[1] - left[1];
+  }
+
+  return left[0].localeCompare(right[0]);
+});
+
+if (entries.length === 0) {
+  console.log('No unknown words found.');
+  process.exit(0);
+}
+
+console.log('Candidate words for cspell.json review:\n');
+
+for (const [word, count] of entries) {
+  console.log(`${String(count).padStart(3, ' ')}  ${word}`);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "types": ["bun"],
     "allowJs": false
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

- define the Phase 02 epic as real-world feed compatibility instead of automation
- add the Phase 02 implementation plan and three small delivery tickets
- tighten the Phase 02 product notes and roadmap to keep polling, Turso, and persistence redesign deferred to Phase 03
- add a reviewed cspell workflow with `spellcheck` and `spellcheck:words`
- document the new spellcheck commands in the README and curate current project jargon in `cspell.json`

## Details

- adds `docs/02-delivery/phase-02/implementation-plan.md`
- adds ticket docs for enclosure-first parsing, missing-codec movie matching, and live manual verification
- updates issue-tracking epic naming to match the new Phase 02 scope
- adds `scripts/spellcheck-words.ts` to turn unknown-word output into a review list
- makes `bun run verify` enforce spellcheck
