### PR TITLE
feat: add foreground daemon command [P4.01]

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It currently supports:
 ## Commands
 
 - `pirate-claw run`
+- `pirate-claw daemon`
 - `pirate-claw status`
 - `pirate-claw retry-failed`
 - `pirate-claw reconcile`
@@ -134,13 +135,20 @@ Pirate Claw keeps local operator state out of git:
 - `pirate-claw.config.json`
 - `pirate-claw.db`
 
+Run the daemon for continuous scheduled operation:
+
+```bash
+./bin/pirate-claw daemon --config ./pirate-claw.config.json
+```
+
+The daemon runs in the foreground, executing run cycles every 30 minutes and reconcile cycles every 1 minute. Stop with `Ctrl+C`.
+
 ## Current Scope
 
 Pirate Claw is intentionally still a local operator tool.
 
 Not in scope yet:
 
-- always-on scheduling or feed polling
 - remote feed capture
 - hosted persistence
 - automatic post-completion file handling

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -10,11 +10,12 @@ Its job is to answer three questions quickly:
 
 ## Current Repo State
 
-Pirate Claw is implemented through Phase 03, with the final Phase 03 delivery ticket having landed.
+Pirate Claw is implemented through Phase 04, with Phase 04 delivery in progress.
 
 Current delivered surface:
 
 - `pirate-claw run`
+- `pirate-claw daemon`
 - `pirate-claw status`
 - `pirate-claw retry-failed`
 - `pirate-claw reconcile`
@@ -28,14 +29,13 @@ Current product boundary:
 - SQLite is the local persistence boundary
 - real-world feed compatibility for EZTV and Atlas is implemented
 - post-queue lifecycle reconciliation and status visibility are implemented for Pirate Claw-queued torrents
+- foreground daemon mode with scheduled run and reconcile cycles
 
 Still deferred:
 
 - web UI
-- always-on scheduling or polling
 - remote feed capture
 - hosted persistence
-- automatic reconciliation polling (manual `reconcile` exists)
 - download renaming or organization rules
 - Synology archiving
 - ingestion redesign beyond the local SQLite model

--- a/docs/02-delivery/phase-04/ticket-01-add-foreground-daemon-command.md
+++ b/docs/02-delivery/phase-04/ticket-01-add-foreground-daemon-command.md
@@ -22,6 +22,14 @@ Phase 04 requires an always-on execution path. Without a daemon entrypoint, all 
 - lock/overlap semantics
 - runtime artifacts
 
+## Rationale
+
+The daemon uses an injectable `runDaemonLoop` that takes cycle callbacks and an `AbortSignal`. This keeps the scheduling loop testable without subprocess overhead or real timers. Initial cycles execute synchronously before interval timers start so the operator gets immediate feedback on startup. Per-cycle errors are caught and logged without crashing the daemon.
+
+Hardcoded defaults (30 min run, 1 min reconcile) are used in this ticket. Config-driven cadence lands in P4.02. Cross-cycle overlap prevention is explicitly deferred to P4.04.
+
+In-flight cycles are tracked and awaited on shutdown so the CLI can safely close the database after the daemon loop returns.
+
 ## Red First Prompt
 
 What user-visible behavior fails first when `pirate-claw daemon` is invoked but no long-running execution loop exists?

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 
 import { ConfigError, loadConfig, resolveConfigPath } from './config';
+import { DEFAULT_DAEMON_OPTIONS, runDaemonLoop } from './daemon';
 import {
   reconcileCandidates,
   retryFailedCandidates,
@@ -85,6 +86,47 @@ export async function runCli(argv: string[]): Promise<number> {
       return 0;
     }
 
+    if (command === 'daemon') {
+      const configPath = parseConfigPath(rest);
+      const resolvedConfigPath = resolveConfigPath(configPath);
+      const config = await loadConfig(resolvedConfigPath);
+      const database = openDatabase();
+
+      try {
+        ensureSchema(database);
+        const repository = createRepository(database);
+        const downloader = createTransmissionDownloader(config.transmission);
+
+        const controller = new AbortController();
+        process.on('SIGINT', () => controller.abort());
+        process.on('SIGTERM', () => controller.abort());
+
+        await runDaemonLoop({
+          runCycle: async () => {
+            const result = await runPipeline({
+              config,
+              repository,
+              downloader,
+            });
+            console.log(formatRunSummary(result));
+          },
+          reconcileCycle: async () => {
+            const result = await reconcileCandidates({
+              repository,
+              downloader,
+            });
+            console.log(formatReconcileSummary(result));
+          },
+          options: DEFAULT_DAEMON_OPTIONS,
+          signal: controller.signal,
+        });
+      } finally {
+        database.close();
+      }
+
+      return 0;
+    }
+
     if (command === 'status') {
       const database = openStatusDatabase();
 
@@ -104,7 +146,7 @@ export async function runCli(argv: string[]): Promise<number> {
     }
 
     console.error(
-      'Unknown command. Available commands: "run", "status", "retry-failed", "reconcile".',
+      'Unknown command. Available commands: "run", "daemon", "status", "retry-failed", "reconcile".',
     );
     return 1;
   } catch (error) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,8 +98,9 @@ export async function runCli(argv: string[]): Promise<number> {
         const downloader = createTransmissionDownloader(config.transmission);
 
         const controller = new AbortController();
-        process.on('SIGINT', () => controller.abort());
-        process.on('SIGTERM', () => controller.abort());
+        const onSignal = () => controller.abort();
+        process.once('SIGINT', onSignal);
+        process.once('SIGTERM', onSignal);
 
         await runDaemonLoop({
           runCycle: async () => {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,0 +1,66 @@
+export type DaemonOptions = {
+  runIntervalMs: number;
+  reconcileIntervalMs: number;
+};
+
+export const DEFAULT_DAEMON_OPTIONS: DaemonOptions = {
+  runIntervalMs: 30 * 60 * 1000,
+  reconcileIntervalMs: 60 * 1000,
+};
+
+export async function runDaemonLoop(input: {
+  runCycle: () => Promise<void>;
+  reconcileCycle: () => Promise<void>;
+  options: DaemonOptions;
+  signal: AbortSignal;
+  log?: (message: string) => void;
+}): Promise<void> {
+  const { runCycle, reconcileCycle, options, signal } = input;
+  const log = input.log ?? console.log;
+
+  log('daemon started');
+
+  await executeCycle('run', runCycle, log);
+  await executeCycle('reconcile', reconcileCycle, log);
+
+  if (signal.aborted) {
+    log('daemon stopped');
+    return;
+  }
+
+  const runTimer = setInterval(
+    () => void executeCycle('run', runCycle, log),
+    options.runIntervalMs,
+  );
+  const reconcileTimer = setInterval(
+    () => void executeCycle('reconcile', reconcileCycle, log),
+    options.reconcileIntervalMs,
+  );
+
+  await new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+
+    signal.addEventListener('abort', () => resolve(), { once: true });
+  });
+
+  clearInterval(runTimer);
+  clearInterval(reconcileTimer);
+  log('daemon stopped');
+}
+
+async function executeCycle(
+  type: string,
+  cycle: () => Promise<void>,
+  log: (message: string) => void,
+): Promise<void> {
+  try {
+    await cycle();
+    log(`${type} cycle completed`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log(`${type} cycle failed: ${message}`);
+  }
+}

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -28,14 +28,15 @@ export async function runDaemonLoop(input: {
     return;
   }
 
-  const runTimer = setInterval(
-    () => void executeCycle('run', runCycle, log),
-    options.runIntervalMs,
-  );
-  const reconcileTimer = setInterval(
-    () => void executeCycle('reconcile', reconcileCycle, log),
-    options.reconcileIntervalMs,
-  );
+  let runInFlight: Promise<void> | undefined;
+  let reconcileInFlight: Promise<void> | undefined;
+
+  const runTimer = setInterval(() => {
+    runInFlight = executeCycle('run', runCycle, log);
+  }, options.runIntervalMs);
+  const reconcileTimer = setInterval(() => {
+    reconcileInFlight = executeCycle('reconcile', reconcileCycle, log);
+  }, options.reconcileIntervalMs);
 
   await new Promise<void>((resolve) => {
     if (signal.aborted) {
@@ -48,6 +49,11 @@ export async function runDaemonLoop(input: {
 
   clearInterval(runTimer);
   clearInterval(reconcileTimer);
+
+  await Promise.allSettled(
+    [runInFlight, reconcileInFlight].filter(Boolean) as Promise<void>[],
+  );
+
   log('daemon stopped');
 }
 

--- a/test/daemon.test.ts
+++ b/test/daemon.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'bun:test';
+
+import { runDaemonLoop } from '../src/daemon';
+
+describe('daemon', () => {
+  it('runs initial run and reconcile cycles on startup', async () => {
+    const log: string[] = [];
+    const controller = new AbortController();
+    let runCount = 0;
+    let reconcileCount = 0;
+
+    await runDaemonLoop({
+      runCycle: async () => {
+        runCount += 1;
+      },
+      reconcileCycle: async () => {
+        reconcileCount += 1;
+        controller.abort();
+      },
+      options: { runIntervalMs: 600_000, reconcileIntervalMs: 600_000 },
+      signal: controller.signal,
+      log: (msg) => log.push(msg),
+    });
+
+    expect(runCount).toBe(1);
+    expect(reconcileCount).toBe(1);
+    expect(log).toContain('daemon started');
+    expect(log).toContain('run cycle completed');
+    expect(log).toContain('reconcile cycle completed');
+    expect(log).toContain('daemon stopped');
+  });
+
+  it('catches run cycle errors without crashing the daemon', async () => {
+    const log: string[] = [];
+    const controller = new AbortController();
+
+    await runDaemonLoop({
+      runCycle: async () => {
+        throw new Error('feed unavailable');
+      },
+      reconcileCycle: async () => {
+        controller.abort();
+      },
+      options: { runIntervalMs: 600_000, reconcileIntervalMs: 600_000 },
+      signal: controller.signal,
+      log: (msg) => log.push(msg),
+    });
+
+    expect(log).toContain('run cycle failed: feed unavailable');
+    expect(log).toContain('reconcile cycle completed');
+    expect(log).toContain('daemon stopped');
+  });
+
+  it('catches reconcile cycle errors without crashing the daemon', async () => {
+    const log: string[] = [];
+    const controller = new AbortController();
+
+    await runDaemonLoop({
+      runCycle: async () => {},
+      reconcileCycle: async () => {
+        throw new Error('transmission unreachable');
+      },
+      options: { runIntervalMs: 600_000, reconcileIntervalMs: 10 },
+      signal: controller.signal,
+      log: (msg) => {
+        log.push(msg);
+        if (log.filter((m) => m.includes('reconcile cycle failed')).length >= 2)
+          controller.abort();
+      },
+    });
+
+    expect(log).toContain('reconcile cycle failed: transmission unreachable');
+    expect(log).toContain('daemon stopped');
+  });
+
+  it('schedules recurring reconcile cycles after initial execution', async () => {
+    const log: string[] = [];
+    const controller = new AbortController();
+    let reconcileCount = 0;
+
+    await runDaemonLoop({
+      runCycle: async () => {},
+      reconcileCycle: async () => {
+        reconcileCount += 1;
+        if (reconcileCount >= 3) {
+          controller.abort();
+        }
+      },
+      options: { runIntervalMs: 600_000, reconcileIntervalMs: 10 },
+      signal: controller.signal,
+      log: (msg) => log.push(msg),
+    });
+
+    expect(reconcileCount).toBeGreaterThanOrEqual(3);
+    expect(log).toContain('daemon stopped');
+  });
+
+  it('stops immediately when signal is already aborted', async () => {
+    const log: string[] = [];
+    const controller = new AbortController();
+    controller.abort();
+
+    let runCount = 0;
+    let reconcileCount = 0;
+
+    await runDaemonLoop({
+      runCycle: async () => {
+        runCount += 1;
+      },
+      reconcileCycle: async () => {
+        reconcileCount += 1;
+      },
+      options: { runIntervalMs: 600_000, reconcileIntervalMs: 600_000 },
+      signal: controller.signal,
+      log: (msg) => log.push(msg),
+    });
+
+    expect(runCount).toBe(1);
+    expect(reconcileCount).toBe(1);
+    expect(log).toContain('daemon stopped');
+  });
+
+  it('executes run cycle before reconcile cycle on startup', async () => {
+    const order: string[] = [];
+    const controller = new AbortController();
+
+    await runDaemonLoop({
+      runCycle: async () => {
+        order.push('run');
+      },
+      reconcileCycle: async () => {
+        order.push('reconcile');
+        controller.abort();
+      },
+      options: { runIntervalMs: 600_000, reconcileIntervalMs: 600_000 },
+      signal: controller.signal,
+    });
+
+    expect(order[0]).toBe('run');
+    expect(order[1]).toBe('reconcile');
+  });
+});

--- a/test/daemon.test.ts
+++ b/test/daemon.test.ts
@@ -95,7 +95,7 @@ describe('daemon', () => {
     expect(log).toContain('daemon stopped');
   });
 
-  it('stops immediately when signal is already aborted', async () => {
+  it('runs initial cycles then stops without scheduling when signal is pre-aborted', async () => {
     const log: string[] = [];
     const controller = new AbortController();
     controller.abort();


### PR DESCRIPTION
## Summary

- delivery ticket: `P4.01 Add Foreground Daemon Command`
- ticket file: `docs/02-delivery/phase-04/ticket-01-add-foreground-daemon-command.md`
- stacked base branch: `main`
- internal review: completed at `2026-04-05T09:29:30.932Z`

## External AI Review

- outcome: `patched`
- reviewed commit: `9960a9ea6edb`
- current branch head: `f6f7f58b98bd`
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- vendors: `qodo`

### Actions Taken

- `f6f7f58b98bd` [qodo] fix: patch AI review findings for daemon lifecycle and docs [P4.01]