### PR TITLE
feat: add shared runtime lock and overlap skip semantics [P4.04]

### DIFF
--- a/docs/02-delivery/phase-04/ticket-04-add-shared-runtime-lock-and-overlap-skip-semantics.md
+++ b/docs/02-delivery/phase-04/ticket-04-add-shared-runtime-lock-and-overlap-skip-semantics.md
@@ -19,6 +19,12 @@ Without a shared lock, run and reconcile cycles can overlap and create race-pron
 - artifact formatting and retention logic
 - policy changes for codec or Transmission labels
 
+## Rationale
+
+A single boolean `busy` flag inside `runDaemonLoop` acts as a shared runtime lock. Before any cycle (run or reconcile) executes, the `guardedCycle` wrapper checks `busy`. If set, the cycle is skipped and `{type} cycle skipped: already_running` is logged. The flag is released in a `finally` block so it clears even when the cycle throws.
+
+This keeps the lock in-process and zero-dependency. File-based or IPC locks were considered but add complexity for a single-process daemon with no multi-instance requirement. The shared lock means a long-running run cycle blocks reconcile and vice versa, which is the intended behavior: preventing concurrent database and poll-state mutations.
+
 ## Red First Prompt
 
 What deterministic runtime behavior fails first when due cycles are allowed to overlap instead of being skipped with `already_running`?

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -22,6 +22,7 @@ export async function runDaemonLoop(input: {
   const { runCycle, reconcileCycle, options, signal } = input;
   const log = input.log ?? console.log;
   let busy = false;
+  let inFlight: Promise<void> | undefined;
 
   async function guardedCycle(
     type: string,
@@ -35,9 +36,12 @@ export async function runDaemonLoop(input: {
     busy = true;
 
     try {
-      await executeCycle(type, cycle, log);
+      const promise = executeCycle(type, cycle, log);
+      inFlight = promise;
+      await promise;
     } finally {
       busy = false;
+      inFlight = undefined;
     }
   }
 
@@ -51,14 +55,11 @@ export async function runDaemonLoop(input: {
     return;
   }
 
-  let runInFlight: Promise<void> | undefined;
-  let reconcileInFlight: Promise<void> | undefined;
-
   const runTimer = setInterval(() => {
-    runInFlight = guardedCycle('run', runCycle);
+    guardedCycle('run', runCycle);
   }, options.runIntervalMs);
   const reconcileTimer = setInterval(() => {
-    reconcileInFlight = guardedCycle('reconcile', reconcileCycle);
+    guardedCycle('reconcile', reconcileCycle);
   }, options.reconcileIntervalMs);
 
   await new Promise<void>((resolve) => {
@@ -73,9 +74,9 @@ export async function runDaemonLoop(input: {
   clearInterval(runTimer);
   clearInterval(reconcileTimer);
 
-  await Promise.allSettled(
-    [runInFlight, reconcileInFlight].filter(Boolean) as Promise<void>[],
-  );
+  if (inFlight) {
+    await inFlight;
+  }
 
   log('daemon stopped');
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -21,11 +21,30 @@ export async function runDaemonLoop(input: {
 }): Promise<void> {
   const { runCycle, reconcileCycle, options, signal } = input;
   const log = input.log ?? console.log;
+  let busy = false;
+
+  async function guardedCycle(
+    type: string,
+    cycle: () => Promise<void>,
+  ): Promise<void> {
+    if (busy) {
+      log(`${type} cycle skipped: already_running`);
+      return;
+    }
+
+    busy = true;
+
+    try {
+      await executeCycle(type, cycle, log);
+    } finally {
+      busy = false;
+    }
+  }
 
   log('daemon started');
 
-  await executeCycle('run', runCycle, log);
-  await executeCycle('reconcile', reconcileCycle, log);
+  await guardedCycle('run', runCycle);
+  await guardedCycle('reconcile', reconcileCycle);
 
   if (signal.aborted) {
     log('daemon stopped');
@@ -36,10 +55,10 @@ export async function runDaemonLoop(input: {
   let reconcileInFlight: Promise<void> | undefined;
 
   const runTimer = setInterval(() => {
-    runInFlight = executeCycle('run', runCycle, log);
+    runInFlight = guardedCycle('run', runCycle);
   }, options.runIntervalMs);
   const reconcileTimer = setInterval(() => {
-    reconcileInFlight = executeCycle('reconcile', reconcileCycle, log);
+    reconcileInFlight = guardedCycle('reconcile', reconcileCycle);
   }, options.reconcileIntervalMs);
 
   await new Promise<void>((resolve) => {

--- a/test/daemon.test.ts
+++ b/test/daemon.test.ts
@@ -217,6 +217,37 @@ describe('daemon', () => {
     expect(completions.length).toBeGreaterThanOrEqual(2);
   });
 
+  it('waits for an in-flight cycle to complete on shutdown even after a skip', async () => {
+    const log: string[] = [];
+    const controller = new AbortController();
+    let recurringRunCompleted = false;
+    let isInitialRun = true;
+
+    await runDaemonLoop({
+      runCycle: async () => {
+        if (isInitialRun) {
+          isInitialRun = false;
+          return;
+        }
+        await Bun.sleep(80);
+        recurringRunCompleted = true;
+      },
+      reconcileCycle: async () => {},
+      options: { runIntervalMs: 30, reconcileIntervalMs: 600_000 },
+      signal: controller.signal,
+      log: (msg) => {
+        log.push(msg);
+        if (msg === 'run cycle skipped: already_running') {
+          controller.abort();
+        }
+      },
+    });
+
+    expect(recurringRunCompleted).toBe(true);
+    expect(log).toContain('run cycle skipped: already_running');
+    expect(log).toContain('daemon stopped');
+  });
+
   it('derives daemon options from runtime config', () => {
     const options = daemonOptionsFromConfig({
       runIntervalMinutes: 15,

--- a/test/daemon.test.ts
+++ b/test/daemon.test.ts
@@ -140,6 +140,83 @@ describe('daemon', () => {
     expect(order[1]).toBe('reconcile');
   });
 
+  it('skips a reconcile cycle with already_running when a run cycle holds the lock', async () => {
+    const log: string[] = [];
+    const controller = new AbortController();
+
+    await runDaemonLoop({
+      runCycle: async () => {
+        await Bun.sleep(60);
+      },
+      reconcileCycle: async () => {},
+      options: { runIntervalMs: 20, reconcileIntervalMs: 20 },
+      signal: controller.signal,
+      log: (msg) => {
+        log.push(msg);
+        if (msg.includes('skipped: already_running')) {
+          controller.abort();
+        }
+      },
+    });
+
+    expect(log).toContain('reconcile cycle skipped: already_running');
+    expect(log).toContain('daemon stopped');
+  });
+
+  it('skips a run cycle with already_running when a reconcile cycle holds the lock', async () => {
+    const log: string[] = [];
+    const controller = new AbortController();
+
+    await runDaemonLoop({
+      runCycle: async () => {},
+      reconcileCycle: async () => {
+        await Bun.sleep(60);
+      },
+      options: { runIntervalMs: 20, reconcileIntervalMs: 20 },
+      signal: controller.signal,
+      log: (msg) => {
+        log.push(msg);
+        if (msg.includes('run cycle skipped: already_running')) {
+          controller.abort();
+        }
+      },
+    });
+
+    expect(log).toContain('run cycle skipped: already_running');
+    expect(log).toContain('daemon stopped');
+  });
+
+  it('executes the cycle after the lock is released', async () => {
+    const log: string[] = [];
+    const controller = new AbortController();
+
+    await runDaemonLoop({
+      runCycle: async () => {
+        await Bun.sleep(40);
+      },
+      reconcileCycle: async () => {},
+      options: { runIntervalMs: 100, reconcileIntervalMs: 15 },
+      signal: controller.signal,
+      log: (msg) => {
+        log.push(msg);
+        if (
+          log.includes('reconcile cycle skipped: already_running') &&
+          log.filter((m) => m === 'reconcile cycle completed').length >= 2
+        ) {
+          controller.abort();
+        }
+      },
+    });
+
+    const skips = log.filter((m) =>
+      m.includes('reconcile cycle skipped: already_running'),
+    );
+    const completions = log.filter((m) => m === 'reconcile cycle completed');
+
+    expect(skips.length).toBeGreaterThanOrEqual(1);
+    expect(completions.length).toBeGreaterThanOrEqual(2);
+  });
+
   it('derives daemon options from runtime config', () => {
     const options = daemonOptionsFromConfig({
       runIntervalMinutes: 15,


### PR DESCRIPTION
## Summary

- delivery ticket: `P4.04 Add Shared Runtime Lock And Overlap Skip Semantics`
- ticket file: `docs/02-delivery/phase-04/ticket-04-add-shared-runtime-lock-and-overlap-skip-semantics.md`
- stacked base branch: `agents/p4-03-add-due-feed-scheduling-and-poll-state-persistence`
- internal review: completed at `2026-04-05T09:58:47.912Z`

## External AI Review

- outcome: `patched`
- reviewed commit: `50bb2d9b729b`
- current branch head: `5eb1ded7df33`
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- vendors: `qodo`

### Actions Taken

- `5eb1ded7df33` [qodo] fix: track shared in-flight promise to prevent early shutdown [P4.04]