### PR TITLE
refactor: tighten ai review PR body rendering

### DIFF
--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -567,7 +567,7 @@ describe('delivery orchestrator', () => {
         ],
         vendors: ['coderabbit'],
       }),
-    ).toContain('triage led to prudent follow-up patches');
+    ).toContain('## External AI Review');
 
     expect(
       buildStandaloneAiReviewSection({
@@ -575,7 +575,7 @@ describe('delivery orchestrator', () => {
         note: 'External AI review completed without prudent follow-up changes.',
         vendors: ['qodo'],
       }),
-    ).toContain('triage found no prudent follow-up changes');
+    ).toContain('no prudent follow-up changes were required.');
   });
 
   it('keeps standalone pr bodies free of artifact paths', () => {
@@ -619,15 +619,14 @@ describe('delivery orchestrator', () => {
       },
     );
 
-    expect(body).toContain(
-      'External AI review completed without prudent follow-up changes.',
-    );
+    expect(body).toContain('no prudent follow-up changes were required.');
     expect(body).not.toContain('Ignored 1 summary comment');
     expect(body).not.toContain('### Vendor Summary Noise');
     expect(body).not.toContain('non-action summary:');
+    expect(body).not.toContain('summary-only updates');
   });
 
-  it('compresses current vendor summary noise and demotes resolved items', () => {
+  it('omits summary noise and renders resolved findings for reviewers', () => {
     const body = buildPullRequestBody(
       {
         planKey: 'phase-03',
@@ -710,17 +709,16 @@ describe('delivery orchestrator', () => {
       },
     );
 
-    expect(body).toContain('### Current Findings');
+    expect(body).toContain('## External AI Review');
+    expect(body).toContain('### Resolved Review Findings');
     expect(body).toContain(
-      '[coderabbit] patched; native GitHub thread resolved: Guard the null return here.',
+      '[coderabbit] Guard the null return here. (native GitHub thread resolved)',
     );
-    expect(body).toContain('### Vendor Summary Noise');
-    expect(body).toContain('[qodo] compressed 2 summary-only updates.');
-    expect(body).not.toContain('[qodo] summary only: Overall this looks good.');
-    expect(body).toContain('### Stale / Resolved History');
-    expect(body).toContain(
-      '[coderabbit] already resolved: Previous concern already resolved.',
-    );
+    expect(body).not.toContain('### Vendor Summary Noise');
+    expect(body).not.toContain('[qodo] compressed 2 summary-only updates.');
+    expect(body).not.toContain('Overall this looks good.');
+    expect(body).toContain('### Resolved Review Findings');
+    expect(body).toContain('[coderabbit] Previous concern already resolved.');
   });
 
   it('keeps reviewed findings current when the current head sha is unknown', () => {
@@ -744,10 +742,10 @@ describe('delivery orchestrator', () => {
       vendors: ['coderabbit'],
     });
 
-    expect(body).toContain('### Current Findings');
-    expect(body).not.toContain('### Stale / Resolved History');
+    expect(body).toContain('### Unresolved Review Findings');
+    expect(body).not.toContain('### Resolved Review Findings');
     expect(body).not.toContain(
-      'no current-SHA `ai-code-review` status is recorded',
+      'the latest recorded external AI review applies to an older branch head',
     );
   });
 
@@ -805,12 +803,10 @@ describe('delivery orchestrator', () => {
     );
 
     expect(body).toContain(
-      'no current-SHA `ai-code-review` status is recorded',
+      'the latest recorded external AI review applies to an older branch head',
     );
-    expect(body).toContain('### Stale / Resolved History');
-    expect(body).toContain(
-      '[coderabbit] stale history: Guard the null return here.',
-    );
+    expect(body).toContain('### Resolved Review Findings');
+    expect(body).toContain('[coderabbit] Guard the null return here.');
     expect(body).toContain('[thread](https://example.test/comment/1)');
   });
 

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -723,6 +723,34 @@ describe('delivery orchestrator', () => {
     );
   });
 
+  it('keeps reviewed findings current when the current head sha is unknown', () => {
+    const body = buildStandaloneAiReviewSection({
+      outcome: 'operator_input_needed',
+      note: 'Actionable AI review findings were detected and still need follow-up.',
+      reviewedHeadSha: 'abcdef1234567890',
+      comments: [
+        {
+          vendor: 'coderabbit',
+          channel: 'inline_review',
+          authorLogin: 'coderabbitai',
+          authorType: 'Bot',
+          body: 'Guard the null return here.',
+          kind: 'finding',
+          path: 'src/example.ts',
+          line: 42,
+          url: 'https://example.test/comment/1',
+        },
+      ],
+      vendors: ['coderabbit'],
+    });
+
+    expect(body).toContain('### Current Findings');
+    expect(body).not.toContain('### Stale / Resolved History');
+    expect(body).not.toContain(
+      'no current-SHA `ai-code-review` status is recorded',
+    );
+  });
+
   it('renders stale ai review history separately from current head status', () => {
     const body = buildPullRequestBody(
       {

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -578,6 +578,19 @@ describe('delivery orchestrator', () => {
     ).toContain('triage found no prudent follow-up changes');
   });
 
+  it('keeps standalone pr bodies free of artifact paths', () => {
+    const body = buildStandaloneAiReviewSection({
+      outcome: 'patched',
+      note: 'Patched the prudent AI review follow-up.',
+      artifactJsonPath: '.codex/ai-review/pr-32/review.json',
+      artifactTextPath: '.codex/ai-review/pr-32/review.txt',
+      vendors: ['coderabbit'],
+    });
+
+    expect(body).not.toContain('artifact (json)');
+    expect(body).not.toContain('artifact (text)');
+  });
+
   it('does not include external summary-only noise in the ticket pr body', () => {
     const body = buildPullRequestBody(
       {
@@ -610,7 +623,104 @@ describe('delivery orchestrator', () => {
       'External AI review completed without prudent follow-up changes.',
     );
     expect(body).not.toContain('Ignored 1 summary comment');
+    expect(body).not.toContain('### Vendor Summary Noise');
     expect(body).not.toContain('non-action summary:');
+  });
+
+  it('compresses current vendor summary noise and demotes resolved items', () => {
+    const body = buildPullRequestBody(
+      {
+        planKey: 'phase-03',
+        planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+        statePath: '.agents/delivery/phase-03/state.json',
+        reviewsDirPath: '.agents/delivery/phase-03/reviews',
+        handoffsDirPath: '.agents/delivery/phase-03/handoffs',
+        reviewPollIntervalMinutes: 2,
+        reviewPollMaxWaitMinutes: 8,
+        tickets: [],
+      },
+      {
+        id: 'P3.01',
+        title: 'Persist Transmission Identity For Queued Torrents',
+        ticketFile:
+          'docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md',
+        baseBranch: 'main',
+        reviewActionSummary: 'Patched 1 finding comment.',
+        reviewComments: [
+          {
+            vendor: 'coderabbit',
+            channel: 'inline_review',
+            authorLogin: 'coderabbitai',
+            authorType: 'Bot',
+            body: 'Guard the null return here.',
+            kind: 'finding',
+            path: 'src/example.ts',
+            line: 42,
+            threadId: 'thread_example_1',
+            url: 'https://example.test/comment/1',
+          },
+          {
+            vendor: 'qodo',
+            channel: 'review_summary',
+            authorLogin: 'qodo-bot',
+            authorType: 'Bot',
+            body: 'Overall this looks good.',
+            kind: 'summary',
+            url: 'https://example.test/comment/2',
+          },
+          {
+            vendor: 'qodo',
+            channel: 'review_summary',
+            authorLogin: 'qodo-bot',
+            authorType: 'Bot',
+            body: 'No blocking issues found.',
+            kind: 'summary',
+            url: 'https://example.test/comment/3',
+          },
+          {
+            vendor: 'coderabbit',
+            channel: 'inline_review',
+            authorLogin: 'coderabbitai',
+            authorType: 'Bot',
+            body: 'Previous concern already resolved.',
+            isResolved: true,
+            kind: 'finding',
+            path: 'src/example.ts',
+            line: 30,
+            threadId: 'thread_example_2',
+            url: 'https://example.test/comment/4',
+          },
+        ],
+        reviewHeadSha: 'abcdef1234567890',
+        reviewNote: 'Patched the prudent AI review follow-up.',
+        reviewOutcome: 'patched',
+        reviewThreadResolutions: [
+          {
+            status: 'resolved',
+            threadId: 'thread_example_1',
+            url: 'https://example.test/comment/1',
+            vendor: 'coderabbit',
+          },
+        ],
+        reviewVendors: ['coderabbit', 'qodo'],
+        status: 'reviewed',
+      },
+      {
+        currentHeadSha: 'abcdef1234567890',
+      },
+    );
+
+    expect(body).toContain('### Current Findings');
+    expect(body).toContain(
+      '[coderabbit] patched; native GitHub thread resolved: Guard the null return here.',
+    );
+    expect(body).toContain('### Vendor Summary Noise');
+    expect(body).toContain('[qodo] compressed 2 summary-only updates.');
+    expect(body).not.toContain('[qodo] summary only: Overall this looks good.');
+    expect(body).toContain('### Stale / Resolved History');
+    expect(body).toContain(
+      '[coderabbit] already resolved: Previous concern already resolved.',
+    );
   });
 
   it('renders stale ai review history separately from current head status', () => {
@@ -669,7 +779,7 @@ describe('delivery orchestrator', () => {
     expect(body).toContain(
       'no current-SHA `ai-code-review` status is recorded',
     );
-    expect(body).toContain('### Stale Review History');
+    expect(body).toContain('### Stale / Resolved History');
     expect(body).toContain(
       '[coderabbit] stale history: Guard the null return here.',
     );

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -1656,6 +1656,120 @@ describe('delivery orchestrator', () => {
     ]);
   });
 
+  it('preserves patched as the cumulative outcome when a later poll is clean', async () => {
+    const state: DeliveryState = {
+      planKey: 'phase-03',
+      planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+      statePath: '.codex/delivery/phase-03/state.json',
+      reviewsDirPath: '.codex/delivery/phase-03/reviews',
+      handoffsDirPath: '.codex/delivery/phase-03/handoffs',
+      reviewPollIntervalMinutes: 2,
+      reviewPollMaxWaitMinutes: 8,
+      tickets: [
+        {
+          id: 'P3.01',
+          title: 'Persist Transmission Identity For Queued Torrents',
+          slug: 'persist-transmission-identity-for-queued-torrents',
+          ticketFile:
+            'docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md',
+          status: 'in_review',
+          branch:
+            'codex/p3-01-persist-transmission-identity-for-queued-torrents',
+          baseBranch: 'main',
+          worktreePath: '/tmp/p3_01',
+          prUrl: 'https://example.test/pull/20',
+          prNumber: 20,
+          prOpenedAt: '2026-04-01T10:00:00.000Z',
+          reviewOutcome: 'patched',
+          reviewNote: 'Patched the prudent AI review follow-up.',
+        },
+      ],
+    };
+
+    const nextState = await pollReview(state, '/tmp/pirate_claw', 'P3.01', {
+      now: () => Date.parse('2026-04-01T10:00:00.000Z'),
+      sleep: async () => {},
+      fetcher: () => ({
+        agents: [
+          {
+            agent: 'coderabbit',
+            state: 'completed',
+            note: 'review completed without actionable findings',
+          },
+        ],
+        detected: true,
+        artifactText: 'normalized ai review artifact',
+        reviewedHeadSha: 'abcdef1234567890',
+        vendors: ['coderabbit'],
+        comments: [],
+      }),
+      triager: () => ({
+        outcome: 'clean',
+        note: 'External AI review completed without prudent follow-up changes.',
+        vendors: ['coderabbit'],
+      }),
+      updatePullRequestBody: async () => {},
+    });
+
+    expect(nextState.tickets[0]).toMatchObject({
+      status: 'reviewed',
+      reviewOutcome: 'patched',
+      reviewNote:
+        'External AI review completed without prudent follow-up changes. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
+    });
+  });
+
+  it('preserves patched as the cumulative outcome when a later poll finds no ai review', async () => {
+    const state: DeliveryState = {
+      planKey: 'phase-03',
+      planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+      statePath: '.codex/delivery/phase-03/state.json',
+      reviewsDirPath: '.codex/delivery/phase-03/reviews',
+      handoffsDirPath: '.codex/delivery/phase-03/handoffs',
+      reviewPollIntervalMinutes: 2,
+      reviewPollMaxWaitMinutes: 8,
+      tickets: [
+        {
+          id: 'P3.01',
+          title: 'Persist Transmission Identity For Queued Torrents',
+          slug: 'persist-transmission-identity-for-queued-torrents',
+          ticketFile:
+            'docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md',
+          status: 'in_review',
+          branch:
+            'codex/p3-01-persist-transmission-identity-for-queued-torrents',
+          baseBranch: 'main',
+          worktreePath: '/tmp/p3_01',
+          prUrl: 'https://example.test/pull/20',
+          prNumber: 20,
+          prOpenedAt: '2026-04-01T10:00:00.000Z',
+          reviewOutcome: 'patched',
+          reviewNote: 'Patched the prudent AI review follow-up.',
+        },
+      ],
+    };
+
+    const nextState = await pollReview(state, '/tmp/pirate_claw', 'P3.01', {
+      now: () => Date.parse('2026-04-01T10:00:00.000Z'),
+      sleep: async () => {},
+      fetcher: () => ({
+        agents: [],
+        detected: false,
+        artifactText: '',
+        vendors: [],
+        comments: [],
+      }),
+      updatePullRequestBody: async () => {},
+    });
+
+    expect(nextState.tickets[0]).toMatchObject({
+      status: 'reviewed',
+      reviewOutcome: 'patched',
+      reviewNote:
+        'No AI review feedback was detected within the 8-minute polling window. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
+    });
+  });
+
   it('uses the normal polling cadence when prOpenedAt is missing', async () => {
     const state: DeliveryState = {
       planKey: 'phase-03',
@@ -1797,6 +1911,52 @@ describe('delivery orchestrator', () => {
           vendor: 'coderabbit',
         },
       ],
+    });
+  });
+
+  it('does not downgrade a patched review outcome when recording clean later', async () => {
+    const state: DeliveryState = {
+      planKey: 'phase-03',
+      planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+      statePath: '.codex/delivery/phase-03/state.json',
+      reviewsDirPath: '.codex/delivery/phase-03/reviews',
+      handoffsDirPath: '.codex/delivery/phase-03/handoffs',
+      reviewPollIntervalMinutes: 2,
+      reviewPollMaxWaitMinutes: 8,
+      tickets: [
+        {
+          id: 'P3.01',
+          title: 'Persist Transmission Identity For Queued Torrents',
+          slug: 'persist-transmission-identity-for-queued-torrents',
+          ticketFile:
+            'docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md',
+          status: 'operator_input_needed',
+          branch:
+            'codex/p3-01-persist-transmission-identity-for-queued-torrents',
+          baseBranch: 'main',
+          worktreePath: '/tmp/p3_01',
+          reviewOutcome: 'patched',
+          reviewNote: 'Patched the prudent AI review follow-up.',
+        },
+      ],
+    };
+
+    const nextState = await recordReview(
+      state,
+      '/tmp/pirate_claw',
+      'P3.01',
+      'clean',
+      'External AI review completed without prudent follow-up changes.',
+      {
+        updatePullRequestBody: async () => {},
+      },
+    );
+
+    expect(nextState.tickets[0]).toMatchObject({
+      status: 'reviewed',
+      reviewOutcome: 'patched',
+      reviewNote:
+        'External AI review completed without prudent follow-up changes. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
     });
   });
 

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -2883,114 +2883,68 @@ function formatResolutionSuffix(
   }
 }
 
-function describeReviewComment(
+function extractHighlightedReviewText(body: string): string | undefined {
+  const boldMatches = [...body.matchAll(/\*\*([^*]+)\*\*/g)];
+
+  for (const match of boldMatches) {
+    const candidate = match[1]?.trim();
+    if (
+      candidate &&
+      !candidate.toLowerCase().startsWith('actionable comments posted')
+    ) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+function summarizeReviewerFacingFinding(body: string): string {
+  const highlighted = extractHighlightedReviewText(body);
+  if (highlighted) {
+    return highlighted;
+  }
+
+  const firstMeaningfulLine = body
+    .split('\n')
+    .map((line) => line.trim())
+    .find(
+      (line) =>
+        line.length > 0 &&
+        !line.startsWith('```') &&
+        !line.startsWith('<') &&
+        !line.startsWith('>') &&
+        !line.startsWith('<!--'),
+    );
+
+  return summarizeReviewComment(firstMeaningfulLine ?? body);
+}
+
+function formatReviewFindingBullet(
   comment: AiReviewComment,
-  context: 'current' | 'history',
-  status: TicketStatus | ReviewResult,
-  resolution: AiReviewThreadResolution | undefined,
+  detail?: string,
 ): string {
-  if (context === 'history') {
-    return 'stale history';
-  }
-
-  if (comment.isOutdated) {
-    return 'outdated';
-  }
-
-  if (comment.isResolved) {
-    return 'already resolved';
-  }
-
-  if (comment.kind === 'summary') {
-    return 'summary only';
-  }
-
-  if (comment.kind === 'unknown') {
-    return 'manual judgment';
-  }
-
-  if (status === 'patched') {
-    return `patched${formatResolutionSuffix(resolution)}`;
-  }
-
-  if (status === 'needs_patch') {
-    return 'follow-up pending';
-  }
-
-  if (status === 'operator_input_needed') {
-    return 'operator input needed';
-  }
-
-  return 'finding';
+  const base = `- [${comment.vendor}] ${summarizeReviewerFacingFinding(comment.body)}`;
+  const suffix = detail ? ` (${detail})` : '';
+  return `${base}${suffix}${formatReviewCommentLocation(comment)}${formatReviewThreadLink(comment.url)}`;
 }
 
 function buildReviewCommentBullet(
   comment: AiReviewComment,
-  context: 'current' | 'history',
-  status: TicketStatus | ReviewResult,
-  resolutionByThreadId: ReadonlyMap<string, AiReviewThreadResolution>,
+  detail?: string,
 ): string {
-  const description = describeReviewComment(
-    comment,
-    context,
-    status,
-    comment.threadId ? resolutionByThreadId.get(comment.threadId) : undefined,
-  );
-  return `- [${comment.vendor}] ${description}: ${summarizeReviewComment(comment.body)}${formatReviewCommentLocation(comment)}${formatReviewThreadLink(comment.url)}`;
+  return formatReviewFindingBullet(comment, detail);
 }
 
 function buildReviewCommentBullets(
   comments: AiReviewComment[] | undefined,
-  context: 'current' | 'history',
-  status: TicketStatus | ReviewResult,
-  threadResolutions: AiReviewThreadResolution[] | undefined,
+  detail?: string,
 ): string[] {
   if (!comments || comments.length === 0) {
     return [];
   }
 
-  const resolutionByThreadId = new Map(
-    (threadResolutions ?? []).map((resolution) => [
-      resolution.threadId,
-      resolution,
-    ]),
-  );
-
-  return comments.map((comment) =>
-    buildReviewCommentBullet(comment, context, status, resolutionByThreadId),
-  );
-}
-
-function formatVendorSourceLinks(comments: AiReviewComment[]): string {
-  const urls = [
-    ...new Set(comments.map((comment) => comment.url).filter(Boolean)),
-  ];
-
-  if (urls.length === 1) {
-    return ` [source](${urls[0]})`;
-  }
-
-  return '';
-}
-
-function buildVendorSummaryNoiseBullets(comments: AiReviewComment[]): string[] {
-  if (comments.length === 0) {
-    return [];
-  }
-
-  const commentsByVendor = new Map<string, AiReviewComment[]>();
-
-  for (const comment of comments) {
-    const existing = commentsByVendor.get(comment.vendor) ?? [];
-    existing.push(comment);
-    commentsByVendor.set(comment.vendor, existing);
-  }
-
-  return [...commentsByVendor.entries()].map(([vendor, vendorComments]) => {
-    const count = vendorComments.length;
-    const noun = count === 1 ? 'summary-only update' : 'summary-only updates';
-    return `- [${vendor}] compressed ${count} ${noun}.${formatVendorSourceLinks(vendorComments)}`;
-  });
+  return comments.map((comment) => buildReviewCommentBullet(comment, detail));
 }
 
 function buildAiReviewDetailLines(input: {
@@ -3034,44 +2988,16 @@ function buildAiReviewDetailLines(input: {
     );
   }
 
-  if (reviewStatus === 'clean') {
-    lines.push(
-      input.note === formatNoAiReviewFeedbackNote(input.maxWaitMinutes)
-        ? `- No \`ai-code-review\` feedback was detected during the ${input.maxWaitMinutes}-minute polling window.`
-        : '- `ai-code-review` triage found no prudent follow-up changes.',
-    );
-  } else if (reviewStatus === 'needs_patch') {
-    lines.push(
-      '- `ai-code-review` triage found actionable follow-up work that still needs patching.',
-    );
-  } else if (reviewStatus === 'patched') {
-    lines.push(
-      '- `ai-code-review` triage led to prudent follow-up patches that are now included in this branch.',
-    );
-  } else {
-    lines.push(
-      '- `ai-code-review` stopped for operator input before follow-up could be completed safely.',
-    );
-  }
-
   if (input.reviewedHeadSha && input.currentHeadSha && !appliesToCurrentHead) {
     lines.push(
-      '- no current-SHA `ai-code-review` status is recorded for the current branch head; the latest recorded review is shown below as stale history.',
+      '- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.',
     );
-  }
-
-  if (input.note) {
-    lines.push(`- follow-up note: ${input.note}`);
   }
 
   if (input.vendors && input.vendors.length > 0) {
     lines.push(
       `- vendors: ${input.vendors.map((vendor) => `\`${vendor}\``).join(', ')}`,
     );
-  }
-
-  if (input.actionSummary) {
-    lines.push(`- action summary: ${input.actionSummary}`);
   }
 
   const effectiveContext =
@@ -3095,44 +3021,71 @@ function buildAiReviewDetailLines(input: {
           (comment) => comment.isOutdated || comment.isResolved,
         );
 
-  const currentActionBullets = buildReviewCommentBullets(
-    currentActionableComments,
-    'current',
-    reviewStatus,
-    input.threadResolutions,
+  const resolutionByThreadId = new Map(
+    (input.threadResolutions ?? []).map((resolution) => [
+      resolution.threadId,
+      resolution,
+    ]),
   );
+  const resolvedFindingComments = [
+    ...(reviewStatus === 'patched' ? currentActionableComments : []),
+    ...staleOrResolvedComments,
+  ];
+  const unresolvedFindingComments =
+    reviewStatus === 'needs_patch' || reviewStatus === 'operator_input_needed'
+      ? currentActionableComments
+      : [];
 
-  if (currentActionBullets.length > 0) {
-    lines.push('', '### Current Findings', '', ...currentActionBullets);
+  if (
+    reviewStatus === 'clean' &&
+    currentActionableComments.length === 0 &&
+    currentSummaryNoiseComments.length === 0 &&
+    resolvedFindingComments.length === 0
+  ) {
+    lines.push('- no prudent follow-up changes were required.');
   }
 
-  const vendorSummaryNoiseBullets = buildVendorSummaryNoiseBullets(
-    currentSummaryNoiseComments,
-  );
+  const resolvedFindingBullets = resolvedFindingComments.map((comment) => {
+    const resolution = comment.threadId
+      ? resolutionByThreadId.get(comment.threadId)
+      : undefined;
+    const detail =
+      comment.isResolved || comment.isOutdated || effectiveContext === 'history'
+        ? undefined
+        : resolution
+          ? formatResolutionSuffix(resolution).replace(/^;\s*/, '')
+          : reviewStatus === 'patched'
+            ? 'patched'
+            : undefined;
+    return buildReviewCommentBullet(comment, detail);
+  });
 
-  if (vendorSummaryNoiseBullets.length > 0) {
+  if (resolvedFindingBullets.length > 0) {
     lines.push(
       '',
-      '### Vendor Summary Noise',
+      '### Resolved Review Findings',
       '',
-      ...vendorSummaryNoiseBullets,
+      ...resolvedFindingBullets,
     );
   }
 
-  const staleOrResolvedBullets = buildReviewCommentBullets(
-    staleOrResolvedComments,
-    effectiveContext === 'history' ? 'history' : 'current',
-    reviewStatus,
-    input.threadResolutions,
+  const unresolvedFindingBullets = buildReviewCommentBullets(
+    unresolvedFindingComments,
   );
 
-  if (staleOrResolvedBullets.length > 0) {
+  if (unresolvedFindingBullets.length > 0) {
     lines.push(
       '',
-      '### Stale / Resolved History',
+      '### Unresolved Review Findings',
       '',
-      ...staleOrResolvedBullets,
+      ...unresolvedFindingBullets,
     );
+    if (input.note) {
+      lines.push('', `- triage note: ${input.note}`);
+    }
+    if (input.actionSummary) {
+      lines.push(`- triage summary: ${input.actionSummary}`);
+    }
   }
 
   return lines;
@@ -3184,7 +3137,7 @@ export function buildPullRequestBody(
     ticket.status === 'needs_patch' ||
     ticket.status === 'operator_input_needed'
   ) {
-    lines.push('', '## AI Review Follow-Up', '');
+    lines.push('', '## External AI Review', '');
     lines.push(
       ...buildAiReviewDetailLines({
         actionSummary: ticket.reviewActionSummary,
@@ -3629,7 +3582,11 @@ export function buildStandaloneAiReviewSection(
     currentHeadSha?: string;
   } = {},
 ): string {
-  const lines = [STANDALONE_AI_REVIEW_SECTION_START, '## AI Review', ''];
+  const lines = [
+    STANDALONE_AI_REVIEW_SECTION_START,
+    '## External AI Review',
+    '',
+  ];
   lines.push(
     ...buildAiReviewDetailLines({
       actionSummary: result.actionSummary,
@@ -3644,8 +3601,6 @@ export function buildStandaloneAiReviewSection(
       vendors: result.vendors,
     }),
   );
-
-  lines.push(`- outcome: \`${result.outcome}\``);
 
   lines.push(STANDALONE_AI_REVIEW_SECTION_END);
   return lines.join('\n');

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -2328,6 +2328,10 @@ export async function pollReview(
       triage.vendors.length > 0 ? triage.vendors : detectedReview.vendors;
     const nextStatus =
       triage.outcome === 'needs_patch' ? 'needs_patch' : 'reviewed';
+    const latestReviewOutcome =
+      triage.outcome === 'clean' || triage.outcome === 'patched'
+        ? triage.outcome
+        : undefined;
     const nextState: DeliveryState = {
       ...state,
       tickets: state.tickets.map((ticket) =>
@@ -2349,17 +2353,20 @@ export async function pollReview(
               reviewFetchedAt: new Date(now()).toISOString(),
               reviewHeadSha: detectedReview.reviewedHeadSha,
               reviewNonActionSummary: triage.nonActionSummary,
-              reviewOutcome:
-                triage.outcome === 'clean' || triage.outcome === 'patched'
-                  ? triage.outcome
-                  : undefined,
+              reviewOutcome: mergeReviewOutcome(
+                ticket.reviewOutcome,
+                latestReviewOutcome,
+              ),
               reviewNote:
                 reviewPollResult.status === 'partial_timeout'
                   ? formatPartialAiReviewTimeoutNote(
                       reviewPollResult.effectiveMaxWaitMinutes,
                       reviewPollResult.incompleteAgents,
                     )
-                  : triage.note,
+                  : ticket.reviewOutcome === 'patched' &&
+                      triage.outcome === 'clean'
+                    ? formatCumulativePatchedReviewNote(triage.note)
+                    : triage.note,
               reviewIncompleteAgents:
                 reviewPollResult.status === 'partial_timeout'
                   ? reviewPollResult.incompleteAgents
@@ -2406,13 +2413,19 @@ export async function pollReview(
             reviewArtifactPath: undefined,
             reviewHeadSha: undefined,
             reviewNonActionSummary: undefined,
-            reviewOutcome: 'clean',
+            reviewOutcome: mergeReviewOutcome(ticket.reviewOutcome, 'clean'),
             reviewNote: reviewPollResult.incompleteAgents?.length
               ? formatIncompleteAiReviewWithoutFindingsNote(
                   reviewPollResult.effectiveMaxWaitMinutes,
                   reviewPollResult.incompleteAgents,
                 )
-              : formatNoAiReviewFeedbackNote(state.reviewPollMaxWaitMinutes),
+              : ticket.reviewOutcome === 'patched'
+                ? formatCumulativePatchedReviewNote(
+                    formatNoAiReviewFeedbackNote(
+                      state.reviewPollMaxWaitMinutes,
+                    ),
+                  )
+                : formatNoAiReviewFeedbackNote(state.reviewPollMaxWaitMinutes),
             reviewIncompleteAgents: reviewPollResult.incompleteAgents,
             reviewThreadResolutions: undefined,
             reviewVendors: [],
@@ -2444,6 +2457,10 @@ async function runStandaloneAiReview(
   prNumber?: number,
 ): Promise<StandaloneAiReviewResult> {
   const pullRequest = resolveStandalonePullRequest(cwd, prNumber);
+  const previousOutcome = await readStandaloneAiReviewOutcome(
+    cwd,
+    pullRequest.number,
+  );
 
   await emitNotificationWarnings(notifier, cwd, [
     buildStandaloneReviewStartedEvent(pullRequest.number, pullRequest.url),
@@ -2478,6 +2495,14 @@ async function runStandaloneAiReview(
         threadResolutions,
       );
     }
+    const latestOutcome =
+      triage.outcome === 'needs_patch'
+        ? 'operator_input_needed'
+        : triage.outcome;
+    const cumulativeOutcome: ReviewResult =
+      latestOutcome === 'clean' || latestOutcome === 'patched'
+        ? (mergeReviewOutcome(previousOutcome, latestOutcome) ?? latestOutcome)
+        : latestOutcome;
     const standaloneResult: StandaloneAiReviewResult = {
       actionSummary: triage.actionSummary,
       artifactJsonPath: relativeToRepo(cwd, artifacts.artifactJsonPath),
@@ -2492,13 +2517,12 @@ async function runStandaloneAiReview(
               reviewPollResult.effectiveMaxWaitMinutes,
               reviewPollResult.incompleteAgents,
             )
-          : triage.note,
+          : cumulativeOutcome === 'patched' && latestOutcome === 'clean'
+            ? formatCumulativePatchedReviewNote(triage.note)
+            : triage.note,
       comments: detectedReview.comments,
       nonActionSummary: triage.nonActionSummary,
-      outcome:
-        triage.outcome === 'needs_patch'
-          ? 'operator_input_needed'
-          : triage.outcome,
+      outcome: cumulativeOutcome,
       prNumber: pullRequest.number,
       prUrl: pullRequest.url,
       reviewedHeadSha: detectedReview.reviewedHeadSha,
@@ -2529,8 +2553,12 @@ async function runStandaloneAiReview(
           reviewPollResult.effectiveMaxWaitMinutes,
           reviewPollResult.incompleteAgents,
         )
-      : formatNoAiReviewFeedbackNote(DEFAULT_REVIEW_POLL_MAX_WAIT_MINUTES),
-    outcome: 'clean',
+      : previousOutcome === 'patched'
+        ? formatCumulativePatchedReviewNote(
+            formatNoAiReviewFeedbackNote(DEFAULT_REVIEW_POLL_MAX_WAIT_MINUTES),
+          )
+        : formatNoAiReviewFeedbackNote(DEFAULT_REVIEW_POLL_MAX_WAIT_MINUTES),
+    outcome: mergeReviewOutcome(previousOutcome, 'clean') ?? 'clean',
     prNumber: pullRequest.number,
     prUrl: pullRequest.url,
     vendors: [],
@@ -2657,11 +2685,16 @@ export async function recordReview(
               outcome === 'operator_input_needed'
                 ? 'operator_input_needed'
                 : 'reviewed',
-            reviewOutcome:
+            reviewOutcome: mergeReviewOutcome(
+              ticket.reviewOutcome,
               outcome === 'clean' || outcome === 'patched'
                 ? outcome
                 : undefined,
-            reviewNote: note ?? ticket.reviewNote,
+            ),
+            reviewNote:
+              ticket.reviewOutcome === 'patched' && outcome === 'clean'
+                ? formatCumulativePatchedReviewNote(note ?? ticket.reviewNote)
+                : (note ?? ticket.reviewNote),
             reviewThreadResolutions:
               outcome === 'patched' ? reviewThreadResolutions : undefined,
           }
@@ -2839,6 +2872,54 @@ function preferCodexBranch(branches: string[]): string {
 
 function shortenSha(sha: string | undefined): string | undefined {
   return sha ? sha.slice(0, 12) : undefined;
+}
+
+function mergeReviewOutcome(
+  previous: ReviewOutcome | undefined,
+  next: ReviewOutcome | undefined,
+): ReviewOutcome | undefined {
+  if (previous === 'patched' || next === 'patched') {
+    return 'patched';
+  }
+
+  return previous ?? next;
+}
+
+function formatCumulativePatchedReviewNote(note: string | undefined): string {
+  if (note === undefined || note.length === 0) {
+    return 'Earlier review cycles led to prudent follow-up patches; the latest review pass found no additional prudent changes.';
+  }
+
+  if (note.includes('no additional prudent follow-up changes')) {
+    return note;
+  }
+
+  return `${note} Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.`;
+}
+
+async function readStandaloneAiReviewOutcome(
+  cwd: string,
+  prNumber: number,
+): Promise<ReviewOutcome | undefined> {
+  const notePath = resolve(
+    cwd,
+    '.agents/ai-review',
+    `pr-${prNumber}`,
+    'note.md',
+  );
+
+  if (!existsSync(notePath)) {
+    return undefined;
+  }
+
+  const note = await readFile(notePath, 'utf8');
+  const match = note.match(/^- Outcome: `([^`]+)`$/m);
+
+  if (match?.[1] === 'clean' || match?.[1] === 'patched') {
+    return match[1];
+  }
+
+  return undefined;
 }
 
 function summarizeReviewComment(body: string): string {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -2924,6 +2924,27 @@ function describeReviewComment(
   return 'finding';
 }
 
+function buildReviewCommentBullet(
+  comment: AiReviewComment,
+  context: 'current' | 'history',
+  status: TicketStatus | ReviewResult,
+  threadResolutions: AiReviewThreadResolution[] | undefined,
+): string {
+  const resolutionByThreadId = new Map(
+    (threadResolutions ?? []).map((resolution) => [
+      resolution.threadId,
+      resolution,
+    ]),
+  );
+  const description = describeReviewComment(
+    comment,
+    context,
+    status,
+    comment.threadId ? resolutionByThreadId.get(comment.threadId) : undefined,
+  );
+  return `- [${comment.vendor}] ${description}: ${summarizeReviewComment(comment.body)}${formatReviewCommentLocation(comment)}${formatReviewThreadLink(comment.url)}`;
+}
+
 function buildReviewCommentBullets(
   comments: AiReviewComment[] | undefined,
   context: 'current' | 'history',
@@ -2934,21 +2955,40 @@ function buildReviewCommentBullets(
     return [];
   }
 
-  const resolutionByThreadId = new Map(
-    (threadResolutions ?? []).map((resolution) => [
-      resolution.threadId,
-      resolution,
-    ]),
+  return comments.map((comment) =>
+    buildReviewCommentBullet(comment, context, status, threadResolutions),
   );
+}
 
-  return comments.map((comment) => {
-    const description = describeReviewComment(
-      comment,
-      context,
-      status,
-      comment.threadId ? resolutionByThreadId.get(comment.threadId) : undefined,
-    );
-    return `- [${comment.vendor}] ${description}: ${summarizeReviewComment(comment.body)}${formatReviewCommentLocation(comment)}${formatReviewThreadLink(comment.url)}`;
+function formatVendorSourceLinks(comments: AiReviewComment[]): string {
+  const urls = [
+    ...new Set(comments.map((comment) => comment.url).filter(Boolean)),
+  ];
+
+  if (urls.length === 1) {
+    return ` [source](${urls[0]})`;
+  }
+
+  return '';
+}
+
+function buildVendorSummaryNoiseBullets(comments: AiReviewComment[]): string[] {
+  if (comments.length === 0) {
+    return [];
+  }
+
+  const commentsByVendor = new Map<string, AiReviewComment[]>();
+
+  for (const comment of comments) {
+    const existing = commentsByVendor.get(comment.vendor) ?? [];
+    existing.push(comment);
+    commentsByVendor.set(comment.vendor, existing);
+  }
+
+  return [...commentsByVendor.entries()].map(([vendor, vendorComments]) => {
+    const count = vendorComments.length;
+    const noun = count === 1 ? 'summary-only update' : 'summary-only updates';
+    return `- [${vendor}] compressed ${count} ${noun}.${formatVendorSourceLinks(vendorComments)}`;
   });
 }
 
@@ -3033,25 +3073,62 @@ function buildAiReviewDetailLines(input: {
     lines.push(`- action summary: ${input.actionSummary}`);
   }
 
-  if (input.nonActionSummary) {
-    lines.push(`- non-action summary: ${input.nonActionSummary}`);
-  }
+  const effectiveContext =
+    appliesToCurrentHead || !input.reviewedHeadSha ? 'current' : 'history';
+  const currentComments =
+    effectiveContext === 'current' ? (input.comments ?? []) : [];
+  const currentActionableComments = currentComments.filter(
+    (comment) =>
+      !comment.isOutdated && !comment.isResolved && comment.kind !== 'summary',
+  );
+  const currentSummaryNoiseComments = currentComments.filter(
+    (comment) =>
+      !comment.isOutdated && !comment.isResolved && comment.kind === 'summary',
+  );
+  const staleOrResolvedComments =
+    effectiveContext === 'history'
+      ? (input.comments ?? [])
+      : (input.comments ?? []).filter(
+          (comment) => comment.isOutdated || comment.isResolved,
+        );
 
-  const bullets = buildReviewCommentBullets(
-    input.comments,
-    appliesToCurrentHead || !input.reviewedHeadSha ? 'current' : 'history',
+  const currentActionBullets = buildReviewCommentBullets(
+    currentActionableComments,
+    'current',
     reviewStatus,
     input.threadResolutions,
   );
 
-  if (bullets.length > 0) {
+  if (currentActionBullets.length > 0) {
+    lines.push('', '### Current Findings', '', ...currentActionBullets);
+  }
+
+  const vendorSummaryNoiseBullets = buildVendorSummaryNoiseBullets(
+    currentSummaryNoiseComments,
+  );
+
+  if (vendorSummaryNoiseBullets.length > 0) {
     lines.push(
       '',
-      appliesToCurrentHead || !input.reviewedHeadSha
-        ? '### Review Items'
-        : '### Stale Review History',
+      '### Vendor Summary Noise',
       '',
-      ...bullets,
+      ...vendorSummaryNoiseBullets,
+    );
+  }
+
+  const staleOrResolvedBullets = buildReviewCommentBullets(
+    staleOrResolvedComments,
+    effectiveContext === 'history' ? 'history' : 'current',
+    reviewStatus,
+    input.threadResolutions,
+  );
+
+  if (staleOrResolvedBullets.length > 0) {
+    lines.push(
+      '',
+      '### Stale / Resolved History',
+      '',
+      ...staleOrResolvedBullets,
     );
   }
 
@@ -3566,14 +3643,6 @@ export function buildStandaloneAiReviewSection(
   );
 
   lines.push(`- outcome: \`${result.outcome}\``);
-
-  if (result.artifactJsonPath) {
-    lines.push(`- artifact (json): \`${result.artifactJsonPath}\``);
-  }
-
-  if (result.artifactTextPath) {
-    lines.push(`- artifact (text): \`${result.artifactTextPath}\``);
-  }
 
   lines.push(STANDALONE_AI_REVIEW_SECTION_END);
   return lines.join('\n');

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -2928,14 +2928,8 @@ function buildReviewCommentBullet(
   comment: AiReviewComment,
   context: 'current' | 'history',
   status: TicketStatus | ReviewResult,
-  threadResolutions: AiReviewThreadResolution[] | undefined,
+  resolutionByThreadId: ReadonlyMap<string, AiReviewThreadResolution>,
 ): string {
-  const resolutionByThreadId = new Map(
-    (threadResolutions ?? []).map((resolution) => [
-      resolution.threadId,
-      resolution,
-    ]),
-  );
   const description = describeReviewComment(
     comment,
     context,
@@ -2955,8 +2949,15 @@ function buildReviewCommentBullets(
     return [];
   }
 
+  const resolutionByThreadId = new Map(
+    (threadResolutions ?? []).map((resolution) => [
+      resolution.threadId,
+      resolution,
+    ]),
+  );
+
   return comments.map((comment) =>
-    buildReviewCommentBullet(comment, context, status, threadResolutions),
+    buildReviewCommentBullet(comment, context, status, resolutionByThreadId),
   );
 }
 
@@ -3074,7 +3075,9 @@ function buildAiReviewDetailLines(input: {
   }
 
   const effectiveContext =
-    appliesToCurrentHead || !input.reviewedHeadSha ? 'current' : 'history';
+    input.reviewedHeadSha && input.currentHeadSha && !appliesToCurrentHead
+      ? 'history'
+      : 'current';
   const currentComments =
     effectiveContext === 'current' ? (input.comments ?? []) : [];
   const currentActionableComments = currentComments.filter(


### PR DESCRIPTION
## Summary
- tighten the normalized AI Review PR-body section so current actionable findings stay visible while vendor summary chatter is compacted
- demote stale, resolved, and history-only material into a separate subsection so the default view stays decision-oriented
- keep reviewed-head vs current-head semantics and existing review artifact fidelity intact

## Verification
- `bun run ci`

<!-- ai-review:start -->
## External AI Review

- reviewed commit: `24edc0b14976`
- current branch head: `24edc0b14976`
- vendors: `coderabbit`, `qodo`

### Resolved Review Findings

- [coderabbit] Don’t mark reviews as stale when the current head is unknown, and don’t leave stale status text looking current. `tools/delivery/orchestrator.ts:3104` [thread](https://github.com/cesarnml/pirate_claw/pull/36#discussion_r3035526235)
<!-- ai-review:end -->
