### PR TITLE
type: summary [P3.01]

### DIFF
--- a/docs/02-delivery/phase-03/ticket-01-rationale.md
+++ b/docs/02-delivery/phase-03/ticket-01-rationale.md
@@ -1,0 +1,6 @@
+# P3.01 Rationale
+
+- `Red first:` repository and pipeline behavior that proved a successfully queued candidate did not retain the Transmission identifiers needed for later reconciliation.
+- `Why this path:` extending the existing `candidate_state` row with sticky Transmission fields was the smallest acceptable way to preserve queue identity without adding a new history table or changing the CLI surface.
+- `Alternative considered:` storing downloader identity only in `feed_item_outcomes` was rejected because reconciliation needs one durable per-identity record rather than searching run-local outcome history.
+- `Deferred:` active reconciliation, lifecycle transitions after queueing, and status presentation changes remain in later Phase 03 tickets.

--- a/docs/03-engineering/sqlite-schema.md
+++ b/docs/03-engineering/sqlite-schema.md
@@ -69,6 +69,9 @@ Important fields:
 - `media_type`
 - `status`: `queued`, `failed`, or `skipped_duplicate`
 - `queued_at`
+- `transmission_torrent_id`
+- `transmission_torrent_name`
+- `transmission_torrent_hash`
 - `rule_name`
 - `score`
 - `reasons_json`
@@ -82,6 +85,7 @@ Behavioral role:
 - collapses competing releases onto one durable identity
 - records the current best-known state for that identity
 - blocks requeueing when a prior candidate was already queued
+- preserves the Transmission identity needed for later reconciliation
 - powers `retry-failed` by storing the last retryable failed candidate with its `download_url`
 
 ## `feed_item_outcomes`
@@ -151,6 +155,7 @@ Important nuance:
 - `candidate_state.first_seen_run_id` never changes after the first insert.
 - `candidate_state.last_seen_run_id` moves forward as later runs encounter the same identity.
 - `candidate_state.queued_at` is sticky once a candidate has been queued.
+- persisted Transmission identifiers remain sticky unless a later successful queue provides replacement values.
 - `feed_item_outcomes` is append-only from the application point of view; it records each run decision rather than overwriting history.
 - `listRetryableCandidates` only returns `candidate_state` rows with `status = 'failed'` and a non-empty `download_url`.
 

--- a/docs/03-engineering/sqlite-schema.mmd
+++ b/docs/03-engineering/sqlite-schema.mmd
@@ -21,6 +21,9 @@ erDiagram
     TEXT media_type
     TEXT status
     TEXT queued_at
+    INTEGER transmission_torrent_id
+    TEXT transmission_torrent_name
+    TEXT transmission_torrent_hash
     TEXT rule_name
     INTEGER score
     TEXT reasons_json

--- a/src/pipeline-runner.ts
+++ b/src/pipeline-runner.ts
@@ -116,6 +116,9 @@ export async function submitCandidate(
       ...input,
       status: 'queued',
       message: 'Queued in Transmission.',
+      transmissionTorrentId: submission.torrentId,
+      transmissionTorrentName: submission.torrentName,
+      transmissionTorrentHash: submission.torrentHash,
     });
     return;
   }
@@ -199,6 +202,9 @@ function recordCandidateResult(
   input: SubmissionInput & {
     status: 'queued' | 'failed' | 'skipped_duplicate';
     message: string;
+    transmissionTorrentId?: number;
+    transmissionTorrentName?: string;
+    transmissionTorrentHash?: string;
   },
 ): void {
   repository.recordCandidateOutcome({
@@ -207,6 +213,9 @@ function recordCandidateResult(
     feedItem: input.feedItem,
     match: input.match,
     status: input.status,
+    transmissionTorrentId: input.transmissionTorrentId,
+    transmissionTorrentName: input.transmissionTorrentName,
+    transmissionTorrentHash: input.transmissionTorrentHash,
   });
   recordFeedItemOutcome(repository, {
     runId: input.runId,

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -52,6 +52,9 @@ export type CandidateStateRecord = {
   mediaType: NormalizedFeedItem['mediaType'];
   status: CandidateStatus;
   queuedAt?: string;
+  transmissionTorrentId?: number;
+  transmissionTorrentName?: string;
+  transmissionTorrentHash?: string;
   ruleName: string;
   score: number;
   reasons: string[];
@@ -78,6 +81,9 @@ export type RecordCandidateOutcomeInput = {
   feedItem: RawFeedItem;
   match: CandidateMatchRecord;
   status: CandidateStatus;
+  transmissionTorrentId?: number;
+  transmissionTorrentName?: string;
+  transmissionTorrentHash?: string;
   updatedAt?: string;
 };
 
@@ -147,6 +153,9 @@ export function ensureSchema(database: Database): void {
       media_type TEXT NOT NULL,
       status TEXT NOT NULL,
       queued_at TEXT,
+      transmission_torrent_id INTEGER,
+      transmission_torrent_name TEXT,
+      transmission_torrent_hash TEXT,
       rule_name TEXT NOT NULL,
       score INTEGER NOT NULL,
       reasons_json TEXT NOT NULL,
@@ -189,6 +198,10 @@ export function ensureSchema(database: Database): void {
       `ALTER TABLE runs ADD COLUMN status TEXT NOT NULL DEFAULT 'running'`,
     );
   }
+
+  ensureCandidateStateColumn(database, 'transmission_torrent_id', 'INTEGER');
+  ensureCandidateStateColumn(database, 'transmission_torrent_name', 'TEXT');
+  ensureCandidateStateColumn(database, 'transmission_torrent_hash', 'TEXT');
 }
 
 export function hasStatusSchema(database: Database): boolean {
@@ -266,6 +279,9 @@ export function createRepository(database: Database): Repository {
       media_type AS mediaType,
       status,
       queued_at AS queuedAt,
+      transmission_torrent_id AS transmissionTorrentId,
+      transmission_torrent_name AS transmissionTorrentName,
+      transmission_torrent_hash AS transmissionTorrentHash,
       rule_name AS ruleName,
       score,
       reasons_json AS reasonsJson,
@@ -293,6 +309,9 @@ export function createRepository(database: Database): Repository {
       media_type,
       status,
       queued_at,
+      transmission_torrent_id,
+      transmission_torrent_name,
+      transmission_torrent_hash,
       rule_name,
       score,
       reasons_json,
@@ -313,12 +332,24 @@ export function createRepository(database: Database): Repository {
       updated_at
     ) VALUES (
       ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
-      ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22
+      ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25
     )
     ON CONFLICT(identity_key) DO UPDATE SET
       media_type = excluded.media_type,
       status = excluded.status,
       queued_at = COALESCE(candidate_state.queued_at, excluded.queued_at),
+      transmission_torrent_id = COALESCE(
+        excluded.transmission_torrent_id,
+        candidate_state.transmission_torrent_id
+      ),
+      transmission_torrent_name = COALESCE(
+        excluded.transmission_torrent_name,
+        candidate_state.transmission_torrent_name
+      ),
+      transmission_torrent_hash = COALESCE(
+        excluded.transmission_torrent_hash,
+        candidate_state.transmission_torrent_hash
+      ),
       rule_name = excluded.rule_name,
       score = excluded.score,
       reasons_json = excluded.reasons_json,
@@ -400,6 +431,9 @@ export function createRepository(database: Database): Repository {
       media_type AS mediaType,
       status,
       queued_at AS queuedAt,
+      transmission_torrent_id AS transmissionTorrentId,
+      transmission_torrent_name AS transmissionTorrentName,
+      transmission_torrent_hash AS transmissionTorrentHash,
       rule_name AS ruleName,
       score,
       reasons_json AS reasonsJson,
@@ -428,6 +462,9 @@ export function createRepository(database: Database): Repository {
       media_type AS mediaType,
       status,
       queued_at AS queuedAt,
+      transmission_torrent_id AS transmissionTorrentId,
+      transmission_torrent_name AS transmissionTorrentName,
+      transmission_torrent_hash AS transmissionTorrentHash,
       rule_name AS ruleName,
       score,
       reasons_json AS reasonsJson,
@@ -524,6 +561,9 @@ export function createRepository(database: Database): Repository {
         input.match.item.mediaType,
         input.status,
         queuedAt,
+        input.transmissionTorrentId ?? null,
+        input.transmissionTorrentName ?? null,
+        input.transmissionTorrentHash ?? null,
         input.match.ruleName,
         input.match.score,
         JSON.stringify(input.match.reasons),
@@ -627,6 +667,25 @@ function requireRow<T>(row: T | null | undefined, label: string): T {
   return row;
 }
 
+function ensureCandidateStateColumn(
+  database: Database,
+  columnName: string,
+  columnDefinition: string,
+): void {
+  const hasColumn =
+    (database
+      .query(
+        `SELECT 1 FROM pragma_table_info('candidate_state') WHERE name = ?1`,
+      )
+      .get(columnName) as { 1: number } | null | undefined) !== null;
+
+  if (!hasColumn) {
+    database.run(
+      `ALTER TABLE candidate_state ADD COLUMN ${columnName} ${columnDefinition}`,
+    );
+  }
+}
+
 function mapRunRow(row: {
   id: number;
   startedAt: string;
@@ -671,6 +730,9 @@ function mapCandidateStateRow(row: CandidateStateRow): CandidateStateRecord {
     mediaType: row.mediaType,
     status: row.status,
     queuedAt: row.queuedAt ?? undefined,
+    transmissionTorrentId: row.transmissionTorrentId ?? undefined,
+    transmissionTorrentName: row.transmissionTorrentName ?? undefined,
+    transmissionTorrentHash: row.transmissionTorrentHash ?? undefined,
     ruleName: row.ruleName,
     score: Number(row.score),
     reasons: JSON.parse(row.reasonsJson) as string[],
@@ -734,6 +796,9 @@ type CandidateStateRow = {
   mediaType: NormalizedFeedItem['mediaType'];
   status: CandidateStatus;
   queuedAt: string | null;
+  transmissionTorrentId: number | null;
+  transmissionTorrentName: string | null;
+  transmissionTorrentHash: string | null;
   ruleName: string;
   score: number;
   reasonsJson: string;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -140,6 +140,9 @@ describe('pirate-claw run', () => {
       repository.getCandidateState('movie:example movie|2024'),
     ).toMatchObject({
       queuedAt: expect.any(String),
+      transmissionTorrentId: 42,
+      transmissionTorrentName: 'Queued Torrent',
+      transmissionTorrentHash: 'hash-42',
     });
     expect(repository.getCandidateState('movie:retry me|2024')).toMatchObject({
       status: 'failed',
@@ -502,6 +505,9 @@ describe('pirate-claw retry-failed', () => {
     expect(repository.getCandidateState('movie:retry me|2024')).toMatchObject({
       status: 'queued',
       queuedAt: expect.any(String),
+      transmissionTorrentId: 52,
+      transmissionTorrentName: 'Retried Torrent',
+      transmissionTorrentHash: 'hash-52',
       lastFeedItemId: retryMeBefore?.lastFeedItemId,
     });
     expect(

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -76,6 +76,9 @@ describe('runPipeline', () => {
         submit: async () => ({
           ok: true as const,
           status: 'queued' as const,
+          torrentId: 7,
+          torrentName: 'Example Show S01E02',
+          torrentHash: 'show-s01e02-2160p',
         }),
       },
       fetchFeed: async () => [
@@ -122,6 +125,9 @@ describe('runPipeline', () => {
       status: 'queued',
       rawTitle: 'Example.Show.S01E02.2160p.WEB.x265-GROUP',
       resolution: '2160p',
+      transmissionTorrentId: 7,
+      transmissionTorrentName: 'Example Show S01E02',
+      transmissionTorrentHash: 'show-s01e02-2160p',
     });
   });
 

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -48,6 +48,9 @@ describe('SQLite repository', () => {
       feedItem: firstFeedItem,
       match: firstMatch,
       status: 'queued',
+      transmissionTorrentId: 7,
+      transmissionTorrentName: 'Example Movie',
+      transmissionTorrentHash: 'abcdef123456',
       updatedAt: '2026-03-30T00:10:00.000Z',
     });
 
@@ -80,6 +83,9 @@ describe('SQLite repository', () => {
       identityKey: 'movie:example movie|2024',
       status: 'skipped_duplicate',
       queuedAt: '2026-03-30T00:10:00.000Z',
+      transmissionTorrentId: 7,
+      transmissionTorrentName: 'Example Movie',
+      transmissionTorrentHash: 'abcdef123456',
       feedName: 'Movie Feed',
       guidOrLink: 'https://example.test/releases/example-movie-bluray',
       firstSeenRunId: firstRun.id,
@@ -132,6 +138,9 @@ describe('SQLite repository', () => {
       feedItem: secondFeedItem,
       match: retryMatch,
       status: 'queued',
+      transmissionTorrentId: 9,
+      transmissionTorrentName: 'Retry Me',
+      transmissionTorrentHash: 'retry-hash-123',
       updatedAt: '2026-03-30T03:10:00.000Z',
     });
 
@@ -139,6 +148,9 @@ describe('SQLite repository', () => {
       identityKey: 'movie:retry me|2024',
       status: 'queued',
       queuedAt: '2026-03-30T03:10:00.000Z',
+      transmissionTorrentId: 9,
+      transmissionTorrentName: 'Retry Me',
+      transmissionTorrentHash: 'retry-hash-123',
       firstSeenRunId: firstRun.id,
       lastSeenRunId: secondRun.id,
       lastFeedItemId: secondFeedItem.id,
@@ -340,6 +352,81 @@ describe('SQLite repository', () => {
         updatedAt: '2026-03-30T02:10:00.000Z',
       },
     ]);
+  });
+
+  it('adds transmission identity columns to pre-phase-03 databases', async () => {
+    const path = await createDatabasePath();
+    const database = openDatabase(path);
+
+    openDatabases.push(database);
+    database.run(`
+      CREATE TABLE runs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        started_at TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'running',
+        completed_at TEXT
+      );
+
+      CREATE TABLE feed_items (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_id INTEGER NOT NULL REFERENCES runs(id),
+        feed_name TEXT NOT NULL,
+        guid_or_link TEXT NOT NULL,
+        raw_title TEXT NOT NULL,
+        published_at TEXT NOT NULL,
+        download_url TEXT NOT NULL
+      );
+
+      CREATE TABLE candidate_state (
+        identity_key TEXT PRIMARY KEY,
+        media_type TEXT NOT NULL,
+        status TEXT NOT NULL,
+        queued_at TEXT,
+        rule_name TEXT NOT NULL,
+        score INTEGER NOT NULL,
+        reasons_json TEXT NOT NULL,
+        raw_title TEXT NOT NULL,
+        normalized_title TEXT NOT NULL,
+        season INTEGER,
+        episode INTEGER,
+        year INTEGER,
+        resolution TEXT,
+        codec TEXT,
+        feed_name TEXT NOT NULL,
+        guid_or_link TEXT NOT NULL,
+        published_at TEXT NOT NULL,
+        download_url TEXT NOT NULL,
+        first_seen_run_id INTEGER NOT NULL REFERENCES runs(id),
+        last_seen_run_id INTEGER NOT NULL REFERENCES runs(id),
+        last_feed_item_id INTEGER REFERENCES feed_items(id),
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE feed_item_outcomes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_id INTEGER NOT NULL REFERENCES runs(id),
+        feed_item_id INTEGER REFERENCES feed_items(id),
+        status TEXT NOT NULL,
+        identity_key TEXT,
+        rule_name TEXT,
+        message TEXT,
+        created_at TEXT NOT NULL
+      );
+    `);
+
+    ensureSchema(database);
+
+    const columns = database
+      .query(`SELECT name FROM pragma_table_info('candidate_state')`)
+      .all() as Array<{ name: string }>;
+
+    expect(columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        'transmission_torrent_id',
+        'transmission_torrent_name',
+        'transmission_torrent_hash',
+      ]),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- delivery ticket: `P3.01 Persist Transmission Identity For Queued Torrents`
- ticket file: `docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md`
- stacked base branch: `main`

## AI Review Follow-Up

- `qodo-code-review` triage found no prudent follow-up changes.
- follow-up note: No qodo-code-review comments after the 5-minute review wait; only a StackBlitz comment was present.

## Verification

- `bun run ci`