### PR TITLE
feat: allow movies with missing codec metadata [P2.02]

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Tickets 01-10 are implemented:
 - RSS fetch-and-parse entrypoint that converts RSS items into a raw feed-item shape and prefers `enclosure.url` over `<link>` for queueable downloads
 - title-normalization module that extracts matching metadata for TV and movie releases
 - TV rule matcher that evaluates normalized items against name-based rules with optional regex overrides plus codec and resolution filters
-- movie policy matcher that accepts releases by global year and quality policy without per-title rules
+- movie policy matcher that accepts releases by global year and quality policy without per-title rules, including movie titles that omit codec metadata
 - SQLite-backed run history and candidate-state persistence that preserves dedupe and retryability
 - Transmission RPC adapter that negotiates session ids, submits torrent URLs, and returns structured queueing failures without wiring the full run pipeline yet
 - end-to-end `media-sync run` orchestration that fetches feeds, matches candidates, persists per-feed-item outcomes, submits winners, and prints a compact run summary

--- a/docs/02-delivery/phase-02/ticket-02-rationale.md
+++ b/docs/02-delivery/phase-02/ticket-02-rationale.md
@@ -1,0 +1,6 @@
+# P2.02 Rationale
+
+- `Red first:` movie matcher tests proving year-and-resolution matches survive when codec is absent, plus a ranking test proving explicit allowed codec hits beat otherwise equivalent unknown-codec releases.
+- `Why this path:` keeping the config schema unchanged and treating missing codec as a movie-only scoring case was the smallest acceptable way to support YTS-style titles without loosening TV matching semantics.
+- `Alternative considered:` adding a new config flag for unknown-codec movies was rejected because the live-feed behavior is consistent enough for a local policy adjustment in this ticket.
+- `Deferred:` any broader quality-policy redesign, source-specific matching overrides, or scheduling/capture automation remains later-phase work.

--- a/src/movie-match.ts
+++ b/src/movie-match.ts
@@ -51,7 +51,7 @@ function matchesMovieQuality(
   }
 
   if (codec === undefined) {
-    return true;
+    return policy.codecs.length > 0;
   }
 
   return matchesAllowedQuality(
@@ -68,16 +68,16 @@ function scoreMovieQualityPreference(
   policy: MoviePolicy,
 ): number {
   if (codec === undefined) {
-    const bestAllowedCodec = policy.codecs[0];
+    const worstAllowedCodec = policy.codecs.at(-1);
 
-    if (bestAllowedCodec === undefined) {
+    if (worstAllowedCodec === undefined) {
       return 0;
     }
 
     return (
       scoreQualityPreference(
         resolution,
-        bestAllowedCodec,
+        worstAllowedCodec,
         policy.resolutions,
         policy.codecs,
       ) - 1

--- a/src/movie-match.ts
+++ b/src/movie-match.ts
@@ -22,9 +22,8 @@ export function matchMovieItem(
     item.mediaType !== 'movie' ||
     year === undefined ||
     resolution === undefined ||
-    codec === undefined ||
     !policy.years.includes(year) ||
-    !matchesAllowedQuality(resolution, codec, policy.resolutions, policy.codecs)
+    !matchesMovieQuality(resolution, codec, policy)
   ) {
     return undefined;
   }
@@ -32,17 +31,75 @@ export function matchMovieItem(
   return {
     ruleName: MOVIE_POLICY_RULE_NAME,
     identityKey: buildIdentityKey(item),
-    score: scoreQualityPreference(
-      resolution,
-      codec,
-      policy.resolutions,
-      policy.codecs,
-    ),
-    reasons: [`year:${year}`, `resolution:${resolution}`, `codec:${codec}`],
+    score: scoreMovieQualityPreference(resolution, codec, policy),
+    reasons: createReasons(year, resolution, codec),
     item,
   };
 }
 
 function buildIdentityKey(item: NormalizedFeedItem): string {
   return `movie:${item.normalizedTitle.trim().toLowerCase()}|${item.year ?? ''}`;
+}
+
+function matchesMovieQuality(
+  resolution: string,
+  codec: string | undefined,
+  policy: MoviePolicy,
+): boolean {
+  if (!policy.resolutions.includes(resolution)) {
+    return false;
+  }
+
+  if (codec === undefined) {
+    return true;
+  }
+
+  return matchesAllowedQuality(
+    resolution,
+    codec,
+    policy.resolutions,
+    policy.codecs,
+  );
+}
+
+function scoreMovieQualityPreference(
+  resolution: string,
+  codec: string | undefined,
+  policy: MoviePolicy,
+): number {
+  if (codec === undefined) {
+    const bestAllowedCodec = policy.codecs[0];
+
+    if (bestAllowedCodec === undefined) {
+      return 0;
+    }
+
+    return (
+      scoreQualityPreference(
+        resolution,
+        bestAllowedCodec,
+        policy.resolutions,
+        policy.codecs,
+      ) - 1
+    );
+  }
+
+  return scoreQualityPreference(
+    resolution,
+    codec,
+    policy.resolutions,
+    policy.codecs,
+  );
+}
+
+function createReasons(
+  year: number,
+  resolution: string,
+  codec: string | undefined,
+): string[] {
+  return [
+    `year:${year}`,
+    `resolution:${resolution}`,
+    codec === undefined ? 'codec:unknown' : `codec:${codec}`,
+  ];
 }

--- a/test/movie-match.test.ts
+++ b/test/movie-match.test.ts
@@ -127,6 +127,26 @@ describe('matchMovieItem', () => {
     );
   });
 
+  it('keeps lower-preference explicit codecs above unknown-codec releases', () => {
+    const lowerPreferenceCodec = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: 'Example.Movie.2024.1080p.WEB.x264-GROUP',
+    });
+    const unknownCodec = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: 'Example.Movie.2024.1080p.WEB-GROUP',
+    });
+    const policy: MoviePolicy = {
+      years: [2024],
+      resolutions: ['1080p'],
+      codecs: ['x265', 'x264'],
+    };
+
+    expect(
+      matchMovieItem(lowerPreferenceCodec, policy)?.score ?? 0,
+    ).toBeGreaterThan(matchMovieItem(unknownCodec, policy)?.score ?? 0);
+  });
+
   it.each([
     {
       name: 'year is not allowed',
@@ -197,6 +217,20 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265'],
+    };
+
+    expect(matchMovieItem(item, policy)).toBeUndefined();
+  });
+
+  it('rejects unknown-codec movies when the policy allows no codecs', () => {
+    const item = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: 'Example.Movie.2024.1080p.WEB-GROUP',
+    });
+    const policy: MoviePolicy = {
+      years: [2024],
+      resolutions: ['1080p'],
+      codecs: [],
     };
 
     expect(matchMovieItem(item, policy)).toBeUndefined();

--- a/test/movie-match.test.ts
+++ b/test/movie-match.test.ts
@@ -25,6 +25,26 @@ describe('matchMovieItem', () => {
     });
   });
 
+  it('accepts a movie release when codec is missing but year and resolution are allowed', () => {
+    const item = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: 'Example.Movie.2024.1080p.WEB-GROUP',
+    });
+    const policy: MoviePolicy = {
+      years: [2024],
+      resolutions: ['1080p'],
+      codecs: ['x265'],
+    };
+
+    expect(matchMovieItem(item, policy)).toEqual({
+      ruleName: 'movies',
+      identityKey: 'movie:example movie|2024',
+      score: 99,
+      reasons: ['year:2024', 'resolution:1080p', 'codec:unknown'],
+      item,
+    });
+  });
+
   it('matches by policy without requiring any title-pattern semantics', () => {
     const item = normalizeFeedItem({
       mediaType: 'movie',
@@ -84,6 +104,29 @@ describe('matchMovieItem', () => {
     );
   });
 
+  it('ranks explicit allowed codecs above otherwise equivalent unknown-codec releases', () => {
+    const explicitCodec = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: 'Example.Movie.2024.1080p.WEB.x265-GROUP',
+    });
+    const unknownCodec = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: 'Example.Movie.2024.1080p.WEB-GROUP',
+    });
+    const policy: MoviePolicy = {
+      years: [2024],
+      resolutions: ['1080p'],
+      codecs: ['x265', 'x264'],
+    };
+
+    expect(matchMovieItem(explicitCodec, policy)?.identityKey).toBe(
+      matchMovieItem(unknownCodec, policy)?.identityKey,
+    );
+    expect(matchMovieItem(explicitCodec, policy)?.score ?? 0).toBeGreaterThan(
+      matchMovieItem(unknownCodec, policy)?.score ?? 0,
+    );
+  });
+
   it.each([
     {
       name: 'year is not allowed',
@@ -106,8 +149,12 @@ describe('matchMovieItem', () => {
       rawTitle: 'Example Movie 2024 WEB x265',
     },
     {
-      name: 'codec is missing',
-      rawTitle: 'Example Movie 2024 1080p WEB',
+      name: 'year and codec are missing',
+      rawTitle: 'Example Movie 1080p WEB',
+    },
+    {
+      name: 'resolution is missing',
+      rawTitle: 'Example Movie 2024 WEB',
     },
     {
       name: 'item is not a movie',
@@ -140,4 +187,18 @@ describe('matchMovieItem', () => {
       expect(matchMovieItem(item, policy)).toBeUndefined();
     },
   );
+
+  it('rejects an explicit codec when it is not allowed even if year and resolution match', () => {
+    const item = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: 'Example.Movie.2024.1080p.WEB.x264-GROUP',
+    });
+    const policy: MoviePolicy = {
+      years: [2024],
+      resolutions: ['1080p'],
+      codecs: ['x265'],
+    };
+
+    expect(matchMovieItem(item, policy)).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- allow movie items with valid year and resolution to match even when codec metadata is absent
- keep explicit disallowed codecs rejected
- rank explicit allowed codec hits above otherwise equivalent unknown-codec releases

## Rationale

- Why this path: the matcher now treats missing codec as a movie-only scoring case, which keeps the config schema unchanged and avoids drifting TV semantics.
- Alternative considered: a new config flag for unknown-codec movies was rejected because this live-feed behavior is consistent enough for a local policy adjustment.
- Deferred: broader quality-policy redesign and any source-specific matching overrides remain out of scope for Phase 02.

## Branch History

- Initial branch commit: `feat: allow movies with missing codec metadata`
- Follow-up commit after PR creation: `fix: keep unknown movie codecs below explicit matches`

## AI Review Follow-Up

- `qodo-code-review` triage surfaced two actionable correctness issues.
- The follow-up fix commit keeps unknown-codec candidates below every explicit allowed codec at the same resolution and rejects unknown-codec matches when `codecs: []`.
