### PR TITLE
feat: add due-feed scheduling and poll state persistence [P4.03]

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Pirate Claw keeps local operator state out of git:
 
 - `pirate-claw.config.json`
 - `pirate-claw.db`
+- `.pirate-claw/runtime/poll-state.json` -- persisted feed poll timestamps used by the daemon to resume due-feed scheduling across restarts
 
 Run the daemon for continuous scheduled operation:
 

--- a/docs/02-delivery/phase-04/ticket-03-add-due-feed-scheduling-and-poll-state-persistence.md
+++ b/docs/02-delivery/phase-04/ticket-03-add-due-feed-scheduling-and-poll-state-persistence.md
@@ -20,6 +20,14 @@ Per-feed cadence is core to Phase 04 value and efficiency. Without due-feed sele
 - run/reconcile overlap lock behavior
 - runtime artifact generation
 
+## Rationale
+
+Due-feed filtering happens before `runPipeline` by constructing a reduced `config.feeds` array. This keeps the core pipeline unchanged; only the daemon run cycle selects which feeds to include.
+
+Poll state persists as a JSON file under `runtime.artifactDir`. On first run, all feeds are due because they have no recorded `lastPolledAt`. After each successful cycle, the daemon records the poll timestamp per feed. On restart, the daemon reloads this file and resumes where it left off.
+
+Per-feed `pollIntervalMinutes` overrides the global `runIntervalMinutes` for that feed's due check. If absent, the global default applies.
+
 ## Red First Prompt
 
 What user-visible scheduling behavior fails first when due-feed selection and feed polling state persistence are absent?

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,7 @@
 import { existsSync } from 'node:fs';
 
+import { join } from 'node:path';
+
 import { ConfigError, loadConfig, resolveConfigPath } from './config';
 import { daemonOptionsFromConfig, runDaemonLoop } from './daemon';
 import {
@@ -7,6 +9,12 @@ import {
   retryFailedCandidates,
   runPipeline,
 } from './pipeline';
+import {
+  filterDueFeeds,
+  loadPollState,
+  recordFeedPolled,
+  savePollState,
+} from './poll-state';
 import {
   type CandidateLifecycleStatus,
   createRepository,
@@ -102,13 +110,39 @@ export async function runCli(argv: string[]): Promise<number> {
         process.once('SIGINT', onSignal);
         process.once('SIGTERM', onSignal);
 
+        const pollStatePath = join(
+          config.runtime.artifactDir,
+          'poll-state.json',
+        );
+
         await runDaemonLoop({
           runCycle: async () => {
+            let pollState = loadPollState(pollStatePath);
+            const now = Date.now();
+            const dueFeeds = filterDueFeeds(
+              config.feeds,
+              pollState,
+              config.runtime,
+              now,
+            );
+
+            if (dueFeeds.length === 0) {
+              console.log('run cycle: no feeds due');
+              return;
+            }
+
             const result = await runPipeline({
-              config,
+              config: { ...config, feeds: dueFeeds },
               repository,
               downloader,
             });
+
+            const polledAt = new Date(now).toISOString();
+            for (const feed of dueFeeds) {
+              pollState = recordFeedPolled(pollState, feed.name, polledAt);
+            }
+            savePollState(pollStatePath, pollState);
+
             console.log(formatRunSummary(result));
           },
           reconcileCycle: async () => {

--- a/src/poll-state.ts
+++ b/src/poll-state.ts
@@ -1,0 +1,92 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import type { FeedConfig, RuntimeConfig } from './config';
+
+export type FeedPollRecord = {
+  lastPolledAt: string;
+};
+
+export type PollState = {
+  feeds: Record<string, FeedPollRecord>;
+};
+
+export function loadPollState(path: string): PollState {
+  if (!existsSync(path)) {
+    return { feeds: {} };
+  }
+
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw) as unknown;
+
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'feeds' in parsed &&
+      typeof (parsed as Record<string, unknown>).feeds === 'object'
+    ) {
+      return parsed as PollState;
+    }
+
+    return { feeds: {} };
+  } catch {
+    return { feeds: {} };
+  }
+}
+
+export function savePollState(path: string, state: PollState): void {
+  const dir = dirname(path);
+
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  writeFileSync(path, JSON.stringify(state, null, 2) + '\n');
+}
+
+export function isDueFeed(
+  feed: FeedConfig,
+  state: PollState,
+  runtime: RuntimeConfig,
+  now: number,
+): boolean {
+  const record = state.feeds[feed.name];
+
+  if (!record) {
+    return true;
+  }
+
+  const intervalMs =
+    (feed.pollIntervalMinutes ?? runtime.runIntervalMinutes) * 60 * 1000;
+  const lastPolled = Date.parse(record.lastPolledAt);
+
+  if (Number.isNaN(lastPolled)) {
+    return true;
+  }
+
+  return now - lastPolled >= intervalMs;
+}
+
+export function filterDueFeeds(
+  feeds: FeedConfig[],
+  state: PollState,
+  runtime: RuntimeConfig,
+  now: number,
+): FeedConfig[] {
+  return feeds.filter((feed) => isDueFeed(feed, state, runtime, now));
+}
+
+export function recordFeedPolled(
+  state: PollState,
+  feedName: string,
+  polledAt: string,
+): PollState {
+  return {
+    ...state,
+    feeds: {
+      ...state.feeds,
+      [feedName]: { lastPolledAt: polledAt },
+    },
+  };
+}

--- a/src/poll-state.ts
+++ b/src/poll-state.ts
@@ -1,5 +1,11 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname } from 'node:path';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
 
 import type { FeedConfig, RuntimeConfig } from './config';
 
@@ -20,11 +26,14 @@ export function loadPollState(path: string): PollState {
     const raw = readFileSync(path, 'utf-8');
     const parsed = JSON.parse(raw) as unknown;
 
+    const feeds = (parsed as Record<string, unknown>)?.feeds;
+
     if (
       typeof parsed === 'object' &&
       parsed !== null &&
-      'feeds' in parsed &&
-      typeof (parsed as Record<string, unknown>).feeds === 'object'
+      typeof feeds === 'object' &&
+      feeds !== null &&
+      !Array.isArray(feeds)
     ) {
       return parsed as PollState;
     }
@@ -42,7 +51,9 @@ export function savePollState(path: string, state: PollState): void {
     mkdirSync(dir, { recursive: true });
   }
 
-  writeFileSync(path, JSON.stringify(state, null, 2) + '\n');
+  const tmpPath = join(dir, `.poll-state.${process.pid}.tmp`);
+  writeFileSync(tmpPath, JSON.stringify(state, null, 2) + '\n');
+  renameSync(tmpPath, path);
 }
 
 export function isDueFeed(

--- a/test/poll-state.test.ts
+++ b/test/poll-state.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdtemp as createTempDir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { FeedConfig } from '../src/config';
+import { DEFAULT_RUNTIME_CONFIG } from '../src/config';
+import {
+  filterDueFeeds,
+  isDueFeed,
+  loadPollState,
+  recordFeedPolled,
+  savePollState,
+  type PollState,
+} from '../src/poll-state';
+
+const tempDirs: string[] = [];
+
+describe('poll state', () => {
+  afterEach(async () => {
+    while (tempDirs.length > 0) {
+      const directory = tempDirs.pop();
+      if (directory) {
+        await Bun.$`rm -rf ${directory}`;
+      }
+    }
+  });
+
+  it('returns empty state when file does not exist', () => {
+    const state = loadPollState('/nonexistent/poll-state.json');
+    expect(state).toEqual({ feeds: {} });
+  });
+
+  it('persists and reloads poll state across calls', async () => {
+    const dir = await mkdtemp();
+    const path = join(dir, 'runtime', 'poll-state.json');
+
+    let state: PollState = { feeds: {} };
+    state = recordFeedPolled(state, 'EZTV', '2026-04-05T09:00:00.000Z');
+    state = recordFeedPolled(state, 'Atlas Movies', '2026-04-05T08:30:00.000Z');
+    savePollState(path, state);
+
+    expect(existsSync(path)).toBe(true);
+
+    const loaded = loadPollState(path);
+    expect(loaded.feeds['EZTV']?.lastPolledAt).toBe('2026-04-05T09:00:00.000Z');
+    expect(loaded.feeds['Atlas Movies']?.lastPolledAt).toBe(
+      '2026-04-05T08:30:00.000Z',
+    );
+  });
+
+  it('treats a feed as due when it has never been polled', () => {
+    const feed = createFeed('EZTV');
+    const state: PollState = { feeds: {} };
+
+    expect(isDueFeed(feed, state, DEFAULT_RUNTIME_CONFIG, Date.now())).toBe(
+      true,
+    );
+  });
+
+  it('treats a feed as not due when polled within its interval', () => {
+    const now = Date.now();
+    const feed = createFeed('EZTV');
+    const state: PollState = {
+      feeds: {
+        EZTV: { lastPolledAt: new Date(now - 10 * 60 * 1000).toISOString() },
+      },
+    };
+
+    expect(isDueFeed(feed, state, DEFAULT_RUNTIME_CONFIG, now)).toBe(false);
+  });
+
+  it('treats a feed as due when its interval has elapsed', () => {
+    const now = Date.now();
+    const feed = createFeed('EZTV');
+    const state: PollState = {
+      feeds: {
+        EZTV: { lastPolledAt: new Date(now - 31 * 60 * 1000).toISOString() },
+      },
+    };
+
+    expect(isDueFeed(feed, state, DEFAULT_RUNTIME_CONFIG, now)).toBe(true);
+  });
+
+  it('uses per-feed pollIntervalMinutes when present', () => {
+    const now = Date.now();
+    const feed = createFeed('EZTV', { pollIntervalMinutes: 10 });
+    const state: PollState = {
+      feeds: {
+        EZTV: { lastPolledAt: new Date(now - 11 * 60 * 1000).toISOString() },
+      },
+    };
+
+    expect(isDueFeed(feed, state, DEFAULT_RUNTIME_CONFIG, now)).toBe(true);
+  });
+
+  it('respects per-feed interval over global default', () => {
+    const now = Date.now();
+    const feed = createFeed('EZTV', { pollIntervalMinutes: 60 });
+    const state: PollState = {
+      feeds: {
+        EZTV: { lastPolledAt: new Date(now - 31 * 60 * 1000).toISOString() },
+      },
+    };
+
+    expect(isDueFeed(feed, state, DEFAULT_RUNTIME_CONFIG, now)).toBe(false);
+  });
+
+  it('filters due feeds from a mixed list', () => {
+    const now = Date.now();
+    const feeds = [
+      createFeed('EZTV'),
+      createFeed('Atlas Movies', { pollIntervalMinutes: 60 }),
+    ];
+    const state: PollState = {
+      feeds: {
+        EZTV: { lastPolledAt: new Date(now - 31 * 60 * 1000).toISOString() },
+        'Atlas Movies': {
+          lastPolledAt: new Date(now - 10 * 60 * 1000).toISOString(),
+        },
+      },
+    };
+
+    const due = filterDueFeeds(feeds, state, DEFAULT_RUNTIME_CONFIG, now);
+    expect(due.map((f) => f.name)).toEqual(['EZTV']);
+  });
+
+  it('treats all feeds as due on first ever run', () => {
+    const feeds = [createFeed('EZTV'), createFeed('Atlas Movies')];
+    const state: PollState = { feeds: {} };
+
+    const due = filterDueFeeds(
+      feeds,
+      state,
+      DEFAULT_RUNTIME_CONFIG,
+      Date.now(),
+    );
+    expect(due.map((f) => f.name)).toEqual(['EZTV', 'Atlas Movies']);
+  });
+
+  it('handles corrupt poll state file gracefully', async () => {
+    const dir = await mkdtemp();
+    const path = join(dir, 'poll-state.json');
+    await Bun.write(path, 'not valid json');
+
+    const state = loadPollState(path);
+    expect(state).toEqual({ feeds: {} });
+  });
+});
+
+async function mkdtemp(): Promise<string> {
+  const directory = await createTempDir(
+    join(tmpdir(), 'pirate-claw-poll-state-'),
+  );
+  tempDirs.push(directory);
+  return directory;
+}
+
+function createFeed(name: string, overrides?: Partial<FeedConfig>): FeedConfig {
+  return {
+    name,
+    url: `https://example.test/${name.toLowerCase().replace(/\s/g, '-')}.rss`,
+    mediaType: 'tv',
+    ...overrides,
+  };
+}

--- a/test/poll-state.test.ts
+++ b/test/poll-state.test.ts
@@ -139,6 +139,15 @@ describe('poll state', () => {
     expect(due.map((f) => f.name)).toEqual(['EZTV', 'Atlas Movies']);
   });
 
+  it('handles null feeds in poll state file gracefully', async () => {
+    const dir = await mkdtemp();
+    const path = join(dir, 'poll-state.json');
+    await Bun.write(path, JSON.stringify({ feeds: null }));
+
+    const state = loadPollState(path);
+    expect(state).toEqual({ feeds: {} });
+  });
+
   it('handles corrupt poll state file gracefully', async () => {
     const dir = await mkdtemp();
     const path = join(dir, 'poll-state.json');


### PR DESCRIPTION
## Summary

- delivery ticket: `P4.03 Add Due-Feed Scheduling And Poll-State Persistence`
- ticket file: `docs/02-delivery/phase-04/ticket-03-add-due-feed-scheduling-and-poll-state-persistence.md`
- stacked base branch: `agents/p4-02-add-runtime-config-and-default-cadences`

## External AI Review

- outcome: `patched`
- current branch head: `543daa2f7bd2`