### PR TITLE
fix: harden the delivery orchestrator flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 .vscode/settings.json
 .codex/delivery/
+.codex/analysis/
 pirate-claw.config.json
 pirate-claw.db

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 node_modules/
 .vscode/
 bun.lock
+.codex/analysis/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - For phase delivery, do not stop at a completed ticket if the orchestrator can continue. Implement the ticket, verify it, push/open the PR, wait for `qodo-code-review`, patch prudent review findings, refresh the PR state, then advance to the next ticket branch/worktree.
 - Stop only when the current ticket cannot be completed safely, a prerequisite is missing, review triage is ambiguous enough to require user input, the orchestrator cannot advance cleanly, or the user explicitly interrupts the phase run.
 
-- `pr`: if a delivery ticket is clear from branch/docs/diff, use a human-readable Conventional-Commit-style subject plus `[P1.01]`. Otherwise omit the suffix.
+- `pr`: if a delivery ticket is clear from branch/docs/diff, use a human-readable Conventional-Commit-style subject plus the active delivery ticket suffix, for example `[P3.02]`. Otherwise omit the suffix.
 
 ## Ticket Completion Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - For phase delivery, do not stop at a completed ticket if the orchestrator can continue. Implement the ticket, verify it, push/open the PR, wait for `qodo-code-review`, patch prudent review findings, refresh the PR state, then advance to the next ticket branch/worktree.
 - Stop only when the current ticket cannot be completed safely, a prerequisite is missing, review triage is ambiguous enough to require user input, the orchestrator cannot advance cleanly, or the user explicitly interrupts the phase run.
 
-- `pr`: if a delivery ticket is clear from branch/docs/diff, use `type: summary [P1.01]`. Otherwise omit the suffix.
+- `pr`: if a delivery ticket is clear from branch/docs/diff, use a human-readable Conventional-Commit-style subject plus `[P1.01]`. Otherwise omit the suffix.
 
 ## Ticket Completion Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - Stop only when the current ticket cannot be completed safely, a prerequisite is missing, review triage is ambiguous enough to require user input, the orchestrator cannot advance cleanly, or the user explicitly interrupts the phase run.
 
 - `pr`: if a delivery ticket is clear from branch/docs/diff, use a human-readable Conventional-Commit-style subject plus the active delivery ticket suffix, for example `[P3.02]`. Otherwise omit the suffix.
+- Any PR creation or PR-body drafting should follow the same `pr` shortcut conventions even when the user did not literally type `pr`.
 
 ## Ticket Completion Checklist
 

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -141,7 +141,7 @@ State is written under:
 PR descriptions are maintained as delivery metadata, not one-shot text.
 
 - `open-pr` creates the initial PR body
-- `open-pr` uses the repo delivery PR title format: `type: summary [P?.??]`
+- `open-pr` uses a human-readable Conventional-Commit-style title plus the delivery ticket suffix, for example `feat: add torrent lifecycle reconciliation [P3.02]`
 - rerunning `open-pr` refreshes the existing PR title/body instead of failing on an already-open branch
 - `record-review` stores the triage result and optional note
 - `advance` refreshes the PR body from that recorded review state, then marks the ticket done and optionally starts the next one

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -24,12 +24,11 @@ What is phase-specific is:
 - where local state and review artifacts are stored
 - which ticket IDs, titles, and files exist in that plan
 
-So the orchestrator takes either:
+So the orchestrator takes a plan path:
 
-- `--phase phase-02`
-- or `--plan docs/02-delivery/phase-02/implementation-plan.md`
+- `--plan docs/02-delivery/phase-02/implementation-plan.md`
 
-The current `phase-02` alias is just a convenience mapping to the committed plan file.
+That is the canonical interface. The tool is primarily AI-facing, so the explicit plan artifact is more important than a phase nickname.
 
 ## What It Owns
 
@@ -39,7 +38,9 @@ The orchestrator owns process mechanics:
 - durable local state under `.codex/delivery/<plan-key>/`
 - per-ticket handoff artifacts under `.codex/delivery/<plan-key>/handoffs/`
 - deterministic branch and worktree naming
+- bootstrapping fresh Bun ticket work trees before implementation starts
 - stacked PR base chaining
+- idempotent PR open/update behavior for already-pushed ticket branches
 - a 5-minute review wait before fetch
 - saving raw `qodo-code-review` output locally
 - blocking advancement until review has been explicitly recorded
@@ -95,12 +96,6 @@ That inference is intentionally conservative. It reconstructs enough state to re
 Use the generic command:
 
 ```bash
-bun run deliver --phase phase-02 status
-```
-
-or:
-
-```bash
 bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md status
 ```
 
@@ -114,21 +109,15 @@ Available commands:
 - `record-review <ticket-id> <clean|needs_patch|patched> [note]`
 - `advance [--no-start-next]`
 
-There is also a convenience alias:
-
-```bash
-bun run phase02 status
-```
-
 ## Typical Flow
 
 ```bash
-bun run deliver --phase phase-02 start
-bun run deliver --phase phase-02 open-pr
-bun run deliver --phase phase-02 fetch-review
+bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md start
+bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md open-pr
+bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md fetch-review
 # use the qodo-code-review skill to triage the saved review artifact
-bun run deliver --phase phase-02 record-review P2.02 patched "patched the two actionable correctness issues"
-bun run deliver --phase phase-02 advance
+bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md record-review P2.02 patched "patched the two actionable correctness issues"
+bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md advance
 ```
 
 At each ticket boundary, read the generated handoff artifact before continuing implementation.
@@ -152,6 +141,8 @@ State is written under:
 PR descriptions are maintained as delivery metadata, not one-shot text.
 
 - `open-pr` creates the initial PR body
+- `open-pr` uses the repo delivery PR title format: `type: summary [P?.??]`
+- rerunning `open-pr` refreshes the existing PR title/body instead of failing on an already-open branch
 - `record-review` stores the triage result and optional note
 - `advance` refreshes the PR body from that recorded review state, then marks the ticket done and optionally starts the next one
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "format:check": "prettier --check .",
     "hooks:install": "git config core.hooksPath .githooks",
     "lint": "eslint .",
-    "phase02": "bun run ./scripts/deliver.ts --phase phase-02",
     "run": "bun run ./src/cli.ts",
     "spellcheck": "cspell lint . --gitignore --no-progress",
     "spellcheck:words": "cspell lint . --gitignore --no-progress --no-summary --no-exit-code --words-only | bun run ./scripts/spellcheck-words.ts",

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -264,9 +264,24 @@ describe('delivery orchestrator', () => {
   });
 
   it('uses the repo delivery PR title format', () => {
-    expect(buildPullRequestTitle({ id: 'P3.02' })).toBe(
-      'type: summary [P3.02]',
-    );
+    expect(
+      buildPullRequestTitle(
+        { id: 'P3.02', title: 'Reconcile Torrent Lifecycle From Transmission' },
+        'feat: add torrent lifecycle reconciliation',
+      ),
+    ).toBe('feat: add torrent lifecycle reconciliation [P3.02]');
+    expect(
+      buildPullRequestTitle(
+        { id: 'P3.02', title: 'Reconcile Torrent Lifecycle From Transmission' },
+        'feat: add torrent lifecycle reconciliation [P3.02]',
+      ),
+    ).toBe('feat: add torrent lifecycle reconciliation [P3.02]');
+    expect(
+      buildPullRequestTitle({
+        id: 'P3.02',
+        title: 'Reconcile Torrent Lifecycle From Transmission',
+      }),
+    ).toBe('feat: reconcile torrent lifecycle from transmission [P3.02]');
   });
 
   it('prefers an explicit review fetcher environment variable', () => {

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 
 import {
+  buildPullRequestTitle,
   buildTicketHandoff,
   canAdvanceTicket,
   createOptions,
   deriveBranchName,
+  derivePlanKey,
   deriveWorktreePath,
   findExistingBranch,
   parsePlan,
@@ -52,19 +54,25 @@ describe('delivery orchestrator', () => {
     ]);
   });
 
-  it('builds options from a phase alias', () => {
-    expect(createOptions({ phase: 'phase-02' })).toEqual({
-      planPath: 'docs/02-delivery/phase-02/implementation-plan.md',
-      planKey: 'phase-02',
-      statePath: '.codex/delivery/phase-02/state.json',
-      reviewsDirPath: '.codex/delivery/phase-02/reviews',
-      handoffsDirPath: '.codex/delivery/phase-02/handoffs',
+  it('builds options from a plan path', () => {
+    expect(
+      createOptions({
+        planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+      }),
+    ).toEqual({
+      planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+      planKey: 'phase-03',
+      statePath: '.codex/delivery/phase-03/state.json',
+      reviewsDirPath: '.codex/delivery/phase-03/reviews',
+      handoffsDirPath: '.codex/delivery/phase-03/handoffs',
       reviewWaitMinutes: 5,
     });
   });
 
   it('syncs state while preserving runtime metadata and inferred branch chaining', () => {
-    const options = createOptions({ phase: 'phase-02' });
+    const options = createOptions({
+      planPath: 'docs/02-delivery/phase-02/implementation-plan.md',
+    });
     const existing: DeliveryState = {
       planKey: 'phase-02',
       planPath: options.planPath,
@@ -195,6 +203,15 @@ describe('delivery orchestrator', () => {
     );
   });
 
+  it('derives plan keys from implementation plan directories', () => {
+    expect(
+      derivePlanKey('docs/02-delivery/phase-03/implementation-plan.md'),
+    ).toBe('phase-03');
+    expect(derivePlanKey('./plans/custom/implementation-plan.md')).toBe(
+      'custom',
+    );
+  });
+
   it('prefers existing ticket-id branch matches over title-derived names', () => {
     expect(
       findExistingBranch(
@@ -244,6 +261,12 @@ describe('delivery orchestrator', () => {
         reviewOutcome: 'needs_patch',
       }),
     ).toBe(false);
+  });
+
+  it('uses the repo delivery PR title format', () => {
+    expect(buildPullRequestTitle({ id: 'P3.02' })).toBe(
+      'type: summary [P3.02]',
+    );
   });
 
   it('prefers an explicit review fetcher environment variable', () => {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -722,7 +722,10 @@ async function openPullRequest(
 
   ensureBranchPushed(target.worktreePath, target.branch);
 
-  const title = buildPullRequestTitle(target);
+  const title = buildPullRequestTitle(
+    target,
+    readLatestCommitSubject(target.worktreePath),
+  );
   const body = buildPullRequestBody(state, target);
   const existingPullRequest = findOpenPullRequest(
     target.worktreePath,
@@ -968,8 +971,17 @@ export function buildPullRequestBody(
   return lines.join('\n');
 }
 
-export function buildPullRequestTitle(ticket: Pick<TicketState, 'id'>): string {
-  return `type: summary [${ticket.id}]`;
+export function buildPullRequestTitle(
+  ticket: Pick<TicketState, 'id' | 'title'>,
+  commitSubject?: string,
+): string {
+  const fallbackSubject = `feat: ${ticket.title.toLowerCase()}`;
+  const baseSubject = (commitSubject?.trim() || fallbackSubject).replace(
+    /\s+\[[A-Z0-9.]+\]$/,
+    '',
+  );
+
+  return `${baseSubject} [${ticket.id}]`;
 }
 
 export function buildTicketHandoff(
@@ -1107,6 +1119,10 @@ function findOpenPullRequest(
   ]);
   const parsed = JSON.parse(stdout) as Array<PullRequestSummary>;
   return parsed[0];
+}
+
+function readLatestCommitSubject(cwd: string): string {
+  return runProcess(cwd, ['git', 'log', '-1', '--pretty=%s']).trim();
 }
 
 function ensureBranchPushed(cwd: string, branch: string): void {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -353,12 +353,16 @@ export function resolveReviewFetcher(): string {
 }
 
 export function createOptions(input: {
-  phase?: string;
   planPath?: string;
 }): OrchestratorOptions {
-  const alias = resolvePhaseAlias(input.phase);
-  const planPath = normalizeRepoPath(input.planPath ?? alias.planPath);
-  const planKey = alias.planKey ?? derivePlanKey(planPath);
+  if (!input.planPath) {
+    throw new Error(
+      'Pass --plan <plan-path>. Phase aliases are no longer supported.',
+    );
+  }
+
+  const planPath = normalizeRepoPath(input.planPath);
+  const planKey = derivePlanKey(planPath);
 
   return {
     planPath,
@@ -370,34 +374,12 @@ export function createOptions(input: {
   };
 }
 
-function resolvePhaseAlias(phase?: string): {
-  planPath: string;
-  planKey?: string;
-} {
-  if (!phase) {
-    return {
-      planPath: 'docs/02-delivery/phase-02/implementation-plan.md',
-      planKey: 'phase-02',
-    };
-  }
-
-  if (phase === 'phase-02') {
-    return {
-      planPath: 'docs/02-delivery/phase-02/implementation-plan.md',
-      planKey: 'phase-02',
-    };
-  }
-
-  throw new Error(`Unknown phase alias "${phase}". Pass --plan instead.`);
-}
-
 function parseCliArgs(argv: string[]): {
   command: string;
   positionals: string[];
   flags: Set<string>;
   options: OrchestratorOptions;
 } {
-  let phase: string | undefined;
   let planPath: string | undefined;
   const flags = new Set<string>();
   const positionals: string[] = [];
@@ -405,16 +387,16 @@ function parseCliArgs(argv: string[]): {
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
 
-    if (value === '--phase') {
-      phase = argv[index + 1];
-      index += 1;
-      continue;
-    }
-
     if (value === '--plan') {
       planPath = argv[index + 1];
       index += 1;
       continue;
+    }
+
+    if (value === '--phase') {
+      throw new Error(
+        '--phase has been removed. Pass --plan <plan-path> instead.',
+      );
     }
 
     if (value?.startsWith('--')) {
@@ -435,14 +417,13 @@ function parseCliArgs(argv: string[]): {
     command,
     positionals: rest,
     flags,
-    options: createOptions({ phase, planPath }),
+    options: createOptions({ planPath }),
   };
 }
 
 function getUsage(): string {
   return [
-    'Usage: bun run deliver --phase <phase-key> <command>',
-    '   or: bun run deliver --plan <plan-path> <command>',
+    'Usage: bun run deliver --plan <plan-path> <command>',
     '',
     'Commands:',
     '  sync',
@@ -507,8 +488,10 @@ function inferStateFromRepo(
     'branch',
     '--format=%(refname:short)',
   ]);
-  const branchCatalog = [...new Set([...localBranches, ...remoteBranches])];
   const pullRequests = listPullRequests(cwd);
+  const branchCatalog = [
+    ...new Set([...localBranches, ...remoteBranches, ...pullRequests.keys()]),
+  ];
 
   const tickets = ticketDefinitions.map((definition, index) => {
     const branch =
@@ -520,7 +503,9 @@ function inferStateFromRepo(
         : (findExistingBranch(branchCatalog, ticketDefinitions[index - 1]!)
             ?.branch ?? deriveBranchName(ticketDefinitions[index - 1]!));
     const branchExists = branchCatalog.includes(branch);
-    const pr = pullRequests.get(branch);
+    const pr =
+      pullRequests.get(branch) ??
+      findPullRequestForTicket(pullRequests, definition);
     const nextBranch = ticketDefinitions[index + 1]
       ? (findExistingBranch(branchCatalog, ticketDefinitions[index + 1]!)
           ?.branch ?? deriveBranchName(ticketDefinitions[index + 1]!))
@@ -532,7 +517,7 @@ function inferStateFromRepo(
 
     if (branchExists && nextBranchExists) {
       status = 'done';
-    } else if (branchExists && pr) {
+    } else if (pr) {
       status = 'in_review';
     } else if (branchExists) {
       status = 'in_progress';
@@ -631,6 +616,27 @@ function listPullRequests(cwd: string): Map<string, PullRequestSummary> {
   );
 }
 
+function findPullRequestForTicket(
+  pullRequests: Map<string, PullRequestSummary>,
+  definition: Pick<TicketDefinition, 'id'>,
+): PullRequestSummary | undefined {
+  const ticketIdToken = definition.id.toLowerCase().replace('.', '-');
+
+  for (const [headRefName, summary] of pullRequests.entries()) {
+    const normalized = headRefName.toLowerCase();
+
+    if (
+      normalized.includes(`/${ticketIdToken}`) ||
+      normalized.includes(`-${ticketIdToken}`) ||
+      normalized.endsWith(ticketIdToken)
+    ) {
+      return summary;
+    }
+  }
+
+  return undefined;
+}
+
 async function startTicket(
   state: DeliveryState,
   cwd: string,
@@ -680,6 +686,8 @@ async function startTicket(
     ]);
   }
 
+  await bootstrapWorktreeIfNeeded(target.worktreePath);
+
   const handoff = await writeTicketHandoff(state, cwd, target.id);
 
   return {
@@ -712,32 +720,47 @@ async function openPullRequest(
     throw new Error('No in-progress ticket found to open as a PR.');
   }
 
-  runProcess(target.worktreePath, [
-    'git',
-    'push',
-    '-u',
-    'origin',
-    target.branch,
-  ]);
+  ensureBranchPushed(target.worktreePath, target.branch);
 
-  const title = `${state.planKey}: ${target.title} [${target.id}]`;
+  const title = buildPullRequestTitle(target);
   const body = buildPullRequestBody(state, target);
-
-  const prUrl = runProcess(target.worktreePath, [
-    'gh',
-    'pr',
-    'create',
-    '--base',
-    target.baseBranch,
-    '--head',
+  const existingPullRequest = findOpenPullRequest(
+    target.worktreePath,
     target.branch,
-    '--title',
-    title,
-    '--body',
-    body,
-  ]).trim();
+  );
+  let prUrl: string;
+  let prNumber: number;
 
-  const prNumber = parsePullRequestNumber(prUrl);
+  if (existingPullRequest) {
+    runProcess(target.worktreePath, [
+      'gh',
+      'pr',
+      'edit',
+      String(existingPullRequest.number),
+      '--title',
+      title,
+      '--body',
+      body,
+    ]);
+    prUrl = existingPullRequest.url;
+    prNumber = existingPullRequest.number;
+  } else {
+    prUrl = runProcess(target.worktreePath, [
+      'gh',
+      'pr',
+      'create',
+      '--base',
+      target.baseBranch,
+      '--head',
+      target.branch,
+      '--title',
+      title,
+      '--body',
+      body,
+    ]).trim();
+    prNumber = parsePullRequestNumber(prUrl);
+  }
+
   const now = new Date().toISOString();
 
   return {
@@ -945,6 +968,10 @@ export function buildPullRequestBody(
   return lines.join('\n');
 }
 
+export function buildPullRequestTitle(ticket: Pick<TicketState, 'id'>): string {
+  return `type: summary [${ticket.id}]`;
+}
+
 export function buildTicketHandoff(
   state: DeliveryState,
   ticket: Pick<
@@ -1063,6 +1090,76 @@ function updatePullRequestBody(
   ]);
 }
 
+function findOpenPullRequest(
+  cwd: string,
+  branch: string,
+): PullRequestSummary | undefined {
+  const stdout = runProcess(cwd, [
+    'gh',
+    'pr',
+    'list',
+    '--state',
+    'open',
+    '--head',
+    branch,
+    '--json',
+    'number,url,state',
+  ]);
+  const parsed = JSON.parse(stdout) as Array<PullRequestSummary>;
+  return parsed[0];
+}
+
+function ensureBranchPushed(cwd: string, branch: string): void {
+  const localSha = runGitLines(cwd, ['git', 'rev-parse', branch])[0];
+  const remoteRef = runProcessResult(cwd, [
+    'git',
+    'ls-remote',
+    '--heads',
+    'origin',
+    branch,
+  ]);
+
+  if (remoteRef.exitCode !== 0) {
+    throw new Error(
+      formatCommandFailure(
+        ['git', 'ls-remote', '--heads', 'origin', branch],
+        remoteRef,
+      ),
+    );
+  }
+
+  const remoteSha = remoteRef.stdout.trim().split(/\s+/)[0] || undefined;
+
+  if (!remoteSha) {
+    runProcess(cwd, ['git', 'push', '-u', 'origin', branch]);
+    return;
+  }
+
+  if (remoteSha !== localSha) {
+    runProcess(cwd, ['git', 'push', 'origin', branch]);
+  }
+
+  const upstream = runProcessResult(cwd, [
+    'git',
+    'branch',
+    '--set-upstream-to',
+    `origin/${branch}`,
+    branch,
+  ]);
+
+  if (
+    upstream.exitCode !== 0 &&
+    !upstream.stderr.includes('is already set up to track')
+  ) {
+    throw new Error(
+      formatCommandFailure(
+        ['git', 'branch', '--set-upstream-to', `origin/${branch}`, branch],
+        upstream,
+      ),
+    );
+  }
+}
+
 function parsePullRequestNumber(prUrl: string): number {
   const match = prUrl.match(/\/pull\/(\d+)$/);
 
@@ -1074,6 +1171,23 @@ function parsePullRequestNumber(prUrl: string): number {
 }
 
 function runProcess(cwd: string, cmd: string[]): string {
+  const result = runProcessResult(cwd, cmd);
+
+  if (result.exitCode !== 0) {
+    throw new Error(formatCommandFailure(cmd, result));
+  }
+
+  return result.stdout;
+}
+
+function runProcessResult(
+  cwd: string,
+  cmd: string[],
+): {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+} {
   const result = Bun.spawnSync(cmd, {
     cwd,
     stderr: 'pipe',
@@ -1081,26 +1195,41 @@ function runProcess(cwd: string, cmd: string[]): string {
     env: process.env,
   });
 
-  if (result.exitCode !== 0) {
-    throw new Error(
-      [
-        `Command failed: ${cmd.join(' ')}`,
-        new TextDecoder().decode(result.stderr).trim(),
-      ]
-        .filter(Boolean)
-        .join('\n'),
-    );
-  }
+  return {
+    exitCode: result.exitCode,
+    stderr: new TextDecoder().decode(result.stderr).trim(),
+    stdout: new TextDecoder().decode(result.stdout),
+  };
+}
 
-  return new TextDecoder().decode(result.stdout);
+function formatCommandFailure(
+  cmd: string[],
+  result: {
+    stderr: string;
+    stdout: string;
+  },
+): string {
+  return [
+    `Command failed: ${cmd.join(' ')}`,
+    result.stderr.trim(),
+    result.stdout.trim(),
+  ]
+    .filter(Boolean)
+    .join('\n');
 }
 
 function normalizeRepoPath(value: string): string {
   return value.replace(/^\.?\//, '');
 }
 
-function derivePlanKey(planPath: string): string {
-  return planPath
+export function derivePlanKey(planPath: string): string {
+  const normalizedPlanPath = normalizeRepoPath(planPath);
+
+  if (basename(normalizedPlanPath).toLowerCase() === 'implementation-plan.md') {
+    return slugify(basename(dirname(normalizedPlanPath)));
+  }
+
+  return normalizedPlanPath
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
@@ -1122,6 +1251,28 @@ function sleep(milliseconds: number): Promise<void> {
   return new Promise((resolvePromise) =>
     setTimeout(resolvePromise, milliseconds),
   );
+}
+
+async function bootstrapWorktreeIfNeeded(worktreePath: string): Promise<void> {
+  if (
+    !existsSync(resolve(worktreePath, 'package.json')) ||
+    !existsSync(resolve(worktreePath, 'bun.lock')) ||
+    existsSync(resolve(worktreePath, 'node_modules'))
+  ) {
+    return;
+  }
+
+  runProcess(worktreePath, ['bun', 'install']);
+
+  const packageJson = JSON.parse(
+    await readFile(resolve(worktreePath, 'package.json'), 'utf8'),
+  ) as {
+    scripts?: Record<string, string>;
+  };
+
+  if (packageJson.scripts?.['hooks:install']) {
+    runProcess(worktreePath, ['bun', 'run', 'hooks:install']);
+  }
 }
 
 function formatStatus(state: DeliveryState): string {


### PR DESCRIPTION
## Summary

- make --plan the only canonical orchestrator entrypoint and remove phase alias drift from the repo surface
- derive delivery state paths from the implementation plan directory and harden branch and PR-based state inference
- make open-pr idempotent, bootstrap fresh Bun ticket work trees automatically, and align delivery PR titles with repo policy

## Policy Follow-Up

- clarify that delivery PR titles should use a human-readable Conventional-Commit-style subject plus the active ticket suffix
- clarify the AGENTS.md example so agents substitute the active delivery ticket id instead of cargo-culting a literal example
