### PR TITLE
feat: persist transmission identity for queued torrents [P3.01]

### DIFF
--- a/docs/02-delivery/phase-03/ticket-01-rationale.md
+++ b/docs/02-delivery/phase-03/ticket-01-rationale.md
@@ -1,0 +1,6 @@
+# `P3.01` Rationale
+
+- Red first: a queued candidate could not be reconciled later because Pirate Claw discarded the Transmission identity returned at submission time.
+- Smallest acceptable path: keep the existing queue flow and extend `candidate_state` with sticky Transmission identifiers captured only on successful queueing.
+- Rejected alternative: introducing a separate lifecycle table in ticket 01 would widen scope before any reconciliation behavior exists.
+- Deferred: live Transmission lookup, richer post-queue state, and status output changes remain in later Phase 03 tickets.

--- a/docs/03-engineering/sqlite-schema.md
+++ b/docs/03-engineering/sqlite-schema.md
@@ -69,6 +69,9 @@ Important fields:
 - `media_type`
 - `status`: `queued`, `failed`, or `skipped_duplicate`
 - `queued_at`
+- `transmission_torrent_id`
+- `transmission_torrent_name`
+- `transmission_torrent_hash`
 - `rule_name`
 - `score`
 - `reasons_json`
@@ -83,6 +86,7 @@ Behavioral role:
 - records the current best-known state for that identity
 - blocks requeueing when a prior candidate was already queued
 - powers `retry-failed` by storing the last retryable failed candidate with its `download_url`
+- preserves the Transmission identity needed for later reconciliation
 
 ## `feed_item_outcomes`
 
@@ -144,6 +148,7 @@ Important nuance:
 
 - `skipped_no_match` is not a `candidate_state` value because unmatched feed items do not create a durable candidate identity
 - `queued_at` is preserved once set, even if later upserts touch the same identity
+- the persisted Transmission identity is sticky once the downloader returns it for a queued candidate
 
 ## Current Invariants
 
@@ -151,12 +156,13 @@ Important nuance:
 - `candidate_state.first_seen_run_id` never changes after the first insert.
 - `candidate_state.last_seen_run_id` moves forward as later runs encounter the same identity.
 - `candidate_state.queued_at` is sticky once a candidate has been queued.
+- `candidate_state.transmission_torrent_id`, `candidate_state.transmission_torrent_name`, and `candidate_state.transmission_torrent_hash` are sticky once recorded from Transmission.
 - `feed_item_outcomes` is append-only from the application point of view; it records each run decision rather than overwriting history.
 - `listRetryableCandidates` only returns `candidate_state` rows with `status = 'failed'` and a non-empty `download_url`.
 
 ## What This Doc Intentionally Does Not Freeze
 
-This note describes the current Phase 01 and early Phase 02 local model. It does not promise that the schema is final for later ingestion work.
+This note describes the current local model through early Phase 03. It does not promise that the schema is final for later ingestion work.
 
 Likely future pressure points:
 

--- a/docs/03-engineering/sqlite-schema.mmd
+++ b/docs/03-engineering/sqlite-schema.mmd
@@ -21,6 +21,9 @@ erDiagram
     TEXT media_type
     TEXT status
     TEXT queued_at
+    INTEGER transmission_torrent_id
+    TEXT transmission_torrent_name
+    TEXT transmission_torrent_hash
     TEXT rule_name
     INTEGER score
     TEXT reasons_json

--- a/src/pipeline-runner.ts
+++ b/src/pipeline-runner.ts
@@ -116,6 +116,9 @@ export async function submitCandidate(
       ...input,
       status: 'queued',
       message: 'Queued in Transmission.',
+      torrentId: submission.torrentId,
+      torrentName: submission.torrentName,
+      torrentHash: submission.torrentHash,
     });
     return;
   }
@@ -199,6 +202,9 @@ function recordCandidateResult(
   input: SubmissionInput & {
     status: 'queued' | 'failed' | 'skipped_duplicate';
     message: string;
+    torrentId?: number;
+    torrentName?: string;
+    torrentHash?: string;
   },
 ): void {
   repository.recordCandidateOutcome({
@@ -207,6 +213,9 @@ function recordCandidateResult(
     feedItem: input.feedItem,
     match: input.match,
     status: input.status,
+    torrentId: input.torrentId,
+    torrentName: input.torrentName,
+    torrentHash: input.torrentHash,
   });
   recordFeedItemOutcome(repository, {
     runId: input.runId,

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -52,6 +52,9 @@ export type CandidateStateRecord = {
   mediaType: NormalizedFeedItem['mediaType'];
   status: CandidateStatus;
   queuedAt?: string;
+  torrentId?: number;
+  torrentName?: string;
+  torrentHash?: string;
   ruleName: string;
   score: number;
   reasons: string[];
@@ -78,6 +81,9 @@ export type RecordCandidateOutcomeInput = {
   feedItem: RawFeedItem;
   match: CandidateMatchRecord;
   status: CandidateStatus;
+  torrentId?: number;
+  torrentName?: string;
+  torrentHash?: string;
   updatedAt?: string;
 };
 
@@ -147,6 +153,9 @@ export function ensureSchema(database: Database): void {
       media_type TEXT NOT NULL,
       status TEXT NOT NULL,
       queued_at TEXT,
+      transmission_torrent_id INTEGER,
+      transmission_torrent_name TEXT,
+      transmission_torrent_hash TEXT,
       rule_name TEXT NOT NULL,
       score INTEGER NOT NULL,
       reasons_json TEXT NOT NULL,
@@ -188,6 +197,34 @@ export function ensureSchema(database: Database): void {
     database.run(
       `ALTER TABLE runs ADD COLUMN status TEXT NOT NULL DEFAULT 'running'`,
     );
+  }
+
+  const candidateStateColumns = [
+    {
+      name: 'transmission_torrent_id',
+      ddl: `ALTER TABLE candidate_state ADD COLUMN transmission_torrent_id INTEGER`,
+    },
+    {
+      name: 'transmission_torrent_name',
+      ddl: `ALTER TABLE candidate_state ADD COLUMN transmission_torrent_name TEXT`,
+    },
+    {
+      name: 'transmission_torrent_hash',
+      ddl: `ALTER TABLE candidate_state ADD COLUMN transmission_torrent_hash TEXT`,
+    },
+  ];
+
+  for (const column of candidateStateColumns) {
+    const hasColumn =
+      (database
+        .query(
+          `SELECT 1 FROM pragma_table_info('candidate_state') WHERE name = ?1`,
+        )
+        .get(column.name) as { 1: number } | null | undefined) !== null;
+
+    if (!hasColumn) {
+      database.run(column.ddl);
+    }
   }
 }
 
@@ -266,6 +303,9 @@ export function createRepository(database: Database): Repository {
       media_type AS mediaType,
       status,
       queued_at AS queuedAt,
+      transmission_torrent_id AS torrentId,
+      transmission_torrent_name AS torrentName,
+      transmission_torrent_hash AS torrentHash,
       rule_name AS ruleName,
       score,
       reasons_json AS reasonsJson,
@@ -293,6 +333,9 @@ export function createRepository(database: Database): Repository {
       media_type,
       status,
       queued_at,
+      transmission_torrent_id,
+      transmission_torrent_name,
+      transmission_torrent_hash,
       rule_name,
       score,
       reasons_json,
@@ -313,12 +356,24 @@ export function createRepository(database: Database): Repository {
       updated_at
     ) VALUES (
       ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
-      ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22
+      ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25
     )
     ON CONFLICT(identity_key) DO UPDATE SET
       media_type = excluded.media_type,
       status = excluded.status,
       queued_at = COALESCE(candidate_state.queued_at, excluded.queued_at),
+      transmission_torrent_id = COALESCE(
+        candidate_state.transmission_torrent_id,
+        excluded.transmission_torrent_id
+      ),
+      transmission_torrent_name = COALESCE(
+        candidate_state.transmission_torrent_name,
+        excluded.transmission_torrent_name
+      ),
+      transmission_torrent_hash = COALESCE(
+        candidate_state.transmission_torrent_hash,
+        excluded.transmission_torrent_hash
+      ),
       rule_name = excluded.rule_name,
       score = excluded.score,
       reasons_json = excluded.reasons_json,
@@ -400,6 +455,9 @@ export function createRepository(database: Database): Repository {
       media_type AS mediaType,
       status,
       queued_at AS queuedAt,
+      transmission_torrent_id AS torrentId,
+      transmission_torrent_name AS torrentName,
+      transmission_torrent_hash AS torrentHash,
       rule_name AS ruleName,
       score,
       reasons_json AS reasonsJson,
@@ -428,6 +486,9 @@ export function createRepository(database: Database): Repository {
       media_type AS mediaType,
       status,
       queued_at AS queuedAt,
+      transmission_torrent_id AS torrentId,
+      transmission_torrent_name AS torrentName,
+      transmission_torrent_hash AS torrentHash,
       rule_name AS ruleName,
       score,
       reasons_json AS reasonsJson,
@@ -524,6 +585,9 @@ export function createRepository(database: Database): Repository {
         input.match.item.mediaType,
         input.status,
         queuedAt,
+        input.torrentId ?? null,
+        input.torrentName ?? null,
+        input.torrentHash ?? null,
         input.match.ruleName,
         input.match.score,
         JSON.stringify(input.match.reasons),
@@ -671,6 +735,9 @@ function mapCandidateStateRow(row: CandidateStateRow): CandidateStateRecord {
     mediaType: row.mediaType,
     status: row.status,
     queuedAt: row.queuedAt ?? undefined,
+    torrentId: row.torrentId ?? undefined,
+    torrentName: row.torrentName ?? undefined,
+    torrentHash: row.torrentHash ?? undefined,
     ruleName: row.ruleName,
     score: Number(row.score),
     reasons: JSON.parse(row.reasonsJson) as string[],
@@ -734,6 +801,9 @@ type CandidateStateRow = {
   mediaType: NormalizedFeedItem['mediaType'];
   status: CandidateStatus;
   queuedAt: string | null;
+  torrentId: number | null;
+  torrentName: string | null;
+  torrentHash: string | null;
   ruleName: string;
   score: number;
   reasonsJson: string;

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -76,6 +76,9 @@ describe('runPipeline', () => {
         submit: async () => ({
           ok: true as const,
           status: 'queued' as const,
+          torrentId: 7,
+          torrentName: 'Example Show S01E02',
+          torrentHash: 'abcdef123456',
         }),
       },
       fetchFeed: async () => [
@@ -122,6 +125,9 @@ describe('runPipeline', () => {
       status: 'queued',
       rawTitle: 'Example.Show.S01E02.2160p.WEB.x265-GROUP',
       resolution: '2160p',
+      torrentId: 7,
+      torrentName: 'Example Show S01E02',
+      torrentHash: 'abcdef123456',
     });
   });
 

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -48,6 +48,9 @@ describe('SQLite repository', () => {
       feedItem: firstFeedItem,
       match: firstMatch,
       status: 'queued',
+      torrentId: 7,
+      torrentName: 'Example Movie',
+      torrentHash: 'abcdef123456',
       updatedAt: '2026-03-30T00:10:00.000Z',
     });
 
@@ -80,6 +83,9 @@ describe('SQLite repository', () => {
       identityKey: 'movie:example movie|2024',
       status: 'skipped_duplicate',
       queuedAt: '2026-03-30T00:10:00.000Z',
+      torrentId: 7,
+      torrentName: 'Example Movie',
+      torrentHash: 'abcdef123456',
       feedName: 'Movie Feed',
       guidOrLink: 'https://example.test/releases/example-movie-bluray',
       firstSeenRunId: firstRun.id,
@@ -132,6 +138,9 @@ describe('SQLite repository', () => {
       feedItem: secondFeedItem,
       match: retryMatch,
       status: 'queued',
+      torrentId: 9,
+      torrentName: 'Retry Me',
+      torrentHash: 'fedcba654321',
       updatedAt: '2026-03-30T03:10:00.000Z',
     });
 
@@ -139,6 +148,9 @@ describe('SQLite repository', () => {
       identityKey: 'movie:retry me|2024',
       status: 'queued',
       queuedAt: '2026-03-30T03:10:00.000Z',
+      torrentId: 9,
+      torrentName: 'Retry Me',
+      torrentHash: 'fedcba654321',
       firstSeenRunId: firstRun.id,
       lastSeenRunId: secondRun.id,
       lastFeedItemId: secondFeedItem.id,
@@ -340,6 +352,123 @@ describe('SQLite repository', () => {
         updatedAt: '2026-03-30T02:10:00.000Z',
       },
     ]);
+  });
+
+  it('keeps Transmission identity sticky across later candidate updates', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+    const firstRun = repository.startRun('2026-03-30T00:00:00.000Z');
+    const firstFeedItem = repository.recordFeedItem(firstRun.id, {
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/example-movie-web',
+      rawTitle: 'Example.Movie.2024.1080p.WEB.x265-GROUP',
+      publishedAt: '2026-03-30T00:05:00.000Z',
+      downloadUrl: 'https://example.test/downloads/example-movie-web.torrent',
+    });
+    const match = requireMovieMatch(firstFeedItem.rawTitle);
+
+    repository.recordCandidateOutcome({
+      runId: firstRun.id,
+      feedItemId: firstFeedItem.id,
+      feedItem: firstFeedItem,
+      match,
+      status: 'queued',
+      torrentId: 7,
+      torrentName: 'Example Movie',
+      torrentHash: 'abcdef123456',
+      updatedAt: '2026-03-30T00:10:00.000Z',
+    });
+
+    const secondRun = repository.startRun('2026-03-30T01:00:00.000Z');
+    const secondFeedItem = repository.recordFeedItem(secondRun.id, {
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/example-movie-rerun',
+      rawTitle: 'Example.Movie.2024.2160p.WEB.x265-NEWGROUP',
+      publishedAt: '2026-03-30T01:05:00.000Z',
+      downloadUrl: 'https://example.test/downloads/example-movie-rerun.torrent',
+    });
+
+    const state = repository.recordCandidateOutcome({
+      runId: secondRun.id,
+      feedItemId: secondFeedItem.id,
+      feedItem: secondFeedItem,
+      match: requireMovieMatch(secondFeedItem.rawTitle),
+      status: 'skipped_duplicate',
+      updatedAt: '2026-03-30T01:10:00.000Z',
+    });
+
+    expect(state).toMatchObject({
+      status: 'skipped_duplicate',
+      torrentId: 7,
+      torrentName: 'Example Movie',
+      torrentHash: 'abcdef123456',
+    });
+  });
+
+  it('adds Transmission identity columns to older candidate_state schemas', async () => {
+    const database = openDatabase(await createDatabasePath());
+
+    openDatabases.push(database);
+
+    database.run(`
+      CREATE TABLE candidate_state (
+        identity_key TEXT PRIMARY KEY,
+        media_type TEXT NOT NULL,
+        status TEXT NOT NULL,
+        queued_at TEXT,
+        rule_name TEXT NOT NULL,
+        score INTEGER NOT NULL,
+        reasons_json TEXT NOT NULL,
+        raw_title TEXT NOT NULL,
+        normalized_title TEXT NOT NULL,
+        season INTEGER,
+        episode INTEGER,
+        year INTEGER,
+        resolution TEXT,
+        codec TEXT,
+        feed_name TEXT NOT NULL,
+        guid_or_link TEXT NOT NULL,
+        published_at TEXT NOT NULL,
+        download_url TEXT NOT NULL,
+        first_seen_run_id INTEGER NOT NULL,
+        last_seen_run_id INTEGER NOT NULL,
+        last_feed_item_id INTEGER,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE runs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        started_at TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'running',
+        completed_at TEXT
+      );
+
+      CREATE TABLE feed_item_outcomes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_id INTEGER NOT NULL,
+        feed_item_id INTEGER,
+        status TEXT NOT NULL,
+        identity_key TEXT,
+        rule_name TEXT,
+        message TEXT,
+        created_at TEXT NOT NULL
+      );
+    `);
+
+    ensureSchema(database);
+
+    const columns = database
+      .query(
+        `SELECT name FROM pragma_table_info('candidate_state') ORDER BY cid`,
+      )
+      .all() as Array<{ name: string }>;
+
+    expect(columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        'transmission_torrent_id',
+        'transmission_torrent_name',
+        'transmission_torrent_hash',
+      ]),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- delivery ticket: `P3.01 Persist Transmission Identity For Queued Torrents`
- ticket file: `docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md`
- stacked base branch: `main`

## Verification

- `bun run ci`