### PR TITLE
docs: define phase 04-06 product and delivery plans

### DIFF
--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -74,6 +74,77 @@ Future pressure and ideation:
 - final media placement may be owned either by Transmission or by Pirate Claw once completion tracking is reliable enough to make that boundary explicit
 - if Transmission labels can drive downloader-side placement rules reliably, Pirate Claw may eventually assign labels such as movie or tv at queue time instead of owning final move logic itself
 
+## Phase 04: Always-On Local Runtime
+
+Goal:
+
+- add a foreground daemon mode for continuous local operation
+- schedule queue-intake and reconcile cycles with clear defaults
+- make runtime activity machine-readable through JSON/Markdown artifacts
+
+Committed scope:
+
+- `pirate-claw daemon` as a long-running local command
+- default cadence: run every 30 minutes, reconcile every 1 minute
+- per-feed poll interval overrides with due-feed-only run behavior
+- one shared runtime lock and overlap-skip reason `already_running`
+- runtime artifacts under `.pirate-claw/runtime` with 7-day retention
+
+Explicitly deferred:
+
+- movie codec strictness policy mode
+- Transmission label/category routing
+- NAS packaging and deployment automation
+- dashboard/UI artifact rendering
+
+Working notes:
+
+- `docs/01-product/phase-04-always-on-local-runtime.md`
+- `docs/02-delivery/phase-04/implementation-plan.md`
+
+## Phase 05: Intake Policy And Transmission Routing
+
+Goal:
+
+- allow movie codec behavior to be configured as preference or hard requirement
+- add media-type routing labels on Transmission submissions
+- preserve queueing with warning+fallback when labels are unsupported
+
+Committed scope:
+
+- `movies.codecPolicy: "prefer" | "require"`
+- queue-time `movie` / `tv` labels for Transmission
+- warn-and-retry-unlabeled fallback when label arguments are rejected
+
+Explicitly deferred:
+
+- generalized per-feed custom routing labels
+- hard-fail strict mode for unsupported labels
+- media placement ownership redesign
+
+Working notes:
+
+- `docs/01-product/phase-05-intake-policy-and-routing.md`
+
+## Phase 06: Synology Runbook
+
+Goal:
+
+- provide a validated runbook for always-on Pirate Claw + Transmission operation on Synology
+
+Committed scope:
+
+- tested setup and operations documentation only
+
+Explicitly deferred:
+
+- repo-managed Docker Compose deployment bundle
+- backup/restore and one-click installation automation
+
+Working notes:
+
+- `docs/01-product/phase-06-synology-runbook.md`
+
 ## Planning Rules
 
 - keep phase docs outcome-focused

--- a/docs/01-product/phase-04-always-on-local-runtime.md
+++ b/docs/01-product/phase-04-always-on-local-runtime.md
@@ -1,0 +1,68 @@
+# Phase 04 Always-On Local Runtime
+
+Phase 04 changes Pirate Claw from a manual one-shot CLI into a useful always-on local tool without widening into NAS deployment, UI, or downloader-placement policy redesign.
+
+## Phase Goal
+
+Phase 04 should leave Pirate Claw in a state where a local operator can run one long-lived process that:
+
+- executes queue-intake runs on a schedule
+- executes Transmission reconciliation on a separate schedule
+- keeps behavior deterministic when cycles overlap
+- writes machine-readable runtime artifacts for later dashboard ingestion
+
+## Product Goals For This Phase
+
+- keep the operating model local-first and simple on macOS
+- preserve existing one-shot commands while adding a long-running command
+- add scheduling without introducing remote services
+- make runtime behavior observable through structured artifacts
+
+## Committed Scope
+
+- add a foreground long-running command: `pirate-claw daemon`
+- add default scheduling cadence:
+  - run cycle every `30` minutes
+  - reconcile cycle every `1` minute
+- support per-feed polling intervals for run cycles
+- run only feeds that are due during a given run cycle
+- enforce one shared runtime lock for run/reconcile to avoid overlap
+- when a cycle is due while work is already in progress, skip it and record reason `already_running`
+- emit runtime artifacts on each scheduled cycle as both JSON and Markdown
+- write artifacts under `.pirate-claw/runtime` by default
+- prune runtime artifacts older than `7` days
+- keep `pirate-claw status` DB-driven in this phase
+
+## Configuration Surface Added In This Phase
+
+The config shape should gain a runtime block and per-feed polling override:
+
+- `runtime.runIntervalMinutes` (default `30`)
+- `runtime.reconcileIntervalMinutes` (default `1`)
+- `runtime.artifactDir` (default `.pirate-claw/runtime`)
+- `runtime.artifactRetentionDays` (default `7`)
+- `feeds[].pollIntervalMinutes` (optional; feed-specific run interval override)
+
+## Exit Condition
+
+A local operator can run `pirate-claw daemon --config ./pirate-claw.config.json` and observe:
+
+- scheduled run and reconcile cycles execute continuously
+- due-feed scheduling works with per-feed overrides
+- overlapping cycles are skipped deterministically with `already_running`
+- JSON and Markdown artifacts are generated and retained for 7 days
+
+## Explicit Deferrals
+
+These are intentionally outside Phase 04:
+
+- movie codec strictness policy
+- Transmission label/category routing
+- downloader-side file placement ownership decisions
+- Synology/NAS deployment packaging
+- dashboard/UI rendering of artifacts
+- hosted persistence or remote capture
+
+## Why The Scope Stays Narrow
+
+The highest-value gap today is always-on execution. Phase 04 addresses that directly while preserving the existing product boundary and avoiding policy or infrastructure expansion that belongs in later phases.

--- a/docs/01-product/phase-05-intake-policy-and-routing.md
+++ b/docs/01-product/phase-05-intake-policy-and-routing.md
@@ -1,0 +1,43 @@
+# Phase 05 Intake Policy And Transmission Routing
+
+Phase 05 adds policy control for movie codec handling and queue-time routing metadata for Transmission, without changing the Phase 04 runtime model.
+
+## Phase Goal
+
+Phase 05 should leave Pirate Claw in a state where a local operator can:
+
+- choose whether movie codec is a preference or a hard requirement
+- submit torrents with media-type routing labels for Transmission
+- continue queueing safely when label support is unavailable
+
+## Committed Scope
+
+- add movie codec policy mode:
+  - `movies.codecPolicy: "prefer" | "require"`
+- keep existing `movies.codecs` list and apply it according to policy mode
+- when policy is `require`, skip movie candidates with missing or non-matching codec
+- add queue-time Transmission labels based on media type:
+  - `movie` for movie feeds
+  - `tv` for TV feeds
+- if Transmission rejects label arguments, log a warning and retry submission without labels
+- preserve existing queueing semantics when fallback path succeeds
+
+## Exit Condition
+
+With `movies.codecPolicy` set to `require`, movie candidates that do not explicitly match configured codecs are not queued.
+
+Torrent submissions include media-type labels when supported by Transmission, and fallback-to-unlabeled submission keeps the pipeline functional when label support is unavailable.
+
+## Explicit Deferrals
+
+These are intentionally outside Phase 05:
+
+- generalized per-feed custom label policy
+- hard-fail mode when labels are unsupported
+- media placement policy owned by Pirate Claw
+- NAS packaging and deployment automation
+- UI/dashboard implementation
+
+## Why The Scope Stays Narrow
+
+Phase 05 focuses on two bounded policy changes that directly affect operator outcomes while avoiding broader routing and deployment design expansion.

--- a/docs/01-product/phase-06-synology-runbook.md
+++ b/docs/01-product/phase-06-synology-runbook.md
@@ -1,0 +1,35 @@
+# Phase 06 Synology Runbook
+
+Phase 06 makes Pirate Claw operational for NAS use as a documentation-and-validation phase, not an implementation phase for deployment tooling.
+
+## Phase Goal
+
+Phase 06 should leave Pirate Claw in a state where an operator can follow a tested runbook to run Pirate Claw and Transmission continuously on Synology.
+
+## Committed Scope
+
+- provide a validated Synology deployment runbook that covers:
+  - prerequisites
+  - setup steps
+  - runtime expectations
+  - restart behavior
+  - upgrade path
+  - troubleshooting
+- document operational boundaries and what remains manual
+
+## Exit Condition
+
+A clean Synology environment can be configured by following the runbook only, resulting in an always-on Pirate Claw + Transmission setup with documented operator verification steps.
+
+## Explicit Deferrals
+
+These are intentionally outside Phase 06:
+
+- repo-managed Docker Compose bundle
+- backup/restore automation scripts
+- health-check daemon behavior beyond what existing runtime already supports
+- one-click installation tooling
+
+## Why The Scope Stays Narrow
+
+The immediate value is repeatable operator setup with low ambiguity. Tooling automation can follow once the runbook path is proven stable.

--- a/docs/02-delivery/phase-04/implementation-plan.md
+++ b/docs/02-delivery/phase-04/implementation-plan.md
@@ -1,0 +1,68 @@
+# Phase 04 Implementation Plan
+
+Phase 04 delivers always-on local runtime value first. It introduces scheduled execution and runtime artifacts while preserving current one-shot CLI behavior.
+
+## Epic
+
+- `Phase 04 Always-On Local Runtime`
+
+Follow the shared guidance in [`docs/02-delivery/phase-implementation-guidance.md`](../phase-implementation-guidance.md) when shaping or revising tickets for this phase. If scope still feels fuzzy, use `grill-me` before implementation.
+
+## Ticket Order
+
+1. `P4.01 Add Foreground Daemon Command`
+2. `P4.02 Add Runtime Config And Default Cadences`
+3. `P4.03 Add Due-Feed Scheduling And Poll-State Persistence`
+4. `P4.04 Add Shared Runtime Lock And Overlap Skip Semantics`
+5. `P4.05 Add Runtime JSON/Markdown Artifacts And 7-Day Retention`
+
+## Ticket Files
+
+- `ticket-01-add-foreground-daemon-command.md`
+- `ticket-02-add-runtime-config-and-default-cadences.md`
+- `ticket-03-add-due-feed-scheduling-and-poll-state-persistence.md`
+- `ticket-04-add-shared-runtime-lock-and-overlap-skip-semantics.md`
+- `ticket-05-add-runtime-artifacts-and-retention.md`
+
+## Exit Condition
+
+`pirate-claw daemon --config ./pirate-claw.config.json` can run continuously and provide deterministic scheduled behavior for both queue intake and reconciliation.
+
+The expected Phase 04 behavior is:
+
+- daemon mode runs in foreground and preserves existing one-shot commands
+- default cadence is run every 30 minutes and reconcile every 1 minute
+- per-feed run intervals are supported via `feeds[].pollIntervalMinutes`
+- run cycles process only feeds that are due
+- run/reconcile never overlap; due cycles while busy are skipped with reason `already_running`
+- runtime artifacts are emitted as JSON and Markdown under `.pirate-claw/runtime`
+- runtime artifacts older than 7 days are pruned
+- `status` remains DB-driven in this phase
+
+## Review Rules
+
+Review and merge in ticket order.
+
+Do not start the next ticket until:
+
+- the previous tests are green
+- the behavior change is explained in the ticket and rationale
+- the phase-level defaults and deferrals remain unchanged
+
+## Explicit Deferrals
+
+These are intentionally out of scope for Phase 04:
+
+- movie codec strict-mode policy (`movies.codecPolicy`)
+- Transmission label/category routing
+- Synology deployment packaging
+- dashboard/UI consumption of runtime artifacts
+- hosted persistence and remote feed capture
+
+## Stop Conditions
+
+Pause for review if:
+
+- due-feed scheduling requires a broader pipeline redesign beyond bounded slice changes
+- runtime locking cannot be implemented without introducing unsafe deadlock risk
+- artifact requirements force a product-level status UX redesign in this phase

--- a/docs/02-delivery/phase-04/ticket-01-add-foreground-daemon-command.md
+++ b/docs/02-delivery/phase-04/ticket-01-add-foreground-daemon-command.md
@@ -1,0 +1,27 @@
+# `P4.01 Add Foreground Daemon Command`
+
+## Goal
+
+Add a new long-running `pirate-claw daemon` command that continuously executes scheduled work while preserving existing one-shot commands.
+
+## Why This Ticket Exists
+
+Phase 04 requires an always-on execution path. Without a daemon entrypoint, all scheduling and runtime orchestration remains scattered and manual.
+
+## Scope
+
+- add CLI command handling for `pirate-claw daemon`
+- keep process in the foreground (no background service manager in this ticket)
+- ensure existing commands (`run`, `status`, `retry-failed`, `reconcile`) remain unchanged
+- add tests proving daemon command routing and baseline lifecycle behavior
+
+## Out Of Scope
+
+- runtime config schema changes for cadence
+- per-feed due scheduling
+- lock/overlap semantics
+- runtime artifacts
+
+## Red First Prompt
+
+What user-visible behavior fails first when `pirate-claw daemon` is invoked but no long-running execution loop exists?

--- a/docs/02-delivery/phase-04/ticket-02-add-runtime-config-and-default-cadences.md
+++ b/docs/02-delivery/phase-04/ticket-02-add-runtime-config-and-default-cadences.md
@@ -1,0 +1,29 @@
+# `P4.02 Add Runtime Config And Default Cadences`
+
+## Goal
+
+Define and validate runtime scheduling config so daemon mode has explicit defaults and predictable operator control.
+
+## Why This Ticket Exists
+
+Daemon mode needs durable configuration for cadence and runtime output location. Phase 04 decisions are not implementable safely without explicit config surface.
+
+## Scope
+
+- add runtime config fields:
+  - `runtime.runIntervalMinutes` (default `30`)
+  - `runtime.reconcileIntervalMinutes` (default `1`)
+  - `runtime.artifactDir` (default `.pirate-claw/runtime`)
+  - `runtime.artifactRetentionDays` (default `7`)
+- add `feeds[].pollIntervalMinutes` as optional per-feed run override
+- add config validation and defaults behavior tests
+
+## Out Of Scope
+
+- due-feed scheduling execution logic
+- overlap locking
+- artifact file emission
+
+## Red First Prompt
+
+What configuration-level behavior fails first when daemon scheduling defaults and runtime config validation are missing?

--- a/docs/02-delivery/phase-04/ticket-03-add-due-feed-scheduling-and-poll-state-persistence.md
+++ b/docs/02-delivery/phase-04/ticket-03-add-due-feed-scheduling-and-poll-state-persistence.md
@@ -1,0 +1,25 @@
+# `P4.03 Add Due-Feed Scheduling And Poll-State Persistence`
+
+## Goal
+
+Implement due-feed run scheduling so each cycle processes only feeds that are due, with persisted poll state across restarts.
+
+## Why This Ticket Exists
+
+Per-feed cadence is core to Phase 04 value and efficiency. Without due-feed selection and persisted state, daemon behavior is either wasteful or inconsistent.
+
+## Scope
+
+- execute run cycles only for due feeds
+- use `feeds[].pollIntervalMinutes` override when present
+- persist last-polled feed state so daemon restarts do not reset scheduling behavior
+- add tests for due vs not-due feed execution and restart continuity
+
+## Out Of Scope
+
+- run/reconcile overlap lock behavior
+- runtime artifact generation
+
+## Red First Prompt
+
+What user-visible scheduling behavior fails first when due-feed selection and feed polling state persistence are absent?

--- a/docs/02-delivery/phase-04/ticket-04-add-shared-runtime-lock-and-overlap-skip-semantics.md
+++ b/docs/02-delivery/phase-04/ticket-04-add-shared-runtime-lock-and-overlap-skip-semantics.md
@@ -1,0 +1,24 @@
+# `P4.04 Add Shared Runtime Lock And Overlap Skip Semantics`
+
+## Goal
+
+Guarantee deterministic daemon behavior by preventing overlapping run/reconcile execution and recording explicit skip semantics.
+
+## Why This Ticket Exists
+
+Without a shared lock, run and reconcile cycles can overlap and create race-prone state transitions. Phase 04 explicitly requires skip-on-busy with reason `already_running`.
+
+## Scope
+
+- enforce one shared runtime lock across run and reconcile tasks
+- if a cycle is due while another task is running, skip and record `already_running`
+- add tests for overlap prevention and skip reason behavior
+
+## Out Of Scope
+
+- artifact formatting and retention logic
+- policy changes for codec or Transmission labels
+
+## Red First Prompt
+
+What deterministic runtime behavior fails first when due cycles are allowed to overlap instead of being skipped with `already_running`?

--- a/docs/02-delivery/phase-04/ticket-05-add-runtime-artifacts-and-retention.md
+++ b/docs/02-delivery/phase-04/ticket-05-add-runtime-artifacts-and-retention.md
@@ -1,0 +1,26 @@
+# `P4.05 Add Runtime JSON/Markdown Artifacts And 7-Day Retention`
+
+## Goal
+
+Emit machine-readable runtime artifacts for scheduled cycles and prune old artifacts to bounded retention.
+
+## Why This Ticket Exists
+
+Phase 04 requires runtime visibility for future dashboard ingestion and human review. Without artifacts, daemon behavior is opaque.
+
+## Scope
+
+- emit JSON and Markdown artifacts for scheduled run/reconcile cycles
+- write artifacts under configured runtime path (default `.pirate-claw/runtime`)
+- include skipped-cycle artifact entries (for example `already_running`)
+- prune artifacts older than 7 days by default
+- add tests for artifact writing and retention pruning
+
+## Out Of Scope
+
+- dashboard/UI rendering
+- status command redesign (remains DB-driven)
+
+## Red First Prompt
+
+What operator-visible behavior fails first when scheduled runtime activity is not persisted as artifacts with bounded retention?

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,9 +5,11 @@ The docs are organized by purpose so later phases can be added without flattenin
 ## Recommended Reading Order
 
 1. `00-overview/start-here.md`
-2. `01-product/phase-03-post-queue-lifecycle.md`
-3. `02-delivery/phase-04/implementation-plan.md`
-4. `03-engineering/tdd-workflow.md`
+2. `00-overview/roadmap.md`
+3. `03-engineering/delivery-orchestrator.md`
+4. `01-product/phase-04-always-on-local-runtime.md`
+5. `02-delivery/phase-04/implementation-plan.md`
+6. `03-engineering/tdd-workflow.md`
 
 ## Folder Structure
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,8 @@ The docs are organized by purpose so later phases can be added without flattenin
 ## Recommended Reading Order
 
 1. `00-overview/start-here.md`
-2. `01-product/phase-01-mvp.md`
-3. `02-delivery/phase-01/implementation-plan.md`
+2. `01-product/phase-03-post-queue-lifecycle.md`
+3. `02-delivery/phase-04/implementation-plan.md`
 4. `03-engineering/tdd-workflow.md`
 
 ## Folder Structure
@@ -23,6 +23,11 @@ Entry-point docs for new contributors or new Codex threads.
 Phase-level product definitions.
 
 - `phase-01-mvp.md`: current MVP scope and data flow
+- `phase-02-real-world-feed-compatibility.md`: live-feed compatibility scope and deferrals
+- `phase-03-post-queue-lifecycle.md`: lifecycle reconciliation and status semantics
+- `phase-04-always-on-local-runtime.md`: always-on scheduling, locking, and runtime artifacts
+- `phase-05-intake-policy-and-routing.md`: codec policy mode and Transmission routing labels
+- `phase-06-synology-runbook.md`: Synology runbook goals and boundaries
 
 ### `02-delivery`
 
@@ -32,6 +37,9 @@ Execution plans, issue conventions, and ticket breakdowns.
 - `phase-01/implementation-plan.md`: ordered delivery plan for phase 01
 - `phase-01/ticket-*.md`: one file per ticket
 - `phase-01/*-rationale.md`: rationale notes for tickets and the post-phase polish pass
+- `phase-02/implementation-plan.md`: real-world feed compatibility delivery plan
+- `phase-03/implementation-plan.md`: post-queue lifecycle delivery plan
+- `phase-04/implementation-plan.md`: always-on local runtime delivery plan
 
 ### `03-engineering`
 
@@ -49,7 +57,7 @@ Architecture and tooling decisions that should remain explicit and reviewable.
 
 ## Repo Rules
 
-- Do not implement all of phase 01 in one pass.
+- Do not implement all of a phase in one pass.
 - Ship one small red-green-refactor slice at a time.
 - Each ticket should be reviewable in roughly 1-3 hours of human-equivalent work.
 - Use Bun as the repo runtime and default test runner unless a ticket explicitly justifies otherwise.


### PR DESCRIPTION
## Summary
- add Phase 04 product definition for always-on local runtime
- add Phase 05 product definition for codec policy and Transmission routing labels
- add Phase 06 product definition for Synology runbook-only operationalization
- add Phase 04 implementation plan and refresh roadmap/docs index links
- add Phase 04 ticket docs (`P4.01`-`P4.05`) so implementation work is reviewable before execution
- align docs reading order with `start-here` phase-planning guidance

<!-- ai-review:start -->
## External AI Review
- outcome: `clean`
- reviewed commit: `c87f955ca43a`
- current branch head: `c87f955ca43a`
- vendors: `coderabbit`, `qodo`

### Actions Taken
- `c87f955`: accepted Qodo feedback to add missing Phase 04 ticket docs listed by the implementation plan
- `c87f955`: accepted Qodo feedback to align `docs/README.md` reading order with `docs/00-overview/start-here.md`
<!-- ai-review:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added multi-phase roadmap (phases 4–6) outlining planned capabilities
  * Documented Phase 4: always-on daemon mode with configurable scheduling cycles (queue intake, reconciliation), per-feed poll overrides, and machine-readable runtime artifacts
  * Documented Phase 5: movie codec policies and Transmission routing enhancements with fallback resilience
  * Documented Phase 6: Synology NAS operations runbook and setup guidance
  * Added Phase 4 implementation plan and five detailed execution tickets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->