### PR TITLE
feat: persist Transmission identity for queued torrents [P3.01]

### DIFF
--- a/docs/02-delivery/phase-03/ticket-01-rationale.md
+++ b/docs/02-delivery/phase-03/ticket-01-rationale.md
@@ -1,0 +1,6 @@
+# `P3.01` Rationale
+
+- red first: queued candidates had no durable Transmission pointer, so later lifecycle reconciliation had no reliable torrent identity to look up
+- chosen path: extend `candidate_state` with sticky Transmission torrent id/name/hash fields and thread them through the existing queue-success persistence path
+- alternative rejected: storing a separate submission-history table now would widen the ticket into lifecycle history design before Phase 03 proves the narrower reconciliation slice
+- deferred: richer downloader-state persistence, repeated reconciliation history, and any status-surface changes beyond what tests need

--- a/docs/03-engineering/sqlite-schema.md
+++ b/docs/03-engineering/sqlite-schema.md
@@ -69,6 +69,7 @@ Important fields:
 - `media_type`
 - `status`: `queued`, `failed`, or `skipped_duplicate`
 - `queued_at`
+- `transmission_torrent_id`, `transmission_torrent_name`, `transmission_torrent_hash`
 - `rule_name`
 - `score`
 - `reasons_json`
@@ -83,6 +84,7 @@ Behavioral role:
 - records the current best-known state for that identity
 - blocks requeueing when a prior candidate was already queued
 - powers `retry-failed` by storing the last retryable failed candidate with its `download_url`
+- retains the downloader identity needed for later lifecycle reconciliation after queueing
 
 ## `feed_item_outcomes`
 
@@ -144,6 +146,7 @@ Important nuance:
 
 - `skipped_no_match` is not a `candidate_state` value because unmatched feed items do not create a durable candidate identity
 - `queued_at` is preserved once set, even if later upserts touch the same identity
+- queued Transmission identity fields are sticky once present, so later duplicate or failure updates do not lose the original downloader pointer
 
 ## Current Invariants
 

--- a/docs/03-engineering/sqlite-schema.mmd
+++ b/docs/03-engineering/sqlite-schema.mmd
@@ -21,6 +21,9 @@ erDiagram
     TEXT media_type
     TEXT status
     TEXT queued_at
+    INTEGER transmission_torrent_id
+    TEXT transmission_torrent_name
+    TEXT transmission_torrent_hash
     TEXT rule_name
     INTEGER score
     TEXT reasons_json

--- a/src/pipeline-runner.ts
+++ b/src/pipeline-runner.ts
@@ -116,6 +116,9 @@ export async function submitCandidate(
       ...input,
       status: 'queued',
       message: 'Queued in Transmission.',
+      transmissionTorrentId: submission.torrentId,
+      transmissionTorrentName: submission.torrentName,
+      transmissionTorrentHash: submission.torrentHash,
     });
     return;
   }
@@ -199,6 +202,9 @@ function recordCandidateResult(
   input: SubmissionInput & {
     status: 'queued' | 'failed' | 'skipped_duplicate';
     message: string;
+    transmissionTorrentId?: number;
+    transmissionTorrentName?: string;
+    transmissionTorrentHash?: string;
   },
 ): void {
   repository.recordCandidateOutcome({
@@ -207,6 +213,9 @@ function recordCandidateResult(
     feedItem: input.feedItem,
     match: input.match,
     status: input.status,
+    transmissionTorrentId: input.transmissionTorrentId,
+    transmissionTorrentName: input.transmissionTorrentName,
+    transmissionTorrentHash: input.transmissionTorrentHash,
   });
   recordFeedItemOutcome(repository, {
     runId: input.runId,

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -52,6 +52,9 @@ export type CandidateStateRecord = {
   mediaType: NormalizedFeedItem['mediaType'];
   status: CandidateStatus;
   queuedAt?: string;
+  transmissionTorrentId?: number;
+  transmissionTorrentName?: string;
+  transmissionTorrentHash?: string;
   ruleName: string;
   score: number;
   reasons: string[];
@@ -78,6 +81,9 @@ export type RecordCandidateOutcomeInput = {
   feedItem: RawFeedItem;
   match: CandidateMatchRecord;
   status: CandidateStatus;
+  transmissionTorrentId?: number;
+  transmissionTorrentName?: string;
+  transmissionTorrentHash?: string;
   updatedAt?: string;
 };
 
@@ -147,6 +153,9 @@ export function ensureSchema(database: Database): void {
       media_type TEXT NOT NULL,
       status TEXT NOT NULL,
       queued_at TEXT,
+      transmission_torrent_id INTEGER,
+      transmission_torrent_name TEXT,
+      transmission_torrent_hash TEXT,
       rule_name TEXT NOT NULL,
       score INTEGER NOT NULL,
       reasons_json TEXT NOT NULL,
@@ -189,6 +198,10 @@ export function ensureSchema(database: Database): void {
       `ALTER TABLE runs ADD COLUMN status TEXT NOT NULL DEFAULT 'running'`,
     );
   }
+
+  ensureCandidateStateColumn(database, 'transmission_torrent_id', 'INTEGER');
+  ensureCandidateStateColumn(database, 'transmission_torrent_name', 'TEXT');
+  ensureCandidateStateColumn(database, 'transmission_torrent_hash', 'TEXT');
 }
 
 export function hasStatusSchema(database: Database): boolean {
@@ -266,6 +279,9 @@ export function createRepository(database: Database): Repository {
       media_type AS mediaType,
       status,
       queued_at AS queuedAt,
+      transmission_torrent_id AS transmissionTorrentId,
+      transmission_torrent_name AS transmissionTorrentName,
+      transmission_torrent_hash AS transmissionTorrentHash,
       rule_name AS ruleName,
       score,
       reasons_json AS reasonsJson,
@@ -293,6 +309,9 @@ export function createRepository(database: Database): Repository {
       media_type,
       status,
       queued_at,
+      transmission_torrent_id,
+      transmission_torrent_name,
+      transmission_torrent_hash,
       rule_name,
       score,
       reasons_json,
@@ -313,12 +332,25 @@ export function createRepository(database: Database): Repository {
       updated_at
     ) VALUES (
       ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
-      ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22
+      ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22,
+      ?23, ?24, ?25
     )
     ON CONFLICT(identity_key) DO UPDATE SET
       media_type = excluded.media_type,
       status = excluded.status,
       queued_at = COALESCE(candidate_state.queued_at, excluded.queued_at),
+      transmission_torrent_id = COALESCE(
+        candidate_state.transmission_torrent_id,
+        excluded.transmission_torrent_id
+      ),
+      transmission_torrent_name = COALESCE(
+        candidate_state.transmission_torrent_name,
+        excluded.transmission_torrent_name
+      ),
+      transmission_torrent_hash = COALESCE(
+        candidate_state.transmission_torrent_hash,
+        excluded.transmission_torrent_hash
+      ),
       rule_name = excluded.rule_name,
       score = excluded.score,
       reasons_json = excluded.reasons_json,
@@ -400,6 +432,9 @@ export function createRepository(database: Database): Repository {
       media_type AS mediaType,
       status,
       queued_at AS queuedAt,
+      transmission_torrent_id AS transmissionTorrentId,
+      transmission_torrent_name AS transmissionTorrentName,
+      transmission_torrent_hash AS transmissionTorrentHash,
       rule_name AS ruleName,
       score,
       reasons_json AS reasonsJson,
@@ -428,6 +463,9 @@ export function createRepository(database: Database): Repository {
       media_type AS mediaType,
       status,
       queued_at AS queuedAt,
+      transmission_torrent_id AS transmissionTorrentId,
+      transmission_torrent_name AS transmissionTorrentName,
+      transmission_torrent_hash AS transmissionTorrentHash,
       rule_name AS ruleName,
       score,
       reasons_json AS reasonsJson,
@@ -524,6 +562,9 @@ export function createRepository(database: Database): Repository {
         input.match.item.mediaType,
         input.status,
         queuedAt,
+        input.transmissionTorrentId ?? null,
+        input.transmissionTorrentName ?? null,
+        input.transmissionTorrentHash ?? null,
         input.match.ruleName,
         input.match.score,
         JSON.stringify(input.match.reasons),
@@ -619,6 +660,25 @@ function lastInsertedRowId(database: Database): number {
   );
 }
 
+function ensureCandidateStateColumn(
+  database: Database,
+  columnName: string,
+  columnType: 'INTEGER' | 'TEXT',
+): void {
+  const hasColumn =
+    (database
+      .query(
+        `SELECT 1 FROM pragma_table_info('candidate_state') WHERE name = ?1`,
+      )
+      .get(columnName) as { 1: number } | null | undefined) !== null;
+
+  if (!hasColumn) {
+    database.run(
+      `ALTER TABLE candidate_state ADD COLUMN ${columnName} ${columnType}`,
+    );
+  }
+}
+
 function requireRow<T>(row: T | null | undefined, label: string): T {
   if (!row) {
     throw new Error(`Failed to load ${label} row.`);
@@ -671,6 +731,9 @@ function mapCandidateStateRow(row: CandidateStateRow): CandidateStateRecord {
     mediaType: row.mediaType,
     status: row.status,
     queuedAt: row.queuedAt ?? undefined,
+    transmissionTorrentId: row.transmissionTorrentId ?? undefined,
+    transmissionTorrentName: row.transmissionTorrentName ?? undefined,
+    transmissionTorrentHash: row.transmissionTorrentHash ?? undefined,
     ruleName: row.ruleName,
     score: Number(row.score),
     reasons: JSON.parse(row.reasonsJson) as string[],
@@ -734,6 +797,9 @@ type CandidateStateRow = {
   mediaType: NormalizedFeedItem['mediaType'];
   status: CandidateStatus;
   queuedAt: string | null;
+  transmissionTorrentId: number | null;
+  transmissionTorrentName: string | null;
+  transmissionTorrentHash: string | null;
   ruleName: string;
   score: number;
   reasonsJson: string;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -140,6 +140,9 @@ describe('pirate-claw run', () => {
       repository.getCandidateState('movie:example movie|2024'),
     ).toMatchObject({
       queuedAt: expect.any(String),
+      transmissionTorrentId: 42,
+      transmissionTorrentName: 'Queued Torrent',
+      transmissionTorrentHash: 'hash-42',
     });
     expect(repository.getCandidateState('movie:retry me|2024')).toMatchObject({
       status: 'failed',
@@ -503,6 +506,9 @@ describe('pirate-claw retry-failed', () => {
       status: 'queued',
       queuedAt: expect.any(String),
       lastFeedItemId: retryMeBefore?.lastFeedItemId,
+      transmissionTorrentId: 52,
+      transmissionTorrentName: 'Retried Torrent',
+      transmissionTorrentHash: 'hash-52',
     });
     expect(
       repository.getCandidateState('movie:example movie|2024'),

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -76,6 +76,9 @@ describe('runPipeline', () => {
         submit: async () => ({
           ok: true as const,
           status: 'queued' as const,
+          torrentId: 7,
+          torrentName: 'Example Show S01E02',
+          torrentHash: 'abcdef123456',
         }),
       },
       fetchFeed: async () => [
@@ -122,6 +125,9 @@ describe('runPipeline', () => {
       status: 'queued',
       rawTitle: 'Example.Show.S01E02.2160p.WEB.x265-GROUP',
       resolution: '2160p',
+      transmissionTorrentId: 7,
+      transmissionTorrentName: 'Example Show S01E02',
+      transmissionTorrentHash: 'abcdef123456',
     });
   });
 

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -48,6 +48,9 @@ describe('SQLite repository', () => {
       feedItem: firstFeedItem,
       match: firstMatch,
       status: 'queued',
+      transmissionTorrentId: 7,
+      transmissionTorrentName: 'Example Movie 2024',
+      transmissionTorrentHash: 'abcdef123456',
       updatedAt: '2026-03-30T00:10:00.000Z',
     });
 
@@ -80,6 +83,9 @@ describe('SQLite repository', () => {
       identityKey: 'movie:example movie|2024',
       status: 'skipped_duplicate',
       queuedAt: '2026-03-30T00:10:00.000Z',
+      transmissionTorrentId: 7,
+      transmissionTorrentName: 'Example Movie 2024',
+      transmissionTorrentHash: 'abcdef123456',
       feedName: 'Movie Feed',
       guidOrLink: 'https://example.test/releases/example-movie-bluray',
       firstSeenRunId: firstRun.id,
@@ -144,6 +150,114 @@ describe('SQLite repository', () => {
       lastFeedItemId: secondFeedItem.id,
     });
     expect(repository.isCandidateQueued(retryMatch.identityKey)).toBe(true);
+  });
+
+  it('adds and preserves Transmission identity columns for queued candidates', async () => {
+    const path = await createDatabasePath();
+    const database = openDatabase(path);
+
+    openDatabases.push(database);
+    database.run(`
+      CREATE TABLE runs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        started_at TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'running',
+        completed_at TEXT
+      );
+
+      CREATE TABLE feed_items (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_id INTEGER NOT NULL REFERENCES runs(id),
+        feed_name TEXT NOT NULL,
+        guid_or_link TEXT NOT NULL,
+        raw_title TEXT NOT NULL,
+        published_at TEXT NOT NULL,
+        download_url TEXT NOT NULL
+      );
+
+      CREATE TABLE candidate_state (
+        identity_key TEXT PRIMARY KEY,
+        media_type TEXT NOT NULL,
+        status TEXT NOT NULL,
+        queued_at TEXT,
+        rule_name TEXT NOT NULL,
+        score INTEGER NOT NULL,
+        reasons_json TEXT NOT NULL,
+        raw_title TEXT NOT NULL,
+        normalized_title TEXT NOT NULL,
+        season INTEGER,
+        episode INTEGER,
+        year INTEGER,
+        resolution TEXT,
+        codec TEXT,
+        feed_name TEXT NOT NULL,
+        guid_or_link TEXT NOT NULL,
+        published_at TEXT NOT NULL,
+        download_url TEXT NOT NULL,
+        first_seen_run_id INTEGER NOT NULL REFERENCES runs(id),
+        last_seen_run_id INTEGER NOT NULL REFERENCES runs(id),
+        last_feed_item_id INTEGER REFERENCES feed_items(id),
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE feed_item_outcomes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_id INTEGER NOT NULL REFERENCES runs(id),
+        feed_item_id INTEGER REFERENCES feed_items(id),
+        status TEXT NOT NULL,
+        identity_key TEXT,
+        rule_name TEXT,
+        message TEXT,
+        created_at TEXT NOT NULL
+      );
+    `);
+
+    ensureSchema(database);
+    const repository = createRepository(database);
+    const run = repository.startRun('2026-03-30T00:00:00.000Z');
+    const feedItem = repository.recordFeedItem(run.id, {
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/example-movie-web',
+      rawTitle: 'Example.Movie.2024.1080p.WEB.x265-GROUP',
+      publishedAt: '2026-03-30T00:05:00.000Z',
+      downloadUrl: 'https://example.test/downloads/example-movie-web.torrent',
+    });
+    const match = requireMovieMatch(feedItem.rawTitle);
+
+    repository.recordCandidateOutcome({
+      runId: run.id,
+      feedItemId: feedItem.id,
+      feedItem,
+      match,
+      status: 'queued',
+      transmissionTorrentId: 7,
+      transmissionTorrentName: 'Example Movie 2024',
+      transmissionTorrentHash: 'abcdef123456',
+      updatedAt: '2026-03-30T00:10:00.000Z',
+    });
+
+    const updatedFeedItem = repository.recordFeedItem(run.id, {
+      feedName: 'Movie Feed',
+      guidOrLink: 'https://example.test/releases/example-movie-rerun',
+      rawTitle: 'Example Movie 2024 2160p BluRay x265 OTHER',
+      publishedAt: '2026-03-30T00:06:00.000Z',
+      downloadUrl: 'https://example.test/downloads/example-movie-rerun.torrent',
+    });
+
+    const state = repository.recordCandidateOutcome({
+      runId: run.id,
+      feedItemId: updatedFeedItem.id,
+      feedItem: updatedFeedItem,
+      match: requireMovieMatch(updatedFeedItem.rawTitle),
+      status: 'skipped_duplicate',
+      updatedAt: '2026-03-30T00:11:00.000Z',
+    });
+
+    expect(state).toMatchObject({
+      transmissionTorrentId: 7,
+      transmissionTorrentName: 'Example Movie 2024',
+      transmissionTorrentHash: 'abcdef123456',
+    });
   });
 
   it('distinguishes failed runs from completed runs', async () => {


### PR DESCRIPTION
## Summary

- delivery ticket: `P3.01 Persist Transmission Identity For Queued Torrents`
- ticket file: `docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md`
- stacked base branch: `main`

## AI Review Follow-Up

- `qodo-code-review` triage found no prudent follow-up changes.
- follow-up note: no qodo-code-review comments after the configured wait window

## Verification

- `bun run ci`