### PR TITLE
feat: enclosure-first feed parsing [P2.01]

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Phase 01 ends at successful queueing in Transmission. It does not include a web 
 Tickets 01-10 are implemented:
 
 - minimal Bun + TypeScript CLI skeleton with JSON config loading and validation for `media-sync run`
-- RSS fetch-and-parse entrypoint that converts RSS items into a raw feed-item shape
+- RSS fetch-and-parse entrypoint that converts RSS items into a raw feed-item shape and prefers `enclosure.url` over `<link>` for queueable downloads
 - title-normalization module that extracts matching metadata for TV and movie releases
 - TV rule matcher that evaluates normalized items against name-based rules with optional regex overrides plus codec and resolution filters
 - movie policy matcher that accepts releases by global year and quality policy without per-title rules

--- a/docs/02-delivery/phase-02/ticket-01-rationale.md
+++ b/docs/02-delivery/phase-02/ticket-01-rationale.md
@@ -1,0 +1,6 @@
+# P2.01 Rationale
+
+- `Red first:` parser tests proving RSS items with both `<link>` and `<enclosure url="...">` use the enclosure as the queueable `downloadUrl`, plus a fallback test proving feeds without enclosures still use `<link>`.
+- `Why this path:` adding one small enclosure extractor inside the existing feed parser was the smallest acceptable way to make Transmission receive torrent payload URLs without widening config or introducing feed-specific parsing rules.
+- `Alternative considered:` adding per-feed parser hints or source-specific URL selection was rejected because the ticket targets a generic RSS behavior that should remain source-agnostic.
+- `Deferred:` any feed-specific normalization beyond enclosure-vs-link fallback, plus polling or capture automation, remain later-phase work.

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -60,6 +60,7 @@ function parseItem(
 ): RawFeedItem {
   const rawTitle = requireText(feed, item, 'title', index);
   const link = requireText(feed, item, 'link', index);
+  const enclosureUrl = optionalEnclosureUrl(item);
   const guid = optionalText(item, 'guid');
   const pubDate = requireText(feed, item, 'pubDate', index);
   const publishedAt = normalizePublishedAt(feed, pubDate, index);
@@ -69,14 +70,14 @@ function parseItem(
     guidOrLink: guid ?? link,
     rawTitle,
     publishedAt,
-    downloadUrl: link,
+    downloadUrl: enclosureUrl ?? link,
   };
 }
 
 function requireText(
   feed: FeedConfig,
   item: ParsedFeedItem,
-  tagName: keyof ParsedFeedItem,
+  tagName: ParsedFeedTextTag,
   index: number,
 ): string {
   const value = optionalText(item, tagName);
@@ -92,10 +93,27 @@ function requireText(
 
 function optionalText(
   item: ParsedFeedItem,
-  tagName: keyof ParsedFeedItem,
+  tagName: ParsedFeedTextTag,
 ): string | undefined {
   const value = textValue(item[tagName]);
   return value && value.length > 0 ? value : undefined;
+}
+
+function optionalEnclosureUrl(item: ParsedFeedItem): string | undefined {
+  const enclosure = item.enclosure;
+  const firstEnclosure = Array.isArray(enclosure) ? enclosure[0] : enclosure;
+
+  if (
+    firstEnclosure &&
+    typeof firstEnclosure === 'object' &&
+    '@_url' in firstEnclosure &&
+    typeof firstEnclosure['@_url'] === 'string'
+  ) {
+    const value = firstEnclosure['@_url'].trim();
+    return value.length > 0 ? value : undefined;
+  }
+
+  return undefined;
 }
 
 function normalizePublishedAt(
@@ -160,12 +178,15 @@ function toArray<T>(value: T | T[] | undefined): T[] {
 }
 
 type ParsedXmlValue = string | { '#text'?: string; '@_isPermaLink'?: string };
+type ParsedEnclosure = { '@_url'?: string };
+type ParsedFeedTextTag = 'title' | 'link' | 'guid' | 'pubDate';
 
 type ParsedFeedItem = {
   title?: ParsedXmlValue;
   link?: ParsedXmlValue;
   guid?: ParsedXmlValue;
   pubDate?: ParsedXmlValue;
+  enclosure?: ParsedEnclosure | ParsedEnclosure[];
 };
 
 type ParsedFeedDocument = {

--- a/test/feed.test.ts
+++ b/test/feed.test.ts
@@ -19,7 +19,7 @@ describe('fetchFeed', () => {
     globalThis.fetch = originalFetch;
   });
 
-  it('parses multiple TV-style RSS items and prefers guid over link', async () => {
+  it('parses multiple TV-style RSS items and prefers enclosure url over link', async () => {
     const server = await startFeedServer(200, tvFeedFixture);
     const feed = createFeedConfig('TV Feed', `${server.url}/eztv`, 'tv');
 
@@ -31,19 +31,19 @@ describe('fetchFeed', () => {
         guidOrLink: 'eztv-1001',
         rawTitle: 'Example Show S01E02 1080p WEB h264',
         publishedAt: '2026-03-29T10:15:00.000Z',
-        downloadUrl: 'https://download.example.test/tv/1001',
+        downloadUrl: 'https://torrents.example.test/tv/1001.torrent',
       },
       {
         feedName: 'TV Feed',
         guidOrLink: 'https://download.example.test/tv/1002',
         rawTitle: 'Example Show S01E03 1080p WEB x265',
         publishedAt: '2026-03-29T11:30:00.000Z',
-        downloadUrl: 'https://download.example.test/tv/1002',
+        downloadUrl: 'https://torrents.example.test/tv/1002.torrent',
       },
     ]);
   });
 
-  it('parses multiple movie-style RSS items with standard fields only', async () => {
+  it('parses multiple movie-style RSS items with enclosure-first download urls', async () => {
     const server = await startFeedServer(200, movieFeedFixture);
     const feed = createFeedConfig('Movie Feed', `${server.url}/feed`, 'movie');
 
@@ -55,14 +55,35 @@ describe('fetchFeed', () => {
         guidOrLink: 'atlas-2001',
         rawTitle: 'Example Movie 2024 1080p WEB-DL x265',
         publishedAt: '2026-03-29T06:00:00.000Z',
-        downloadUrl: 'https://download.example.test/movie/2001',
+        downloadUrl: 'https://torrents.example.test/movie/2001.torrent',
       },
       {
         feedName: 'Movie Feed',
         guidOrLink: 'atlas-2002',
         rawTitle: 'Another Movie 2024 2160p WEB-DL x265',
         publishedAt: '2026-03-29T08:45:00.000Z',
-        downloadUrl: 'https://download.example.test/movie/2002',
+        downloadUrl: 'https://torrents.example.test/movie/2002.torrent',
+      },
+    ]);
+  });
+
+  it('falls back to link when an item does not include an enclosure url', async () => {
+    const server = await startFeedServer(200, linkOnlyFeedFixture);
+    const feed = createFeedConfig(
+      'Fallback Feed',
+      `${server.url}/fallback`,
+      'movie',
+    );
+
+    const items = await fetchFeed(feed);
+
+    expect(items).toEqual([
+      {
+        feedName: 'Fallback Feed',
+        guidOrLink: 'fallback-3001',
+        rawTitle: 'Fallback Movie 2024 1080p WEB-DL',
+        publishedAt: '2026-03-29T09:15:00.000Z',
+        downloadUrl: 'https://download.example.test/movie/fallback-3001',
       },
     ]);
   });
@@ -167,12 +188,14 @@ const tvFeedFixture = `<?xml version="1.0" encoding="UTF-8"?>
     <item>
       <title><![CDATA[Example Show S01E02 1080p WEB h264]]></title>
       <link>https://download.example.test/tv/1001</link>
+      <enclosure url="https://torrents.example.test/tv/1001.torrent" type="application/x-bittorrent" />
       <guid isPermaLink="false">eztv-1001</guid>
       <pubDate>Sun, 29 Mar 2026 10:15:00 GMT</pubDate>
     </item>
     <item>
       <title>Example Show S01E03 1080p WEB x265</title>
       <link>https://download.example.test/tv/1002</link>
+      <enclosure url="https://torrents.example.test/tv/1002.torrent" type="application/x-bittorrent" />
       <pubDate>Sun, 29 Mar 2026 11:30:00 GMT</pubDate>
     </item>
   </channel>
@@ -185,14 +208,29 @@ const movieFeedFixture = `<?xml version="1.0" encoding="UTF-8"?>
     <item>
       <title>Example Movie 2024 1080p WEB-DL x265</title>
       <link>https://download.example.test/movie/2001</link>
+      <enclosure url="https://torrents.example.test/movie/2001.torrent" type="application/x-bittorrent" />
       <guid isPermaLink="false">atlas-2001</guid>
       <pubDate>Sun, 29 Mar 2026 06:00:00 GMT</pubDate>
     </item>
     <item>
       <title><![CDATA[Another Movie 2024 2160p WEB-DL x265]]></title>
       <link>https://download.example.test/movie/2002</link>
+      <enclosure url="https://torrents.example.test/movie/2002.torrent" type="application/x-bittorrent" />
       <guid isPermaLink="false">atlas-2002</guid>
       <pubDate>Sun, 29 Mar 2026 08:45:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+const linkOnlyFeedFixture = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Fallback Feed</title>
+    <item>
+      <title>Fallback Movie 2024 1080p WEB-DL</title>
+      <link>https://download.example.test/movie/fallback-3001</link>
+      <guid isPermaLink="false">fallback-3001</guid>
+      <pubDate>Sun, 29 Mar 2026 09:15:00 GMT</pubDate>
     </item>
   </channel>
 </rss>`;


### PR DESCRIPTION
## Summary

- prefer RSS `enclosure.url` over `<link>` when building queueable `downloadUrl` values
- keep `<link>` as the fallback when no enclosure is present
- add parser coverage and a short rationale note for the slice

## Rationale

- Why this path: a small parser-level enclosure extractor keeps the behavior source-agnostic and avoids widening config for a generic RSS rule.
- Alternative considered: feed-specific parser hints were rejected because this ticket only needs a standard RSS fallback order.
- Deferred: any source-specific normalization or feed-capture automation remains out of scope for Phase 02.

## Branch History

- Initial branch commit: `feat: prefer enclosure-first feed parsing`
- No additional follow-up commits were pushed after PR creation.

## AI Review Follow-Up

- `qodo-code-review` triage found no prudent follow-up changes.
