### PR TITLE
fix: add state repair and read-ahead guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,16 @@
 # Repo Rules
 
-- If the user asks to begin a phase, implement a phase, start a ticket, or continue planned delivery work, first read `docs/00-overview/start-here.md` and `docs/03-engineering/delivery-orchestrator.md`, then surface the repo delivery/orchestration path before coding.
-- For planned phase work in this repo, prefer the delivery orchestrator as the default workflow entrypoint rather than bypassing it with ad hoc implementation.
-- For orchestrated ticket work, treat the generated handoff artifact under `.codex/delivery/<plan-key>/handoffs/` as required input alongside the plan and ticket docs before implementing.
-- If the user says `begin phase`, `implement phase`, or equivalent, interpret that as a request to run the full orchestrated stacked-ticket workflow for that phase until blocked, not as a request to stop after the first completed ticket.
-- For phase delivery, do not stop at a completed ticket if the orchestrator can continue. Implement the ticket, verify it, push/open the PR, wait for the configured `qodo-code-review` window, patch prudent review findings if any appear, refresh the PR state, then advance to the next ticket branch/worktree.
-- The lack of `qodo-code-review` feedback after the configured wait window is not a blocker by itself. Record the review as `clean` and continue unless real ambiguity or actionable feedback exists.
-- Stop only when the current ticket cannot be completed safely, a prerequisite is missing, review triage is ambiguous enough to require user input, the orchestrator cannot advance cleanly, or the user explicitly interrupts the phase run.
+- For phase work, first read `docs/00-overview/start-here.md` and `docs/03-engineering/delivery-orchestrator.md`, then surface the orchestrator path before coding.
+- Prefer `bun run deliver --plan ...` over ad hoc implementation.
+- For orchestrated ticket work, the handoff under `.codex/delivery/<plan-key>/handoffs/` is required input alongside the plan and ticket docs.
+- `begin phase` / `implement phase` means run the stacked-ticket workflow until blocked, not just the first ticket.
+- Phase flow: implement, verify, push/open PR, wait through the configured `qodo-code-review` window, patch prudent findings if any appear, refresh PR state, then advance.
+- No `qodo-code-review` feedback after the wait window is not a blocker; record `clean` and continue unless real ambiguity or actionable feedback exists.
+- During external waits, read-ahead into the next ticket, handoff, and adjacent seams is encouraged. Do not write ahead until the current ticket is cleared.
+- Stop only for unsafe work, missing prerequisites, ambiguous review triage, orchestrator blockage, or explicit user interruption.
 
-- `pr`: if a delivery ticket is clear from branch/docs/diff, use a human-readable Conventional-Commit-style subject plus the active delivery ticket suffix, for example `[P3.02]`. Otherwise omit the suffix.
-- Any PR creation or PR-body drafting should follow the same `pr` shortcut conventions even when the user did not literally type `pr`.
+- `pr`: if a delivery ticket is clear from branch/docs/diff, use a human-readable Conventional-Commit-style subject plus the active ticket suffix, for example `[P3.02]`. Otherwise omit the suffix.
+- Any PR creation or PR-body drafting should follow the same `pr` conventions even when the user did not literally type `pr`.
 
 ## Ticket Completion Checklist
 

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -88,6 +88,7 @@ When implementing a ticket:
 - keep the ticket end to end
 - test what the user can observe
 - for orchestrated stacked delivery, re-read the handoff artifact and required docs at each ticket boundary instead of relying on prior conversational context
+- during external waits such as AI-review windows, read ahead into the next ticket and nearby seams if it helps maintain momentum, but do not write ahead across ticket boundaries
 - avoid unrelated cleanup during the ticket unless required to land safely
 - update rationale and operator-facing docs when behavior changes
 - stop at the ticket boundary unless the user explicitly says to continue

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -38,6 +38,7 @@ The orchestrator owns process mechanics:
 - durable local state under `.codex/delivery/<plan-key>/`
 - per-ticket handoff artifacts under `.codex/delivery/<plan-key>/handoffs/`
 - deterministic branch and worktree naming
+- copying a local `.env` into fresh ticket work trees when the invoking worktree has one
 - bootstrapping fresh Bun ticket work trees before implementation starts
 - stacked PR base chaining
 - idempotent PR open/update behavior for already-pushed ticket branches
@@ -81,6 +82,8 @@ The handoff includes:
 
 This does not automatically create a brand-new Codex thread, but it is the current repo mechanism for reducing reasoning carryover between tickets while preserving stacked branch continuity.
 
+During external waits such as AI-review windows, the worker may read ahead into the next ticket, handoff, and adjacent seams to prepare the next slice. That read-ahead must not turn into write-ahead; implementation for the next ticket still starts only after the current ticket is cleared.
+
 ## Existing Phase 02 Work
 
 Phase 02 was already processed once through a more brittle route before this tool existed.
@@ -106,6 +109,7 @@ Available commands:
 
 - `sync`
 - `status`
+- `repair-state`
 - `start [ticket-id]`
 - `open-pr [ticket-id]`
 - `fetch-review [ticket-id]`
@@ -135,6 +139,8 @@ bun run deliver restack
 ```
 
 from the current child ticket worktree before continuing review. `restack` infers the delivery plan and current ticket from the checked-out branch, fetches `origin`, rebases away the old parent ancestry, and updates the open PR base/body so GitHub review follows the new stack shape. If branch inference is ambiguous, pass `--plan` explicitly.
+
+If local state drifts from repo reality, use `repair-state` to snapshot the stale state file, rebuild clean state from current repo facts, and print the repaired fields before resuming delivery.
 
 ## Optional Telegram Notifications
 

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'bun:test';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import {
   buildPullRequestTitle,
   buildTicketHandoff,
   canAdvanceTicket,
+  copyLocalEnvIfPresent,
   createOptions,
   deriveBranchName,
   derivePlanKey,
@@ -21,6 +25,7 @@ import {
   resolvePlanPathForBranch,
   resolveNotifier,
   resolveReviewFetcher,
+  summarizeStateDifferences,
   syncStateWithPlan,
   type DeliveryState,
 } from './orchestrator';
@@ -429,7 +434,7 @@ describe('delivery orchestrator', () => {
         ticketTitle: 'Persist Transmission Identity For Queued Torrents',
         branch: 'codex/p3-01-persist-transmission-identity-for-queued-torrents',
       }),
-    ).toContain('Started phase-03 P3.01');
+    ).toContain('Anton\nP3.01 underway for phase-03.');
     expect(
       formatNotificationMessage('/tmp/pirate_claw', {
         kind: 'run_blocked',
@@ -437,7 +442,7 @@ describe('delivery orchestrator', () => {
         command: 'open-pr',
         reason: 'No in-progress ticket found to open as a PR.',
       }),
-    ).toContain('Run blocked for phase-03');
+    ).toContain('Anton\nStopped in phase-03.');
   });
 
   it('surfaces the review wait window after opening a PR', () => {
@@ -540,6 +545,84 @@ describe('delivery orchestrator', () => {
         ],
       }).map((event) => event.kind),
     ).toEqual(['ticket_completed', 'ticket_started']);
+  });
+
+  it('summarizes stale-state mismatches against repo reality', () => {
+    const changes = summarizeStateDifferences(
+      {
+        planKey: 'phase-03',
+        planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+        statePath: '.codex/delivery/phase-03/state.json',
+        reviewsDirPath: '.codex/delivery/phase-03/reviews',
+        handoffsDirPath: '.codex/delivery/phase-03/handoffs',
+        reviewWaitMinutes: 5,
+        tickets: [
+          {
+            id: 'P3.01',
+            title: 'Persist Transmission Identity For Queued Torrents',
+            slug: 'persist-transmission-identity-for-queued-torrents',
+            ticketFile:
+              'docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md',
+            status: 'in_review',
+            branch:
+              'codex/p3-01-persist-transmission-identity-for-queued-torrents',
+            baseBranch: 'main',
+            worktreePath: '/tmp/old_p3_01',
+            prUrl: 'https://example.test/pull/20',
+          },
+        ],
+      },
+      {
+        planKey: 'phase-03',
+        planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+        statePath: '.codex/delivery/phase-03/state.json',
+        reviewsDirPath: '.codex/delivery/phase-03/reviews',
+        handoffsDirPath: '.codex/delivery/phase-03/handoffs',
+        reviewWaitMinutes: 5,
+        tickets: [
+          {
+            id: 'P3.01',
+            title: 'Persist Transmission Identity For Queued Torrents',
+            slug: 'persist-transmission-identity-for-queued-torrents',
+            ticketFile:
+              'docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md',
+            status: 'pending',
+            branch:
+              'codex/p3-01-persist-transmission-identity-for-queued-torrents',
+            baseBranch: 'main',
+            worktreePath: '/tmp/new_p3_01',
+          },
+        ],
+      },
+    );
+
+    expect(changes).toContain('P3.01: status in_review -> pending');
+    expect(changes).toContain(
+      'P3.01: worktree /tmp/old_p3_01 -> /tmp/new_p3_01',
+    );
+    expect(changes).toContain('P3.01: pr https://example.test/pull/20 -> none');
+  });
+
+  it('copies a local .env into a fresh ticket worktree when missing', async () => {
+    const sourceDir = await mkdtemp(join(tmpdir(), 'orchestrator-source-'));
+    const targetDir = await mkdtemp(join(tmpdir(), 'orchestrator-target-'));
+
+    try {
+      await writeFile(
+        join(sourceDir, '.env'),
+        'TELEGRAM_CHAT_ID=123\n',
+        'utf8',
+      );
+
+      await copyLocalEnvIfPresent(sourceDir, targetDir);
+
+      expect(await readFile(join(targetDir, '.env'), 'utf8')).toBe(
+        'TELEGRAM_CHAT_ID=123\n',
+      );
+    } finally {
+      await rm(sourceDir, { recursive: true, force: true });
+      await rm(targetDir, { recursive: true, force: true });
+    }
   });
 
   it('keeps notification failures best-effort', async () => {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { readdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 
@@ -53,6 +54,13 @@ export type OrchestratorOptions = {
   reviewsDirPath: string;
   handoffsDirPath: string;
   reviewWaitMinutes: number;
+};
+
+type RepairStateResult = {
+  state: DeliveryState;
+  backupPath?: string;
+  changes: string[];
+  hadExistingState: boolean;
 };
 
 type PullRequestSummary = {
@@ -161,6 +169,17 @@ export async function runDeliveryOrchestrator(
       ...parsed,
       planPath: options.planPath,
     };
+
+    if (parsed.command === 'repair-state') {
+      const repaired = await repairState(cwd, options);
+      console.log(
+        [formatStatus(repaired.state), formatRepairSummary(repaired)]
+          .filter(Boolean)
+          .join('\n\n'),
+      );
+      return 0;
+    }
+
     const state = await loadState(cwd, options);
 
     switch (parsed.command) {
@@ -605,6 +624,7 @@ function getUsage(): string {
     'Commands:',
     '  sync',
     '  status',
+    '  repair-state',
     '  start [ticket-id]',
     '  open-pr [ticket-id]',
     '  fetch-review [ticket-id]',
@@ -627,10 +647,8 @@ async function loadState(
   cwd: string,
   options: OrchestratorOptions,
 ): Promise<DeliveryState> {
-  const planMarkdown = await readFile(resolve(cwd, options.planPath), 'utf8');
-  const ticketDefinitions = parsePlan(planMarkdown, options.planPath);
-  const absoluteStatePath = resolve(cwd, options.statePath);
-  const inferred = inferStateFromRepo(cwd, ticketDefinitions, options);
+  const { absoluteStatePath, inferred, ticketDefinitions } =
+    await loadPlanContext(cwd, options);
 
   if (!existsSync(absoluteStatePath)) {
     return syncStateWithPlan(
@@ -713,6 +731,78 @@ async function listImplementationPlans(cwd: string): Promise<string[]> {
     )
     .filter((planPath) => existsSync(resolve(cwd, planPath)))
     .sort();
+}
+
+async function loadPlanContext(
+  cwd: string,
+  options: OrchestratorOptions,
+): Promise<{
+  absoluteStatePath: string;
+  inferred: DeliveryState;
+  ticketDefinitions: TicketDefinition[];
+}> {
+  const planMarkdown = await readFile(resolve(cwd, options.planPath), 'utf8');
+  const ticketDefinitions = parsePlan(planMarkdown, options.planPath);
+  const absoluteStatePath = resolve(cwd, options.statePath);
+  const inferred = inferStateFromRepo(cwd, ticketDefinitions, options);
+
+  return {
+    absoluteStatePath,
+    inferred,
+    ticketDefinitions,
+  };
+}
+
+async function repairState(
+  cwd: string,
+  options: OrchestratorOptions,
+): Promise<RepairStateResult> {
+  const { absoluteStatePath, inferred, ticketDefinitions } =
+    await loadPlanContext(cwd, options);
+  const repairedState = syncStateWithPlan(
+    undefined,
+    ticketDefinitions,
+    cwd,
+    options,
+    inferred,
+  );
+  const hadExistingState = existsSync(absoluteStatePath);
+
+  if (!hadExistingState) {
+    await saveState(cwd, repairedState);
+
+    return {
+      state: repairedState,
+      changes: [
+        'No prior state file existed; wrote clean state from repo reality.',
+      ],
+      hadExistingState: false,
+    };
+  }
+
+  const existing = JSON.parse(
+    await readFile(absoluteStatePath, 'utf8'),
+  ) as DeliveryState;
+  const changes = summarizeStateDifferences(existing, repairedState);
+  let backupPath: string | undefined;
+
+  if (changes.length > 0) {
+    backupPath = await backupStateFile(absoluteStatePath);
+  }
+
+  await saveState(cwd, repairedState);
+
+  return {
+    state: repairedState,
+    backupPath: backupPath ? relativeToRepo(cwd, backupPath) : undefined,
+    changes:
+      changes.length > 0
+        ? changes
+        : [
+            'Saved state already matched repo reality; rewrote normalized state.',
+          ],
+    hadExistingState: true,
+  };
 }
 
 async function saveState(cwd: string, state: DeliveryState): Promise<void> {
@@ -838,6 +928,74 @@ export function findExistingBranch(
   return undefined;
 }
 
+export function summarizeStateDifferences(
+  existing: DeliveryState,
+  repaired: DeliveryState,
+): string[] {
+  const changes: string[] = [];
+
+  if (existing.planKey !== repaired.planKey) {
+    changes.push(`planKey: ${existing.planKey} -> ${repaired.planKey}`);
+  }
+
+  if (existing.planPath !== repaired.planPath) {
+    changes.push(`planPath: ${existing.planPath} -> ${repaired.planPath}`);
+  }
+
+  for (const repairedTicket of repaired.tickets) {
+    const existingTicket = existing.tickets.find(
+      (candidate) => candidate.id === repairedTicket.id,
+    );
+
+    if (!existingTicket) {
+      changes.push(`${repairedTicket.id}: missing from existing state`);
+      continue;
+    }
+
+    if (existingTicket.status !== repairedTicket.status) {
+      changes.push(
+        `${repairedTicket.id}: status ${existingTicket.status} -> ${repairedTicket.status}`,
+      );
+    }
+
+    if (existingTicket.branch !== repairedTicket.branch) {
+      changes.push(
+        `${repairedTicket.id}: branch ${existingTicket.branch} -> ${repairedTicket.branch}`,
+      );
+    }
+
+    if (existingTicket.baseBranch !== repairedTicket.baseBranch) {
+      changes.push(
+        `${repairedTicket.id}: base ${existingTicket.baseBranch} -> ${repairedTicket.baseBranch}`,
+      );
+    }
+
+    if (existingTicket.worktreePath !== repairedTicket.worktreePath) {
+      changes.push(
+        `${repairedTicket.id}: worktree ${existingTicket.worktreePath} -> ${repairedTicket.worktreePath}`,
+      );
+    }
+
+    if (existingTicket.prUrl !== repairedTicket.prUrl) {
+      changes.push(
+        `${repairedTicket.id}: pr ${existingTicket.prUrl ?? 'none'} -> ${repairedTicket.prUrl ?? 'none'}`,
+      );
+    }
+  }
+
+  for (const existingTicket of existing.tickets) {
+    if (
+      !repaired.tickets.find((candidate) => candidate.id === existingTicket.id)
+    ) {
+      changes.push(
+        `${existingTicket.id}: present in existing state but absent after repair`,
+      );
+    }
+  }
+
+  return changes;
+}
+
 function listPullRequests(cwd: string): Map<string, PullRequestSummary> {
   const stdout = runProcess(cwd, [
     'gh',
@@ -939,6 +1097,7 @@ async function startTicket(
     ]);
   }
 
+  await copyLocalEnvIfPresent(cwd, target.worktreePath);
   await bootstrapWorktreeIfNeeded(target.worktreePath);
 
   const handoff = await writeTicketHandoff(state, cwd, target.id);
@@ -956,6 +1115,20 @@ async function startTicket(
         : ticket,
     ),
   };
+}
+
+export async function copyLocalEnvIfPresent(
+  sourceWorktreePath: string,
+  targetWorktreePath: string,
+): Promise<void> {
+  const sourceEnvPath = resolve(sourceWorktreePath, '.env');
+  const targetEnvPath = resolve(targetWorktreePath, '.env');
+
+  if (!existsSync(sourceEnvPath) || existsSync(targetEnvPath)) {
+    return;
+  }
+
+  await copyFile(sourceEnvPath, targetEnvPath);
 }
 
 async function openPullRequest(
@@ -1802,6 +1975,23 @@ async function sendTelegramMessage(
   }
 }
 
+async function backupStateFile(absoluteStatePath: string): Promise<string> {
+  const backupPath = absoluteStatePath.replace(
+    /\.json$/,
+    `.stale-${new Date()
+      .toISOString()
+      .replace(/[-:]/g, '')
+      .replace(/\.\d{3}Z$/, 'Z')}.json`,
+  );
+
+  await writeFile(
+    backupPath,
+    await readFile(absoluteStatePath, 'utf8'),
+    'utf8',
+  );
+  return backupPath;
+}
+
 function parsePullRequestNumber(prUrl: string): number {
   const match = prUrl.match(/\/pull\/(\d+)$/);
 
@@ -1947,33 +2137,37 @@ function formatStatus(state: DeliveryState): string {
   ].join('\n');
 }
 
-function deriveRepoDisplayName(cwd: string): string {
-  return basename(resolve(cwd))
-    .replace(/_p\d+(_\d+)?$/, '')
-    .split(/[-_]/)
-    .filter(Boolean)
-    .map((part) => `${part[0]?.toUpperCase() ?? ''}${part.slice(1)}`)
-    .join(' ');
+function formatRepairSummary(result: RepairStateResult): string {
+  return [
+    'State Repair',
+    result.hadExistingState
+      ? 'Existing state file inspected and rebuilt from repo reality.'
+      : 'Created fresh state from repo reality.',
+    result.backupPath ? `- backup: ${result.backupPath}` : undefined,
+    ...result.changes.map((change) => `- ${change}`),
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join('\n');
 }
 
 export function formatNotificationMessage(
   cwd: string,
   event: DeliveryNotificationEvent,
 ): string {
-  const header = `${deriveRepoDisplayName(cwd)} Delivery`;
+  const header = 'Anton';
 
   switch (event.kind) {
     case 'ticket_started':
       return [
         header,
-        `Started ${event.planKey} ${event.ticketId}`,
+        `${event.ticketId} underway for ${event.planKey}.`,
         event.ticketTitle,
         `Branch: ${event.branch}`,
       ].join('\n');
     case 'pr_opened':
       return [
         header,
-        `PR opened for ${event.planKey} ${event.ticketId}`,
+        `${event.ticketId} is up for review in ${event.planKey}.`,
         event.ticketTitle,
         `Branch: ${event.branch}`,
         `PR: ${event.prUrl}`,
@@ -1981,7 +2175,7 @@ export function formatNotificationMessage(
     case 'review_window_ready':
       return [
         header,
-        `Review window started for ${event.planKey} ${event.ticketId}`,
+        `Review window is open for ${event.ticketId}.`,
         event.ticketTitle,
         `Branch: ${event.branch}`,
         `PR: ${event.prUrl}`,
@@ -1991,7 +2185,7 @@ export function formatNotificationMessage(
     case 'review_recorded':
       return [
         header,
-        `Review recorded for ${event.planKey} ${event.ticketId}`,
+        `${event.ticketId} review triaged.`,
         event.ticketTitle,
         `Branch: ${event.branch}`,
         `Outcome: ${event.outcome}`,
@@ -2003,7 +2197,7 @@ export function formatNotificationMessage(
     case 'ticket_completed':
       return [
         header,
-        `Completed ${event.planKey} ${event.ticketId}`,
+        `${event.ticketId} cleared.`,
         event.ticketTitle,
         `Branch: ${event.branch}`,
         event.prUrl ? `PR: ${event.prUrl}` : undefined,
@@ -2013,7 +2207,7 @@ export function formatNotificationMessage(
     case 'run_blocked':
       return [
         header,
-        `Run blocked${event.planKey ? ` for ${event.planKey}` : ''}`,
+        `Stopped${event.planKey ? ` in ${event.planKey}` : ''}.`,
         event.command ? `Command: ${event.command}` : undefined,
         `Reason: ${event.reason}`,
       ]


### PR DESCRIPTION
## Summary

- add a `repair-state` command that snapshots stale delivery state and rebuilds clean local state from repo reality
- propagate a local `.env` into fresh ticket worktrees and codify read-ahead during waits without allowing write-ahead across ticket boundaries
- tighten the AI-facing repo guidance and delivery docs around orchestration waits and recovery
