### PR TITLE
feat: show post-queue lifecycle in status [P3.03]

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Inspect the current state with:
 ./bin/pirate-claw status
 ```
 
+When a torrent has been reconciled from Transmission, `status` shows the latest known lifecycle and brief downloader detail alongside the stored candidate state.
+
 Retry failed submissions with:
 
 ```bash

--- a/docs/02-delivery/phase-03/ticket-03-rationale.md
+++ b/docs/02-delivery/phase-03/ticket-03-rationale.md
@@ -1,0 +1,6 @@
+# `P3.03` Rationale
+
+- red first: after `P3.02`, reconciliation data existed only in SQLite, so an operator still had to inspect the database directly to see post-queue lifecycle
+- chosen path: keep `status` read-only, surface `lifecycle_status` when present, and sort candidates by the latest known lifecycle timestamp with only cheap extra downloader detail
+- alternative rejected: making `status` perform live reconciliation would blur the read/write boundary and bypass the dedicated reconciliation command added in `P3.02`
+- deferred: completion and missing-from-Transmission semantics remain in `P3.04`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -210,11 +210,11 @@ function formatCandidateStates(candidates: CandidateStateRecord[]): string[] {
     return ['No candidate states recorded.'];
   }
 
-  return candidates.map((candidate) =>
+  return sortCandidatesForStatus(candidates).map((candidate) =>
     [
-      `${candidate.identityKey} | status=${candidate.status} | rule=${candidate.ruleName} | title=${candidate.normalizedTitle}`,
+      `${candidate.identityKey} | status=${candidate.lifecycleStatus ?? candidate.status} | rule=${candidate.ruleName} | title=${candidate.normalizedTitle}`,
       formatCandidateMetadata(candidate),
-      `updated=${candidate.updatedAt} | queued=${candidate.queuedAt ?? '-'}`,
+      `updated=${candidate.updatedAt} | queued=${candidate.queuedAt ?? '-'} | reconciled=${candidate.reconciledAt ?? '-'}`,
     ].join('\n'),
   );
 }
@@ -229,10 +229,31 @@ function formatCandidateMetadata(candidate: CandidateStateRecord): string {
     candidate.year !== undefined ? `year=${candidate.year}` : undefined,
     candidate.resolution ? `resolution=${candidate.resolution}` : undefined,
     candidate.codec ? `codec=${candidate.codec}` : undefined,
+    candidate.transmissionPercentDone !== undefined
+      ? `progress=${Math.round(candidate.transmissionPercentDone * 100)}%`
+      : undefined,
+    candidate.transmissionTorrentName
+      ? `torrent=${candidate.transmissionTorrentName}`
+      : undefined,
     `feed=${candidate.feedName}`,
   ].filter((value): value is string => value !== undefined);
 
   return details.join(' | ');
+}
+
+function sortCandidatesForStatus(
+  candidates: CandidateStateRecord[],
+): CandidateStateRecord[] {
+  return [...candidates].sort((left, right) => {
+    const leftTime = Date.parse(left.reconciledAt ?? left.updatedAt);
+    const rightTime = Date.parse(right.reconciledAt ?? right.updatedAt);
+
+    if (leftTime !== rightTime) {
+      return rightTime - leftTime;
+    }
+
+    return left.identityKey.localeCompare(right.identityKey);
+  });
 }
 
 function formatUnexpectedError(error: unknown): string {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -344,6 +344,13 @@ describe('pirate-claw status', () => {
       status: 'queued',
       updatedAt: '2026-03-30T00:10:00.000Z',
     });
+    repository.recordCandidateReconciliation({
+      identityKey: 'movie:example movie|2024',
+      lifecycleStatus: 'downloading',
+      transmissionTorrentName: 'Queued Torrent',
+      transmissionPercentDone: 0.5,
+      reconciledAt: '2026-03-30T02:10:00.000Z',
+    });
 
     const failedFeedItem = repository.recordFeedItem(secondRun.id, {
       feedName: 'Movie Feed',
@@ -373,6 +380,13 @@ describe('pirate-claw status', () => {
       status: 'failed',
       updatedAt: '2026-03-30T01:10:00.000Z',
     });
+    repository.recordCandidateReconciliation({
+      identityKey: 'movie:retry me|2024',
+      lifecycleStatus: 'queued',
+      transmissionTorrentName: 'Retry Me',
+      transmissionPercentDone: 0,
+      reconciledAt: '2026-03-30T01:20:00.000Z',
+    });
 
     const runsBefore = repository.listRecentRunSummaries();
     const candidatesBefore = repository.listCandidateStates();
@@ -390,10 +404,22 @@ describe('pirate-claw status', () => {
     );
     expect(status.stdout).toContain('Candidate states');
     expect(status.stdout).toContain(
-      'movie:retry me|2024 | status=failed | rule=movie-policy | title=retry me',
+      'movie:example movie|2024 | status=downloading | rule=movie-policy | title=example movie',
     );
     expect(status.stdout).toContain(
-      'movie:example movie|2024 | status=queued | rule=movie-policy | title=example movie',
+      'progress=50% | torrent=Queued Torrent | feed=Movie Feed',
+    );
+    expect(status.stdout).toContain(
+      'updated=2026-03-30T00:10:00.000Z | queued=2026-03-30T00:10:00.000Z | reconciled=2026-03-30T02:10:00.000Z',
+    );
+    expect(status.stdout).toContain(
+      'movie:retry me|2024 | status=queued | rule=movie-policy | title=retry me',
+    );
+
+    expect(
+      status.stdout.indexOf('movie:example movie|2024 | status=downloading'),
+    ).toBeLessThan(
+      status.stdout.indexOf('movie:retry me|2024 | status=queued'),
     );
 
     expect(repository.listRecentRunSummaries()).toEqual(runsBefore);


### PR DESCRIPTION
## Summary

- delivery ticket: `P3.03 Show Post-Queue Lifecycle In Status`
- ticket file: `docs/02-delivery/phase-03/ticket-03-show-post-queue-lifecycle-in-status.md`
- stacked base branch: `codex/p3-02-reconcile-torrent-lifecycle-from-transmission`

## AI Review Follow-Up

- `qodo-code-review` triage found no prudent follow-up changes.
- follow-up note: no qodo-code-review comments after the configured wait window

## Verification

- `bun run ci`