### PR TITLE
fix: tighten AI-review PR-body reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Useful local commands:
 - `bun run deliver --plan <plan-path> poll-review` to run the orchestrator's 2/4/6/8-minute `ai-code-review` polling loop for the active PR and persist reviewed-SHA provenance plus vendor-attributed review artifacts
 - `bun run deliver --plan <plan-path> record-review <ticket-id> patched ...` to record patched follow-up and make a best-effort attempt to resolve mapped native GitHub inline review threads
 
-The delivery orchestrator applies reviewer-facing PR-body guards during PR create/edit flows. It rejects likely escaped-newline formatting sequences and malformed markdown basics (for example, unmatched fenced code blocks or malformed headings), while allowing literal `\\n` examples inside inline-code spans.
+The delivery orchestrator applies reviewer-facing PR-body guards during PR create/edit flows. It rejects likely escaped-newline formatting sequences and malformed markdown basics (for example, unmatched fenced code blocks or malformed headings), bans `Summary by ...` / `Validation` / `Verification` sections, and allows literal `\\n` examples inside inline-code spans.
 
 The review hooks and triage guidance for that flow live in the repo-local skill at [`./.agents/skills/ai-code-review/SKILL.md`](./.agents/skills/ai-code-review/SKILL.md). The orchestrator consumes repo-local fetcher and triager scripts there, not a Codex-specific runtime.
 

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -557,6 +557,13 @@ describe('delivery orchestrator', () => {
     );
     expect(replaced.match(/<!-- ai-review:start -->/g)?.length ?? 0).toBe(1);
     expect(replaced).not.toContain('- stale');
+    const deduped = mergeStandaloneAiReviewSection(
+      '## Summary\n- existing body\n\n<!-- ai-review:start -->\nold-1\n<!-- ai-review:end -->\n\n<!-- ai-review:start -->\nold-2\n<!-- ai-review:end -->\n',
+      section,
+    );
+    expect(deduped.match(/<!-- ai-review:start -->/g)?.length ?? 0).toBe(1);
+    expect(deduped).not.toContain('old-1');
+    expect(deduped).not.toContain('old-2');
   });
 
   it('renders final standalone ai review outcomes accurately', () => {
@@ -1322,6 +1329,11 @@ describe('delivery orchestrator', () => {
     expect(merged).toContain('```md');
     expect(merged).toContain('## Verification');
     expect(merged).toContain('- example snippet');
+    expect(() =>
+      assertReviewerFacingMarkdown(
+        '## Summary\n\n~~~md\n## Verification\n- example snippet\n~~~\n',
+      ),
+    ).not.toThrow();
   });
 
   it('requires internal review before opening a ticket-linked PR', async () => {

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -545,6 +545,12 @@ describe('delivery orchestrator', () => {
         section,
       ),
     ).not.toContain('\nold\n');
+    const sanitized = mergeStandaloneAiReviewSection(
+      '## Summary\n- existing body\n\n## Summary by CodeRabbit\n- noisy recap\n\n## Verification\n- bun run verify\n',
+      section,
+    );
+    expect(sanitized).not.toContain('Summary by CodeRabbit');
+    expect(sanitized).not.toContain('## Verification');
   });
 
   it('renders final standalone ai review outcomes accurately', () => {
@@ -577,6 +583,13 @@ describe('delivery orchestrator', () => {
         vendors: ['qodo'],
       }),
     ).toContain('no prudent follow-up changes were required.');
+    expect(
+      buildStandaloneAiReviewSection({
+        outcome: 'clean',
+        note: 'External AI review completed without prudent follow-up changes.',
+        vendors: ['qodo'],
+      }),
+    ).toContain('- outcome: `clean`');
   });
 
   it('keeps standalone pr bodies free of artifact paths', () => {
@@ -625,6 +638,7 @@ describe('delivery orchestrator', () => {
     expect(body).not.toContain('### Vendor Summary Noise');
     expect(body).not.toContain('non-action summary:');
     expect(body).not.toContain('summary-only updates');
+    expect(body).not.toContain('## Verification');
   });
 
   it('renders no-action rationale when non-action summary exists on clean outcome', () => {
@@ -642,7 +656,7 @@ describe('delivery orchestrator', () => {
     );
   });
 
-  it('omits summary noise and renders resolved findings for reviewers', () => {
+  it('omits summary noise and renders actions taken for reviewers', () => {
     const body = buildPullRequestBody(
       {
         planKey: 'phase-03',
@@ -721,20 +735,30 @@ describe('delivery orchestrator', () => {
         status: 'reviewed',
       },
       {
+        actionCommits: [
+          {
+            sha: 'c87f955ca43a1234',
+            subject: 'resolve null-guard follow-up',
+            vendors: ['coderabbit'],
+          },
+        ],
         currentHeadSha: 'abcdef1234567890',
       },
     );
 
     expect(body).toContain('## External AI Review');
-    expect(body).toContain('### Resolved Review Findings');
+    expect(body).toContain('### Actions Taken');
     expect(body).toContain(
-      '[coderabbit] Guard the null return here. (native GitHub thread resolved)',
+      '`c87f955ca43a` [coderabbit] resolve null-guard follow-up',
     );
     expect(body).not.toContain('### Vendor Summary Noise');
     expect(body).not.toContain('[qodo] compressed 2 summary-only updates.');
     expect(body).not.toContain('Overall this looks good.');
-    expect(body).toContain('### Resolved Review Findings');
-    expect(body).toContain('[coderabbit] Previous concern already resolved.');
+    expect(body).not.toContain('### Resolved Review Findings');
+    expect(body).not.toContain(
+      '[coderabbit] Previous concern already resolved.',
+    );
+    expect(body).toContain('- outcome: `patched`');
   });
 
   it('keeps reviewed findings current when the current head sha is unknown', () => {
@@ -1251,7 +1275,9 @@ describe('delivery orchestrator', () => {
 
   it('accepts reviewer-facing markdown with proper headings and lists', () => {
     expect(() =>
-      assertReviewerFacingMarkdown('## Summary\n\n- item\n\n## Verification\n'),
+      assertReviewerFacingMarkdown(
+        '## Summary\n\n- item\n\n## External AI Review\n',
+      ),
     ).not.toThrow();
   });
 
@@ -1261,6 +1287,15 @@ describe('delivery orchestrator', () => {
         '## Summary\n\n- guard against literal `\\\\n` in malformed generated bodies\n',
       ),
     ).not.toThrow();
+  });
+
+  it('rejects pr bodies that contain banned headings', () => {
+    expect(() =>
+      assertReviewerFacingMarkdown('## Summary by CodeRabbit\n\n- noisy recap'),
+    ).toThrow('PR body guard failed: banned section heading');
+    expect(() =>
+      assertReviewerFacingMarkdown('## Verification\n\n- bun run verify'),
+    ).toThrow('PR body guard failed: banned section heading');
   });
 
   it('requires internal review before opening a ticket-linked PR', async () => {

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -1315,23 +1315,27 @@ describe('delivery orchestrator', () => {
     expect(() =>
       assertReviewerFacingMarkdown('## Summary by: Qodo\n\n- noisy recap'),
     ).toThrow('PR body guard failed: banned section heading');
+    expect(() =>
+      assertReviewerFacingMarkdown('Verification\n---\n\n- bun run verify'),
+    ).toThrow('PR body guard failed: banned section heading');
   });
 
   it('does not strip banned-looking headings inside fenced code blocks', () => {
     const merged = mergeStandaloneAiReviewSection(
-      '## Summary\n\n```md\n## Verification\n- example snippet\n```\n',
+      '## Summary\n\n~~~md\n```ts\n## Verification\n```\n- example snippet\n~~~\n',
       buildStandaloneAiReviewSection({
         outcome: 'clean',
         note: 'External AI review completed without prudent follow-up changes.',
         vendors: ['coderabbit'],
       }),
     );
-    expect(merged).toContain('```md');
+    expect(merged).toContain('~~~md');
+    expect(merged).toContain('```ts');
     expect(merged).toContain('## Verification');
     expect(merged).toContain('- example snippet');
     expect(() =>
       assertReviewerFacingMarkdown(
-        '## Summary\n\n~~~md\n## Verification\n- example snippet\n~~~\n',
+        '## Summary\n\n~~~md\n```ts\n## Verification\n```\n- example snippet\n~~~\n',
       ),
     ).not.toThrow();
   });

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -551,6 +551,12 @@ describe('delivery orchestrator', () => {
     );
     expect(sanitized).not.toContain('Summary by CodeRabbit');
     expect(sanitized).not.toContain('## Verification');
+    const replaced = mergeStandaloneAiReviewSection(
+      '## Summary\n- existing body\n\n<!-- ai-review:start -->\n## External AI Review\n\n## Verification\n- stale\n<!-- ai-review:end -->\n',
+      section,
+    );
+    expect(replaced.match(/<!-- ai-review:start -->/g)?.length ?? 0).toBe(1);
+    expect(replaced).not.toContain('- stale');
   });
 
   it('renders final standalone ai review outcomes accurately', () => {
@@ -1296,6 +1302,26 @@ describe('delivery orchestrator', () => {
     expect(() =>
       assertReviewerFacingMarkdown('## Verification\n\n- bun run verify'),
     ).toThrow('PR body guard failed: banned section heading');
+    expect(() =>
+      assertReviewerFacingMarkdown('## Verification ##\n\n- bun run verify'),
+    ).toThrow('PR body guard failed: banned section heading');
+    expect(() =>
+      assertReviewerFacingMarkdown('## Summary by: Qodo\n\n- noisy recap'),
+    ).toThrow('PR body guard failed: banned section heading');
+  });
+
+  it('does not strip banned-looking headings inside fenced code blocks', () => {
+    const merged = mergeStandaloneAiReviewSection(
+      '## Summary\n\n```md\n## Verification\n- example snippet\n```\n',
+      buildStandaloneAiReviewSection({
+        outcome: 'clean',
+        note: 'External AI review completed without prudent follow-up changes.',
+        vendors: ['coderabbit'],
+      }),
+    );
+    expect(merged).toContain('```md');
+    expect(merged).toContain('## Verification');
+    expect(merged).toContain('- example snippet');
   });
 
   it('requires internal review before opening a ticket-linked PR', async () => {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -3230,7 +3230,7 @@ export function assertReviewerFacingMarkdown(body: string): void {
   const sanitizedLines: string[] = [];
 
   for (const line of lines) {
-    if (/^\s*```/.test(line)) {
+    if (/^\s*(```|~~~)/.test(line)) {
       inFencedCodeBlock = !inFencedCodeBlock;
       sanitizedLines.push('');
       continue;
@@ -3975,11 +3975,12 @@ export function mergeStandaloneAiReviewSection(
 ): string {
   const pattern = new RegExp(
     `${STANDALONE_AI_REVIEW_SECTION_START}[\\s\\S]*?${STANDALONE_AI_REVIEW_SECTION_END}`,
+    'g',
   );
-  const mergedBody = pattern.test(body)
-    ? body.replace(pattern, section)
-    : body.trimEnd().length > 0
-      ? `${body.trimEnd()}\n\n${section}\n`
+  const bodyWithoutAiReviewSections = body.replace(pattern, '').trimEnd();
+  const mergedBody =
+    bodyWithoutAiReviewSections.length > 0
+      ? `${bodyWithoutAiReviewSections}\n\n${section}\n`
       : `${section}\n`;
 
   return `${stripBannedPrBodySections(mergedBody).trimEnd()}\n`;

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -241,6 +241,12 @@ type AiReviewThreadResolution = {
   vendor: string;
 };
 
+type ReviewActionCommit = {
+  sha: string;
+  subject: string;
+  vendors: string[];
+};
+
 type AiReviewFetcherResult = {
   agents: AiReviewAgentResult[];
   artifactText: string;
@@ -1652,8 +1658,16 @@ export async function openPullRequest(
     target,
     readLatestCommitSubject(target.worktreePath),
   );
+  const currentHeadSha = readHeadSha(target.worktreePath);
   const body = buildPullRequestBody(state, target, {
-    currentHeadSha: readHeadSha(target.worktreePath),
+    actionCommits: listReviewActionCommits(
+      target.worktreePath,
+      target.reviewHeadSha,
+      currentHeadSha,
+      target.reviewComments,
+      target.reviewVendors,
+    ),
+    currentHeadSha,
   });
   assertReviewerFacingMarkdown(body);
   const existingPullRequest = findOpenPullRequest(
@@ -2885,6 +2899,7 @@ async function restackTicket(
   const pullRequest = findOpenPullRequest(cwd, target.branch);
 
   if (pullRequest) {
+    const currentHeadSha = readHeadSha(updatedTarget.worktreePath);
     runProcess(cwd, [
       'gh',
       'pr',
@@ -2894,7 +2909,14 @@ async function restackTicket(
       nextBaseBranch,
       '--body',
       buildPullRequestBody(nextState, updatedTarget, {
-        currentHeadSha: readHeadSha(updatedTarget.worktreePath),
+        actionCommits: listReviewActionCommits(
+          updatedTarget.worktreePath,
+          updatedTarget.reviewHeadSha,
+          currentHeadSha,
+          updatedTarget.reviewComments,
+          updatedTarget.reviewVendors,
+        ),
+        currentHeadSha,
       }),
     ]);
   }
@@ -2907,6 +2929,106 @@ function runGitLines(cwd: string, cmd: string[]): string[] {
     .split('\n')
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
+}
+
+function parseMarkdownHeading(
+  line: string,
+): { level: number; title: string } | undefined {
+  const match = line.trim().match(/^(#{1,6})\s+(.+?)\s*$/);
+  if (!match) {
+    return undefined;
+  }
+  return { level: match[1].length, title: match[2].trim() };
+}
+
+function isBannedPrBodyHeadingTitle(title: string): boolean {
+  const normalized = title.toLowerCase();
+  return (
+    normalized === 'validation' ||
+    normalized === 'verification' ||
+    normalized.startsWith('summary by ')
+  );
+}
+
+function stripBannedPrBodySections(body: string): string {
+  const lines = body.split('\n');
+  const kept: string[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const heading = parseMarkdownHeading(lines[index]!);
+    if (!heading || !isBannedPrBodyHeadingTitle(heading.title)) {
+      kept.push(lines[index]!);
+      index += 1;
+      continue;
+    }
+
+    index += 1;
+    while (index < lines.length) {
+      const nextHeading = parseMarkdownHeading(lines[index]!);
+      if (nextHeading && nextHeading.level <= heading.level) {
+        break;
+      }
+      index += 1;
+    }
+  }
+
+  return kept
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd();
+}
+
+function collectActionVendors(
+  comments: AiReviewComment[] | undefined,
+  vendors: string[] | undefined,
+): string[] {
+  const fromFindings = (comments ?? [])
+    .filter((comment) => comment.kind === 'finding')
+    .map((comment) => comment.vendor);
+  const merged = fromFindings.length > 0 ? fromFindings : (vendors ?? []);
+  return [...new Set(merged)];
+}
+
+function listReviewActionCommits(
+  cwd: string,
+  reviewedHeadSha: string | undefined,
+  currentHeadSha: string | undefined,
+  comments: AiReviewComment[] | undefined,
+  vendors: string[] | undefined,
+): ReviewActionCommit[] {
+  if (
+    !reviewedHeadSha ||
+    !currentHeadSha ||
+    reviewedHeadSha === currentHeadSha
+  ) {
+    return [];
+  }
+
+  const actionVendors = collectActionVendors(comments, vendors);
+  try {
+    return runGitLines(cwd, [
+      'git',
+      'log',
+      '--reverse',
+      '--format=%H%x09%s',
+      `${reviewedHeadSha}..${currentHeadSha}`,
+    ])
+      .map((line) => {
+        const [sha, subject] = line.split('\t', 2);
+        if (!sha || !subject) {
+          return undefined;
+        }
+        return {
+          sha,
+          subject: summarizeReviewMessage(subject),
+          vendors: actionVendors,
+        } satisfies ReviewActionCommit;
+      })
+      .filter((commit): commit is ReviewActionCommit => commit !== undefined);
+  } catch {
+    return [];
+  }
 }
 
 function preferCodexBranch(branches: string[]): string {
@@ -3112,9 +3234,20 @@ export function assertReviewerFacingMarkdown(body: string): void {
       `PR body guard failed: malformed markdown heading "${malformedHeading.trim()}".`,
     );
   }
+
+  const bannedHeading = sanitizedLines.find((line) => {
+    const heading = parseMarkdownHeading(line);
+    return heading ? isBannedPrBodyHeadingTitle(heading.title) : false;
+  });
+  if (bannedHeading) {
+    throw new Error(
+      `PR body guard failed: banned section heading "${bannedHeading.trim()}".`,
+    );
+  }
 }
 
 function buildAiReviewDetailLines(input: {
+  actionCommits?: ReviewActionCommit[];
   actionSummary?: string;
   comments?: AiReviewComment[];
   currentHeadSha?: string;
@@ -3139,6 +3272,8 @@ function buildAiReviewDetailLines(input: {
   ) {
     return lines;
   }
+
+  lines.push(`- outcome: \`${reviewStatus}\``);
 
   const appliesToCurrentHead =
     !!input.reviewedHeadSha &&
@@ -3227,7 +3362,15 @@ function buildAiReviewDetailLines(input: {
     return buildReviewCommentBullet(comment, detail);
   });
 
-  if (resolvedFindingBullets.length > 0) {
+  const actionCommitBullets = (input.actionCommits ?? []).map((commit) => {
+    const vendorTag =
+      commit.vendors.length > 0 ? ` [${commit.vendors.join(',')}]` : '';
+    return `- \`${shortenSha(commit.sha)}\`${vendorTag} ${commit.subject}`;
+  });
+
+  if (actionCommitBullets.length > 0) {
+    lines.push('', '### Actions Taken', '', ...actionCommitBullets);
+  } else if (resolvedFindingBullets.length > 0) {
     lines.push(
       '',
       '### Resolved Review Findings',
@@ -3291,6 +3434,7 @@ export function buildPullRequestBody(
     | 'reviewVendors'
   >,
   options: {
+    actionCommits?: ReviewActionCommit[];
     currentHeadSha?: string;
   } = {},
 ): string {
@@ -3317,6 +3461,7 @@ export function buildPullRequestBody(
     lines.push(
       ...buildAiReviewDetailLines({
         actionSummary: ticket.reviewActionSummary,
+        actionCommits: options.actionCommits,
         comments: ticket.reviewComments,
         currentHeadSha: options.currentHeadSha,
         maxWaitMinutes: state.reviewPollMaxWaitMinutes,
@@ -3337,9 +3482,7 @@ export function buildPullRequestBody(
     }
   }
 
-  lines.push('', '## Verification', '', '- `bun run ci`');
-
-  return lines.join('\n');
+  return stripBannedPrBodySections(lines.join('\n'));
 }
 
 export function buildPullRequestTitle(
@@ -3728,8 +3871,16 @@ function updatePullRequestBody(
     return;
   }
 
+  const currentHeadSha = readHeadSha(ticket.worktreePath);
   const body = buildPullRequestBody(state, ticket, {
-    currentHeadSha: readHeadSha(ticket.worktreePath),
+    actionCommits: listReviewActionCommits(
+      ticket.worktreePath,
+      ticket.reviewHeadSha,
+      currentHeadSha,
+      ticket.reviewComments,
+      ticket.reviewVendors,
+    ),
+    currentHeadSha,
   });
   assertReviewerFacingMarkdown(body);
 
@@ -3758,6 +3909,7 @@ export function buildStandaloneAiReviewSection(
     | 'vendors'
   >,
   options: {
+    actionCommits?: ReviewActionCommit[];
     currentHeadSha?: string;
   } = {},
 ): string {
@@ -3769,6 +3921,7 @@ export function buildStandaloneAiReviewSection(
   lines.push(
     ...buildAiReviewDetailLines({
       actionSummary: result.actionSummary,
+      actionCommits: options.actionCommits,
       comments: result.comments,
       currentHeadSha: options.currentHeadSha,
       maxWaitMinutes: DEFAULT_REVIEW_POLL_MAX_WAIT_MINUTES,
@@ -3782,23 +3935,24 @@ export function buildStandaloneAiReviewSection(
   );
 
   lines.push(STANDALONE_AI_REVIEW_SECTION_END);
-  return lines.join('\n');
+  return stripBannedPrBodySections(lines.join('\n'));
 }
 
 export function mergeStandaloneAiReviewSection(
   body: string,
   section: string,
 ): string {
+  const sanitizedBody = stripBannedPrBodySections(body);
   const pattern = new RegExp(
     `${STANDALONE_AI_REVIEW_SECTION_START}[\\s\\S]*?${STANDALONE_AI_REVIEW_SECTION_END}`,
   );
 
-  if (pattern.test(body)) {
-    return body.replace(pattern, section);
+  if (pattern.test(sanitizedBody)) {
+    return sanitizedBody.replace(pattern, section);
   }
 
-  return body.trimEnd().length > 0
-    ? `${body.trimEnd()}\n\n${section}\n`
+  return sanitizedBody.trimEnd().length > 0
+    ? `${sanitizedBody.trimEnd()}\n\n${section}\n`
     : `${section}\n`;
 }
 
@@ -3810,6 +3964,13 @@ function updateStandalonePullRequestBody(
   const nextBody = mergeStandaloneAiReviewSection(
     pullRequest.body,
     buildStandaloneAiReviewSection(result, {
+      actionCommits: listReviewActionCommits(
+        cwd,
+        result.reviewedHeadSha,
+        pullRequest.headRefOid,
+        result.comments,
+        result.vendors,
+      ),
       currentHeadSha: pullRequest.headRefOid,
     }),
   );

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -191,6 +191,7 @@ type NotificationPayload = {
 
 const DEFAULT_REVIEW_POLL_INTERVAL_MINUTES = 2;
 const DEFAULT_REVIEW_POLL_MAX_WAIT_MINUTES = 8;
+const MAX_ACTION_COMMITS = 20;
 const STANDALONE_AI_REVIEW_SECTION_START = '<!-- ai-review:start -->';
 const STANDALONE_AI_REVIEW_SECTION_END = '<!-- ai-review:end -->';
 
@@ -2934,7 +2935,7 @@ function runGitLines(cwd: string, cmd: string[]): string[] {
 function parseMarkdownHeading(
   line: string,
 ): { level: number; title: string } | undefined {
-  const match = line.trim().match(/^(#{1,6})\s+(.+?)\s*$/);
+  const match = line.trim().match(/^(#{1,6})\s+(.+?)(?:\s+#+\s*)?$/);
   if (!match) {
     return undefined;
   }
@@ -2942,11 +2943,15 @@ function parseMarkdownHeading(
 }
 
 function isBannedPrBodyHeadingTitle(title: string): boolean {
-  const normalized = title.toLowerCase();
+  const normalized = title
+    .toLowerCase()
+    .replace(/[#:]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
   return (
-    normalized === 'validation' ||
-    normalized === 'verification' ||
-    normalized.startsWith('summary by ')
+    /^validation\b/.test(normalized) ||
+    /^verification\b/.test(normalized) ||
+    /^summary by\b/.test(normalized)
   );
 }
 
@@ -2954,8 +2959,22 @@ function stripBannedPrBodySections(body: string): string {
   const lines = body.split('\n');
   const kept: string[] = [];
   let index = 0;
+  let inFencedCodeBlock = false;
 
   while (index < lines.length) {
+    const line = lines[index]!;
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFencedCodeBlock = !inFencedCodeBlock;
+      kept.push(line);
+      index += 1;
+      continue;
+    }
+    if (inFencedCodeBlock) {
+      kept.push(line);
+      index += 1;
+      continue;
+    }
+
     const heading = parseMarkdownHeading(lines[index]!);
     if (!heading || !isBannedPrBodyHeadingTitle(heading.title)) {
       kept.push(lines[index]!);
@@ -2965,6 +2984,16 @@ function stripBannedPrBodySections(body: string): string {
 
     index += 1;
     while (index < lines.length) {
+      const nextLine = lines[index]!;
+      if (/^\s*(```|~~~)/.test(nextLine)) {
+        inFencedCodeBlock = !inFencedCodeBlock;
+        index += 1;
+        continue;
+      }
+      if (inFencedCodeBlock) {
+        index += 1;
+        continue;
+      }
       const nextHeading = parseMarkdownHeading(lines[index]!);
       if (nextHeading && nextHeading.level <= heading.level) {
         break;
@@ -3010,7 +3039,9 @@ function listReviewActionCommits(
     return runGitLines(cwd, [
       'git',
       'log',
+      '--no-merges',
       '--reverse',
+      `--max-count=${MAX_ACTION_COMMITS}`,
       '--format=%H%x09%s',
       `${reviewedHeadSha}..${currentHeadSha}`,
     ])
@@ -3942,18 +3973,16 @@ export function mergeStandaloneAiReviewSection(
   body: string,
   section: string,
 ): string {
-  const sanitizedBody = stripBannedPrBodySections(body);
   const pattern = new RegExp(
     `${STANDALONE_AI_REVIEW_SECTION_START}[\\s\\S]*?${STANDALONE_AI_REVIEW_SECTION_END}`,
   );
+  const mergedBody = pattern.test(body)
+    ? body.replace(pattern, section)
+    : body.trimEnd().length > 0
+      ? `${body.trimEnd()}\n\n${section}\n`
+      : `${section}\n`;
 
-  if (pattern.test(sanitizedBody)) {
-    return sanitizedBody.replace(pattern, section);
-  }
-
-  return sanitizedBody.trimEnd().length > 0
-    ? `${sanitizedBody.trimEnd()}\n\n${section}\n`
-    : `${section}\n`;
+  return `${stripBannedPrBodySections(mergedBody).trimEnd()}\n`;
 }
 
 function updateStandalonePullRequestBody(

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -2934,12 +2934,54 @@ function runGitLines(cwd: string, cmd: string[]): string[] {
 
 function parseMarkdownHeading(
   line: string,
-): { level: number; title: string } | undefined {
+): { level: number; lineCount: number; title: string } | undefined {
   const match = line.trim().match(/^(#{1,6})\s+(.+?)(?:\s+#+\s*)?$/);
   if (!match) {
     return undefined;
   }
-  return { level: match[1].length, title: match[2].trim() };
+  return { level: match[1].length, lineCount: 1, title: match[2].trim() };
+}
+
+function parseUnderlineHeading(
+  lines: string[],
+  index: number,
+): { level: number; lineCount: number; title: string } | undefined {
+  const titleLine = lines[index]?.trim();
+  const underlineLine = lines[index + 1]?.trim();
+  if (!titleLine || !underlineLine) {
+    return undefined;
+  }
+
+  if (/^-{1,}\s*$/.test(underlineLine)) {
+    return { level: 2, lineCount: 2, title: titleLine };
+  }
+  if (/^={1,}\s*$/.test(underlineLine)) {
+    return { level: 1, lineCount: 2, title: titleLine };
+  }
+  return undefined;
+}
+
+function parseMarkdownHeadingAt(
+  lines: string[],
+  index: number,
+): { level: number; lineCount: number; title: string } | undefined {
+  return (
+    parseMarkdownHeading(lines[index]!) ?? parseUnderlineHeading(lines, index)
+  );
+}
+
+function parseFenceMarker(
+  line: string,
+): { char: '`' | '~'; length: number; trailing: string } | undefined {
+  const match = line.match(/^\s*(`{3,}|~{3,})(.*)$/);
+  if (!match) {
+    return undefined;
+  }
+  return {
+    char: match[1]![0] as '`' | '~',
+    length: match[1]!.length,
+    trailing: match[2] ?? '',
+  };
 }
 
 function isBannedPrBodyHeadingTitle(title: string): boolean {
@@ -2959,42 +3001,63 @@ function stripBannedPrBodySections(body: string): string {
   const lines = body.split('\n');
   const kept: string[] = [];
   let index = 0;
-  let inFencedCodeBlock = false;
+  let activeFence: { char: '`' | '~'; length: number } | undefined;
 
   while (index < lines.length) {
     const line = lines[index]!;
-    if (/^\s*(```|~~~)/.test(line)) {
-      inFencedCodeBlock = !inFencedCodeBlock;
+    const fenceMarker = parseFenceMarker(line);
+    if (fenceMarker) {
+      if (!activeFence) {
+        activeFence = { char: fenceMarker.char, length: fenceMarker.length };
+      } else if (
+        fenceMarker.char === activeFence.char &&
+        fenceMarker.length >= activeFence.length &&
+        fenceMarker.trailing.trim().length === 0
+      ) {
+        activeFence = undefined;
+      }
       kept.push(line);
       index += 1;
       continue;
     }
-    if (inFencedCodeBlock) {
+    if (activeFence) {
       kept.push(line);
       index += 1;
       continue;
     }
 
-    const heading = parseMarkdownHeading(lines[index]!);
+    const heading = parseMarkdownHeadingAt(lines, index);
     if (!heading || !isBannedPrBodyHeadingTitle(heading.title)) {
       kept.push(lines[index]!);
       index += 1;
       continue;
     }
 
-    index += 1;
+    index += heading.lineCount;
     while (index < lines.length) {
       const nextLine = lines[index]!;
-      if (/^\s*(```|~~~)/.test(nextLine)) {
-        inFencedCodeBlock = !inFencedCodeBlock;
+      const nextFenceMarker = parseFenceMarker(nextLine);
+      if (nextFenceMarker) {
+        if (!activeFence) {
+          activeFence = {
+            char: nextFenceMarker.char,
+            length: nextFenceMarker.length,
+          };
+        } else if (
+          nextFenceMarker.char === activeFence.char &&
+          nextFenceMarker.length >= activeFence.length &&
+          nextFenceMarker.trailing.trim().length === 0
+        ) {
+          activeFence = undefined;
+        }
         index += 1;
         continue;
       }
-      if (inFencedCodeBlock) {
+      if (activeFence) {
         index += 1;
         continue;
       }
-      const nextHeading = parseMarkdownHeading(lines[index]!);
+      const nextHeading = parseMarkdownHeadingAt(lines, index);
       if (nextHeading && nextHeading.level <= heading.level) {
         break;
       }
@@ -3226,17 +3289,26 @@ function buildReviewCommentBullets(
 
 export function assertReviewerFacingMarkdown(body: string): void {
   const lines = body.split('\n');
-  let inFencedCodeBlock = false;
+  let activeFence: { char: '`' | '~'; length: number } | undefined;
   const sanitizedLines: string[] = [];
 
   for (const line of lines) {
-    if (/^\s*(```|~~~)/.test(line)) {
-      inFencedCodeBlock = !inFencedCodeBlock;
+    const fenceMarker = parseFenceMarker(line);
+    if (fenceMarker) {
+      if (!activeFence) {
+        activeFence = { char: fenceMarker.char, length: fenceMarker.length };
+      } else if (
+        fenceMarker.char === activeFence.char &&
+        fenceMarker.length >= activeFence.length &&
+        fenceMarker.trailing.trim().length === 0
+      ) {
+        activeFence = undefined;
+      }
       sanitizedLines.push('');
       continue;
     }
 
-    if (inFencedCodeBlock) {
+    if (activeFence) {
       sanitizedLines.push('');
       continue;
     }
@@ -3244,7 +3316,7 @@ export function assertReviewerFacingMarkdown(body: string): void {
     sanitizedLines.push(line.replace(/`[^`]*`/g, ''));
   }
 
-  if (inFencedCodeBlock) {
+  if (activeFence) {
     throw new Error(
       'PR body guard failed: markdown contains an unmatched fenced code block.',
     );
@@ -3266,8 +3338,8 @@ export function assertReviewerFacingMarkdown(body: string): void {
     );
   }
 
-  const bannedHeading = sanitizedLines.find((line) => {
-    const heading = parseMarkdownHeading(line);
+  const bannedHeading = sanitizedLines.find((line, index) => {
+    const heading = parseMarkdownHeadingAt(sanitizedLines, index);
     return heading ? isBannedPrBodyHeadingTitle(heading.title) : false;
   });
   if (bannedHeading) {


### PR DESCRIPTION
## Summary

- ban PR-body sections that add noise: any `Summary by ...`, `Validation`, and `Verification` headings are removed/blocked
- keep reviewer-facing `External AI Review` concise and explicit with `- outcome: ...`
- make `### Actions Taken` commit-history-driven and include vendor tags (for example `[qodo]`, `[coderabbit]`)
- sanitize existing standalone PR bodies during section merge so banned sections cannot persist
- remove orchestrator-authored `## Verification` section from ticket PR body rendering

<!-- ai-review:start -->
## External AI Review

- outcome: `clean`
- reviewed commit: `53297f1d4275`
- current branch head: `53297f1d4275`
- vendors: `coderabbit`, `qodo`

### Resolved Review Findings

- [coderabbit] Add a duplicate-marker regression here. `tools/delivery/orchestrator.test.ts:559` [thread](https://github.com/cesarnml/pirate_claw/pull/39#discussion_r3036486291)
- [coderabbit] Exercise the validator here too, and cover `~~~` fences. `tools/delivery/orchestrator.test.ts:1341` [thread](https://github.com/cesarnml/pirate_claw/pull/39#discussion_r3036486292)
- [coderabbit] Setext headings bypass the banned-section guard. `tools/delivery/orchestrator.ts:2997` [thread](https://github.com/cesarnml/pirate_claw/pull/39#discussion_r3036497022)
- [coderabbit] Ignore fenced code blocks while stripping banned sections. `tools/delivery/orchestrator.ts:3071` [thread](https://github.com/cesarnml/pirate_claw/pull/39#discussion_r3036477960)
- [qodo] 1\. Stripper breaks fenced blocks <code>🐞 Bug</code> <code>≡ Correctness</code> `tools/delivery/orchestrator.ts:3066` [thread](https://github.com/cesarnml/pirate_claw/pull/39#discussion_r3036474056)
- [coderabbit] Track the active fence delimiter instead of toggling on any fence-looking line. `tools/delivery/orchestrator.ts:2999` [thread](https://github.com/cesarnml/pirate_claw/pull/39#discussion_r3036497023)
- [coderabbit] Replace the legacy AI-review block before sanitizing the body. `tools/delivery/orchestrator.ts:3956` [thread](https://github.com/cesarnml/pirate_claw/pull/39#discussion_r3036477962)
<!-- ai-review:end -->
