### PR TITLE
feat: add runtime config and default cadences [P4.02]

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ The repo includes a checked-in example at [`pirate-claw.config.example.json`](./
 
 High-level config shape:
 
-- `feeds`: RSS sources to inspect
+- `feeds`: RSS sources to inspect (optional `pollIntervalMinutes` per feed)
 - `tv`: per-show rules for title, resolution, and codec
 - `movies`: global movie intake policy
 - `transmission`: local Transmission RPC settings
+- `runtime`: daemon scheduling and artifact settings (optional, all fields have defaults)
 
 Example:
 
@@ -98,6 +99,12 @@ Example:
     "url": "http://localhost:9091/transmission/rpc",
     "username": "your-user",
     "password": "your-password"
+  },
+  "runtime": {
+    "runIntervalMinutes": 30,
+    "reconcileIntervalMinutes": 1,
+    "artifactDir": ".pirate-claw/runtime",
+    "artifactRetentionDays": 7
   }
 }
 ```

--- a/docs/02-delivery/phase-04/ticket-02-add-runtime-config-and-default-cadences.md
+++ b/docs/02-delivery/phase-04/ticket-02-add-runtime-config-and-default-cadences.md
@@ -24,6 +24,12 @@ Daemon mode needs durable configuration for cadence and runtime output location.
 - overlap locking
 - artifact file emission
 
+## Rationale
+
+The `runtime` config section is optional with full defaults so existing configs work unchanged. Each field validates as a positive number when present. The daemon derives its interval options from the validated config rather than using hardcoded constants, making cadence operator-controllable without code changes.
+
+`feeds[].pollIntervalMinutes` is validated here alongside the config surface but not consumed until P4.03 (due-feed scheduling).
+
 ## Red First Prompt
 
 What configuration-level behavior fails first when daemon scheduling defaults and runtime config validation are missing?

--- a/pirate-claw.config.example.json
+++ b/pirate-claw.config.example.json
@@ -27,5 +27,11 @@
     "url": "http://localhost:9091/transmission/rpc",
     "username": "REPLACE_WITH_YOUR_TRANSMISSION_USERNAME",
     "password": "REPLACE_WITH_YOUR_TRANSMISSION_PASSWORD"
+  },
+  "runtime": {
+    "runIntervalMinutes": 30,
+    "reconcileIntervalMinutes": 1,
+    "artifactDir": ".pirate-claw/runtime",
+    "artifactRetentionDays": 7
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 
 import { ConfigError, loadConfig, resolveConfigPath } from './config';
-import { DEFAULT_DAEMON_OPTIONS, runDaemonLoop } from './daemon';
+import { daemonOptionsFromConfig, runDaemonLoop } from './daemon';
 import {
   reconcileCandidates,
   retryFailedCandidates,
@@ -118,7 +118,7 @@ export async function runCli(argv: string[]): Promise<number> {
             });
             console.log(formatReconcileSummary(result));
           },
-          options: DEFAULT_DAEMON_OPTIONS,
+          options: daemonOptionsFromConfig(config.runtime),
           signal: controller.signal,
         });
       } finally {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ export type FeedConfig = {
   url: string;
   mediaType: 'tv' | 'movie';
   parserHints?: Record<string, unknown>;
+  pollIntervalMinutes?: number;
 };
 
 export type TvRule = {
@@ -25,11 +26,26 @@ export type TransmissionConfig = {
   downloadDir?: string;
 };
 
+export type RuntimeConfig = {
+  runIntervalMinutes: number;
+  reconcileIntervalMinutes: number;
+  artifactDir: string;
+  artifactRetentionDays: number;
+};
+
+export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
+  runIntervalMinutes: 30,
+  reconcileIntervalMinutes: 1,
+  artifactDir: '.pirate-claw/runtime',
+  artifactRetentionDays: 7,
+};
+
 export type AppConfig = {
   feeds: FeedConfig[];
   tv: TvRule[];
   movies: MoviePolicy;
   transmission: TransmissionConfig;
+  runtime: RuntimeConfig;
 };
 
 const DEFAULT_CONFIG_PATH = 'pirate-claw.config.json';
@@ -80,6 +96,7 @@ export function validateConfig(input: unknown, path = 'config'): AppConfig {
     tv: tv.map((entry, index) => validateTvRule(entry, path, index)),
     movies: validateMoviePolicy(movies, path),
     transmission: validateTransmission(transmission, path),
+    runtime: validateRuntime(input.runtime, path),
   };
 }
 
@@ -93,6 +110,10 @@ function validateFeed(input: unknown, path: string, index: number): FeedConfig {
     parserHints: optionalRecord(
       feed.parserHints,
       `${path} feeds[${index}] parserHints`,
+    ),
+    pollIntervalMinutes: optionalPositiveNumber(
+      feed.pollIntervalMinutes,
+      `${path} feeds[${index}] pollIntervalMinutes`,
     ),
   };
 }
@@ -331,6 +352,50 @@ const supportedCodecs = new Set(['x264', 'x265']);
 function expectString(input: unknown, path: string): string {
   if (typeof input !== 'string' || input.length === 0) {
     throw new ConfigError(`Config file "${path}" must be a non-empty string.`);
+  }
+
+  return input;
+}
+
+function validateRuntime(input: unknown, path: string): RuntimeConfig {
+  if (input === undefined) {
+    return { ...DEFAULT_RUNTIME_CONFIG };
+  }
+
+  const runtime = expectRecord(input, `${path} runtime`);
+
+  return {
+    runIntervalMinutes:
+      optionalPositiveNumber(
+        runtime.runIntervalMinutes,
+        `${path} runtime runIntervalMinutes`,
+      ) ?? DEFAULT_RUNTIME_CONFIG.runIntervalMinutes,
+    reconcileIntervalMinutes:
+      optionalPositiveNumber(
+        runtime.reconcileIntervalMinutes,
+        `${path} runtime reconcileIntervalMinutes`,
+      ) ?? DEFAULT_RUNTIME_CONFIG.reconcileIntervalMinutes,
+    artifactDir:
+      optionalString(runtime.artifactDir, `${path} runtime artifactDir`) ??
+      DEFAULT_RUNTIME_CONFIG.artifactDir,
+    artifactRetentionDays:
+      optionalPositiveNumber(
+        runtime.artifactRetentionDays,
+        `${path} runtime artifactRetentionDays`,
+      ) ?? DEFAULT_RUNTIME_CONFIG.artifactRetentionDays,
+  };
+}
+
+function optionalPositiveNumber(
+  input: unknown,
+  path: string,
+): number | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  if (typeof input !== 'number' || Number.isNaN(input) || input <= 0) {
+    throw new ConfigError(`Config file "${path}" must be a positive number.`);
   }
 
   return input;

--- a/src/config.ts
+++ b/src/config.ts
@@ -386,6 +386,8 @@ function validateRuntime(input: unknown, path: string): RuntimeConfig {
   };
 }
 
+const MAX_INTERVAL_MINUTES = 44_640;
+
 function optionalPositiveNumber(
   input: unknown,
   path: string,
@@ -394,8 +396,15 @@ function optionalPositiveNumber(
     return undefined;
   }
 
-  if (typeof input !== 'number' || Number.isNaN(input) || input <= 0) {
-    throw new ConfigError(`Config file "${path}" must be a positive number.`);
+  if (
+    typeof input !== 'number' ||
+    !Number.isFinite(input) ||
+    input <= 0 ||
+    input > MAX_INTERVAL_MINUTES
+  ) {
+    throw new ConfigError(
+      `Config file "${path}" must be a finite positive number (max ${MAX_INTERVAL_MINUTES}).`,
+    );
   }
 
   return input;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,12 +1,16 @@
+import type { RuntimeConfig } from './config';
+
 export type DaemonOptions = {
   runIntervalMs: number;
   reconcileIntervalMs: number;
 };
 
-export const DEFAULT_DAEMON_OPTIONS: DaemonOptions = {
-  runIntervalMs: 30 * 60 * 1000,
-  reconcileIntervalMs: 60 * 1000,
-};
+export function daemonOptionsFromConfig(runtime: RuntimeConfig): DaemonOptions {
+  return {
+    runIntervalMs: runtime.runIntervalMinutes * 60 * 1000,
+    reconcileIntervalMs: runtime.reconcileIntervalMinutes * 60 * 1000,
+  };
+}
 
 export async function runDaemonLoop(input: {
   runCycle: () => Promise<void>;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 
-import { ConfigError, validateConfig } from '../src/config';
+import {
+  ConfigError,
+  DEFAULT_RUNTIME_CONFIG,
+  validateConfig,
+} from '../src/config';
 
 describe('validateConfig', () => {
   it('normalizes tv and movie allowlists to lowercase', () => {
@@ -107,6 +111,126 @@ describe('validateConfig', () => {
     );
   });
 
+  it('applies default runtime config when runtime section is absent', () => {
+    const config = validateConfig(createMinimalConfig());
+
+    expect(config.runtime).toEqual(DEFAULT_RUNTIME_CONFIG);
+    expect(config.runtime.runIntervalMinutes).toBe(30);
+    expect(config.runtime.reconcileIntervalMinutes).toBe(1);
+    expect(config.runtime.artifactDir).toBe('.pirate-claw/runtime');
+    expect(config.runtime.artifactRetentionDays).toBe(7);
+  });
+
+  it('applies partial runtime overrides with defaults for omitted fields', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      runtime: {
+        runIntervalMinutes: 15,
+      },
+    });
+
+    expect(config.runtime.runIntervalMinutes).toBe(15);
+    expect(config.runtime.reconcileIntervalMinutes).toBe(1);
+    expect(config.runtime.artifactDir).toBe('.pirate-claw/runtime');
+    expect(config.runtime.artifactRetentionDays).toBe(7);
+  });
+
+  it('applies all runtime overrides when fully specified', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      runtime: {
+        runIntervalMinutes: 10,
+        reconcileIntervalMinutes: 5,
+        artifactDir: '/custom/path',
+        artifactRetentionDays: 14,
+      },
+    });
+
+    expect(config.runtime).toEqual({
+      runIntervalMinutes: 10,
+      reconcileIntervalMinutes: 5,
+      artifactDir: '/custom/path',
+      artifactRetentionDays: 14,
+    });
+  });
+
+  it('fails when a runtime field is not a positive number', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        runtime: { runIntervalMinutes: 0 },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config runtime runIntervalMinutes" must be a positive number.',
+      ),
+    );
+
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        runtime: { reconcileIntervalMinutes: -1 },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config runtime reconcileIntervalMinutes" must be a positive number.',
+      ),
+    );
+  });
+
+  it('fails when runtime section is not an object', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        runtime: 'invalid',
+      }),
+    ).toThrow(
+      new ConfigError('Config file "config runtime" must be an object.'),
+    );
+  });
+
+  it('parses optional pollIntervalMinutes on feeds', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      feeds: [
+        {
+          name: 'TV Feed',
+          url: 'https://example.test/tv.rss',
+          mediaType: 'tv',
+          pollIntervalMinutes: 15,
+        },
+        {
+          name: 'Movie Feed',
+          url: 'https://example.test/movie.rss',
+          mediaType: 'movie',
+        },
+      ],
+    });
+
+    expect(config.feeds[0]?.pollIntervalMinutes).toBe(15);
+    expect(config.feeds[1]?.pollIntervalMinutes).toBeUndefined();
+  });
+
+  it('fails when pollIntervalMinutes is not a positive number', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        feeds: [
+          {
+            name: 'TV Feed',
+            url: 'https://example.test/tv.rss',
+            mediaType: 'tv',
+            pollIntervalMinutes: 0,
+          },
+        ],
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config feeds[0] pollIntervalMinutes" must be a positive number.',
+      ),
+    );
+  });
+
   it('fails with a precise tv matchPattern path when regex syntax is invalid', () => {
     expect(() =>
       validateConfig({
@@ -141,3 +265,32 @@ describe('validateConfig', () => {
     );
   });
 });
+
+function createMinimalConfig() {
+  return {
+    feeds: [
+      {
+        name: 'TV Feed',
+        url: 'https://example.test/tv.rss',
+        mediaType: 'tv',
+      },
+    ],
+    tv: [
+      {
+        name: 'Example Show',
+        resolutions: ['1080p'],
+        codecs: ['x265'],
+      },
+    ],
+    movies: {
+      years: [2024],
+      resolutions: ['1080p'],
+      codecs: ['x265'],
+    },
+    transmission: {
+      url: 'http://localhost:9091/transmission/rpc',
+      username: 'user',
+      password: 'pass',
+    },
+  };
+}

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -160,22 +160,30 @@ describe('validateConfig', () => {
         ...createMinimalConfig(),
         runtime: { runIntervalMinutes: 0 },
       }),
-    ).toThrow(
-      new ConfigError(
-        'Config file "config runtime runIntervalMinutes" must be a positive number.',
-      ),
-    );
+    ).toThrow(/must be a finite positive number/);
 
     expect(() =>
       validateConfig({
         ...createMinimalConfig(),
         runtime: { reconcileIntervalMinutes: -1 },
       }),
-    ).toThrow(
-      new ConfigError(
-        'Config file "config runtime reconcileIntervalMinutes" must be a positive number.',
-      ),
-    );
+    ).toThrow(/must be a finite positive number/);
+  });
+
+  it('fails when a runtime field exceeds the upper bound', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        runtime: { runIntervalMinutes: 50_000 },
+      }),
+    ).toThrow(/must be a finite positive number/);
+
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        runtime: { runIntervalMinutes: Infinity },
+      }),
+    ).toThrow(/must be a finite positive number/);
   });
 
   it('fails when runtime section is not an object', () => {
@@ -224,11 +232,7 @@ describe('validateConfig', () => {
           },
         ],
       }),
-    ).toThrow(
-      new ConfigError(
-        'Config file "config feeds[0] pollIntervalMinutes" must be a positive number.',
-      ),
-    );
+    ).toThrow(/must be a finite positive number/);
   });
 
   it('fails with a precise tv matchPattern path when regex syntax is invalid', () => {

--- a/test/daemon.test.ts
+++ b/test/daemon.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { runDaemonLoop } from '../src/daemon';
+import { daemonOptionsFromConfig, runDaemonLoop } from '../src/daemon';
 
 describe('daemon', () => {
   it('runs initial run and reconcile cycles on startup', async () => {
@@ -138,5 +138,17 @@ describe('daemon', () => {
 
     expect(order[0]).toBe('run');
     expect(order[1]).toBe('reconcile');
+  });
+
+  it('derives daemon options from runtime config', () => {
+    const options = daemonOptionsFromConfig({
+      runIntervalMinutes: 15,
+      reconcileIntervalMinutes: 2,
+      artifactDir: '.pirate-claw/runtime',
+      artifactRetentionDays: 7,
+    });
+
+    expect(options.runIntervalMs).toBe(15 * 60 * 1000);
+    expect(options.reconcileIntervalMs).toBe(2 * 60 * 1000);
   });
 });

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp as createTempDir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import type { AppConfig } from '../src/config';
+import { type AppConfig, DEFAULT_RUNTIME_CONFIG } from '../src/config';
 import { FeedError } from '../src/feed';
 import { retryFailedCandidates, runPipeline } from '../src/pipeline';
 import {
@@ -329,6 +329,7 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       username: 'user',
       password: 'pass',
     },
+    runtime: { ...DEFAULT_RUNTIME_CONFIG },
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- delivery ticket: `P4.02 Add Runtime Config And Default Cadences`
- ticket file: `docs/02-delivery/phase-04/ticket-02-add-runtime-config-and-default-cadences.md`
- stacked base branch: `agents/p4-01-add-foreground-daemon-command`
- internal review: completed at `2026-04-05T09:39:23.520Z`

## External AI Review

- outcome: `patched`
- reviewed commit: `8a1e7720bff9`
- current branch head: `1dfb3ff51ddc`
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- vendors: `qodo`

### Actions Taken

- `1dfb3ff51ddc` [qodo] fix: add finite upper bound to runtime interval validation [P4.02]