### PR TITLE
fix: clarify the ai review wait behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,8 @@
 - For planned phase work in this repo, prefer the delivery orchestrator as the default workflow entrypoint rather than bypassing it with ad hoc implementation.
 - For orchestrated ticket work, treat the generated handoff artifact under `.codex/delivery/<plan-key>/handoffs/` as required input alongside the plan and ticket docs before implementing.
 - If the user says `begin phase`, `implement phase`, or equivalent, interpret that as a request to run the full orchestrated stacked-ticket workflow for that phase until blocked, not as a request to stop after the first completed ticket.
-- For phase delivery, do not stop at a completed ticket if the orchestrator can continue. Implement the ticket, verify it, push/open the PR, wait for `qodo-code-review`, patch prudent review findings, refresh the PR state, then advance to the next ticket branch/worktree.
+- For phase delivery, do not stop at a completed ticket if the orchestrator can continue. Implement the ticket, verify it, push/open the PR, wait for the configured `qodo-code-review` window, patch prudent review findings if any appear, refresh the PR state, then advance to the next ticket branch/worktree.
+- The lack of `qodo-code-review` feedback after the configured wait window is not a blocker by itself. Record the review as `clean` and continue unless real ambiguity or actionable feedback exists.
 - Stop only when the current ticket cannot be completed safely, a prerequisite is missing, review triage is ambiguous enough to require user input, the orchestrator cannot advance cleanly, or the user explicitly interrupts the phase run.
 
 - `pr`: if a delivery ticket is clear from branch/docs/diff, use a human-readable Conventional-Commit-style subject plus the active delivery ticket suffix, for example `[P3.02]`. Otherwise omit the suffix.

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -56,6 +56,8 @@ That boundary is intentional. The `qodo-code-review` skill already defines the r
 
 So the script fetches and stores review output, but humans or agents still use the skill to decide whether a comment matters.
 
+The absence of `qodo-code-review` comments after the configured wait window is not itself a blocker. In that case, record the review as `clean` and continue unless another real ambiguity or prerequisite issue exists.
+
 When ai-cr triage leads to prudent branch changes, the orchestrator updates the PR body as the final step of `advance`. That timing is intentional: the PR description should reflect the exact branch state that is being handed off before the next ticket starts.
 
 ## Ticket Context Reset
@@ -121,6 +123,8 @@ bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md advance
 ```
 
 At each ticket boundary, read the generated handoff artifact before continuing implementation.
+
+After `open-pr`, the orchestrator should surface the review wait window and the earliest meaningful review-fetch time. An immediate lack of AI comments is informational only; the decisive check happens after that window elapses.
 
 ## Review Artifact Location
 

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -9,6 +9,7 @@ import {
   derivePlanKey,
   deriveWorktreePath,
   findExistingBranch,
+  formatReviewWindowMessage,
   parsePlan,
   resolveReviewFetcher,
   syncStateWithPlan,
@@ -282,6 +283,42 @@ describe('delivery orchestrator', () => {
         title: 'Reconcile Torrent Lifecycle From Transmission',
       }),
     ).toBe('feat: reconcile torrent lifecycle from transmission [P3.02]');
+  });
+
+  it('surfaces the review wait window after opening a PR', () => {
+    const message = formatReviewWindowMessage(
+      {
+        planKey: 'phase-03',
+        planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+        statePath: '.codex/delivery/phase-03/state.json',
+        reviewsDirPath: '.codex/delivery/phase-03/reviews',
+        handoffsDirPath: '.codex/delivery/phase-03/handoffs',
+        reviewWaitMinutes: 5,
+        tickets: [
+          {
+            id: 'P3.01',
+            title: 'Persist Transmission Identity For Queued Torrents',
+            slug: 'persist-transmission-identity-for-queued-torrents',
+            ticketFile:
+              'docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md',
+            status: 'in_review',
+            branch:
+              'codex/p3-01-persist-transmission-identity-for-queued-torrents',
+            baseBranch: 'main',
+            worktreePath: '/tmp/p3_01',
+            prUrl: 'https://example.test/pull/20',
+            prNumber: 20,
+            prOpenedAt: '2026-04-01T10:00:00.000Z',
+          },
+        ],
+      },
+      'P3.01',
+    );
+
+    expect(message).toContain('AI Review Window');
+    expect(message).toContain('wait window: 5 minutes');
+    expect(message).toContain('review due at: 2026-04-01T10:05:00.000Z');
+    expect(message).toContain('record the review as `clean` and continue');
   });
 
   it('prefers an explicit review fetcher environment variable', () => {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -99,7 +99,14 @@ export async function runDeliveryOrchestrator(
           parsed.positionals[0],
         );
         await saveState(cwd, nextState);
-        console.log(formatStatus(nextState));
+        console.log(
+          [
+            formatStatus(nextState),
+            formatReviewWindowMessage(nextState, parsed.positionals[0]),
+          ]
+            .filter(Boolean)
+            .join('\n\n'),
+        );
         return 0;
       }
       case 'fetch-review': {
@@ -434,6 +441,15 @@ function getUsage(): string {
     '  record-review <ticket-id> <clean|needs_patch|patched> [note]',
     '  advance [--no-start-next]',
   ].join('\n');
+}
+
+function findTicketById(
+  state: DeliveryState,
+  ticketId?: string,
+): TicketState | undefined {
+  return ticketId
+    ? state.tickets.find((ticket) => ticket.id === ticketId)
+    : state.tickets.find((ticket) => ticket.status === 'in_review');
 }
 
 async function loadState(
@@ -787,11 +803,7 @@ async function fetchReview(
   cwd: string,
   ticketId?: string,
 ): Promise<DeliveryState> {
-  const target =
-    (ticketId
-      ? state.tickets.find((ticket) => ticket.id === ticketId)
-      : state.tickets.find((ticket) => ticket.status === 'in_review')) ??
-    undefined;
+  const target = findTicketById(state, ticketId);
 
   if (!target || !target.prNumber) {
     throw new Error('No in-review ticket with an open PR was found.');
@@ -1318,6 +1330,34 @@ function formatStatus(state: DeliveryState): string {
         .filter((value): value is string => value !== undefined)
         .join('\n'),
     ),
+  ].join('\n');
+}
+
+export function formatReviewWindowMessage(
+  state: DeliveryState,
+  ticketId?: string,
+): string {
+  const ticket = findTicketById(state, ticketId);
+
+  if (!ticket?.prUrl || !ticket.prOpenedAt) {
+    return '';
+  }
+
+  const openedAt = Date.parse(ticket.prOpenedAt);
+
+  if (Number.isNaN(openedAt)) {
+    return '';
+  }
+
+  const dueAt = new Date(
+    openedAt + state.reviewWaitMinutes * 60_000,
+  ).toISOString();
+
+  return [
+    'AI Review Window',
+    `- wait window: ${state.reviewWaitMinutes} minutes`,
+    `- review due at: ${dueAt}`,
+    `- if no \`qodo-code-review\` feedback appears by then, record the review as \`clean\` and continue`,
   ].join('\n');
 }
 


### PR DESCRIPTION
## Summary

- clarify that the lack of qodo-code-review feedback after the configured wait window is not a blocker by itself
- surface the AI review wait window and due time immediately after delivery PR creation
- keep the phase workflow focused on real ambiguity or actionable review findings instead of immediate no-comment checks

## Policy Follow-Up

- update the repo delivery rules to continue after the wait window when no AI review feedback appears
- document that the immediate post-push check is informational and the meaningful review decision happens after the configured wait window
