### PR TITLE
feat: add per-ticket handoff artifacts to delivery flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 - If the user asks to begin a phase, implement a phase, start a ticket, or continue planned delivery work, first read `docs/00-overview/start-here.md` and `docs/03-engineering/delivery-orchestrator.md`, then surface the repo delivery/orchestration path before coding.
 - For planned phase work in this repo, prefer the delivery orchestrator as the default workflow entrypoint rather than bypassing it with ad hoc implementation.
+- For orchestrated ticket work, treat the generated handoff artifact under `.codex/delivery/<plan-key>/handoffs/` as required input alongside the plan and ticket docs before implementing.
 - If the user says `begin phase`, `implement phase`, or equivalent, interpret that as a request to run the full orchestrated stacked-ticket workflow for that phase until blocked, not as a request to stop after the first completed ticket.
 - For phase delivery, do not stop at a completed ticket if the orchestrator can continue. Implement the ticket, verify it, push/open the PR, wait for `qodo-code-review`, patch prudent review findings, refresh the PR state, then advance to the next ticket branch/worktree.
 - Stop only when the current ticket cannot be completed safely, a prerequisite is missing, review triage is ambiguous enough to require user input, the orchestrator cannot advance cleanly, or the user explicitly interrupts the phase run.

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -64,6 +64,7 @@ If you are doing workflow or delivery-tooling work:
 
 1. Read [`docs/02-delivery/phase-implementation-guidance.md`](../02-delivery/phase-implementation-guidance.md).
 2. Read [`docs/03-engineering/delivery-orchestrator.md`](../03-engineering/delivery-orchestrator.md) if the work touches stacked delivery flow.
+3. If continuing an orchestrated ticket, read the generated handoff artifact under `.codex/delivery/<plan-key>/handoffs/` before implementing.
 
 ## Planning Workflow
 
@@ -86,6 +87,7 @@ When implementing a ticket:
 - land one small real behavior at a time
 - keep the ticket end to end
 - test what the user can observe
+- for orchestrated stacked delivery, re-read the handoff artifact and required docs at each ticket boundary instead of relying on prior conversational context
 - avoid unrelated cleanup during the ticket unless required to land safely
 - update rationale and operator-facing docs when behavior changes
 - stop at the ticket boundary unless the user explicitly says to continue

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -37,6 +37,7 @@ The orchestrator owns process mechanics:
 
 - reading ticket order from the plan
 - durable local state under `.codex/delivery/<plan-key>/`
+- per-ticket handoff artifacts under `.codex/delivery/<plan-key>/handoffs/`
 - deterministic branch and worktree naming
 - stacked PR base chaining
 - a 5-minute review wait before fetch
@@ -55,6 +56,26 @@ That boundary is intentional. The `qodo-code-review` skill already defines the r
 So the script fetches and stores review output, but humans or agents still use the skill to decide whether a comment matters.
 
 When ai-cr triage leads to prudent branch changes, the orchestrator updates the PR body as the final step of `advance`. That timing is intentional: the PR description should reflect the exact branch state that is being handed off before the next ticket starts.
+
+## Ticket Context Reset
+
+The orchestrator also owns the repo-side context reset contract for stacked ticket work.
+
+When a ticket starts, the orchestrator writes a handoff artifact under:
+
+- `.codex/delivery/<plan-key>/handoffs/`
+
+That handoff is the narrow context that the next ticket worker should begin from alongside the current repo state and required docs.
+
+The handoff includes:
+
+- the phase plan path
+- the current ticket id, title, branch, base branch, and worktree path
+- the required docs to re-read before implementation
+- prior ticket PR and review metadata when there is a previous ticket
+- explicit stop conditions for when the worker should pause instead of widening scope
+
+This does not automatically create a brand-new Codex thread, but it is the current repo mechanism for reducing reasoning carryover between tickets while preserving stacked branch continuity.
 
 ## Existing Phase 02 Work
 
@@ -110,11 +131,17 @@ bun run deliver --phase phase-02 record-review P2.02 patched "patched the two ac
 bun run deliver --phase phase-02 advance
 ```
 
+At each ticket boundary, read the generated handoff artifact before continuing implementation.
+
 ## Review Artifact Location
 
 Fetched review output is written under:
 
 - `.codex/delivery/<plan-key>/reviews/`
+
+Generated handoff artifacts are written under:
+
+- `.codex/delivery/<plan-key>/handoffs/`
 
 State is written under:
 

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 
 import {
+  buildTicketHandoff,
   canAdvanceTicket,
   createOptions,
   deriveBranchName,
@@ -57,6 +58,7 @@ describe('delivery orchestrator', () => {
       planKey: 'phase-02',
       statePath: '.codex/delivery/phase-02/state.json',
       reviewsDirPath: '.codex/delivery/phase-02/reviews',
+      handoffsDirPath: '.codex/delivery/phase-02/handoffs',
       reviewWaitMinutes: 5,
     });
   });
@@ -68,6 +70,7 @@ describe('delivery orchestrator', () => {
       planPath: options.planPath,
       statePath: options.statePath,
       reviewsDirPath: options.reviewsDirPath,
+      handoffsDirPath: options.handoffsDirPath,
       reviewWaitMinutes: 5,
       tickets: [
         {
@@ -80,6 +83,8 @@ describe('delivery orchestrator', () => {
           branch: 'codex/p2-01-enclosure-first-feed-parsing',
           baseBranch: 'main',
           worktreePath: '/tmp/p2_01',
+          handoffPath: '.codex/delivery/phase-02/handoffs/p2-01-handoff.md',
+          handoffGeneratedAt: '2026-04-01T00:00:00.000Z',
           prNumber: 14,
           prUrl: 'https://example.test/pull/14',
         },
@@ -115,6 +120,67 @@ describe('delivery orchestrator', () => {
       branch: 'codex/p2-02-movie-matcher-allows-missing-codec',
       baseBranch: 'codex/p2-01-enclosure-first-feed-parsing',
     });
+  });
+
+  it('builds a handoff artifact that resets context and carries forward prior review state', () => {
+    const handoff = buildTicketHandoff(
+      {
+        planKey: 'phase-02',
+        planPath: 'docs/02-delivery/phase-02/implementation-plan.md',
+        statePath: '.codex/delivery/phase-02/state.json',
+        reviewsDirPath: '.codex/delivery/phase-02/reviews',
+        handoffsDirPath: '.codex/delivery/phase-02/handoffs',
+        reviewWaitMinutes: 5,
+        tickets: [
+          {
+            id: 'P2.01',
+            title: 'Enclosure-First Feed Parsing',
+            slug: 'enclosure-first-feed-parsing',
+            ticketFile:
+              'docs/02-delivery/phase-02/ticket-01-enclosure-first-feed-parsing.md',
+            status: 'done',
+            branch: 'codex/p2-01-enclosure-first-feed-parsing',
+            baseBranch: 'main',
+            worktreePath: '/tmp/p2_01',
+            prUrl: 'https://example.test/pull/14',
+            reviewArtifactPath:
+              '.codex/delivery/phase-02/reviews/P2.01-qodo.txt',
+            reviewOutcome: 'patched',
+            reviewNote: 'patched the two actionable correctness issues',
+          },
+          {
+            id: 'P2.02',
+            title: 'Movie Matcher Allows Missing Codec',
+            slug: 'movie-matcher-allows-missing-codec',
+            ticketFile:
+              'docs/02-delivery/phase-02/ticket-02-movie-matcher-allows-missing-codec.md',
+            status: 'pending',
+            branch: 'codex/p2-02-movie-matcher-allows-missing-codec',
+            baseBranch: 'codex/p2-01-enclosure-first-feed-parsing',
+            worktreePath: '/tmp/p2_02',
+          },
+        ],
+      },
+      {
+        id: 'P2.02',
+        title: 'Movie Matcher Allows Missing Codec',
+        ticketFile:
+          'docs/02-delivery/phase-02/ticket-02-movie-matcher-allows-missing-codec.md',
+        branch: 'codex/p2-02-movie-matcher-allows-missing-codec',
+        baseBranch: 'codex/p2-01-enclosure-first-feed-parsing',
+        worktreePath: '/tmp/p2_02',
+      },
+    );
+
+    expect(handoff).toContain('# Ticket Handoff');
+    expect(handoff).toContain('## Required Reads');
+    expect(handoff).toContain('docs/00-overview/start-here.md');
+    expect(handoff).toContain('Start from the current repository state');
+    expect(handoff).toContain('Previous PR: https://example.test/pull/14');
+    expect(handoff).toContain('Review outcome: `patched`');
+    expect(handoff).toContain(
+      'Review artifact: `.codex/delivery/phase-02/reviews/P2.01-qodo.txt`',
+    );
   });
 
   it('derives deterministic branch and worktree names', () => {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -25,6 +25,8 @@ export type TicketState = TicketDefinition & {
   branch: string;
   baseBranch: string;
   worktreePath: string;
+  handoffPath?: string;
+  handoffGeneratedAt?: string;
   prNumber?: number;
   prUrl?: string;
   prOpenedAt?: string;
@@ -39,6 +41,7 @@ export type DeliveryState = {
   planPath: string;
   statePath: string;
   reviewsDirPath: string;
+  handoffsDirPath: string;
   reviewWaitMinutes: number;
   tickets: TicketState[];
 };
@@ -48,6 +51,7 @@ export type OrchestratorOptions = {
   planKey: string;
   statePath: string;
   reviewsDirPath: string;
+  handoffsDirPath: string;
   reviewWaitMinutes: number;
 };
 
@@ -206,6 +210,7 @@ export function syncStateWithPlan(
     planPath: options.planPath,
     statePath: options.statePath,
     reviewsDirPath: options.reviewsDirPath,
+    handoffsDirPath: options.handoffsDirPath,
     reviewWaitMinutes: options.reviewWaitMinutes,
     tickets: ticketDefinitions.map((definition, index) => {
       const previous = existingById.get(definition.id);
@@ -244,6 +249,9 @@ export function syncStateWithPlan(
           previous?.worktreePath ??
           inferredTicket?.worktreePath ??
           deriveWorktreePath(cwd, definition.id),
+        handoffPath: previous?.handoffPath ?? inferredTicket?.handoffPath,
+        handoffGeneratedAt:
+          previous?.handoffGeneratedAt ?? inferredTicket?.handoffGeneratedAt,
         prNumber: previous?.prNumber ?? inferredTicket?.prNumber,
         prUrl: previous?.prUrl ?? inferredTicket?.prUrl,
         prOpenedAt: previous?.prOpenedAt ?? inferredTicket?.prOpenedAt,
@@ -357,6 +365,7 @@ export function createOptions(input: {
     planKey,
     statePath: `.codex/delivery/${planKey}/state.json`,
     reviewsDirPath: `.codex/delivery/${planKey}/reviews`,
+    handoffsDirPath: `.codex/delivery/${planKey}/handoffs`,
     reviewWaitMinutes: DEFAULT_REVIEW_WAIT_MINUTES,
   };
 }
@@ -535,6 +544,8 @@ function inferStateFromRepo(
       branch,
       baseBranch,
       worktreePath: deriveWorktreePath(cwd, definition.id),
+      handoffPath: undefined,
+      handoffGeneratedAt: undefined,
       prNumber: pr?.number,
       prUrl: pr?.url,
       prOpenedAt: undefined,
@@ -550,6 +561,7 @@ function inferStateFromRepo(
     planPath: options.planPath,
     statePath: options.statePath,
     reviewsDirPath: options.reviewsDirPath,
+    handoffsDirPath: options.handoffsDirPath,
     reviewWaitMinutes: options.reviewWaitMinutes,
     tickets,
   };
@@ -668,10 +680,19 @@ async function startTicket(
     ]);
   }
 
+  const handoff = await writeTicketHandoff(state, cwd, target.id);
+
   return {
     ...state,
     tickets: state.tickets.map((ticket) =>
-      ticket.id === target.id ? { ...ticket, status: 'in_progress' } : ticket,
+      ticket.id === target.id
+        ? {
+            ...ticket,
+            status: 'in_progress',
+            handoffPath: handoff.relativePath,
+            handoffGeneratedAt: handoff.generatedAt,
+          }
+        : ticket,
     ),
   };
 }
@@ -924,6 +945,106 @@ export function buildPullRequestBody(
   return lines.join('\n');
 }
 
+export function buildTicketHandoff(
+  state: DeliveryState,
+  ticket: Pick<
+    TicketState,
+    'id' | 'title' | 'ticketFile' | 'branch' | 'baseBranch' | 'worktreePath'
+  >,
+): string {
+  const ticketIndex = state.tickets.findIndex(
+    (candidate) => candidate.id === ticket.id,
+  );
+  const previous = ticketIndex > 0 ? state.tickets[ticketIndex - 1] : undefined;
+  const requiredReads = [
+    'docs/00-overview/start-here.md',
+    state.planPath,
+    ticket.ticketFile,
+    'docs/03-engineering/delivery-orchestrator.md',
+  ];
+  const lines = [
+    '# Ticket Handoff',
+    '',
+    `Phase plan: ${state.planPath}`,
+    `Ticket: ${ticket.id} ${ticket.title}`,
+    `Branch: ${ticket.branch}`,
+    `Base branch: ${ticket.baseBranch}`,
+    `Worktree: ${ticket.worktreePath}`,
+    '',
+    '## Required Reads',
+    '',
+    ...requiredReads.map((path) => `- \`${path}\``),
+    '',
+    '## Context Reset Contract',
+    '',
+    '- Re-read the required docs before implementing.',
+    '- Start from the current repository state and this handoff artifact, not from prior chat assumptions.',
+    '- Carry forward only explicit review notes, review artifacts, and committed branch state.',
+  ];
+
+  if (previous) {
+    lines.push('', '## Carry Forward From Previous Ticket', '');
+    lines.push(`- Previous ticket: \`${previous.id} ${previous.title}\``);
+    lines.push(`- Previous branch: \`${previous.branch}\``);
+
+    if (previous.prUrl) {
+      lines.push(`- Previous PR: ${previous.prUrl}`);
+    }
+
+    if (previous.reviewOutcome) {
+      lines.push(`- Review outcome: \`${previous.reviewOutcome}\``);
+    }
+
+    if (previous.reviewNote) {
+      lines.push(`- Review note: ${previous.reviewNote}`);
+    }
+
+    if (previous.reviewArtifactPath) {
+      lines.push(`- Review artifact: \`${previous.reviewArtifactPath}\``);
+    }
+  }
+
+  lines.push('', '## Stop Conditions', '');
+  lines.push(
+    '- Stop if the current ticket cannot be completed safely or prerequisite state is missing.',
+  );
+  lines.push(
+    '- Stop if review triage is ambiguous enough to require user input.',
+  );
+  lines.push(
+    '- Stop if the work requires a broader redesign beyond the ticket scope.',
+  );
+
+  return lines.join('\n') + '\n';
+}
+
+async function writeTicketHandoff(
+  state: DeliveryState,
+  cwd: string,
+  ticketId: string,
+): Promise<{ relativePath: string; generatedAt: string }> {
+  const ticket = state.tickets.find((candidate) => candidate.id === ticketId);
+
+  if (!ticket) {
+    throw new Error(`Unknown ticket ${ticketId}.`);
+  }
+
+  const absolutePath = resolve(
+    cwd,
+    state.handoffsDirPath,
+    `${ticket.id.toLowerCase().replace('.', '-')}-handoff.md`,
+  );
+  const generatedAt = new Date().toISOString();
+
+  await mkdir(dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, buildTicketHandoff(state, ticket), 'utf8');
+
+  return {
+    relativePath: relativeToRepo(cwd, absolutePath),
+    generatedAt,
+  };
+}
+
 function updatePullRequestBody(
   state: DeliveryState,
   ticket: TicketState,
@@ -1009,6 +1130,7 @@ function formatStatus(state: DeliveryState): string {
     `plan_key=${state.planKey}`,
     `plan=${state.planPath}`,
     `state=${state.statePath}`,
+    `handoffs=${state.handoffsDirPath}`,
     `review_wait_minutes=${state.reviewWaitMinutes}`,
     '',
     ...state.tickets.map((ticket) =>
@@ -1016,6 +1138,7 @@ function formatStatus(state: DeliveryState): string {
         `${ticket.id} | status=${ticket.status} | branch=${ticket.branch} | base=${ticket.baseBranch}`,
         `title=${ticket.title}`,
         `worktree=${ticket.worktreePath}`,
+        ticket.handoffPath ? `handoff=${ticket.handoffPath}` : undefined,
         ticket.prUrl ? `pr=${ticket.prUrl}` : undefined,
         ticket.reviewArtifactPath
           ? `review_artifact=${ticket.reviewArtifactPath}`


### PR DESCRIPTION
## Summary

- add per-ticket handoff artifacts to the delivery orchestrator under `.codex/delivery/<plan-key>/handoffs/`
- carry prior ticket review metadata into the next ticket handoff so stacked work starts from explicit repo state instead of chat carryover
- document the handoff/context-reset contract in the repo workflow docs and AGENTS rules

## Why

The delivery orchestrator already isolates git state per ticket with branches and worktrees, but it did not yet enforce a narrow reasoning-context boundary. This change makes the repo-level reset contract explicit without pretending the tool can spawn a brand-new Codex thread on its own.
