### PR TITLE
feat: define completion and missing semantics [P3.04]

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Inspect the current state with:
 ```
 
 When a torrent has been reconciled from Transmission, `status` shows the latest known lifecycle and brief downloader detail alongside the stored candidate state.
+If a tracked torrent later disappears from Transmission before completion, `status` surfaces it as `missing_from_transmission`; once a torrent has been observed completed, that completed state stays sticky locally.
 
 Retry failed submissions with:
 

--- a/docs/02-delivery/phase-03/ticket-04-rationale.md
+++ b/docs/02-delivery/phase-03/ticket-04-rationale.md
@@ -1,0 +1,6 @@
+# `P3.04` Rationale
+
+- red first: after `P3.03`, a torrent that had fully completed and later disappeared looked indistinguishable from a torrent that vanished before completion
+- chosen path: make `completed` sticky once observed, persist `missing_from_transmission` only for tracked torrents that disappear before any completed observation, and let both reconcile output and status reflect that rule
+- alternative rejected: trying to infer operator intent from a missing torrent would overreach the local CLI boundary and pretend to know whether a removal was manual
+- deferred: seeding policy, media placement, and any recovery workflow for missing torrents remain outside Phase 03

--- a/docs/03-engineering/sqlite-schema.md
+++ b/docs/03-engineering/sqlite-schema.md
@@ -151,6 +151,7 @@ Important nuance:
 - `queued_at` is preserved once set, even if later upserts touch the same identity
 - queued Transmission identity fields are sticky once present, so later duplicate or failure updates do not lose the original downloader pointer
 - `lifecycle_status` and `reconciled_at` reflect the latest successful reconciliation snapshot, separate from the queue-submission `status`
+- `completed` is sticky once observed from Transmission, while torrents that disappear before any completed observation become `missing_from_transmission`
 
 ## Current Invariants
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -120,16 +120,15 @@ export async function runCli(argv: string[]): Promise<number> {
 function formatReconcileSummary(result: {
   trackedCount: number;
   reconciledCount: number;
-  notFoundCount: number;
   counts: Record<CandidateLifecycleStatus, number>;
 }): string {
   return [
     `Tracked torrents: ${result.trackedCount}`,
     `reconciled: ${result.reconciledCount}`,
-    `not_found: ${result.notFoundCount}`,
     `queued: ${result.counts.queued}`,
     `downloading: ${result.counts.downloading}`,
     `completed: ${result.counts.completed}`,
+    `missing_from_transmission: ${result.counts.missing_from_transmission}`,
   ].join('\n');
 }
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -25,7 +25,6 @@ export type FetchFeedFn = (feed: FeedConfig) => Promise<RawFeedItem[]>;
 export type ReconcileCandidatesResult = {
   trackedCount: number;
   reconciledCount: number;
-  notFoundCount: number;
   counts: Record<CandidateLifecycleStatus, number>;
 };
 
@@ -106,7 +105,6 @@ export async function reconcileCandidates(input: {
     return {
       trackedCount: 0,
       reconciledCount: 0,
-      notFoundCount: 0,
       counts: createEmptyReconcileCounts(),
     };
   }
@@ -136,27 +134,27 @@ export async function reconcileCandidates(input: {
   );
   const counts = createEmptyReconcileCounts();
   let reconciledCount = 0;
-  let notFoundCount = 0;
 
   for (const candidate of candidates) {
     const torrent = matchTorrent(candidate, torrentsById, torrentsByHash);
+    const lifecycleStatus = deriveLifecycleStatus(candidate, torrent);
 
-    if (!torrent) {
-      notFoundCount += 1;
-      continue;
-    }
-
-    const lifecycleStatus = deriveLifecycleStatus(torrent);
-
-    input.repository.recordCandidateReconciliation({
-      identityKey: candidate.identityKey,
-      lifecycleStatus,
-      transmissionTorrentName: torrent.torrentName,
-      transmissionStatusCode: torrent.statusCode,
-      transmissionPercentDone: torrent.percentDone,
-      transmissionDoneDate: torrent.doneDate,
-      transmissionDownloadDir: torrent.downloadDir,
-    });
+    input.repository.recordCandidateReconciliation(
+      torrent
+        ? {
+            identityKey: candidate.identityKey,
+            lifecycleStatus,
+            transmissionTorrentName: torrent.torrentName,
+            transmissionStatusCode: torrent.statusCode,
+            transmissionPercentDone: torrent.percentDone,
+            transmissionDoneDate: torrent.doneDate,
+            transmissionDownloadDir: torrent.downloadDir,
+          }
+        : {
+            identityKey: candidate.identityKey,
+            lifecycleStatus,
+          },
+    );
 
     counts[lifecycleStatus] += 1;
     reconciledCount += 1;
@@ -165,7 +163,6 @@ export async function reconcileCandidates(input: {
   return {
     trackedCount: candidates.length,
     reconciledCount,
-    notFoundCount,
     counts,
   };
 }
@@ -195,6 +192,7 @@ function createEmptyReconcileCounts(): Record<
     queued: 0,
     downloading: 0,
     completed: 0,
+    missing_from_transmission: 0,
   };
 }
 
@@ -219,8 +217,15 @@ function matchTorrent(
 }
 
 function deriveLifecycleStatus(
-  torrent: Pick<TorrentSnapshot, 'percentDone' | 'statusCode'>,
+  candidate: Pick<CandidateStateRecord, 'lifecycleStatus'>,
+  torrent?: Pick<TorrentSnapshot, 'percentDone' | 'statusCode'>,
 ): CandidateLifecycleStatus {
+  if (!torrent) {
+    return candidate.lifecycleStatus === 'completed'
+      ? 'completed'
+      : 'missing_from_transmission';
+  }
+
   if (torrent.percentDone !== undefined && torrent.percentDone >= 1) {
     return 'completed';
   }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -5,7 +5,11 @@ import type { NormalizedFeedItem } from './normalize';
 
 export type CandidateStatus = 'queued' | 'failed' | 'skipped_duplicate';
 export type RunStatus = 'running' | 'completed' | 'failed';
-export type CandidateLifecycleStatus = 'queued' | 'downloading' | 'completed';
+export type CandidateLifecycleStatus =
+  | 'queued'
+  | 'downloading'
+  | 'completed'
+  | 'missing_from_transmission';
 
 export type FeedItemOutcomeStatus =
   | 'queued'

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -712,8 +712,8 @@ describe('pirate-claw reconcile', () => {
     expect(reconcile.stderr).toBe('');
     expect(reconcile.stdout).toContain('Tracked torrents: 1');
     expect(reconcile.stdout).toContain('reconciled: 1');
-    expect(reconcile.stdout).toContain('not_found: 0');
     expect(reconcile.stdout).toContain('downloading: 1');
+    expect(reconcile.stdout).toContain('missing_from_transmission: 0');
 
     expect(
       repository.getCandidateState('movie:example movie|2024'),
@@ -724,6 +724,90 @@ describe('pirate-claw reconcile', () => {
       transmissionPercentDone: 0.5,
       transmissionDownloadDir: '/downloads/movies',
     });
+  });
+
+  it('marks missing torrents explicitly unless completion was already observed', async () => {
+    const directory = await mkdtemp();
+    const transmissionServer = startMissingTransmissionLifecycleServer();
+    const configPath = join(directory, 'pirate-claw.config.json');
+    const repository = createTestRepository(join(directory, 'pirate-claw.db'));
+
+    await Bun.write(
+      configPath,
+      JSON.stringify({
+        feeds: [],
+        tv: [],
+        movies: {
+          years: [2024],
+          resolutions: ['2160p', '1080p'],
+          codecs: ['x265'],
+        },
+        transmission: {
+          url: `${transmissionServer.url}/transmission/rpc`,
+          username: 'user',
+          password: 'pass',
+        },
+      }),
+    );
+
+    seedQueuedMovieCandidate(repository, {
+      runId: repository.startRun('2026-03-30T00:00:00.000Z').id,
+      rawTitle: 'Example.Movie.2024.1080p.WEB.x265-GROUP',
+      guidOrLink: 'https://example.test/releases/example-movie-web',
+      downloadUrl: 'https://example.test/downloads/example-movie-web.torrent',
+      updatedAt: '2026-03-30T00:10:00.000Z',
+      status: 'queued',
+      transmissionTorrentId: 42,
+      transmissionTorrentHash: 'hash-42',
+      transmissionTorrentName: 'Queued Torrent',
+    });
+    repository.recordCandidateReconciliation({
+      identityKey: 'movie:example movie|2024',
+      lifecycleStatus: 'completed',
+      reconciledAt: '2026-03-30T01:00:00.000Z',
+    });
+
+    seedQueuedMovieCandidate(repository, {
+      runId: repository.startRun('2026-03-30T00:30:00.000Z').id,
+      rawTitle: 'Retry.Me.2024.1080p.WEB.x265-GROUP',
+      guidOrLink: 'https://example.test/releases/retry-me-web',
+      downloadUrl: 'https://example.test/downloads/retry-me-web.torrent',
+      updatedAt: '2026-03-30T00:40:00.000Z',
+      status: 'queued',
+      transmissionTorrentId: 52,
+      transmissionTorrentHash: 'hash-52',
+      transmissionTorrentName: 'Retry Me',
+    });
+
+    const reconcile = await runSimpleCommand(
+      directory,
+      'reconcile',
+      '--config',
+      './pirate-claw.config.json',
+    );
+
+    expect(reconcile.exitCode).toBe(0);
+    expect(reconcile.stdout).toContain('completed: 1');
+    expect(reconcile.stdout).toContain('missing_from_transmission: 1');
+
+    expect(
+      repository.getCandidateState('movie:example movie|2024'),
+    ).toMatchObject({
+      lifecycleStatus: 'completed',
+    });
+    expect(repository.getCandidateState('movie:retry me|2024')).toMatchObject({
+      lifecycleStatus: 'missing_from_transmission',
+    });
+
+    const status = await runSimpleCommand(directory, 'status');
+
+    expect(status.exitCode).toBe(0);
+    expect(status.stdout).toContain(
+      'movie:retry me|2024 | status=missing_from_transmission | rule=movie-policy | title=retry me',
+    );
+    expect(status.stdout).toContain(
+      'movie:example movie|2024 | status=completed | rule=movie-policy | title=example movie',
+    );
   });
 });
 
@@ -1009,6 +1093,37 @@ function startTransmissionLifecycleServer(): { url: string } {
               hashString: 'hash-42',
               name: 'Queued Torrent',
             },
+          },
+        });
+      },
+    },
+  });
+
+  servers.push(server);
+  return { url: server.url.origin };
+}
+
+function startMissingTransmissionLifecycleServer(): { url: string } {
+  const server = Bun.serve({
+    port: 0,
+    hostname: '127.0.0.1',
+    routes: {
+      '/transmission/rpc': async (request: Request) => {
+        const sessionId = request.headers.get('x-transmission-session-id');
+
+        if (!sessionId) {
+          return new Response(null, {
+            status: 409,
+            headers: {
+              'x-transmission-session-id': 'session-123',
+            },
+          });
+        }
+
+        return Response.json({
+          result: 'success',
+          arguments: {
+            torrents: [],
           },
         });
       },


### PR DESCRIPTION
## Summary

- delivery ticket: `P3.04 Define Completion And Missing Semantics`
- ticket file: `docs/02-delivery/phase-03/ticket-04-define-completion-and-missing-semantics.md`
- stacked base branch: `codex/p3-03-show-post-queue-lifecycle-in-status`

## AI Review Follow-Up

- `qodo-code-review` triage found no prudent follow-up changes.
- follow-up note: no qodo-code-review comments after the configured wait window

## Verification

- `bun run ci`