### PR TITLE
feat: add delivery restack command

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Useful local commands:
 - `bun run test:coverage`
 - `bun run verify`
 - `bun run ci`
+- `bun run deliver --plan docs/02-delivery/phase-03/implementation-plan.md restack` to restack the current delivery ticket after its parent PR was squash-merged to `main`
 
 If you are working on the repo rather than just using the CLI, start with [`docs/00-overview/start-here.md`](./docs/00-overview/start-here.md).
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Useful local commands:
 - `bun run test:coverage`
 - `bun run verify`
 - `bun run ci`
-- `bun run deliver --plan docs/02-delivery/phase-03/implementation-plan.md restack` to restack the current delivery ticket after its parent PR was squash-merged to `main`
+- `bun run deliver restack` to restack the current delivery ticket after its parent PR was squash-merged to `main`
 
 If you are working on the repo rather than just using the CLI, start with [`docs/00-overview/start-here.md`](./docs/00-overview/start-here.md).
 

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -111,6 +111,7 @@ Available commands:
 - `fetch-review [ticket-id]`
 - `record-review <ticket-id> <clean|needs_patch|patched> [note]`
 - `advance [--no-start-next]`
+- `restack [ticket-id]`
 
 ## Typical Flow
 
@@ -126,6 +127,14 @@ bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md advance
 At each ticket boundary, read the generated handoff artifact before continuing implementation.
 
 After `open-pr`, the orchestrator should surface the review wait window and the earliest meaningful review-fetch time. An immediate lack of AI comments is informational only; the decisive check happens after that window elapses.
+
+If a parent ticket was squash-merged onto `main`, run:
+
+```bash
+bun run deliver --plan docs/02-delivery/phase-03/implementation-plan.md restack
+```
+
+from the current child ticket worktree before continuing review. `restack` infers the current ticket from the checked-out branch, fetches `origin`, rebases away the old parent ancestry, and updates the open PR base/body so GitHub review follows the new stack shape.
 
 ## Optional Telegram Notifications
 

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -131,10 +131,10 @@ After `open-pr`, the orchestrator should surface the review wait window and the 
 If a parent ticket was squash-merged onto `main`, run:
 
 ```bash
-bun run deliver --plan docs/02-delivery/phase-03/implementation-plan.md restack
+bun run deliver restack
 ```
 
-from the current child ticket worktree before continuing review. `restack` infers the current ticket from the checked-out branch, fetches `origin`, rebases away the old parent ancestry, and updates the open PR base/body so GitHub review follows the new stack shape.
+from the current child ticket worktree before continuing review. `restack` infers the delivery plan and current ticket from the checked-out branch, fetches `origin`, rebases away the old parent ancestry, and updates the open PR base/body so GitHub review follows the new stack shape. If branch inference is ambiguous, pass `--plan` explicitly.
 
 ## Optional Telegram Notifications
 

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -13,6 +13,7 @@ import {
   eventsForRecordReviewCommand,
   eventsForStartCommand,
   findExistingBranch,
+  findTicketByBranch,
   formatNotificationMessage,
   formatReviewWindowMessage,
   notifyBestEffort,
@@ -237,6 +238,49 @@ describe('delivery orchestrator', () => {
       branch: 'codex/p2-02-movie-matcher-missing-codec',
       source: 'ticket-id',
     });
+  });
+
+  it('finds the tracked ticket for the current branch', () => {
+    expect(
+      findTicketByBranch(
+        {
+          planKey: 'phase-03',
+          planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+          statePath: '.codex/delivery/phase-03/state.json',
+          reviewsDirPath: '.codex/delivery/phase-03/reviews',
+          handoffsDirPath: '.codex/delivery/phase-03/handoffs',
+          reviewWaitMinutes: 5,
+          tickets: [
+            {
+              id: 'P3.01',
+              title: 'Persist Transmission Identity For Queued Torrents',
+              slug: 'persist-transmission-identity-for-queued-torrents',
+              ticketFile:
+                'docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md',
+              status: 'done',
+              branch:
+                'codex/p3-01-persist-transmission-identity-for-queued-torrents',
+              baseBranch: 'main',
+              worktreePath: '/tmp/p3_01',
+            },
+            {
+              id: 'P3.02',
+              title: 'Reconcile Torrent Lifecycle From Transmission',
+              slug: 'reconcile-torrent-lifecycle-from-transmission',
+              ticketFile:
+                'docs/02-delivery/phase-03/ticket-02-reconcile-torrent-lifecycle-from-transmission.md',
+              status: 'in_review',
+              branch:
+                'codex/p3-02-reconcile-torrent-lifecycle-from-transmission',
+              baseBranch:
+                'codex/p3-01-persist-transmission-identity-for-queued-torrents',
+              worktreePath: '/tmp/p3_02',
+            },
+          ],
+        },
+        'codex/p3-02-reconcile-torrent-lifecycle-from-transmission',
+      )?.id,
+    ).toBe('P3.02');
   });
 
   it('only allows advance after clean or patched review outcomes', () => {

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -18,6 +18,7 @@ import {
   formatReviewWindowMessage,
   notifyBestEffort,
   parsePlan,
+  resolvePlanPathForBranch,
   resolveNotifier,
   resolveReviewFetcher,
   syncStateWithPlan,
@@ -281,6 +282,64 @@ describe('delivery orchestrator', () => {
         'codex/p3-02-reconcile-torrent-lifecycle-from-transmission',
       )?.id,
     ).toBe('P3.02');
+  });
+
+  it('resolves a delivery plan from the current branch when the match is unique', () => {
+    expect(
+      resolvePlanPathForBranch(
+        [
+          {
+            planPath: 'docs/02-delivery/phase-02/implementation-plan.md',
+            tickets: [
+              {
+                id: 'P2.02',
+                title: 'Movie Matcher Allows Missing Codec',
+                slug: 'movie-matcher-allows-missing-codec',
+                ticketFile:
+                  'docs/02-delivery/phase-02/ticket-02-movie-matcher-allows-missing-codec.md',
+              },
+            ],
+          },
+          {
+            planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+            tickets: [
+              {
+                id: 'P3.02',
+                title: 'Reconcile Torrent Lifecycle From Transmission',
+                slug: 'reconcile-torrent-lifecycle-from-transmission',
+                ticketFile:
+                  'docs/02-delivery/phase-03/ticket-02-reconcile-torrent-lifecycle-from-transmission.md',
+              },
+            ],
+          },
+        ],
+        'codex/p3-02-reconcile-torrent-lifecycle-from-transmission',
+      ),
+    ).toBe('docs/02-delivery/phase-03/implementation-plan.md');
+  });
+
+  it('fails plan inference cleanly when no plan matches the current branch', () => {
+    expect(() =>
+      resolvePlanPathForBranch(
+        [
+          {
+            planPath: 'docs/02-delivery/phase-02/implementation-plan.md',
+            tickets: [
+              {
+                id: 'P2.02',
+                title: 'Movie Matcher Allows Missing Codec',
+                slug: 'movie-matcher-allows-missing-codec',
+                ticketFile:
+                  'docs/02-delivery/phase-02/ticket-02-movie-matcher-allows-missing-codec.md',
+              },
+            ],
+          },
+        ],
+        'codex/not-a-ticket-branch',
+      ),
+    ).toThrow(
+      'Could not infer a delivery plan for codex/not-a-ticket-branch. Pass --plan <plan-path>.',
+    );
   });
 
   it('only allows advance after clean or patched review outcomes', () => {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -61,6 +61,11 @@ type PullRequestSummary = {
   state: string;
 };
 
+type PullRequestDetail = PullRequestSummary & {
+  baseRefName?: string;
+  mergedAt?: string | null;
+};
+
 type BranchMatch = {
   branch: string;
   source: 'ticket-id' | 'derived';
@@ -238,6 +243,16 @@ export async function runDeliveryOrchestrator(
           cwd,
           eventsForAdvanceCommand(state, nextState),
         );
+        return 0;
+      }
+      case 'restack': {
+        const nextState = await restackTicket(
+          state,
+          cwd,
+          parsed.positionals[0],
+        );
+        await saveState(cwd, nextState);
+        console.log(formatStatus(nextState));
         return 0;
       }
       default: {
@@ -425,6 +440,13 @@ export function findNextPendingTicket(
   return state.tickets.find((ticket) => ticket.status === 'pending');
 }
 
+export function findTicketByBranch(
+  state: DeliveryState,
+  branch: string,
+): TicketState | undefined {
+  return state.tickets.find((ticket) => ticket.branch === branch);
+}
+
 export function canAdvanceTicket(ticket: TicketState): boolean {
   return (
     ticket.status === 'reviewed' &&
@@ -559,6 +581,7 @@ function getUsage(): string {
     '  fetch-review [ticket-id]',
     '  record-review <ticket-id> <clean|needs_patch|patched> [note]',
     '  advance [--no-start-next]',
+    '  restack [ticket-id]',
   ].join('\n');
 }
 
@@ -1040,6 +1063,103 @@ async function advanceToNextTicket(
   return nextState;
 }
 
+async function restackTicket(
+  state: DeliveryState,
+  cwd: string,
+  ticketId?: string,
+): Promise<DeliveryState> {
+  ensureCleanWorktree(cwd);
+  const currentBranch = readCurrentBranch(cwd);
+  const target =
+    (ticketId
+      ? state.tickets.find((ticket) => ticket.id === ticketId)
+      : findTicketByBranch(state, currentBranch)) ?? undefined;
+
+  if (!target) {
+    throw new Error(
+      ticketId
+        ? `Unknown ticket ${ticketId}.`
+        : `Current branch ${currentBranch} is not tracked by the delivery plan.`,
+    );
+  }
+
+  if (target.branch !== currentBranch) {
+    throw new Error(
+      `Restack must run from ${target.branch}. Current branch is ${currentBranch}.`,
+    );
+  }
+
+  runProcess(cwd, ['git', 'fetch', 'origin']);
+
+  const targetIndex = state.tickets.findIndex(
+    (ticket) => ticket.id === target.id,
+  );
+  const previous = targetIndex > 0 ? state.tickets[targetIndex - 1] : undefined;
+
+  let nextBaseBranch = 'main';
+  let rebaseTarget = 'origin/main';
+
+  if (previous) {
+    const oldBase = runProcess(cwd, [
+      'git',
+      'merge-base',
+      target.branch,
+      previous.branch,
+    ]).trim();
+
+    if (!oldBase) {
+      throw new Error(
+        `Could not determine the shared ancestor between ${target.branch} and ${previous.branch}.`,
+      );
+    }
+
+    if (!hasMergedPullRequestForBranch(cwd, previous.branch)) {
+      nextBaseBranch = previous.branch;
+      rebaseTarget = previous.branch;
+    }
+
+    runProcess(cwd, ['git', 'rebase', '--onto', rebaseTarget, oldBase]);
+  } else {
+    runProcess(cwd, ['git', 'rebase', 'origin/main']);
+  }
+
+  const nextState: DeliveryState = {
+    ...state,
+    tickets: state.tickets.map((ticket) =>
+      ticket.id === target.id
+        ? {
+            ...ticket,
+            baseBranch: nextBaseBranch,
+          }
+        : ticket,
+    ),
+  };
+  const updatedTarget = nextState.tickets.find(
+    (ticket) => ticket.id === target.id,
+  );
+
+  if (!updatedTarget) {
+    throw new Error(`Unknown ticket ${target.id}.`);
+  }
+
+  const pullRequest = findOpenPullRequest(cwd, target.branch);
+
+  if (pullRequest) {
+    runProcess(cwd, [
+      'gh',
+      'pr',
+      'edit',
+      String(pullRequest.number),
+      '--base',
+      nextBaseBranch,
+      '--body',
+      buildPullRequestBody(nextState, updatedTarget),
+    ]);
+  }
+
+  return nextState;
+}
+
 function runGitLines(cwd: string, cmd: string[]): string[] {
   return runProcess(cwd, cmd)
     .split('\n')
@@ -1425,8 +1545,53 @@ function findOpenPullRequest(
   return parsed[0];
 }
 
+function findMergedPullRequest(
+  cwd: string,
+  branch: string,
+): PullRequestDetail | undefined {
+  const stdout = runProcess(cwd, [
+    'gh',
+    'pr',
+    'list',
+    '--state',
+    'merged',
+    '--head',
+    branch,
+    '--limit',
+    '1',
+    '--json',
+    'number,url,state,baseRefName,mergedAt',
+  ]);
+  const parsed = JSON.parse(stdout) as Array<PullRequestDetail>;
+  return parsed[0];
+}
+
+function hasMergedPullRequestForBranch(cwd: string, branch: string): boolean {
+  return findMergedPullRequest(cwd, branch) !== undefined;
+}
+
 function readLatestCommitSubject(cwd: string): string {
   return runProcess(cwd, ['git', 'log', '-1', '--pretty=%s']).trim();
+}
+
+function readCurrentBranch(cwd: string): string {
+  const branch = runProcess(cwd, ['git', 'branch', '--show-current']).trim();
+
+  if (!branch) {
+    throw new Error('Restack requires an attached branch checkout.');
+  }
+
+  return branch;
+}
+
+function ensureCleanWorktree(cwd: string): void {
+  const status = runProcess(cwd, ['git', 'status', '--short']).trim();
+
+  if (status) {
+    throw new Error(
+      'Restack requires a clean worktree. Commit, stash, or discard local changes first.',
+    );
+  }
 }
 
 function ensureBranchPushed(cwd: string, branch: string): void {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 
@@ -146,13 +146,22 @@ export async function runDeliveryOrchestrator(
         command: string;
         positionals: string[];
         flags: Set<string>;
-        options: OrchestratorOptions;
+        planPath?: string;
       }
     | undefined;
 
   try {
     parsed = parseCliArgs(argv);
-    const state = await loadState(cwd, parsed.options);
+    const options = await resolveOptionsForCommand(
+      cwd,
+      parsed.command,
+      parsed.planPath,
+    );
+    parsed = {
+      ...parsed,
+      planPath: options.planPath,
+    };
+    const state = await loadState(cwd, options);
 
     switch (parsed.command) {
       case 'sync': {
@@ -263,7 +272,7 @@ export async function runDeliveryOrchestrator(
   } catch (error) {
     await emitNotificationWarnings(notifier, cwd, [
       buildRunBlockedEvent(
-        parsed?.options.planKey,
+        parsed?.planPath ? derivePlanKey(parsed.planPath) : undefined,
         parsed?.command,
         formatError(error),
       ),
@@ -526,7 +535,7 @@ function parseCliArgs(argv: string[]): {
   command: string;
   positionals: string[];
   flags: Set<string>;
-  options: OrchestratorOptions;
+  planPath?: string;
 } {
   let planPath: string | undefined;
   const flags = new Set<string>();
@@ -565,8 +574,28 @@ function parseCliArgs(argv: string[]): {
     command,
     positionals: rest,
     flags,
-    options: createOptions({ planPath }),
+    planPath,
   };
+}
+
+async function resolveOptionsForCommand(
+  cwd: string,
+  command: string,
+  planPath?: string,
+): Promise<OrchestratorOptions> {
+  if (planPath) {
+    return createOptions({ planPath });
+  }
+
+  if (command !== 'restack') {
+    throw new Error(
+      'Pass --plan <plan-path>. Phase aliases are no longer supported.',
+    );
+  }
+
+  const branch = readCurrentBranch(cwd);
+  const inferredPlanPath = await inferPlanPathFromBranch(cwd, branch);
+  return createOptions({ planPath: inferredPlanPath });
 }
 
 function getUsage(): string {
@@ -618,6 +647,72 @@ async function loadState(
   ) as DeliveryState;
 
   return syncStateWithPlan(existing, ticketDefinitions, cwd, options, inferred);
+}
+
+export async function inferPlanPathFromBranch(
+  cwd: string,
+  branch: string,
+): Promise<string> {
+  const planPaths = await listImplementationPlans(cwd);
+  const planIndex: Array<{ planPath: string; tickets: TicketDefinition[] }> =
+    [];
+
+  for (const planPath of planPaths) {
+    const markdown = await readFile(resolve(cwd, planPath), 'utf8');
+    planIndex.push({
+      planPath,
+      tickets: parsePlan(markdown, planPath),
+    });
+  }
+
+  return resolvePlanPathForBranch(planIndex, branch);
+}
+
+export function resolvePlanPathForBranch(
+  planIndex: Array<{ planPath: string; tickets: TicketDefinition[] }>,
+  branch: string,
+): string {
+  const matches: string[] = [];
+
+  for (const plan of planIndex) {
+    if (
+      plan.tickets.some(
+        (ticket) => findExistingBranch([branch], ticket)?.branch === branch,
+      )
+    ) {
+      matches.push(plan.planPath);
+    }
+  }
+
+  if (matches.length === 1) {
+    return matches[0]!;
+  }
+
+  if (matches.length === 0) {
+    throw new Error(
+      `Could not infer a delivery plan for ${branch}. Pass --plan <plan-path>.`,
+    );
+  }
+
+  throw new Error(
+    `Multiple delivery plans match ${branch}: ${matches.join(', ')}. Pass --plan <plan-path>.`,
+  );
+}
+
+async function listImplementationPlans(cwd: string): Promise<string[]> {
+  const deliveryRoot = resolve(cwd, 'docs/02-delivery');
+  const entries = await readdir(deliveryRoot, { withFileTypes: true });
+
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) =>
+      relativeToRepo(
+        cwd,
+        resolve(deliveryRoot, entry.name, 'implementation-plan.md'),
+      ),
+    )
+    .filter((planPath) => existsSync(resolve(cwd, planPath)))
+    .sort();
 }
 
 async function saveState(cwd: string, state: DeliveryState): Promise<void> {


### PR DESCRIPTION
## Summary

- add a `restack` command to the repo delivery orchestrator
- infer the current ticket branch and old parent ancestry so child tickets can be rebased without typing commit hashes
- refresh delivery docs and tests for the new stacked-review workflow

## Verification

- `bun run verify`
- `bun test tools/delivery/orchestrator.test.ts`