### PR TITLE
feat: clarify ai review provenance and thread resolution

### DIFF
--- a/.agents/skills/ai-code-review/SKILL.md
+++ b/.agents/skills/ai-code-review/SKILL.md
@@ -29,6 +29,7 @@ The only contract between them is the repo-local helper script output:
   - `agents: [{"agent":"coderabbit","state":"started|completed|findings_detected",...}]`
   - `detected: true|false`
   - `artifact_text: "<normalized text summary>"`
+  - `reviewed_head_sha?: "<pull request head sha at fetch time>"`
   - `vendors: ["coderabbit", "qodo", ...]`
   - `comments: [...]`
 - triager:
@@ -52,7 +53,7 @@ Use this skill when the orchestrator has saved an AI review artifact or when you
    - comments from bot or vendor identities that correspond to AI review
    - comments whose wording explicitly identifies them as AI-generated code review
    - ordinary human drive-by comments do not count as AI review
-   - preserve inline comment resolution/outdated state so stale bot comments do not block the flow by default
+   - preserve reviewed head SHA plus inline comment resolution/outdated state and native thread identity so stale bot comments do not block the flow by default
 5. Return the fetcher contract to the orchestrator when this is being used inside `poll-review`:
 
 - `detected=false` means keep polling or auto-clean at the end
@@ -71,6 +72,7 @@ Use this skill when the orchestrator has saved an AI review artifact or when you
 - run the smallest relevant verification
 - commit the patch changes in the current repo
 - push the current branch so the PR updates automatically
+- when the originating AI finding came from a native GitHub inline review thread and the thread is still resolvable, mark that thread resolved in the PR UI
 
 ## Output expectations
 
@@ -81,4 +83,5 @@ Use this skill when the orchestrator has saved an AI review artifact or when you
 - Group by unresolved issue, not by raw API payload.
 - Include file and line when available.
 - Call out stale or already-addressed comments explicitly instead of blindly implementing them.
+- Make current-head review versus stale-history review explicit when the reviewed SHA no longer matches the branch head.
 - Only stop for operator input when the right action is genuinely ambiguous.

--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -175,6 +175,7 @@ jq -n \
       | if $channel == "inline_review" then
           if (comment_thread_state.is_outdated or comment_thread_state.is_resolved) then "unknown" else "finding" end
         elif looks_like_started_text or looks_like_summary_noise_text then "summary"
+        elif looks_like_started_text or looks_like_summary_noise_text then "summary"
         elif ($body | test("summary|overall|overview|high level|high-level|general feedback|looks good|no major issues|quick recap")) then "summary"
         elif ($body | test("should|could|must|consider|missing|bug|issue|incorrect|guard|handle|return|null|undefined|race|rename|suggestion:|nit:|nitpick")) then "finding"
         else "unknown"

--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -111,7 +111,7 @@ jq -n \
 
     def looks_like_summary_noise_text:
       (body_text | normalize_text) as $body
-      | ($body | test("review summary by|walkthroughs|file changes|looking for bugs\\?|finishing touches|summary of changes"));
+      | ($body | test("review summary by|code review by|walkthroughs|file changes|looking for bugs\\?|finishing touches|summary of changes|rule violations|bugs \\("));
 
     def vendor_name:
       (author_login | ascii_downcase) as $login
@@ -175,6 +175,7 @@ jq -n \
       | if $channel == "inline_review" then
           if (comment_thread_state.is_outdated or comment_thread_state.is_resolved) then "unknown" else "finding" end
         elif $channel == "review_summary" and ($body | length) == 0 then "summary"
+        elif looks_like_started_text or looks_like_summary_noise_text then "summary"
         elif looks_like_started_text or looks_like_summary_noise_text then "summary"
         elif ($body | test("summary|overall|overview|high level|high-level|general feedback|looks good|no major issues|quick recap")) then "summary"
         elif ($body | test("should|could|must|consider|missing|bug|issue|incorrect|guard|handle|return|null|undefined|race|rename|suggestion:|nit:|nitpick")) then "finding"

--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -174,7 +174,7 @@ jq -n \
       (body_text | normalize_text) as $body
       | if $channel == "inline_review" then
           if (comment_thread_state.is_outdated or comment_thread_state.is_resolved) then "unknown" else "finding" end
-        elif looks_like_started_text or looks_like_summary_noise_text then "summary"
+        elif $channel == "review_summary" and ($body | length) == 0 then "summary"
         elif looks_like_started_text or looks_like_summary_noise_text then "summary"
         elif ($body | test("summary|overall|overview|high level|high-level|general feedback|looks good|no major issues|quick recap")) then "summary"
         elif ($body | test("should|could|must|consider|missing|bug|issue|incorrect|guard|handle|return|null|undefined|race|rename|suggestion:|nit:|nitpick")) then "finding"

--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -42,39 +42,191 @@ else
   review_comments_json='[]'
 fi
 
-review_threads_json="$(
-  gh api graphql \
-    -F owner="$owner" \
-    -F name="$name" \
-    -F number="$pr_number" \
-    -f query='
-      query($owner: String!, $name: String!, $number: Int!) {
-        repository(owner: $owner, name: $name) {
-          pullRequest(number: $number) {
-            reviewThreads(first: 100) {
-              nodes {
-                id
-                isResolved
-                isOutdated
-                viewerCanResolve
-                comments(first: 50) {
-                  nodes {
-                    databaseId
-                    url
+fetch_review_threads_page() {
+  local after_cursor="${1:-}"
+
+  if [[ -n "$after_cursor" ]]; then
+    gh api graphql \
+      -F owner="$owner" \
+      -F name="$name" \
+      -F number="$pr_number" \
+      -F after="$after_cursor" \
+      -f query='
+        query($owner: String!, $name: String!, $number: Int!, $after: String) {
+          repository(owner: $owner, name: $name) {
+            pullRequest(number: $number) {
+              reviewThreads(first: 100, after: $after) {
+                nodes {
+                  id
+                  isResolved
+                  isOutdated
+                  viewerCanResolve
+                  comments(first: 100) {
+                    nodes {
+                      databaseId
+                      url
+                    }
+                    pageInfo {
+                      hasNextPage
+                      endCursor
+                    }
                   }
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
                 }
               }
             }
           }
         }
-      }
-    ' \
-    --jq '.data.repository.pullRequest.reviewThreads.nodes'
-)"
+      '
+  else
+    gh api graphql \
+      -F owner="$owner" \
+      -F name="$name" \
+      -F number="$pr_number" \
+      -f query='
+        query($owner: String!, $name: String!, $number: Int!) {
+          repository(owner: $owner, name: $name) {
+            pullRequest(number: $number) {
+              reviewThreads(first: 100) {
+                nodes {
+                  id
+                  isResolved
+                  isOutdated
+                  viewerCanResolve
+                  comments(first: 100) {
+                    nodes {
+                      databaseId
+                      url
+                    }
+                    pageInfo {
+                      hasNextPage
+                      endCursor
+                    }
+                  }
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+          }
+        }
+      '
+  fi
+}
 
-if [[ -z "$review_threads_json" ]]; then
-  review_threads_json='[]'
-fi
+fetch_thread_comments_page() {
+  local thread_id="$1"
+  local after_cursor="${2:-}"
+
+  if [[ -n "$after_cursor" ]]; then
+    gh api graphql \
+      -F threadId="$thread_id" \
+      -F after="$after_cursor" \
+      -f query='
+        query($threadId: ID!, $after: String) {
+          node(id: $threadId) {
+            ... on PullRequestReviewThread {
+              comments(first: 100, after: $after) {
+                nodes {
+                  databaseId
+                  url
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+          }
+        }
+      '
+  else
+    gh api graphql \
+      -F threadId="$thread_id" \
+      -f query='
+        query($threadId: ID!) {
+          node(id: $threadId) {
+            ... on PullRequestReviewThread {
+              comments(first: 100) {
+                nodes {
+                  databaseId
+                  url
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+          }
+        }
+      '
+  fi
+}
+
+review_threads_json='[]'
+thread_cursor=""
+
+while :; do
+  thread_page_json="$(fetch_review_threads_page "$thread_cursor")"
+  thread_nodes_json="$(printf '%s' "$thread_page_json" | jq '.data.repository.pullRequest.reviewThreads.nodes')"
+
+  if [[ "$thread_nodes_json" != "[]" ]]; then
+    review_threads_json="$(
+      jq -n \
+        --argjson existing "$review_threads_json" \
+        --argjson nodes "$thread_nodes_json" \
+        '$existing + $nodes'
+    )"
+  fi
+
+  thread_has_next="$(printf '%s' "$thread_page_json" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false')"
+  if [[ "$thread_has_next" != "true" ]]; then
+    break
+  fi
+
+  thread_cursor="$(printf '%s' "$thread_page_json" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // ""')"
+done
+
+expanded_review_threads_json='[]'
+while IFS= read -r thread_json; do
+  [[ -z "$thread_json" ]] && continue
+
+  thread_id="$(printf '%s' "$thread_json" | jq -r '.id')"
+  comment_nodes_json="$(printf '%s' "$thread_json" | jq '.comments.nodes // []')"
+  comment_has_next="$(printf '%s' "$thread_json" | jq -r '.comments.pageInfo.hasNextPage // false')"
+  comment_cursor="$(printf '%s' "$thread_json" | jq -r '.comments.pageInfo.endCursor // ""')"
+
+  while [[ "$comment_has_next" == "true" ]]; do
+    comment_page_json="$(fetch_thread_comments_page "$thread_id" "$comment_cursor")"
+    page_nodes_json="$(printf '%s' "$comment_page_json" | jq '.data.node.comments.nodes // []')"
+    comment_nodes_json="$(
+      jq -n \
+        --argjson existing "$comment_nodes_json" \
+        --argjson nodes "$page_nodes_json" \
+        '$existing + $nodes'
+    )"
+    comment_has_next="$(printf '%s' "$comment_page_json" | jq -r '.data.node.comments.pageInfo.hasNextPage // false')"
+    comment_cursor="$(printf '%s' "$comment_page_json" | jq -r '.data.node.comments.pageInfo.endCursor // ""')"
+  done
+
+  expanded_thread_json="$(
+    printf '%s' "$thread_json" | jq --argjson nodes "$comment_nodes_json" '.comments = { nodes: $nodes }'
+  )"
+  expanded_review_threads_json="$(
+    jq -n \
+      --argjson existing "$expanded_review_threads_json" \
+      --argjson thread "$expanded_thread_json" \
+      '$existing + [$thread]'
+  )"
+done < <(printf '%s' "$review_threads_json" | jq -c '.[]')
+
+review_threads_json="$expanded_review_threads_json"
 
 jq -n \
   --argjson pr "$pr_json" \

--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -423,7 +423,7 @@ jq -n \
             + (
               if ($agents | length) > 0 then
                 ["Agent states:"]
-                + ($agents | map("- \(.agent): \(.state)\(if (.findingsCount // 0) > 0 then \" (\(.findingsCount) findings)\" else \"\" end)"))
+                + ($agents | map("- \(.agent): \(.state)\(if (.findingsCount // 0) > 0 then " (\(.findingsCount) findings)" else "" end)"))
                 + [""]
               else
                 []

--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -30,6 +30,8 @@ repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
 owner="${repo%%/*}"
 name="${repo##*/}"
 pr_json="$(gh pr view "$pr_number" --json number,title,url,headRefName,headRefOid,baseRefName,isDraft,state,comments,reviews)"
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "$temp_dir"' EXIT
 
 review_comments_json="$(
   gh api --paginate "repos/$repo/pulls/$pr_number/comments?per_page=100" \
@@ -169,7 +171,8 @@ fetch_thread_comments_page() {
   fi
 }
 
-review_threads_json='[]'
+thread_pages_file="$temp_dir/review-thread-pages.jsonl"
+: >"$thread_pages_file"
 thread_cursor=""
 
 while :; do
@@ -177,12 +180,7 @@ while :; do
   thread_nodes_json="$(printf '%s' "$thread_page_json" | jq '.data.repository.pullRequest.reviewThreads.nodes')"
 
   if [[ "$thread_nodes_json" != "[]" ]]; then
-    review_threads_json="$(
-      jq -n \
-        --argjson existing "$review_threads_json" \
-        --argjson nodes "$thread_nodes_json" \
-        '$existing + $nodes'
-    )"
+    printf '%s\n' "$thread_nodes_json" >>"$thread_pages_file"
   fi
 
   thread_has_next="$(printf '%s' "$thread_page_json" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage // false')"
@@ -193,40 +191,45 @@ while :; do
   thread_cursor="$(printf '%s' "$thread_page_json" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // ""')"
 done
 
-expanded_review_threads_json='[]'
+if [[ -s "$thread_pages_file" ]]; then
+  review_threads_json="$(jq -s 'add // []' "$thread_pages_file")"
+else
+  review_threads_json='[]'
+fi
+
+expanded_threads_file="$temp_dir/expanded-review-threads.jsonl"
+: >"$expanded_threads_file"
 while IFS= read -r thread_json; do
   [[ -z "$thread_json" ]] && continue
 
   thread_id="$(printf '%s' "$thread_json" | jq -r '.id')"
+  comment_pages_file="$(mktemp "$temp_dir/thread-comments.XXXXXX.jsonl")"
   comment_nodes_json="$(printf '%s' "$thread_json" | jq '.comments.nodes // []')"
+  printf '%s\n' "$comment_nodes_json" >"$comment_pages_file"
   comment_has_next="$(printf '%s' "$thread_json" | jq -r '.comments.pageInfo.hasNextPage // false')"
   comment_cursor="$(printf '%s' "$thread_json" | jq -r '.comments.pageInfo.endCursor // ""')"
 
   while [[ "$comment_has_next" == "true" ]]; do
     comment_page_json="$(fetch_thread_comments_page "$thread_id" "$comment_cursor")"
     page_nodes_json="$(printf '%s' "$comment_page_json" | jq '.data.node.comments.nodes // []')"
-    comment_nodes_json="$(
-      jq -n \
-        --argjson existing "$comment_nodes_json" \
-        --argjson nodes "$page_nodes_json" \
-        '$existing + $nodes'
-    )"
+    printf '%s\n' "$page_nodes_json" >>"$comment_pages_file"
     comment_has_next="$(printf '%s' "$comment_page_json" | jq -r '.data.node.comments.pageInfo.hasNextPage // false')"
     comment_cursor="$(printf '%s' "$comment_page_json" | jq -r '.data.node.comments.pageInfo.endCursor // ""')"
   done
 
+  comment_nodes_json="$(jq -s 'add // []' "$comment_pages_file")"
+  rm -f "$comment_pages_file"
   expanded_thread_json="$(
     printf '%s' "$thread_json" | jq --argjson nodes "$comment_nodes_json" '.comments = { nodes: $nodes }'
   )"
-  expanded_review_threads_json="$(
-    jq -n \
-      --argjson existing "$expanded_review_threads_json" \
-      --argjson thread "$expanded_thread_json" \
-      '$existing + [$thread]'
-  )"
+  printf '%s\n' "$expanded_thread_json" >>"$expanded_threads_file"
 done < <(printf '%s' "$review_threads_json" | jq -c '.[]')
 
-review_threads_json="$expanded_review_threads_json"
+if [[ -s "$expanded_threads_file" ]]; then
+  review_threads_json="$(jq -s '.' "$expanded_threads_file")"
+else
+  review_threads_json='[]'
+fi
 
 jq -n \
   --argjson pr "$pr_json" \
@@ -236,6 +239,7 @@ jq -n \
       tostring
       | gsub("\r"; "")
       | gsub("\\s+"; " ")
+      | gsub("^ +| +$"; "")
       | ascii_downcase;
 
     def author_login:
@@ -327,7 +331,6 @@ jq -n \
       | if $channel == "inline_review" then
           if (comment_thread_state.is_outdated or comment_thread_state.is_resolved) then "unknown" else "finding" end
         elif $channel == "review_summary" and ($body | length) == 0 then "summary"
-        elif looks_like_started_text or looks_like_summary_noise_text then "summary"
         elif looks_like_started_text or looks_like_summary_noise_text then "summary"
         elif ($body | test("summary|overall|overview|high level|high-level|general feedback|looks good|no major issues|quick recap")) then "summary"
         elif ($body | test("should|could|must|consider|missing|bug|issue|incorrect|guard|handle|return|null|undefined|race|rename|suggestion:|nit:|nitpick")) then "finding"

--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -29,7 +29,7 @@ fi
 repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
 owner="${repo%%/*}"
 name="${repo##*/}"
-pr_json="$(gh pr view "$pr_number" --json number,title,url,headRefName,baseRefName,isDraft,state,comments,reviews)"
+pr_json="$(gh pr view "$pr_number" --json number,title,url,headRefName,headRefOid,baseRefName,isDraft,state,comments,reviews)"
 
 review_comments_json="$(
   gh api --paginate "repos/$repo/pulls/$pr_number/comments?per_page=100" \
@@ -53,8 +53,10 @@ review_threads_json="$(
           pullRequest(number: $number) {
             reviewThreads(first: 100) {
               nodes {
+                id
                 isResolved
                 isOutdated
+                viewerCanResolve
                 comments(first: 50) {
                   nodes {
                     databaseId
@@ -130,7 +132,9 @@ jq -n \
           | map(
               . + {
                 __thread_is_outdated: ($thread.isOutdated // false),
-                __thread_is_resolved: ($thread.isResolved // false)
+                __thread_is_resolved: ($thread.isResolved // false),
+                __thread_id: ($thread.id // null),
+                __thread_viewer_can_resolve: ($thread.viewerCanResolve // null)
               }
             )
         )
@@ -139,10 +143,12 @@ jq -n \
     def thread_lookup:
       (enrich_threads)
       | map({
+          thread_id: (.__thread_id // null),
           key_db: (if .databaseId then (.databaseId | tostring) else null end),
           key_url: (.url // null),
           is_outdated: .__thread_is_outdated,
-          is_resolved: .__thread_is_resolved
+          is_resolved: .__thread_is_resolved,
+          viewer_can_resolve: (.__thread_viewer_can_resolve // null)
         })
       | map(select(.key_db != null or .key_url != null));
 
@@ -158,8 +164,10 @@ jq -n \
             )
           | .[0]) as $match
       | {
+          thread_id: ($match.thread_id // null),
           is_outdated: ($match.is_outdated // false),
-          is_resolved: ($match.is_resolved // false)
+          is_resolved: ($match.is_resolved // false),
+          viewer_can_resolve: ($match.viewer_can_resolve // null)
         };
 
     def comment_kind($channel):
@@ -194,6 +202,8 @@ jq -n \
             body: body_text,
             path: $path,
             line: $line,
+            thread_id: ($thread_state.thread_id // null),
+            thread_viewer_can_resolve: ($thread_state.viewer_can_resolve // null),
             url: (.html_url // .url // ""),
             updated_at: (.updated_at // .submittedAt // .updatedAt // .createdAt // ""),
             is_outdated: ($thread_state.is_outdated // false),
@@ -209,7 +219,11 @@ jq -n \
     | map(review_entry("review_summary"; null; null)) as $review_summaries
     | $review_comments
     | map(review_entry("inline_review"; (.path // null); (.line // .original_line // null))) as $inline_comments
-    | ($issue_comments + $review_summaries + $inline_comments) as $matches
+    | (
+        ($inline_comments | sort_by((.is_outdated // false), (.is_resolved // false), .vendor, .path, .line))
+        + ($issue_comments | sort_by(.vendor, .updated_at))
+        + ($review_summaries | sort_by(.vendor, .updated_at))
+      ) as $matches
     | ($matches | map(.vendor) | unique | sort) as $vendors
     | (
         $matches
@@ -236,12 +250,14 @@ jq -n \
     | {
         agents: $agents,
         detected: ($matches | length > 0),
+        reviewed_head_sha: ($pr.headRefOid // null),
         artifact_text:
           (
             [
               "PR #\($pr.number): \($pr.title)",
               "URL: \($pr.url)",
               "Branch: \($pr.headRefName) -> \($pr.baseRefName)",
+              "Reviewed head SHA: \($pr.headRefOid // "unknown")",
               "State: \($pr.state)\(if $pr.isDraft then " (draft)" else "" end)",
               "Detected AI review comments: \($matches | length)",
               "Detected AI review agents: \($agents | length)",
@@ -262,6 +278,7 @@ jq -n \
               | map(
                   "- [\(.kind)][\(.vendor)][\(.channel)][\(.derived_state)] \(.author_login)"
                   + (if .path then " on \(.path):\(.line // 0)" else "" end)
+                  + (if .thread_id then " [thread \(.thread_id)]" else "" end)
                   + (if .is_resolved then " [resolved]" else "" end)
                   + (if .is_outdated then " [outdated]" else "" end)
                   + (if .updated_at != "" then " at \(.updated_at)" else "" end)

--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -194,6 +194,8 @@ jq -n \
       | (comment_thread_state) as $thread_state
       | if $vendor == null then
           empty
+        elif $channel == "review_summary" and ((body_text | normalize_text) | length) == 0 then
+          empty
         else
           {
             vendor: $vendor,

--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ Useful local commands:
 - `bun run verify`
 - `bun run ci`
 - `bun run deliver restack` to restack the current delivery ticket after its parent PR was squash-merged to `main`
-- `bun run deliver --plan <plan-path> poll-review` to run the orchestrator's 2/4/6/8-minute `ai-code-review` polling loop for the active PR
+- `bun run deliver --plan <plan-path> poll-review` to run the orchestrator's 2/4/6/8-minute `ai-code-review` polling loop for the active PR and persist reviewed-SHA provenance plus vendor-attributed review artifacts
+- `bun run deliver --plan <plan-path> record-review <ticket-id> patched ...` to record patched follow-up and make a best-effort attempt to resolve mapped native GitHub inline review threads
 
 The review hooks and triage guidance for that flow live in the repo-local skill at [`./.agents/skills/ai-code-review/SKILL.md`](./.agents/skills/ai-code-review/SKILL.md). The orchestrator consumes repo-local fetcher and triager scripts there, not a Codex-specific runtime.
 

--- a/docs/03-engineering/ai-first-delivery-workflow.md
+++ b/docs/03-engineering/ai-first-delivery-workflow.md
@@ -30,6 +30,8 @@ The repo-local `ai-code-review` skill owns the judgment:
 
 The boundary is implemented as repo-local hooks under `.agents/skills/ai-code-review/`: a fetcher that normalizes multi-vendor AI review into structured data, and a triager hook that turns that data into a final outcome plus concise rationale.
 
+The normalized artifact now carries reviewed-commit provenance and native GitHub inline-thread identity when available. That lets the PR body distinguish current-head review from stale-history review, and it lets patched inline findings be resolved in the GitHub PR UI without vendor-specific logic.
+
 That boundary matters. AI is used aggressively, but not blindly.
 
 There is also a Telegram notifier for long-running flow milestones. It can send concise updates when a PR opens, when AI review starts, and when review is recorded.

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -47,6 +47,7 @@ The orchestrator owns process mechanics:
 - optional Telegram milestone notifications for long-running delivery runs
 - blocking advancement until review has been explicitly recorded or auto-recorded as `clean` after the final polling check
 - refreshing the current PR body from recorded ai-cr follow-up notes immediately before advancing to the next ticket
+- resolving native GitHub inline review threads for patched AI-review findings when the saved review artifact exposes a resolvable thread identity
 
 It does **not** own AI-review detection heuristics or triage judgment.
 
@@ -61,7 +62,7 @@ So the orchestrator only consumes the skill hook contracts:
 - fetcher:
   - `detected=false`: keep polling, or auto-record `clean` on the final check
   - `detected=true`: save structured and rendered artifacts, then call the triager hook
-  - preserves vendor identity and inline-comment resolution/outdated metadata in the saved `json` artifact
+  - preserves vendor identity, reviewed head SHA, native thread identity when available, and inline-comment resolution/outdated metadata in the saved `json` artifact
 - triager:
   - returns `clean`, `needs_patch`, or `patched`
   - returns the final note plus concise action and non-action summaries
@@ -205,7 +206,9 @@ PR descriptions are maintained as delivery metadata, not one-shot text.
 - `open-pr` uses a human-readable Conventional-Commit-style title plus the delivery ticket suffix, for example `feat: add torrent lifecycle reconciliation [P3.02]`
 - rerunning `open-pr` refreshes the existing PR title/body instead of failing on an already-open branch
 - `record-review` stores the triage result and optional note
+- `record-review ... patched` also makes a best-effort attempt to resolve mapped native GitHub inline review threads for patched findings
 - `poll-review` auto-records `clean` when no `ai-code-review` feedback is detected by the final check and refreshes the PR body immediately
+- PR-body AI-review notes now distinguish current-head review from stale-history review when the reviewed SHA no longer matches the branch head
 - `advance` refreshes the PR body from that recorded review state, then marks the ticket done and optionally starts the next one
 
 This matters because the repo squash-merges PRs onto `main`, so the PR body needs to mention prudent ai-cr follow-up work before the stack moves on.

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -30,6 +30,7 @@ import {
   parseDotEnv,
   parseGitWorktreeList,
   parseAiReviewFetcherOutput,
+  parseResolveReviewThreadOutput,
   parseAiReviewTriagerOutput,
   parsePlan,
   pollReview,
@@ -1114,6 +1115,34 @@ describe('delivery orchestrator', () => {
     );
   });
 
+  it('parses native review-thread resolution responses', () => {
+    expect(
+      parseResolveReviewThreadOutput(
+        JSON.stringify({
+          data: {
+            resolveReviewThread: {
+              thread: {
+                id: 'thread_example_1',
+                isResolved: true,
+              },
+            },
+          },
+        }),
+      ),
+    ).toEqual({ resolved: true });
+
+    expect(
+      parseResolveReviewThreadOutput(
+        JSON.stringify({
+          errors: [{ message: 'thread is already resolved' }],
+        }),
+      ),
+    ).toEqual({
+      resolved: false,
+      message: 'thread is already resolved',
+    });
+  });
+
   it('waits for all detected agents before triage and saves the artifact', async () => {
     const state: DeliveryState = {
       planKey: 'phase-03',
@@ -1635,6 +1664,78 @@ describe('delivery orchestrator', () => {
         },
       ],
     });
+  });
+
+  it('reuses existing thread resolutions instead of resolving twice', async () => {
+    const state: DeliveryState = {
+      planKey: 'phase-03',
+      planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+      statePath: '.codex/delivery/phase-03/state.json',
+      reviewsDirPath: '.codex/delivery/phase-03/reviews',
+      handoffsDirPath: '.codex/delivery/phase-03/handoffs',
+      reviewPollIntervalMinutes: 2,
+      reviewPollMaxWaitMinutes: 8,
+      tickets: [
+        {
+          id: 'P3.01',
+          title: 'Persist Transmission Identity For Queued Torrents',
+          slug: 'persist-transmission-identity-for-queued-torrents',
+          ticketFile:
+            'docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md',
+          status: 'needs_patch',
+          branch:
+            'codex/p3-01-persist-transmission-identity-for-queued-torrents',
+          baseBranch: 'main',
+          worktreePath: '/tmp/p3_01',
+          reviewComments: [
+            {
+              vendor: 'coderabbit',
+              channel: 'inline_review',
+              authorLogin: 'coderabbitai',
+              authorType: 'Bot',
+              body: 'Guard the null return here.',
+              kind: 'finding',
+              threadId: 'thread_example_1',
+              url: 'https://example.test/comment/1',
+            },
+          ],
+          reviewThreadResolutions: [
+            {
+              status: 'resolved',
+              threadId: 'thread_example_1',
+              url: 'https://example.test/comment/1',
+              vendor: 'coderabbit',
+            },
+          ],
+        },
+      ],
+    };
+    let resolveCalls = 0;
+
+    const nextState = await recordReview(
+      state,
+      '/tmp/pirate_claw',
+      'P3.01',
+      'patched',
+      undefined,
+      {
+        resolveThreads: () => {
+          resolveCalls += 1;
+          return [];
+        },
+        updatePullRequestBody: async () => {},
+      },
+    );
+
+    expect(resolveCalls).toBe(0);
+    expect(nextState.tickets[0]?.reviewThreadResolutions).toEqual([
+      {
+        status: 'resolved',
+        threadId: 'thread_example_1',
+        url: 'https://example.test/comment/1',
+        vendor: 'coderabbit',
+      },
+    ]);
   });
 
   it('keeps notification failures best-effort', async () => {

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -575,7 +575,7 @@ describe('delivery orchestrator', () => {
         note: 'External AI review completed without prudent follow-up changes.',
         vendors: ['qodo'],
       }),
-    ).toContain('did not merit follow-up changes');
+    ).toContain('triage found no prudent follow-up changes');
   });
 
   it('does not include external summary-only noise in the ticket pr body', () => {

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -550,6 +550,20 @@ describe('delivery orchestrator', () => {
       buildStandaloneAiReviewSection({
         outcome: 'patched',
         note: 'Patched the prudent AI review follow-up.',
+        reviewedHeadSha: 'abcdef1234567890',
+        comments: [
+          {
+            vendor: 'coderabbit',
+            channel: 'inline_review',
+            authorLogin: 'coderabbitai',
+            authorType: 'Bot',
+            body: 'Guard the null return here.',
+            kind: 'finding',
+            path: 'src/example.ts',
+            line: 42,
+            url: 'https://example.test/comment/1',
+          },
+        ],
         vendors: ['coderabbit'],
       }),
     ).toContain('triage led to prudent follow-up patches');
@@ -596,6 +610,69 @@ describe('delivery orchestrator', () => {
     );
     expect(body).not.toContain('Ignored 1 summary comment');
     expect(body).not.toContain('non-action summary:');
+  });
+
+  it('renders stale ai review history separately from current head status', () => {
+    const body = buildPullRequestBody(
+      {
+        planKey: 'phase-03',
+        planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+        statePath: '.agents/delivery/phase-03/state.json',
+        reviewsDirPath: '.agents/delivery/phase-03/reviews',
+        handoffsDirPath: '.agents/delivery/phase-03/handoffs',
+        reviewPollIntervalMinutes: 2,
+        reviewPollMaxWaitMinutes: 8,
+        tickets: [],
+      },
+      {
+        id: 'P3.01',
+        title: 'Persist Transmission Identity For Queued Torrents',
+        ticketFile:
+          'docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md',
+        baseBranch: 'main',
+        reviewActionSummary: 'Patched 1 finding comment.',
+        reviewComments: [
+          {
+            vendor: 'coderabbit',
+            channel: 'inline_review',
+            authorLogin: 'coderabbitai',
+            authorType: 'Bot',
+            body: 'Guard the null return here.',
+            kind: 'finding',
+            path: 'src/example.ts',
+            line: 42,
+            threadId: 'thread_example_1',
+            url: 'https://example.test/comment/1',
+          },
+        ],
+        reviewHeadSha: 'abcdef1234567890',
+        reviewNonActionSummary: undefined,
+        reviewNote: 'Patched the prudent AI review follow-up.',
+        reviewOutcome: 'patched',
+        reviewThreadResolutions: [
+          {
+            status: 'resolved',
+            threadId: 'thread_example_1',
+            url: 'https://example.test/comment/1',
+            vendor: 'coderabbit',
+          },
+        ],
+        reviewVendors: ['coderabbit'],
+        status: 'reviewed',
+      },
+      {
+        currentHeadSha: 'fedcba0987654321',
+      },
+    );
+
+    expect(body).toContain(
+      'no current-SHA `ai-code-review` status is recorded',
+    );
+    expect(body).toContain('### Stale Review History');
+    expect(body).toContain(
+      '[coderabbit] stale history: Guard the null return here.',
+    );
+    expect(body).toContain('[thread](https://example.test/comment/1)');
   });
 
   it('surfaces the review wait window after opening a PR', () => {
@@ -859,6 +936,7 @@ describe('delivery orchestrator', () => {
           ],
           detected: true,
           artifact_text: 'normalized review artifact',
+          reviewed_head_sha: 'abcdef1234567890',
           vendors: ['coderabbit', 'qodo'],
           comments: [
             {
@@ -871,6 +949,8 @@ describe('delivery orchestrator', () => {
               is_resolved: false,
               path: 'src/example.ts',
               line: 42,
+              thread_id: 'thread_example_1',
+              thread_viewer_can_resolve: true,
               url: 'https://example.test/comment/1',
               updated_at: '2026-04-04T10:00:00.000Z',
               kind: 'finding',
@@ -902,6 +982,7 @@ describe('delivery orchestrator', () => {
       ],
       detected: true,
       artifactText: 'normalized review artifact',
+      reviewedHeadSha: 'abcdef1234567890',
       vendors: ['coderabbit', 'qodo'],
       comments: [
         {
@@ -914,6 +995,8 @@ describe('delivery orchestrator', () => {
           isResolved: false,
           path: 'src/example.ts',
           line: 42,
+          threadId: 'thread_example_1',
+          threadViewerCanResolve: true,
           url: 'https://example.test/comment/1',
           updatedAt: '2026-04-04T10:00:00.000Z',
           kind: 'finding',
@@ -1106,6 +1189,7 @@ describe('delivery orchestrator', () => {
                 ],
                 detected: true,
                 artifactText: 'normalized ai review artifact',
+                reviewedHeadSha: 'abcdef1234567890',
                 vendors: ['coderabbit', 'qodo'],
                 comments: [
                   {
@@ -1114,6 +1198,8 @@ describe('delivery orchestrator', () => {
                     authorLogin: 'coderabbitai',
                     authorType: 'Bot',
                     body: 'Guard the null return here.',
+                    threadId: 'thread_example_1',
+                    threadViewerCanResolve: true,
                     kind: 'finding',
                   },
                   {
@@ -1149,6 +1235,10 @@ describe('delivery orchestrator', () => {
         'coderabbit',
         'qodo',
       ]);
+      expect(nextState.tickets[0]?.reviewHeadSha).toBe('abcdef1234567890');
+      expect(nextState.tickets[0]?.reviewComments?.[0]?.threadId).toBe(
+        'thread_example_1',
+      );
       expect(
         await readFile(
           join(cwd, '.codex/delivery/phase-03/reviews/P3.01-ai-review.txt'),
@@ -1175,6 +1265,7 @@ describe('delivery orchestrator', () => {
         ],
         artifact_text: 'normalized ai review artifact',
         detected: true,
+        reviewed_head_sha: 'abcdef1234567890',
         vendors: ['coderabbit', 'qodo'],
       });
     } finally {
@@ -1225,6 +1316,7 @@ describe('delivery orchestrator', () => {
         ],
         detected: true,
         artifactText: 'normalized ai review artifact',
+        reviewedHeadSha: 'abcdef1234567890',
         vendors: ['coderabbit'],
         comments: [
           {
@@ -1233,6 +1325,8 @@ describe('delivery orchestrator', () => {
             authorLogin: 'coderabbitai',
             authorType: 'Bot',
             body: 'Guard the null return here.',
+            threadId: 'thread_example_1',
+            threadViewerCanResolve: true,
             kind: 'finding',
           },
         ],
@@ -1244,6 +1338,14 @@ describe('delivery orchestrator', () => {
         nonActionSummary: undefined,
         vendors: ['coderabbit'],
       }),
+      resolveThreads: () => [
+        {
+          status: 'resolved',
+          threadId: 'thread_example_1',
+          url: 'https://example.test/comment/1',
+          vendor: 'coderabbit',
+        },
+      ],
       updatePullRequestBody: async (updatedState, ticket) => {
         prBodyUpdates.push(
           `${updatedState.planKey}:${ticket.reviewOutcome}:${ticket.reviewNote}`,
@@ -1255,6 +1357,14 @@ describe('delivery orchestrator', () => {
       status: 'reviewed',
       reviewOutcome: 'patched',
       reviewNote: 'Patched the prudent AI review follow-up.',
+      reviewThreadResolutions: [
+        {
+          status: 'resolved',
+          threadId: 'thread_example_1',
+          url: 'https://example.test/comment/1',
+          vendor: 'coderabbit',
+        },
+      ],
       reviewVendors: ['coderabbit'],
     });
     expect(prBodyUpdates).toEqual([
@@ -1427,6 +1537,7 @@ describe('delivery orchestrator', () => {
         ],
         detected: true,
         artifactText: 'normalized ai review artifact',
+        reviewedHeadSha: 'abcdef1234567890',
         vendors: ['coderabbit'],
         comments: [
           {
@@ -1435,6 +1546,7 @@ describe('delivery orchestrator', () => {
             authorLogin: 'coderabbitai',
             authorType: 'Bot',
             body: 'Guard the null return here.',
+            threadId: 'thread_example_1',
             kind: 'finding',
           },
         ],
@@ -1472,6 +1584,18 @@ describe('delivery orchestrator', () => {
             'codex/p3-01-persist-transmission-identity-for-queued-torrents',
           baseBranch: 'main',
           worktreePath: '/tmp/p3_01',
+          reviewComments: [
+            {
+              vendor: 'coderabbit',
+              channel: 'inline_review',
+              authorLogin: 'coderabbitai',
+              authorType: 'Bot',
+              body: 'Guard the null return here.',
+              kind: 'finding',
+              threadId: 'thread_example_1',
+              url: 'https://example.test/comment/1',
+            },
+          ],
           reviewNote:
             'Actionable AI review findings were detected and still need follow-up.',
         },
@@ -1483,6 +1607,18 @@ describe('delivery orchestrator', () => {
       '/tmp/pirate_claw',
       'P3.01',
       'patched',
+      undefined,
+      {
+        resolveThreads: () => [
+          {
+            status: 'resolved',
+            threadId: 'thread_example_1',
+            url: 'https://example.test/comment/1',
+            vendor: 'coderabbit',
+          },
+        ],
+        updatePullRequestBody: async () => {},
+      },
     );
 
     expect(nextState.tickets[0]).toMatchObject({
@@ -1490,6 +1626,14 @@ describe('delivery orchestrator', () => {
       reviewOutcome: 'patched',
       reviewNote:
         'Actionable AI review findings were detected and still need follow-up.',
+      reviewThreadResolutions: [
+        {
+          status: 'resolved',
+          threadId: 'thread_example_1',
+          url: 'https://example.test/comment/1',
+          vendor: 'coderabbit',
+        },
+      ],
     });
   });
 

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -1983,6 +1983,65 @@ type PollForAiReviewResult =
       effectiveMaxWaitMinutes: number;
     };
 
+function summarizeReviewMessage(message: string): string {
+  const normalized = message.replace(/\s+/g, ' ').trim();
+  return normalized.length > 180
+    ? `${normalized.slice(0, 177).trimEnd()}...`
+    : normalized;
+}
+
+export function parseResolveReviewThreadOutput(output: string): {
+  message?: string;
+  resolved: boolean;
+} {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(output);
+  } catch (error) {
+    throw new Error(
+      `GitHub review-thread resolution must emit JSON. ${formatError(error)}`.trim(),
+      {
+        cause: error,
+      },
+    );
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error(
+      'GitHub review-thread resolution output must be a JSON object.',
+    );
+  }
+
+  if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+    const firstError = parsed.errors.find(isRecord);
+    return {
+      resolved: false,
+      message: summarizeReviewMessage(
+        typeof firstError?.message === 'string'
+          ? firstError.message
+          : 'GitHub reported a review-thread resolution error.',
+      ),
+    };
+  }
+
+  const thread =
+    isRecord(parsed.data) &&
+    isRecord(parsed.data.resolveReviewThread) &&
+    isRecord(parsed.data.resolveReviewThread.thread)
+      ? parsed.data.resolveReviewThread.thread
+      : undefined;
+
+  if (thread?.isResolved === true) {
+    return { resolved: true };
+  }
+
+  return {
+    resolved: false,
+    message: 'GitHub did not confirm that the review thread was resolved.',
+  };
+}
+
 function resolveNativeReviewThreads(
   worktreePath: string,
   comments: AiReviewComment[],
@@ -2016,7 +2075,7 @@ function resolveNativeReviewThreads(
     }
 
     try {
-      runProcess(worktreePath, [
+      const response = runProcess(worktreePath, [
         'gh',
         'api',
         'graphql',
@@ -2025,6 +2084,19 @@ function resolveNativeReviewThreads(
         '-f',
         'query=mutation($threadId: ID!) { resolveReviewThread(input: { threadId: $threadId }) { thread { id isResolved } } }',
       ]);
+      const parsed = parseResolveReviewThreadOutput(response);
+
+      if (!parsed.resolved) {
+        resolutions.push({
+          status: 'failed',
+          threadId: comment.threadId,
+          url: comment.url,
+          vendor: comment.vendor,
+          message: parsed.message,
+        });
+        continue;
+      }
+
       resolutions.push({
         status: 'resolved',
         threadId: comment.threadId,
@@ -2032,7 +2104,7 @@ function resolveNativeReviewThreads(
         vendor: comment.vendor,
       });
     } catch (error) {
-      const message = formatError(error);
+      const message = summarizeReviewMessage(formatError(error));
       resolutions.push({
         status: message.includes('already resolved')
           ? 'already_resolved'
@@ -2581,9 +2653,13 @@ export async function recordReview(
   const resolveThreads =
     dependencies.resolveThreads ?? resolveNativeReviewThreads;
   const reviewThreadResolutions =
-    outcome === 'patched' && target.reviewComments
-      ? resolveThreads(target.worktreePath, target.reviewComments)
-      : target.reviewThreadResolutions;
+    outcome === 'patched' &&
+    target.reviewThreadResolutions &&
+    target.reviewThreadResolutions.length > 0
+      ? target.reviewThreadResolutions
+      : outcome === 'patched' && target.reviewComments
+        ? resolveThreads(target.worktreePath, target.reviewComments)
+        : target.reviewThreadResolutions;
   if (
     outcome === 'patched' &&
     reviewThreadResolutions &&
@@ -2828,7 +2904,7 @@ function formatResolutionSuffix(
       return '; native GitHub thread could not be resolved automatically';
     case 'failed':
       return resolution.message
-        ? `; native GitHub thread resolution failed: ${resolution.message}`
+        ? `; native GitHub thread resolution failed: ${summarizeReviewMessage(resolution.message)}`
         : '; native GitHub thread resolution failed';
   }
 }

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -740,11 +740,6 @@ export function syncStateWithPlan(
           inferredTicket?.reviewIncompleteAgents,
         reviewComments:
           previous?.reviewComments ?? inferredTicket?.reviewComments,
-        reviewIncompleteAgents:
-          previous?.reviewIncompleteAgents ??
-          inferredTicket?.reviewIncompleteAgents,
-        reviewComments:
-          previous?.reviewComments ?? inferredTicket?.reviewComments,
         reviewOutcome: previous?.reviewOutcome ?? inferredTicket?.reviewOutcome,
         reviewNote: previous?.reviewNote ?? inferredTicket?.reviewNote,
         reviewThreadResolutions:
@@ -2368,19 +2363,6 @@ export async function pollReview(
               reviewIncompleteAgents:
                 reviewPollResult.status === 'partial_timeout'
                   ? reviewPollResult.incompleteAgents
-              reviewThreadResolutions:
-                reviewThreadResolutions.length > 0
-                  ? reviewThreadResolutions
-              reviewNote:
-                reviewPollResult.status === 'partial_timeout'
-                  ? formatPartialAiReviewTimeoutNote(
-                      reviewPollResult.effectiveMaxWaitMinutes,
-                      reviewPollResult.incompleteAgents,
-                    )
-                  : triage.note,
-              reviewIncompleteAgents:
-                reviewPollResult.status === 'partial_timeout'
-                  ? reviewPollResult.incompleteAgents
                   : undefined,
               reviewThreadResolutions:
                 reviewThreadResolutions.length > 0
@@ -2425,14 +2407,6 @@ export async function pollReview(
             reviewHeadSha: undefined,
             reviewNonActionSummary: undefined,
             reviewOutcome: 'clean',
-            reviewNote: reviewPollResult.incompleteAgents?.length
-              ? formatIncompleteAiReviewWithoutFindingsNote(
-                  reviewPollResult.effectiveMaxWaitMinutes,
-                  reviewPollResult.incompleteAgents,
-                )
-              : formatNoAiReviewFeedbackNote(state.reviewPollMaxWaitMinutes),
-            reviewIncompleteAgents: reviewPollResult.incompleteAgents,
-            reviewThreadResolutions: undefined,
             reviewNote: reviewPollResult.incompleteAgents?.length
               ? formatIncompleteAiReviewWithoutFindingsNote(
                   reviewPollResult.effectiveMaxWaitMinutes,

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -41,10 +41,13 @@ export type TicketState = TicketDefinition & {
   reviewArtifactJsonPath?: string;
   reviewActionSummary?: string;
   reviewFetchedAt?: string;
+  reviewHeadSha?: string;
   reviewNonActionSummary?: string;
+  reviewComments?: AiReviewComment[];
   reviewOutcome?: ReviewOutcome;
   reviewNote?: string;
   reviewIncompleteAgents?: string[];
+  reviewThreadResolutions?: AiReviewThreadResolution[];
   reviewVendors?: string[];
 };
 
@@ -217,7 +220,23 @@ type AiReviewComment = {
   kind: AiReviewCommentKind;
   line?: number;
   path?: string;
+  threadId?: string;
+  threadViewerCanResolve?: boolean;
   updatedAt?: string;
+  url?: string;
+  vendor: string;
+};
+
+type AiReviewThreadResolutionStatus =
+  | 'resolved'
+  | 'already_resolved'
+  | 'failed'
+  | 'unresolvable';
+
+type AiReviewThreadResolution = {
+  message?: string;
+  status: AiReviewThreadResolutionStatus;
+  threadId: string;
   url?: string;
   vendor: string;
 };
@@ -227,6 +246,7 @@ type AiReviewFetcherResult = {
   artifactText: string;
   comments: AiReviewComment[];
   detected: boolean;
+  reviewedHeadSha?: string;
   vendors: string[];
 };
 
@@ -241,6 +261,10 @@ type AiReviewTriagerResult = {
 type PollReviewDependencies = {
   fetcher?: (worktreePath: string, prNumber: number) => AiReviewFetcherResult;
   now?: () => number;
+  resolveThreads?: (
+    worktreePath: string,
+    comments: AiReviewComment[],
+  ) => AiReviewThreadResolution[];
   sleep?: (milliseconds: number) => Promise<void>;
   triager?: (
     worktreePath: string,
@@ -257,11 +281,14 @@ type StandaloneAiReviewResult = {
   artifactJsonPath?: string;
   artifactTextPath?: string;
   incompleteAgents?: string[];
+  comments?: AiReviewComment[];
   note: string;
   nonActionSummary?: string;
   outcome: ReviewResult;
   prNumber: number;
   prUrl: string;
+  reviewedHeadSha?: string;
+  threadResolutions?: AiReviewThreadResolution[];
   vendors: string[];
 };
 
@@ -269,6 +296,7 @@ type StandalonePullRequest = {
   body: string;
   createdAt: string;
   headRefName: string;
+  headRefOid: string;
   number: number;
   title: string;
   url: string;
@@ -703,14 +731,25 @@ export function syncStateWithPlan(
           previous?.reviewActionSummary ?? inferredTicket?.reviewActionSummary,
         reviewFetchedAt:
           previous?.reviewFetchedAt ?? inferredTicket?.reviewFetchedAt,
+        reviewHeadSha: previous?.reviewHeadSha ?? inferredTicket?.reviewHeadSha,
         reviewNonActionSummary:
           previous?.reviewNonActionSummary ??
           inferredTicket?.reviewNonActionSummary,
         reviewIncompleteAgents:
           previous?.reviewIncompleteAgents ??
           inferredTicket?.reviewIncompleteAgents,
+        reviewComments:
+          previous?.reviewComments ?? inferredTicket?.reviewComments,
+        reviewIncompleteAgents:
+          previous?.reviewIncompleteAgents ??
+          inferredTicket?.reviewIncompleteAgents,
+        reviewComments:
+          previous?.reviewComments ?? inferredTicket?.reviewComments,
         reviewOutcome: previous?.reviewOutcome ?? inferredTicket?.reviewOutcome,
         reviewNote: previous?.reviewNote ?? inferredTicket?.reviewNote,
+        reviewThreadResolutions:
+          previous?.reviewThreadResolutions ??
+          inferredTicket?.reviewThreadResolutions,
         reviewVendors: previous?.reviewVendors ?? inferredTicket?.reviewVendors,
       };
     }),
@@ -1211,9 +1250,12 @@ function inferStateFromRepo(
       reviewArtifactJsonPath: undefined,
       reviewActionSummary: undefined,
       reviewFetchedAt: undefined,
+      reviewHeadSha: undefined,
       reviewNonActionSummary: undefined,
+      reviewComments: undefined,
       reviewOutcome: undefined,
       reviewNote: undefined,
+      reviewThreadResolutions: undefined,
       reviewVendors: undefined,
     };
   });
@@ -1374,12 +1416,13 @@ function resolveStandalonePullRequest(
     'view',
     ...(target ? [target] : []),
     '--json',
-    'number,url,title,body,headRefName,createdAt',
+    'number,url,title,body,headRefName,headRefOid,createdAt',
   ]);
   const parsed = JSON.parse(stdout) as {
     body: string;
     createdAt: string;
     headRefName: string;
+    headRefOid: string;
     number: number;
     title: string;
     url: string;
@@ -1572,7 +1615,9 @@ export async function openPullRequest(
     target,
     readLatestCommitSubject(target.worktreePath),
   );
-  const body = buildPullRequestBody(state, target);
+  const body = buildPullRequestBody(state, target, {
+    currentHeadSha: readHeadSha(target.worktreePath),
+  });
   const existingPullRequest = findOpenPullRequest(
     target.worktreePath,
     target.branch,
@@ -1779,6 +1824,10 @@ export function parseAiReviewFetcherOutput(
       kind: entry.kind,
       line: parseOptionalNumber(entry.line),
       path: parseOptionalString(entry.path),
+      threadId: parseOptionalString(entry.thread_id),
+      threadViewerCanResolve: parseOptionalBoolean(
+        entry.thread_viewer_can_resolve,
+      ),
       updatedAt: parseOptionalString(entry.updated_at),
       url: parseOptionalString(entry.url),
       vendor: entry.vendor,
@@ -1795,6 +1844,7 @@ export function parseAiReviewFetcherOutput(
     artifactText: parsed.artifact_text,
     comments,
     detected: parsed.detected,
+    reviewedHeadSha: parseOptionalString(parsed.reviewed_head_sha),
     vendors: parsed.vendors,
   };
 }
@@ -1933,6 +1983,71 @@ type PollForAiReviewResult =
       effectiveMaxWaitMinutes: number;
     };
 
+function resolveNativeReviewThreads(
+  worktreePath: string,
+  comments: AiReviewComment[],
+): AiReviewThreadResolution[] {
+  const resolutions: AiReviewThreadResolution[] = [];
+  const seen = new Set<string>();
+
+  for (const comment of comments) {
+    if (
+      comment.channel !== 'inline_review' ||
+      comment.kind !== 'finding' ||
+      comment.isOutdated === true ||
+      comment.isResolved === true ||
+      !comment.threadId ||
+      seen.has(comment.threadId)
+    ) {
+      continue;
+    }
+
+    seen.add(comment.threadId);
+
+    if (comment.threadViewerCanResolve === false) {
+      resolutions.push({
+        status: 'unresolvable',
+        threadId: comment.threadId,
+        url: comment.url,
+        vendor: comment.vendor,
+        message: 'GitHub did not expose this review thread as resolvable.',
+      });
+      continue;
+    }
+
+    try {
+      runProcess(worktreePath, [
+        'gh',
+        'api',
+        'graphql',
+        '-F',
+        `threadId=${comment.threadId}`,
+        '-f',
+        'query=mutation($threadId: ID!) { resolveReviewThread(input: { threadId: $threadId }) { thread { id isResolved } } }',
+      ]);
+      resolutions.push({
+        status: 'resolved',
+        threadId: comment.threadId,
+        url: comment.url,
+        vendor: comment.vendor,
+      });
+    } catch (error) {
+      const message = formatError(error);
+      resolutions.push({
+        status: message.includes('already resolved')
+          ? 'already_resolved'
+          : 'failed',
+        threadId: comment.threadId,
+        url: comment.url,
+        vendor: comment.vendor,
+        message,
+      });
+    }
+  }
+
+  return resolutions;
+}
+
 async function pollForAiReview(
   worktreePath: string,
   prNumber: number,
@@ -2035,6 +2150,7 @@ async function writeAiReviewArtifacts(
           note: agent.note ?? null,
         })),
         detected: result.detected,
+        reviewed_head_sha: result.reviewedHeadSha ?? null,
         vendors: result.vendors,
         comments: result.comments.map((comment) => ({
           author_login: comment.authorLogin,
@@ -2046,10 +2162,13 @@ async function writeAiReviewArtifacts(
           kind: comment.kind,
           line: comment.line ?? null,
           path: comment.path ?? null,
+          thread_id: comment.threadId ?? null,
+          thread_viewer_can_resolve: comment.threadViewerCanResolve ?? null,
           updated_at: comment.updatedAt ?? null,
           url: comment.url ?? null,
           vendor: comment.vendor,
         })),
+        thread_resolutions: [],
       },
       null,
       2,
@@ -2062,6 +2181,31 @@ async function writeAiReviewArtifacts(
     artifactJsonPath,
     artifactTextPath,
   };
+}
+
+async function writeAiReviewThreadResolutions(
+  artifactJsonPath: string | undefined,
+  resolutions: AiReviewThreadResolution[],
+): Promise<void> {
+  if (!artifactJsonPath) {
+    return;
+  }
+
+  const existing = JSON.parse(
+    await readFile(artifactJsonPath, 'utf8'),
+  ) as Record<string, unknown>;
+  existing.thread_resolutions = resolutions.map((resolution) => ({
+    message: resolution.message ?? null,
+    status: resolution.status,
+    thread_id: resolution.threadId,
+    url: resolution.url ?? null,
+    vendor: resolution.vendor,
+  }));
+  await writeFile(
+    artifactJsonPath,
+    JSON.stringify(existing, null, 2) + '\n',
+    'utf8',
+  );
 }
 
 export async function pollReview(
@@ -2078,6 +2222,8 @@ export async function pollReview(
 
   const now = dependencies.now ?? Date.now;
   const triager = dependencies.triager ?? runAiReviewTriager;
+  const resolveThreads =
+    dependencies.resolveThreads ?? resolveNativeReviewThreads;
   const updatePullRequestBodyFn =
     dependencies.updatePullRequestBody ?? updatePullRequestBody;
   const { pollWindowStartedAt, pollWindowStartedAtIso } =
@@ -2101,6 +2247,16 @@ export async function pollReview(
       detectedReview,
     );
     const triage = triager(target.worktreePath, artifacts.artifactJsonPath);
+    const reviewThreadResolutions =
+      triage.outcome === 'patched'
+        ? resolveThreads(target.worktreePath, detectedReview.comments)
+        : [];
+    if (reviewThreadResolutions.length > 0) {
+      await writeAiReviewThreadResolutions(
+        artifacts.artifactJsonPath,
+        reviewThreadResolutions,
+      );
+    }
     const reviewVendors =
       triage.vendors.length > 0 ? triage.vendors : detectedReview.vendors;
     const nextStatus =
@@ -2114,6 +2270,7 @@ export async function pollReview(
               prOpenedAt: ticket.prOpenedAt ?? pollWindowStartedAtIso,
               status: nextStatus,
               reviewActionSummary: triage.actionSummary,
+              reviewComments: detectedReview.comments,
               reviewArtifactJsonPath: relativeToRepo(
                 cwd,
                 artifacts.artifactJsonPath,
@@ -2123,6 +2280,7 @@ export async function pollReview(
                 artifacts.artifactTextPath,
               ),
               reviewFetchedAt: new Date(now()).toISOString(),
+              reviewHeadSha: detectedReview.reviewedHeadSha,
               reviewNonActionSummary: triage.nonActionSummary,
               reviewOutcome:
                 triage.outcome === 'clean' || triage.outcome === 'patched'
@@ -2138,6 +2296,23 @@ export async function pollReview(
               reviewIncompleteAgents:
                 reviewPollResult.status === 'partial_timeout'
                   ? reviewPollResult.incompleteAgents
+              reviewThreadResolutions:
+                reviewThreadResolutions.length > 0
+                  ? reviewThreadResolutions
+              reviewNote:
+                reviewPollResult.status === 'partial_timeout'
+                  ? formatPartialAiReviewTimeoutNote(
+                      reviewPollResult.effectiveMaxWaitMinutes,
+                      reviewPollResult.incompleteAgents,
+                    )
+                  : triage.note,
+              reviewIncompleteAgents:
+                reviewPollResult.status === 'partial_timeout'
+                  ? reviewPollResult.incompleteAgents
+                  : undefined,
+              reviewThreadResolutions:
+                reviewThreadResolutions.length > 0
+                  ? reviewThreadResolutions
                   : undefined,
               reviewVendors,
             }
@@ -2172,8 +2347,10 @@ export async function pollReview(
             prOpenedAt: ticket.prOpenedAt ?? pollWindowStartedAtIso,
             status: 'reviewed',
             reviewActionSummary: undefined,
+            reviewComments: undefined,
             reviewArtifactJsonPath: undefined,
             reviewArtifactPath: undefined,
+            reviewHeadSha: undefined,
             reviewNonActionSummary: undefined,
             reviewOutcome: 'clean',
             reviewNote: reviewPollResult.incompleteAgents?.length
@@ -2183,6 +2360,15 @@ export async function pollReview(
                 )
               : formatNoAiReviewFeedbackNote(state.reviewPollMaxWaitMinutes),
             reviewIncompleteAgents: reviewPollResult.incompleteAgents,
+            reviewThreadResolutions: undefined,
+            reviewNote: reviewPollResult.incompleteAgents?.length
+              ? formatIncompleteAiReviewWithoutFindingsNote(
+                  reviewPollResult.effectiveMaxWaitMinutes,
+                  reviewPollResult.incompleteAgents,
+                )
+              : formatNoAiReviewFeedbackNote(state.reviewPollMaxWaitMinutes),
+            reviewIncompleteAgents: reviewPollResult.incompleteAgents,
+            reviewThreadResolutions: undefined,
             reviewVendors: [],
           }
         : ticket,
@@ -2236,6 +2422,16 @@ async function runStandaloneAiReview(
       detectedReview,
     );
     const triage = runAiReviewTriager(cwd, artifacts.artifactJsonPath);
+    const threadResolutions =
+      triage.outcome === 'patched'
+        ? resolveNativeReviewThreads(cwd, detectedReview.comments)
+        : [];
+    if (threadResolutions.length > 0) {
+      await writeAiReviewThreadResolutions(
+        artifacts.artifactJsonPath,
+        threadResolutions,
+      );
+    }
     const standaloneResult: StandaloneAiReviewResult = {
       actionSummary: triage.actionSummary,
       artifactJsonPath: relativeToRepo(cwd, artifacts.artifactJsonPath),
@@ -2251,6 +2447,7 @@ async function runStandaloneAiReview(
               reviewPollResult.incompleteAgents,
             )
           : triage.note,
+      comments: detectedReview.comments,
       nonActionSummary: triage.nonActionSummary,
       outcome:
         triage.outcome === 'needs_patch'
@@ -2258,6 +2455,9 @@ async function runStandaloneAiReview(
           : triage.outcome,
       prNumber: pullRequest.number,
       prUrl: pullRequest.url,
+      reviewedHeadSha: detectedReview.reviewedHeadSha,
+      threadResolutions:
+        threadResolutions.length > 0 ? threadResolutions : undefined,
       vendors:
         triage.vendors.length > 0 ? triage.vendors : detectedReview.vendors,
     };
@@ -2351,6 +2551,16 @@ export async function recordReview(
   ticketId: string,
   outcome: ReviewResult,
   note?: string,
+  dependencies: {
+    resolveThreads?: (
+      worktreePath: string,
+      comments: AiReviewComment[],
+    ) => AiReviewThreadResolution[];
+    updatePullRequestBody?: (
+      state: DeliveryState,
+      ticket: TicketState,
+    ) => void | Promise<void>;
+  } = {},
 ): Promise<DeliveryState> {
   const target = state.tickets.find((ticket) => ticket.id === ticketId);
 
@@ -2368,7 +2578,26 @@ export async function recordReview(
     );
   }
 
-  return {
+  const resolveThreads =
+    dependencies.resolveThreads ?? resolveNativeReviewThreads;
+  const reviewThreadResolutions =
+    outcome === 'patched' && target.reviewComments
+      ? resolveThreads(target.worktreePath, target.reviewComments)
+      : target.reviewThreadResolutions;
+  if (
+    outcome === 'patched' &&
+    reviewThreadResolutions &&
+    reviewThreadResolutions.length > 0
+  ) {
+    await writeAiReviewThreadResolutions(
+      target.reviewArtifactJsonPath
+        ? resolve(cwd, target.reviewArtifactJsonPath)
+        : undefined,
+      reviewThreadResolutions,
+    );
+  }
+
+  const nextState: DeliveryState = {
     ...state,
     tickets: state.tickets.map((ticket) =>
       ticket.id === ticketId
@@ -2383,10 +2612,29 @@ export async function recordReview(
                 ? outcome
                 : undefined,
             reviewNote: note ?? ticket.reviewNote,
+            reviewThreadResolutions:
+              outcome === 'patched' ? reviewThreadResolutions : undefined,
           }
         : ticket,
     ),
   };
+  const updatedTarget = nextState.tickets.find(
+    (ticket) => ticket.id === ticketId,
+  );
+
+  if (updatedTarget) {
+    const updatePullRequestBodyFn =
+      dependencies.updatePullRequestBody ?? updatePullRequestBody;
+    try {
+      await updatePullRequestBodyFn(nextState, updatedTarget);
+    } catch (error) {
+      console.warn(
+        `Review was recorded locally for ${updatedTarget.id}, but PR body update failed: ${formatError(error)}`,
+      );
+    }
+  }
+
+  return nextState;
 }
 
 async function advanceToNextTicket(
@@ -2519,7 +2767,9 @@ async function restackTicket(
       '--base',
       nextBaseBranch,
       '--body',
-      buildPullRequestBody(nextState, updatedTarget),
+      buildPullRequestBody(nextState, updatedTarget, {
+        currentHeadSha: readHeadSha(updatedTarget.worktreePath),
+      }),
     ]);
   }
 
@@ -2537,6 +2787,227 @@ function preferCodexBranch(branches: string[]): string {
   return branches.find((branch) => branch.startsWith('codex/')) ?? branches[0]!;
 }
 
+function shortenSha(sha: string | undefined): string | undefined {
+  return sha ? sha.slice(0, 12) : undefined;
+}
+
+function summarizeReviewComment(body: string): string {
+  const normalized = body.replace(/\s+/g, ' ').trim();
+  return normalized.length > 140
+    ? `${normalized.slice(0, 137).trimEnd()}...`
+    : normalized;
+}
+
+function formatReviewCommentLocation(comment: AiReviewComment): string {
+  if (!comment.path) {
+    return '';
+  }
+
+  return comment.line
+    ? ` \`${comment.path}:${comment.line}\``
+    : ` \`${comment.path}\``;
+}
+
+function formatReviewThreadLink(url: string | undefined): string {
+  return url ? ` [thread](${url})` : '';
+}
+
+function formatResolutionSuffix(
+  resolution: AiReviewThreadResolution | undefined,
+): string {
+  if (!resolution) {
+    return '';
+  }
+
+  switch (resolution.status) {
+    case 'resolved':
+      return '; native GitHub thread resolved';
+    case 'already_resolved':
+      return '; native GitHub thread was already resolved';
+    case 'unresolvable':
+      return '; native GitHub thread could not be resolved automatically';
+    case 'failed':
+      return resolution.message
+        ? `; native GitHub thread resolution failed: ${resolution.message}`
+        : '; native GitHub thread resolution failed';
+  }
+}
+
+function describeReviewComment(
+  comment: AiReviewComment,
+  context: 'current' | 'history',
+  status: TicketStatus | ReviewResult,
+  resolution: AiReviewThreadResolution | undefined,
+): string {
+  if (context === 'history') {
+    return 'stale history';
+  }
+
+  if (comment.isOutdated) {
+    return 'outdated';
+  }
+
+  if (comment.isResolved) {
+    return 'already resolved';
+  }
+
+  if (comment.kind === 'summary') {
+    return 'summary only';
+  }
+
+  if (comment.kind === 'unknown') {
+    return 'manual judgment';
+  }
+
+  if (status === 'patched') {
+    return `patched${formatResolutionSuffix(resolution)}`;
+  }
+
+  if (status === 'needs_patch') {
+    return 'follow-up pending';
+  }
+
+  if (status === 'operator_input_needed') {
+    return 'operator input needed';
+  }
+
+  return 'finding';
+}
+
+function buildReviewCommentBullets(
+  comments: AiReviewComment[] | undefined,
+  context: 'current' | 'history',
+  status: TicketStatus | ReviewResult,
+  threadResolutions: AiReviewThreadResolution[] | undefined,
+): string[] {
+  if (!comments || comments.length === 0) {
+    return [];
+  }
+
+  const resolutionByThreadId = new Map(
+    (threadResolutions ?? []).map((resolution) => [
+      resolution.threadId,
+      resolution,
+    ]),
+  );
+
+  return comments.map((comment) => {
+    const description = describeReviewComment(
+      comment,
+      context,
+      status,
+      comment.threadId ? resolutionByThreadId.get(comment.threadId) : undefined,
+    );
+    return `- [${comment.vendor}] ${description}: ${summarizeReviewComment(comment.body)}${formatReviewCommentLocation(comment)}${formatReviewThreadLink(comment.url)}`;
+  });
+}
+
+function buildAiReviewDetailLines(input: {
+  actionSummary?: string;
+  comments?: AiReviewComment[];
+  currentHeadSha?: string;
+  maxWaitMinutes: number;
+  nonActionSummary?: string;
+  note?: string;
+  outcome?: ReviewResult;
+  reviewedHeadSha?: string;
+  status?: TicketStatus;
+  threadResolutions?: AiReviewThreadResolution[];
+  vendors?: string[];
+}): string[] {
+  const lines: string[] = [];
+  const reviewStatus = input.outcome ?? input.status;
+
+  if (
+    !reviewStatus ||
+    (reviewStatus !== 'clean' &&
+      reviewStatus !== 'patched' &&
+      reviewStatus !== 'needs_patch' &&
+      reviewStatus !== 'operator_input_needed')
+  ) {
+    return lines;
+  }
+
+  const appliesToCurrentHead =
+    !!input.reviewedHeadSha &&
+    !!input.currentHeadSha &&
+    input.reviewedHeadSha === input.currentHeadSha;
+
+  if (input.reviewedHeadSha) {
+    lines.push(`- reviewed commit: \`${shortenSha(input.reviewedHeadSha)}\``);
+  }
+
+  if (input.currentHeadSha) {
+    lines.push(
+      `- current branch head: \`${shortenSha(input.currentHeadSha)}\``,
+    );
+  }
+
+  if (reviewStatus === 'clean') {
+    lines.push(
+      input.note === formatNoAiReviewFeedbackNote(input.maxWaitMinutes)
+        ? `- No \`ai-code-review\` feedback was detected during the ${input.maxWaitMinutes}-minute polling window.`
+        : '- `ai-code-review` triage found no prudent follow-up changes.',
+    );
+  } else if (reviewStatus === 'needs_patch') {
+    lines.push(
+      '- `ai-code-review` triage found actionable follow-up work that still needs patching.',
+    );
+  } else if (reviewStatus === 'patched') {
+    lines.push(
+      '- `ai-code-review` triage led to prudent follow-up patches that are now included in this branch.',
+    );
+  } else {
+    lines.push(
+      '- `ai-code-review` stopped for operator input before follow-up could be completed safely.',
+    );
+  }
+
+  if (input.reviewedHeadSha && input.currentHeadSha && !appliesToCurrentHead) {
+    lines.push(
+      '- no current-SHA `ai-code-review` status is recorded for the current branch head; the latest recorded review is shown below as stale history.',
+    );
+  }
+
+  if (input.note) {
+    lines.push(`- follow-up note: ${input.note}`);
+  }
+
+  if (input.vendors && input.vendors.length > 0) {
+    lines.push(
+      `- vendors: ${input.vendors.map((vendor) => `\`${vendor}\``).join(', ')}`,
+    );
+  }
+
+  if (input.actionSummary) {
+    lines.push(`- action summary: ${input.actionSummary}`);
+  }
+
+  if (input.nonActionSummary) {
+    lines.push(`- non-action summary: ${input.nonActionSummary}`);
+  }
+
+  const bullets = buildReviewCommentBullets(
+    input.comments,
+    appliesToCurrentHead || !input.reviewedHeadSha ? 'current' : 'history',
+    reviewStatus,
+    input.threadResolutions,
+  );
+
+  if (bullets.length > 0) {
+    lines.push(
+      '',
+      appliesToCurrentHead || !input.reviewedHeadSha
+        ? '### Review Items'
+        : '### Stale Review History',
+      '',
+      ...bullets,
+    );
+  }
+
+  return lines;
+}
+
 export function buildPullRequestBody(
   state: DeliveryState,
   ticket: Pick<
@@ -2548,12 +3019,21 @@ export function buildPullRequestBody(
     | 'internalReviewCompletedAt'
     | 'reviewActionSummary'
     | 'reviewIncompleteAgents'
+    | 'reviewComments'
+    | 'reviewHeadSha'
+    | 'reviewIncompleteAgents'
+    | 'reviewComments'
+    | 'reviewHeadSha'
     | 'status'
     | 'reviewOutcome'
     | 'reviewNote'
     | 'reviewNonActionSummary'
+    | 'reviewThreadResolutions'
     | 'reviewVendors'
   >,
+  options: {
+    currentHeadSha?: string;
+  } = {},
 ): string {
   const lines = [
     '## Summary',
@@ -2575,51 +3055,21 @@ export function buildPullRequestBody(
     ticket.status === 'operator_input_needed'
   ) {
     lines.push('', '## AI Review Follow-Up', '');
-
-    if (ticket.reviewOutcome === 'clean') {
-      lines.push(
-        ticket.reviewNote ===
-          formatNoAiReviewFeedbackNote(state.reviewPollMaxWaitMinutes)
-          ? `- No \`ai-code-review\` feedback was detected during the ${state.reviewPollMaxWaitMinutes}-minute polling window.`
-          : '- `ai-code-review` triage found no prudent follow-up changes.',
-      );
-    }
-
-    if (ticket.status === 'needs_patch') {
-      lines.push(
-        '- `ai-code-review` triage found actionable follow-up work that still needs patching.',
-      );
-    }
-
-    if (ticket.reviewOutcome === 'patched') {
-      lines.push(
-        '- `ai-code-review` triage led to prudent follow-up patches that are now included in this branch.',
-      );
-    }
-
-    if (ticket.status === 'operator_input_needed') {
-      lines.push(
-        '- `ai-code-review` stopped for operator input before follow-up could be completed safely.',
-      );
-    }
-
-    if (ticket.reviewNote) {
-      lines.push(`- follow-up note: ${ticket.reviewNote}`);
-    }
-
-    if (ticket.reviewVendors && ticket.reviewVendors.length > 0) {
-      lines.push(
-        `- vendors: ${ticket.reviewVendors.map((vendor) => `\`${vendor}\``).join(', ')}`,
-      );
-    }
-
-    if (ticket.reviewActionSummary) {
-      lines.push(`- action summary: ${ticket.reviewActionSummary}`);
-    }
-
-    if (ticket.reviewNonActionSummary) {
-      lines.push(`- non-action summary: ${ticket.reviewNonActionSummary}`);
-    }
+    lines.push(
+      ...buildAiReviewDetailLines({
+        actionSummary: ticket.reviewActionSummary,
+        comments: ticket.reviewComments,
+        currentHeadSha: options.currentHeadSha,
+        maxWaitMinutes: state.reviewPollMaxWaitMinutes,
+        nonActionSummary: ticket.reviewNonActionSummary,
+        note: ticket.reviewNote,
+        outcome: ticket.reviewOutcome,
+        reviewedHeadSha: ticket.reviewHeadSha,
+        status: ticket.status,
+        threadResolutions: ticket.reviewThreadResolutions,
+        vendors: ticket.reviewVendors,
+      }),
+    );
 
     if (ticket.reviewIncompleteAgents?.length) {
       lines.push(
@@ -3025,7 +3475,9 @@ function updatePullRequestBody(
     'edit',
     String(ticket.prNumber),
     '--body',
-    buildPullRequestBody(state, ticket),
+    buildPullRequestBody(state, ticket, {
+      currentHeadSha: readHeadSha(ticket.worktreePath),
+    }),
   ]);
 }
 
@@ -3035,47 +3487,35 @@ export function buildStandaloneAiReviewSection(
     | 'actionSummary'
     | 'artifactJsonPath'
     | 'artifactTextPath'
+    | 'comments'
     | 'note'
     | 'nonActionSummary'
     | 'outcome'
+    | 'reviewedHeadSha'
+    | 'threadResolutions'
     | 'vendors'
   >,
+  options: {
+    currentHeadSha?: string;
+  } = {},
 ): string {
   const lines = [STANDALONE_AI_REVIEW_SECTION_START, '## AI Review', ''];
-
-  if (result.outcome === 'clean') {
-    lines.push(
-      result.note ===
-        formatNoAiReviewFeedbackNote(DEFAULT_REVIEW_POLL_MAX_WAIT_MINUTES)
-        ? '- no `ai-code-review` feedback was detected during the 8-minute polling window.'
-        : '- detected `ai-code-review` feedback did not merit follow-up changes.',
-    );
-  } else if (result.outcome === 'operator_input_needed') {
-    lines.push(
-      '- `ai-code-review` completed, but follow-up still needs operator attention.',
-    );
-  } else {
-    lines.push(
-      '- `ai-code-review` triage led to prudent follow-up patches that are now included in the branch.',
-    );
-  }
+  lines.push(
+    ...buildAiReviewDetailLines({
+      actionSummary: result.actionSummary,
+      comments: result.comments,
+      currentHeadSha: options.currentHeadSha,
+      maxWaitMinutes: DEFAULT_REVIEW_POLL_MAX_WAIT_MINUTES,
+      nonActionSummary: result.nonActionSummary,
+      note: result.note,
+      outcome: result.outcome,
+      reviewedHeadSha: result.reviewedHeadSha,
+      threadResolutions: result.threadResolutions,
+      vendors: result.vendors,
+    }),
+  );
 
   lines.push(`- outcome: \`${result.outcome}\``);
-  lines.push(`- note: ${result.note}`);
-
-  if (result.vendors.length > 0) {
-    lines.push(
-      `- vendors: ${result.vendors.map((vendor) => `\`${vendor}\``).join(', ')}`,
-    );
-  }
-
-  if (result.actionSummary) {
-    lines.push(`- action summary: ${result.actionSummary}`);
-  }
-
-  if (result.nonActionSummary) {
-    lines.push(`- non-action summary: ${result.nonActionSummary}`);
-  }
 
   if (result.artifactJsonPath) {
     lines.push(`- artifact (json): \`${result.artifactJsonPath}\``);
@@ -3113,7 +3553,9 @@ function updateStandalonePullRequestBody(
 ): void {
   const nextBody = mergeStandaloneAiReviewSection(
     pullRequest.body,
-    buildStandaloneAiReviewSection(result),
+    buildStandaloneAiReviewSection(result, {
+      currentHeadSha: pullRequest.headRefOid,
+    }),
   );
 
   runProcess(cwd, [
@@ -3172,6 +3614,10 @@ function hasMergedPullRequestForBranch(cwd: string, branch: string): boolean {
 
 function readLatestCommitSubject(cwd: string): string {
   return runProcess(cwd, ['git', 'log', '-1', '--pretty=%s']).trim();
+}
+
+function readHeadSha(cwd: string): string {
+  return runProcess(cwd, ['git', 'rev-parse', 'HEAD']).trim();
 }
 
 function readCurrentBranch(cwd: string): string {


### PR DESCRIPTION
## Summary
- bind saved AI review state to the reviewed head SHA and render stale-history review explicitly when the PR head moves
- enrich normalized review artifacts with reviewed SHA and native GitHub thread identity, then render vendor-attributed item bullets with source links
- resolve mapped native GitHub inline review threads when patched AI-review findings are recorded

## Verification
- bun run ci

## Notes
- internal self-review completed before publish
- follow-up AI review will run through the repo's standalone delivery path for this non-ticket PR

<!-- ai-review:start -->
## AI Review

- reviewed commit: `c4a14761b61b`
- current branch head: `c4a14761b61b`
- `ai-code-review` triage found no prudent follow-up changes.
- follow-up note: External AI review completed without prudent follow-up changes.
- vendors: `coderabbit`, `qodo`

### Review Items

- [qodo] already resolved: <img src="https://www.qodo.ai/wp-content/uploads/2026/01/action-required.png" height="20" alt="Action required"> 1\. Unverified thread re... `tools/delivery/orchestrator.ts:2100` [thread](https://github.com/cesarnml/pirate_claw/pull/35#discussion_r3035477596)
- [coderabbit] outdated: _⚠️ Potential issue_ | _🟡 Minor_ <details> <summary>🧩 Analysis chain</summary> 🏁 Script executed: ```shell find . -name "fetch_ai_pr_c... `.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh:59` [thread](https://github.com/cesarnml/pirate_claw/pull/35#discussion_r3035483426)
- [coderabbit] outdated: _⚠️ Potential issue_ | _🟠 Major_ **Don’t reserialize the full paginated payload through `--argjson` on every append.** Now that this pat... `.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh:184` [thread](https://github.com/cesarnml/pirate_claw/pull/35#discussion_r3035499453)
- [coderabbit] outdated: _⚠️ Potential issue_ | _🟡 Minor_ **Duplicate condition in `comment_kind` function.** Line 331 duplicates the condition from lines 329-33... `.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh:331` [thread](https://github.com/cesarnml/pirate_claw/pull/35#discussion_r3035507028)
- [coderabbit] summary only: <!-- This is an auto-generated comment: summarize by coderabbit.ai --> <!-- This is an auto-generated comment: review paused by coderabbi... [thread](https://github.com/cesarnml/pirate_claw/pull/35#issuecomment-4186963395)
- [qodo] summary only: <h3>Review Summary by Qodo</h3> Clarify AI review provenance and thread resolution <code>✨ Enhancement</code> <img src="https://www.qodo.... [thread](https://github.com/cesarnml/pirate_claw/pull/35#issuecomment-4186963487)
- [qodo] summary only: <h3>Code Review by Qodo</h3> <code>🐞 Bugs (1)</code> <code>📘 Rule violations (0)</code> <code>📎 Requirement gaps (0)</code> <code>🎨 U... [thread](https://github.com/cesarnml/pirate_claw/pull/35#issuecomment-4186963503)
- [coderabbit] summary only: **Actionable comments posted: 1** > [!CAUTION] > Some comments are outside the diff and can’t be posted inline due to platform limitation...
- [coderabbit] summary only: **Actionable comments posted: 1** > [!CAUTION] > Some comments are outside the diff and can’t be posted inline due to platform limitation...
- [coderabbit] summary only: **Actionable comments posted: 1** > [!CAUTION] > Some comments are outside the diff and can’t be posted inline due to platform limitation...
- outcome: `clean`
- artifact (json): `.agents/ai-review/pr-35/review.json`
- artifact (text): `.agents/ai-review/pr-35/review.txt`
<!-- ai-review:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically resolve native GitHub inline review threads when AI findings are patched; records per-thread resolution status.
  * Track reviewed-commit SHA to distinguish current-head reviews from stale review history; PR body now separates “Stale Review History” from current-head findings.
  * PR body rendering includes reviewed-commit provenance and native thread identifiers for clearer context.

* **Documentation**
  * Updated workflow and CLI docs describing review provenance, thread resolution behavior, and record-review usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->