### PR TITLE
docs: add phase 02 real-world verification guide [P2.03]

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Suggested manual verification flow before the rename ticket:
 
 1. Copy the example config to a local file and replace the Transmission credentials.
 2. Change `tv[0].name` to a show title that is currently visible in the EZTV feed.
-3. Run `./bin/media-sync run --config ./test/fixtures/phase-02-real-world.config.json` or the path to your local copy.
+3. Run `./bin/media-sync run --config ./phase-02-real-world.config.json` or the path to your edited local copy, not the checked-in fixture.
 4. Confirm queued items in Transmission use torrent payload URLs instead of details-page links.
 5. Use `./bin/media-sync status` to inspect the resulting run and candidate-state records.
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,80 @@ Useful supporting docs:
 - `./bin/media-sync status`
 - `./bin/media-sync retry-failed --config ./test/fixtures/valid-config.json`
 
+## Phase 02 Manual Verification
+
+Phase 02 is a real-world compatibility slice, not an automation phase yet. The current operator surface is still `media-sync` and `--config`; the final `pirate-claw` rename lands in `P2.04`.
+
+Target feeds for local manual verification:
+
+- `https://myrss.org/eztv`
+- `https://atlas.rssly.org/feed`
+
+Expected behavior in the current Phase 02 build:
+
+- queueable torrent URLs come from RSS `enclosure.url` when present, with `<link>` only as a fallback
+- movie items remain eligible when year and resolution match policy even if codec is absent
+- explicit allowed codecs still outrank otherwise equivalent unknown-codec movie releases
+- local SQLite persistence and manual CLI invocation remain the active workflow
+
+Prerequisites before running against live feeds:
+
+- a reachable Transmission RPC endpoint
+- credentials with permission to add torrents
+- a local config file derived from [`test/fixtures/phase-02-real-world.config.json`](./test/fixtures/phase-02-real-world.config.json)
+- at least one TV rule narrowed to a show you actually want to queue from the current EZTV feed window
+
+Use this example as a starting point for local verification:
+
+```json
+{
+  "feeds": [
+    {
+      "name": "EZTV",
+      "url": "https://myrss.org/eztv",
+      "mediaType": "tv"
+    },
+    {
+      "name": "Atlas Movies",
+      "url": "https://atlas.rssly.org/feed",
+      "mediaType": "movie"
+    }
+  ],
+  "tv": [
+    {
+      "name": "Replace With A Current EZTV Show",
+      "resolutions": ["2160p", "1080p"],
+      "codecs": ["x265", "x264"]
+    }
+  ],
+  "movies": {
+    "years": [2026, 2025, 2024],
+    "resolutions": ["2160p", "1080p"],
+    "codecs": ["x265", "x264"]
+  },
+  "transmission": {
+    "url": "http://localhost:9091/transmission/rpc",
+    "username": "user",
+    "password": "pass"
+  }
+}
+```
+
+Suggested manual verification flow before the rename ticket:
+
+1. Copy the example config to a local file and replace the Transmission credentials.
+2. Change `tv[0].name` to a show title that is currently visible in the EZTV feed.
+3. Run `./bin/media-sync run --config ./test/fixtures/phase-02-real-world.config.json` or the path to your local copy.
+4. Confirm queued items in Transmission use torrent payload URLs instead of details-page links.
+5. Use `./bin/media-sync status` to inspect the resulting run and candidate-state records.
+
+Still deferred after this ticket:
+
+- polling or scheduling
+- remote feed capture or hosted persistence
+- importing buffered feed items into local SQLite
+- the final branded `pirate-claw` command and `pirate-claw.config.json` name
+
 ## CI
 
 - GitHub Actions runs `bun run ci` on pushes to `main`, pushes to `codex/**`, and pull requests.

--- a/docs/02-delivery/phase-02/ticket-03-rationale.md
+++ b/docs/02-delivery/phase-02/ticket-03-rationale.md
@@ -1,0 +1,6 @@
+# P2.03 Rationale
+
+- `Red first:` identify the README gaps that still hid the live-feed workflow, especially the real feed URLs, queueable enclosure behavior, codec-optional movie matching, and the current pre-rename command surface.
+- `Why this path:` a focused README section plus one concrete config example file was the smallest acceptable way to make local Phase 02 verification possible without inventing new tooling or pulling operators back into chat history.
+- `Alternative considered:` documenting only prose steps without a concrete config artifact was rejected because the operator still needs one valid JSON shape to adapt locally against the real feeds.
+- `Deferred:` polling, capture automation, hosted persistence, and the final `pirate-claw` rename remain later tickets rather than being implied by the new docs.

--- a/test/fixtures/phase-02-real-world.config.json
+++ b/test/fixtures/phase-02-real-world.config.json
@@ -1,0 +1,31 @@
+{
+  "feeds": [
+    {
+      "name": "EZTV",
+      "url": "https://myrss.org/eztv",
+      "mediaType": "tv"
+    },
+    {
+      "name": "Atlas Movies",
+      "url": "https://atlas.rssly.org/feed",
+      "mediaType": "movie"
+    }
+  ],
+  "tv": [
+    {
+      "name": "Replace With A Current EZTV Show",
+      "resolutions": ["2160p", "1080p"],
+      "codecs": ["x265", "x264"]
+    }
+  ],
+  "movies": {
+    "years": [2026, 2025, 2024],
+    "resolutions": ["2160p", "1080p"],
+    "codecs": ["x265", "x264"]
+  },
+  "transmission": {
+    "url": "http://localhost:9091/transmission/rpc",
+    "username": "user",
+    "password": "pass"
+  }
+}


### PR DESCRIPTION
## Summary

- document the current Phase 02 live-feed verification path before the rename ticket lands
- add a concrete real-world config example using the EZTV and Atlas feeds
- capture prerequisites, expected behavior, and explicit deferrals in the README

## Rationale

- Why this path: a focused README section plus one concrete config artifact makes local verification possible without adding new tooling.
- Alternative considered: prose-only docs were rejected because operators still need one valid JSON shape to adapt locally.
- Deferred: polling, capture automation, hosted persistence, and the final `pirate-claw` rename remain out of scope for this ticket.

## Branch History

- Initial branch commit: `docs: add phase 02 real-world verification guide`
- Follow-up commit after PR creation: `fix: point manual verification to edited config`

## AI Review Follow-Up

- `qodo-code-review` triage found one actionable documentation issue.
- The follow-up fix changes the manual verification command to point at the operator's edited local config rather than the checked-in placeholder fixture.
