### PR TITLE
fix: harden ai-review triage and PR body guardrails

### DIFF
--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -334,7 +334,18 @@ jq -n \
         elif $vendor == "qodo" and $channel == "issue_comment" and ($body | test("review summary by qodo")) then
           "summary"
         elif $vendor == "qodo" and $channel == "issue_comment" and ($body | test("code review by qodo")) then
-          if (comment_thread_state.is_outdated or comment_thread_state.is_resolved) then "unknown" else "finding" end
+          if (
+            ($body | test("bugs \\(0\\)"))
+            and ($body | test("rule violations \\(0\\)"))
+            and ($body | test("requirement gaps \\(0\\)"))
+            and ($body | test("ux issues \\(0\\)"))
+          ) then
+            "summary"
+          elif (comment_thread_state.is_outdated or comment_thread_state.is_resolved) then
+            "unknown"
+          else
+            "finding"
+          end
         elif $vendor == "coderabbit" and ($channel == "issue_comment" or $channel == "review_summary") then
           "summary"
         elif $channel == "review_summary" and ($body | length) == 0 then

--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -328,13 +328,25 @@ jq -n \
 
     def comment_kind($channel):
       (body_text | normalize_text) as $body
+      | (vendor_name) as $vendor
       | if $channel == "inline_review" then
           if (comment_thread_state.is_outdated or comment_thread_state.is_resolved) then "unknown" else "finding" end
-        elif $channel == "review_summary" and ($body | length) == 0 then "summary"
-        elif looks_like_started_text or looks_like_summary_noise_text then "summary"
-        elif ($body | test("summary|overall|overview|high level|high-level|general feedback|looks good|no major issues|quick recap")) then "summary"
-        elif ($body | test("should|could|must|consider|missing|bug|issue|incorrect|guard|handle|return|null|undefined|race|rename|suggestion:|nit:|nitpick")) then "finding"
-        else "unknown"
+        elif $vendor == "qodo" and $channel == "issue_comment" and ($body | test("review summary by qodo")) then
+          "summary"
+        elif $vendor == "qodo" and $channel == "issue_comment" and ($body | test("code review by qodo")) then
+          if (comment_thread_state.is_outdated or comment_thread_state.is_resolved) then "unknown" else "finding" end
+        elif $vendor == "coderabbit" and ($channel == "issue_comment" or $channel == "review_summary") then
+          "summary"
+        elif $channel == "review_summary" and ($body | length) == 0 then
+          "summary"
+        elif looks_like_started_text or looks_like_summary_noise_text then
+          "summary"
+        elif ($body | test("summary|overall|overview|high level|high-level|general feedback|looks good|no major issues|quick recap")) then
+          "summary"
+        elif ($body | test("should|could|must|consider|missing|bug|issue|incorrect|guard|handle|return|null|undefined|race|rename|suggestion:|nit:|nitpick")) then
+          "finding"
+        else
+          "unknown"
         end;
 
     def derived_agent_state($channel):

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Useful local commands:
 - `bun run deliver --plan <plan-path> poll-review` to run the orchestrator's 2/4/6/8-minute `ai-code-review` polling loop for the active PR and persist reviewed-SHA provenance plus vendor-attributed review artifacts
 - `bun run deliver --plan <plan-path> record-review <ticket-id> patched ...` to record patched follow-up and make a best-effort attempt to resolve mapped native GitHub inline review threads
 
+The delivery orchestrator applies reviewer-facing PR-body guards during PR create/edit flows. It rejects likely escaped-newline formatting sequences and malformed markdown basics (for example, unmatched fenced code blocks or malformed headings), while allowing literal `\\n` examples inside inline-code spans.
+
 The review hooks and triage guidance for that flow live in the repo-local skill at [`./.agents/skills/ai-code-review/SKILL.md`](./.agents/skills/ai-code-review/SKILL.md). The orchestrator consumes repo-local fetcher and triager scripts there, not a Codex-specific runtime.
 
 If you are working on the repo rather than just using the CLI, start with [`docs/00-overview/start-here.md`](./docs/00-overview/start-here.md).

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -1236,7 +1236,9 @@ describe('delivery orchestrator', () => {
   it('rejects pr bodies that contain literal escaped newlines', () => {
     expect(() =>
       assertReviewerFacingMarkdown('## Summary\\n- malformed'),
-    ).toThrow('PR body guard failed: body contains literal "\\n" sequences.');
+    ).toThrow(
+      'PR body guard failed: body contains likely-escaped newline formatting sequences.',
+    );
   });
 
   it('rejects pr bodies that contain unmatched markdown fenced code blocks', () => {
@@ -1250,6 +1252,14 @@ describe('delivery orchestrator', () => {
   it('accepts reviewer-facing markdown with proper headings and lists', () => {
     expect(() =>
       assertReviewerFacingMarkdown('## Summary\n\n- item\n\n## Verification\n'),
+    ).not.toThrow();
+  });
+
+  it('allows literal \\n text when it appears inside inline code', () => {
+    expect(() =>
+      assertReviewerFacingMarkdown(
+        '## Summary\n\n- guard against literal `\\\\n` in malformed generated bodies\n',
+      ),
     ).not.toThrow();
   });
 

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import {
+  assertReviewerFacingMarkdown,
   buildStandaloneAiReviewSection,
   buildReviewPollCheckMinutes,
   buildPullRequestBody,
@@ -626,6 +627,21 @@ describe('delivery orchestrator', () => {
     expect(body).not.toContain('summary-only updates');
   });
 
+  it('renders no-action rationale when non-action summary exists on clean outcome', () => {
+    const body = buildStandaloneAiReviewSection({
+      outcome: 'clean',
+      note: 'External AI review completed without prudent follow-up changes.',
+      nonActionSummary:
+        'Ignored 2 vendor summary comments and 1 stale recommendation.',
+      vendors: ['qodo'],
+    });
+
+    expect(body).toContain('### No-Action Rationale');
+    expect(body).toContain(
+      'Ignored 2 vendor summary comments and 1 stale recommendation.',
+    );
+  });
+
   it('omits summary noise and renders resolved findings for reviewers', () => {
     const body = buildPullRequestBody(
       {
@@ -1215,6 +1231,26 @@ describe('delivery orchestrator', () => {
 
     expect(nextState.tickets[0]?.status).toBe('internally_reviewed');
     expect(nextState.tickets[0]?.internalReviewCompletedAt).toBeTruthy();
+  });
+
+  it('rejects pr bodies that contain literal escaped newlines', () => {
+    expect(() =>
+      assertReviewerFacingMarkdown('## Summary\\n- malformed'),
+    ).toThrow('PR body guard failed: body contains literal "\\n" sequences.');
+  });
+
+  it('rejects pr bodies that contain unmatched markdown fenced code blocks', () => {
+    expect(() =>
+      assertReviewerFacingMarkdown('## Summary\n```md\n- item\n'),
+    ).toThrow(
+      'PR body guard failed: markdown contains an unmatched fenced code block.',
+    );
+  });
+
+  it('accepts reviewer-facing markdown with proper headings and lists', () => {
+    expect(() =>
+      assertReviewerFacingMarkdown('## Summary\n\n- item\n\n## Verification\n'),
+    ).not.toThrow();
   });
 
   it('requires internal review before opening a ticket-linked PR', async () => {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -3072,22 +3072,41 @@ function buildReviewCommentBullets(
 }
 
 export function assertReviewerFacingMarkdown(body: string): void {
-  if (body.includes('\\n')) {
-    throw new Error(
-      'PR body guard failed: body contains literal "\\n" sequences.',
-    );
+  const lines = body.split('\n');
+  let inFencedCodeBlock = false;
+  const sanitizedLines: string[] = [];
+
+  for (const line of lines) {
+    if (/^\s*```/.test(line)) {
+      inFencedCodeBlock = !inFencedCodeBlock;
+      sanitizedLines.push('');
+      continue;
+    }
+
+    if (inFencedCodeBlock) {
+      sanitizedLines.push('');
+      continue;
+    }
+
+    sanitizedLines.push(line.replace(/`[^`]*`/g, ''));
   }
 
-  const fencedCodeBlocks = body.match(/```/g)?.length ?? 0;
-  if (fencedCodeBlocks % 2 !== 0) {
+  if (inFencedCodeBlock) {
     throw new Error(
       'PR body guard failed: markdown contains an unmatched fenced code block.',
     );
   }
 
-  const malformedHeading = body
-    .split('\n')
-    .find((line) => /^(#{1,6})(?!#)\S/.test(line.trim()));
+  const sanitizedBody = sanitizedLines.join('\n');
+  if (/(^|[^`])\\n(#{1,6}\s|- |\* |\d+\.\s)/.test(sanitizedBody)) {
+    throw new Error(
+      'PR body guard failed: body contains likely-escaped newline formatting sequences.',
+    );
+  }
+
+  const malformedHeading = sanitizedLines.find((line) =>
+    /^(#{1,6})(?!#)\S/.test(line.trim()),
+  );
   if (malformedHeading) {
     throw new Error(
       `PR body guard failed: malformed markdown heading "${malformedHeading.trim()}".`,

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -1655,6 +1655,7 @@ export async function openPullRequest(
   const body = buildPullRequestBody(state, target, {
     currentHeadSha: readHeadSha(target.worktreePath),
   });
+  assertReviewerFacingMarkdown(body);
   const existingPullRequest = findOpenPullRequest(
     target.worktreePath,
     target.branch,
@@ -3070,6 +3071,30 @@ function buildReviewCommentBullets(
   return comments.map((comment) => buildReviewCommentBullet(comment, detail));
 }
 
+export function assertReviewerFacingMarkdown(body: string): void {
+  if (body.includes('\\n')) {
+    throw new Error(
+      'PR body guard failed: body contains literal "\\n" sequences.',
+    );
+  }
+
+  const fencedCodeBlocks = body.match(/```/g)?.length ?? 0;
+  if (fencedCodeBlocks % 2 !== 0) {
+    throw new Error(
+      'PR body guard failed: markdown contains an unmatched fenced code block.',
+    );
+  }
+
+  const malformedHeading = body
+    .split('\n')
+    .find((line) => /^(#{1,6})(?!#)\S/.test(line.trim()));
+  if (malformedHeading) {
+    throw new Error(
+      `PR body guard failed: malformed markdown heading "${malformedHeading.trim()}".`,
+    );
+  }
+}
+
 function buildAiReviewDetailLines(input: {
   actionSummary?: string;
   comments?: AiReviewComment[];
@@ -3209,6 +3234,15 @@ function buildAiReviewDetailLines(input: {
     if (input.actionSummary) {
       lines.push(`- triage summary: ${input.actionSummary}`);
     }
+  }
+
+  if (input.nonActionSummary) {
+    lines.push(
+      '',
+      '### No-Action Rationale',
+      '',
+      `- ${input.nonActionSummary}`,
+    );
   }
 
   return lines;
@@ -3675,15 +3709,18 @@ function updatePullRequestBody(
     return;
   }
 
+  const body = buildPullRequestBody(state, ticket, {
+    currentHeadSha: readHeadSha(ticket.worktreePath),
+  });
+  assertReviewerFacingMarkdown(body);
+
   runProcess(ticket.worktreePath, [
     'gh',
     'pr',
     'edit',
     String(ticket.prNumber),
     '--body',
-    buildPullRequestBody(state, ticket, {
-      currentHeadSha: readHeadSha(ticket.worktreePath),
-    }),
+    body,
   ]);
 }
 
@@ -3757,6 +3794,7 @@ function updateStandalonePullRequestBody(
       currentHeadSha: pullRequest.headRefOid,
     }),
   );
+  assertReviewerFacingMarkdown(nextBody);
 
   runProcess(cwd, [
     'gh',


### PR DESCRIPTION
## Summary
- simplify external AI review classification for actionable vs summary comments
- add PR-body markdown guardrails in delivery flow
- ensure reviewer-facing no-action rationale is rendered when available
- refine Qodo handling so zero-count "Code Review by Qodo" containers are not treated as actionable findings

<!-- ai-review:start -->
## External AI Review
- outcome: `clean`
- reviewed commit: `8b4f2a74dc48`
- current branch head: `8b4f2a74dc48`
- vendors: `coderabbit`, `qodo`

### Actions Taken
- `c53f0ec`: harden AI-review triage classification and PR-body rendering
- `86d2e0b`: refine markdown guard behavior and document guardrails in README
- `8b4f2a7`: ignore zero-count Qodo review containers to prevent false actionable follow-up
<!-- ai-review:end -->
