### PR TITLE
feat: add runtime JSON/Markdown artifacts and 7-day retention [P4.05]

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Pirate Claw keeps local operator state out of git:
 - `pirate-claw.config.json`
 - `pirate-claw.db`
 - `.pirate-claw/runtime/poll-state.json` -- persisted feed poll timestamps used by the daemon to resume due-feed scheduling across restarts
-- `.pirate-claw/runtime/cycles/` -- JSON and Markdown artifacts for each daemon cycle (run, reconcile, skipped), pruned to 7 days by default
+- `.pirate-claw/runtime/cycles/` -- JSON and Markdown artifacts for daemon cycle results (completed, failed, or skipped for run/reconcile), pruned to 7 days by default
 
 Run the daemon for continuous scheduled operation:
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Pirate Claw keeps local operator state out of git:
 - `pirate-claw.config.json`
 - `pirate-claw.db`
 - `.pirate-claw/runtime/poll-state.json` -- persisted feed poll timestamps used by the daemon to resume due-feed scheduling across restarts
+- `.pirate-claw/runtime/cycles/` -- JSON and Markdown artifacts for each daemon cycle (run, reconcile, skipped), pruned to 7 days by default
 
 Run the daemon for continuous scheduled operation:
 

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -82,6 +82,10 @@ Goal:
 - schedule queue-intake and reconcile cycles with clear defaults
 - make runtime activity machine-readable through JSON/Markdown artifacts
 
+Current status:
+
+- implemented via `pirate-claw daemon` with configurable cadences, per-feed due scheduling, shared runtime lock, and bounded-retention artifacts
+
 Committed scope:
 
 - `pirate-claw daemon` as a long-running local command

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -10,7 +10,7 @@ Its job is to answer three questions quickly:
 
 ## Current Repo State
 
-Pirate Claw is implemented through Phase 04, with Phase 04 delivery in progress.
+Pirate Claw is implemented through Phase 04.
 
 Current delivered surface:
 
@@ -21,6 +21,7 @@ Current delivered surface:
 - `pirate-claw reconcile`
 - local config via `pirate-claw.config.json`
 - local runtime persistence via `pirate-claw.db`
+- runtime artifacts under `.pirate-claw/runtime/cycles/` with 7-day retention
 
 Current product boundary:
 
@@ -30,6 +31,9 @@ Current product boundary:
 - real-world feed compatibility for EZTV and Atlas is implemented
 - post-queue lifecycle reconciliation and status visibility are implemented for Pirate Claw-queued torrents
 - foreground daemon mode with scheduled run and reconcile cycles
+- per-feed polling cadence with persistent poll state
+- shared runtime lock prevents overlapping cycles
+- machine-readable and human-readable cycle artifacts with bounded retention
 
 Still deferred:
 

--- a/docs/02-delivery/phase-04/ticket-05-add-runtime-artifacts-and-retention.md
+++ b/docs/02-delivery/phase-04/ticket-05-add-runtime-artifacts-and-retention.md
@@ -21,6 +21,14 @@ Phase 04 requires runtime visibility for future dashboard ingestion and human re
 - dashboard/UI rendering
 - status command redesign (remains DB-driven)
 
+## Rationale
+
+Each daemon cycle (run, reconcile, or skipped) produces a pair of JSON and Markdown artifacts under `{artifactDir}/cycles/`. The JSON format is machine-readable for future dashboard ingestion. The Markdown format gives operators a human-readable log. Skipped cycles include the `already_running` reason so operators can see lock contention.
+
+Retention pruning runs after every artifact write, removing files with `mtime` older than `artifactRetentionDays` (default 7). Using `mtime` avoids filename parsing and stays correct even if artifacts are manually touched or copied. Pruning is best-effort and does not prevent daemon operation if the cycles directory is missing.
+
+The daemon exposes an `onCycleResult` callback that the CLI wires to artifact writing and pruning. This keeps the daemon testable without filesystem dependencies.
+
 ## Red First Prompt
 
 What operator-visible behavior fails first when scheduled runtime activity is not persisted as artifacts with bounded retention?

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import {
   recordFeedPolled,
   savePollState,
 } from './poll-state';
+import { pruneArtifacts, writeCycleArtifact } from './runtime-artifacts';
 import {
   type CandidateLifecycleStatus,
   createRepository,
@@ -115,6 +116,8 @@ export async function runCli(argv: string[]): Promise<number> {
           'poll-state.json',
         );
 
+        const { artifactDir, artifactRetentionDays } = config.runtime;
+
         await runDaemonLoop({
           runCycle: async () => {
             let pollState = loadPollState(pollStatePath);
@@ -154,6 +157,10 @@ export async function runCli(argv: string[]): Promise<number> {
           },
           options: daemonOptionsFromConfig(config.runtime),
           signal: controller.signal,
+          onCycleResult: (result) => {
+            writeCycleArtifact(artifactDir, result);
+            pruneArtifacts(artifactDir, artifactRetentionDays);
+          },
         });
       } finally {
         database.close();

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -1,4 +1,5 @@
 import type { RuntimeConfig } from './config';
+import type { CycleResult } from './runtime-artifacts';
 
 export type DaemonOptions = {
   runIntervalMs: number;
@@ -18,9 +19,11 @@ export async function runDaemonLoop(input: {
   options: DaemonOptions;
   signal: AbortSignal;
   log?: (message: string) => void;
+  onCycleResult?: (result: CycleResult) => void;
 }): Promise<void> {
   const { runCycle, reconcileCycle, options, signal } = input;
   const log = input.log ?? console.log;
+  const onCycleResult = input.onCycleResult;
   let busy = false;
   let inFlight: Promise<void> | undefined;
 
@@ -29,14 +32,23 @@ export async function runDaemonLoop(input: {
     cycle: () => Promise<void>,
   ): Promise<void> {
     if (busy) {
+      const now = new Date().toISOString();
       log(`${type} cycle skipped: already_running`);
+      onCycleResult?.({
+        type,
+        status: 'skipped',
+        startedAt: now,
+        completedAt: now,
+        durationMs: 0,
+        skipReason: 'already_running',
+      });
       return;
     }
 
     busy = true;
 
     try {
-      const promise = executeCycle(type, cycle, log);
+      const promise = executeCycle(type, cycle, log, onCycleResult);
       inFlight = promise;
       await promise;
     } finally {
@@ -85,12 +97,31 @@ async function executeCycle(
   type: string,
   cycle: () => Promise<void>,
   log: (message: string) => void,
+  onCycleResult?: (result: CycleResult) => void,
 ): Promise<void> {
+  const startedAt = new Date().toISOString();
+  const startMs = Date.now();
+
   try {
     await cycle();
     log(`${type} cycle completed`);
+    onCycleResult?.({
+      type,
+      status: 'completed',
+      startedAt,
+      completedAt: new Date().toISOString(),
+      durationMs: Date.now() - startMs,
+    });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     log(`${type} cycle failed: ${message}`);
+    onCycleResult?.({
+      type,
+      status: 'failed',
+      startedAt,
+      completedAt: new Date().toISOString(),
+      durationMs: Date.now() - startMs,
+      error: message,
+    });
   }
 }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -23,8 +23,18 @@ export async function runDaemonLoop(input: {
 }): Promise<void> {
   const { runCycle, reconcileCycle, options, signal } = input;
   const log = input.log ?? console.log;
-  const onCycleResult = input.onCycleResult;
   let busy = false;
+
+  const emitCycleResult = (result: CycleResult): void => {
+    if (!input.onCycleResult) return;
+
+    try {
+      input.onCycleResult(result);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log(`cycle result callback failed: ${message}`);
+    }
+  };
   let inFlight: Promise<void> | undefined;
 
   async function guardedCycle(
@@ -34,7 +44,7 @@ export async function runDaemonLoop(input: {
     if (busy) {
       const now = new Date().toISOString();
       log(`${type} cycle skipped: already_running`);
-      onCycleResult?.({
+      emitCycleResult({
         type,
         status: 'skipped',
         startedAt: now,
@@ -48,7 +58,7 @@ export async function runDaemonLoop(input: {
     busy = true;
 
     try {
-      const promise = executeCycle(type, cycle, log, onCycleResult);
+      const promise = executeCycle(type, cycle, log, emitCycleResult);
       inFlight = promise;
       await promise;
     } finally {
@@ -97,7 +107,7 @@ async function executeCycle(
   type: string,
   cycle: () => Promise<void>,
   log: (message: string) => void,
-  onCycleResult?: (result: CycleResult) => void,
+  emitCycleResult: (result: CycleResult) => void,
 ): Promise<void> {
   const startedAt = new Date().toISOString();
   const startMs = Date.now();
@@ -105,7 +115,7 @@ async function executeCycle(
   try {
     await cycle();
     log(`${type} cycle completed`);
-    onCycleResult?.({
+    emitCycleResult({
       type,
       status: 'completed',
       startedAt,
@@ -115,7 +125,7 @@ async function executeCycle(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     log(`${type} cycle failed: ${message}`);
-    onCycleResult?.({
+    emitCycleResult({
       type,
       status: 'failed',
       startedAt,

--- a/src/runtime-artifacts.ts
+++ b/src/runtime-artifacts.ts
@@ -1,0 +1,93 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+export type CycleResult = {
+  type: string;
+  status: 'completed' | 'failed' | 'skipped';
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+  skipReason?: string;
+  error?: string;
+};
+
+export function writeCycleArtifact(
+  artifactDir: string,
+  result: CycleResult,
+): void {
+  const cyclesDir = join(artifactDir, 'cycles');
+
+  if (!existsSync(cyclesDir)) {
+    mkdirSync(cyclesDir, { recursive: true });
+  }
+
+  const stem = `${artifactTimestamp(result.startedAt)}-${result.type}`;
+
+  writeFileSync(
+    join(cyclesDir, `${stem}.json`),
+    JSON.stringify(result, null, 2) + '\n',
+  );
+
+  writeFileSync(join(cyclesDir, `${stem}.md`), formatCycleMarkdown(result));
+}
+
+export function pruneArtifacts(
+  artifactDir: string,
+  retentionDays: number,
+  now?: number,
+): void {
+  const cyclesDir = join(artifactDir, 'cycles');
+
+  if (!existsSync(cyclesDir)) {
+    return;
+  }
+
+  const cutoffMs = (now ?? Date.now()) - retentionDays * 24 * 60 * 60 * 1000;
+  const files = readdirSync(cyclesDir);
+
+  for (const file of files) {
+    const filePath = join(cyclesDir, file);
+    const stat = statSync(filePath);
+
+    if (stat.mtimeMs < cutoffMs) {
+      unlinkSync(filePath);
+    }
+  }
+}
+
+export function formatCycleMarkdown(result: CycleResult): string {
+  const lines: string[] = [
+    `# ${result.type} cycle — ${result.startedAt}`,
+    '',
+    `- **Status**: ${result.status}`,
+  ];
+
+  if (result.status === 'skipped' && result.skipReason) {
+    lines.push(`- **Reason**: ${result.skipReason}`);
+  }
+
+  if (result.error) {
+    lines.push(`- **Error**: ${result.error}`);
+  }
+
+  if (result.status !== 'skipped') {
+    lines.push(`- **Duration**: ${result.durationMs}ms`);
+    lines.push(`- **Started**: ${result.startedAt}`);
+    lines.push(`- **Completed**: ${result.completedAt}`);
+  }
+
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function artifactTimestamp(isoString: string): string {
+  return isoString.replace(/:/g, '-').replace('.', '-');
+}

--- a/src/runtime-artifacts.ts
+++ b/src/runtime-artifacts.ts
@@ -50,14 +50,22 @@ export function pruneArtifacts(
   }
 
   const cutoffMs = (now ?? Date.now()) - retentionDays * 24 * 60 * 60 * 1000;
-  const files = readdirSync(cyclesDir);
+  const entries = readdirSync(cyclesDir, { withFileTypes: true });
 
-  for (const file of files) {
-    const filePath = join(cyclesDir, file);
-    const stat = statSync(filePath);
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
 
-    if (stat.mtimeMs < cutoffMs) {
-      unlinkSync(filePath);
+    try {
+      const filePath = join(cyclesDir, entry.name);
+      const stat = statSync(filePath);
+
+      if (stat.mtimeMs < cutoffMs) {
+        unlinkSync(filePath);
+      }
+    } catch {
+      // best-effort: skip entries that can't be removed
     }
   }
 }

--- a/test/daemon.test.ts
+++ b/test/daemon.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 
 import { daemonOptionsFromConfig, runDaemonLoop } from '../src/daemon';
+import type { CycleResult } from '../src/runtime-artifacts';
 
 describe('daemon', () => {
   it('runs initial run and reconcile cycles on startup', async () => {
@@ -246,6 +247,59 @@ describe('daemon', () => {
     expect(recurringRunCompleted).toBe(true);
     expect(log).toContain('run cycle skipped: already_running');
     expect(log).toContain('daemon stopped');
+  });
+
+  it('fires onCycleResult for completed, failed, and skipped cycles', async () => {
+    const results: CycleResult[] = [];
+    const controller = new AbortController();
+
+    await runDaemonLoop({
+      runCycle: async () => {},
+      reconcileCycle: async () => {
+        throw new Error('boom');
+      },
+      options: { runIntervalMs: 600_000, reconcileIntervalMs: 600_000 },
+      signal: controller.signal,
+      log: () => {
+        controller.abort();
+      },
+      onCycleResult: (result) => results.push(result),
+    });
+
+    expect(results.length).toBe(2);
+
+    expect(results[0].type).toBe('run');
+    expect(results[0].status).toBe('completed');
+    expect(results[0].durationMs).toBeGreaterThanOrEqual(0);
+
+    expect(results[1].type).toBe('reconcile');
+    expect(results[1].status).toBe('failed');
+    expect(results[1].error).toBe('boom');
+  });
+
+  it('fires onCycleResult for skipped cycles', async () => {
+    const results: CycleResult[] = [];
+    const controller = new AbortController();
+
+    await runDaemonLoop({
+      runCycle: async () => {
+        await Bun.sleep(60);
+      },
+      reconcileCycle: async () => {},
+      options: { runIntervalMs: 20, reconcileIntervalMs: 20 },
+      signal: controller.signal,
+      log: (msg) => {
+        if (msg.includes('skipped: already_running')) {
+          controller.abort();
+        }
+      },
+      onCycleResult: (result) => results.push(result),
+    });
+
+    const skippedResults = results.filter((r) => r.status === 'skipped');
+    expect(skippedResults.length).toBeGreaterThanOrEqual(1);
+    expect(skippedResults[0].skipReason).toBe('already_running');
+    expect(skippedResults[0].durationMs).toBe(0);
   });
 
   it('derives daemon options from runtime config', () => {

--- a/test/daemon.test.ts
+++ b/test/daemon.test.ts
@@ -249,7 +249,7 @@ describe('daemon', () => {
     expect(log).toContain('daemon stopped');
   });
 
-  it('fires onCycleResult for completed, failed, and skipped cycles', async () => {
+  it('fires onCycleResult for completed and failed cycles', async () => {
     const results: CycleResult[] = [];
     const controller = new AbortController();
 

--- a/test/runtime-artifacts.test.ts
+++ b/test/runtime-artifacts.test.ts
@@ -1,0 +1,171 @@
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'bun:test';
+import { tmpdir } from 'node:os';
+
+import {
+  type CycleResult,
+  formatCycleMarkdown,
+  pruneArtifacts,
+  writeCycleArtifact,
+} from '../src/runtime-artifacts';
+
+async function mkdtemp(): Promise<string> {
+  const dir = join(tmpdir(), `pirate-claw-test-${Date.now()}-${Math.random()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe('runtime artifacts', () => {
+  it('writes JSON and Markdown artifacts for a completed cycle', async () => {
+    const dir = await mkdtemp();
+    const result: CycleResult = {
+      type: 'run',
+      status: 'completed',
+      startedAt: '2026-04-05T10:00:00.000Z',
+      completedAt: '2026-04-05T10:00:05.000Z',
+      durationMs: 5000,
+    };
+
+    writeCycleArtifact(dir, result);
+
+    const files = readdirSync(join(dir, 'cycles'));
+    const jsonFile = files.find((f) => f.endsWith('.json'));
+    const mdFile = files.find((f) => f.endsWith('.md'));
+
+    expect(jsonFile).toBeDefined();
+    expect(mdFile).toBeDefined();
+    expect(jsonFile).toContain('run');
+    expect(mdFile).toContain('run');
+
+    const json = await Bun.file(join(dir, 'cycles', jsonFile!)).json();
+    expect(json.type).toBe('run');
+    expect(json.status).toBe('completed');
+    expect(json.durationMs).toBe(5000);
+
+    const md = await Bun.file(join(dir, 'cycles', mdFile!)).text();
+    expect(md).toContain('# run cycle');
+    expect(md).toContain('**Status**: completed');
+    expect(md).toContain('**Duration**: 5000ms');
+  });
+
+  it('writes artifacts for a skipped cycle with reason', async () => {
+    const dir = await mkdtemp();
+    const result: CycleResult = {
+      type: 'reconcile',
+      status: 'skipped',
+      startedAt: '2026-04-05T10:01:00.000Z',
+      completedAt: '2026-04-05T10:01:00.000Z',
+      durationMs: 0,
+      skipReason: 'already_running',
+    };
+
+    writeCycleArtifact(dir, result);
+
+    const files = readdirSync(join(dir, 'cycles'));
+    const jsonFile = files.find((f) => f.endsWith('.json'))!;
+    const mdFile = files.find((f) => f.endsWith('.md'))!;
+
+    const json = await Bun.file(join(dir, 'cycles', jsonFile)).json();
+    expect(json.status).toBe('skipped');
+    expect(json.skipReason).toBe('already_running');
+
+    const md = await Bun.file(join(dir, 'cycles', mdFile)).text();
+    expect(md).toContain('**Status**: skipped');
+    expect(md).toContain('**Reason**: already_running');
+    expect(md).not.toContain('**Duration**');
+  });
+
+  it('writes artifacts for a failed cycle with error', async () => {
+    const dir = await mkdtemp();
+    const result: CycleResult = {
+      type: 'run',
+      status: 'failed',
+      startedAt: '2026-04-05T10:02:00.000Z',
+      completedAt: '2026-04-05T10:02:01.200Z',
+      durationMs: 1200,
+      error: 'feed unavailable',
+    };
+
+    writeCycleArtifact(dir, result);
+
+    const files = readdirSync(join(dir, 'cycles'));
+    const jsonFile = files.find((f) => f.endsWith('.json'))!;
+    const mdFile = files.find((f) => f.endsWith('.md'))!;
+
+    const json = await Bun.file(join(dir, 'cycles', jsonFile)).json();
+    expect(json.status).toBe('failed');
+    expect(json.error).toBe('feed unavailable');
+
+    const md = await Bun.file(join(dir, 'cycles', mdFile)).text();
+    expect(md).toContain('**Status**: failed');
+    expect(md).toContain('**Error**: feed unavailable');
+    expect(md).toContain('**Duration**: 1200ms');
+  });
+
+  it('creates the cycles directory if it does not exist', async () => {
+    const dir = await mkdtemp();
+    const cyclesDir = join(dir, 'cycles');
+
+    expect(existsSync(cyclesDir)).toBe(false);
+
+    writeCycleArtifact(dir, {
+      type: 'run',
+      status: 'completed',
+      startedAt: '2026-04-05T10:00:00.000Z',
+      completedAt: '2026-04-05T10:00:01.000Z',
+      durationMs: 1000,
+    });
+
+    expect(existsSync(cyclesDir)).toBe(true);
+  });
+
+  it('prunes artifacts older than retention days', async () => {
+    const dir = await mkdtemp();
+    const cyclesDir = join(dir, 'cycles');
+    mkdirSync(cyclesDir, { recursive: true });
+
+    const now = Date.now();
+    const eightDaysAgo = now - 8 * 24 * 60 * 60 * 1000;
+    const oneDayAgo = now - 1 * 24 * 60 * 60 * 1000;
+
+    const oldFile = join(cyclesDir, 'old-run.json');
+    const recentFile = join(cyclesDir, 'recent-run.json');
+
+    writeFileSync(oldFile, '{}');
+    writeFileSync(recentFile, '{}');
+
+    const { utimesSync } = await import('node:fs');
+    const oldDate = new Date(eightDaysAgo);
+    const recentDate = new Date(oneDayAgo);
+    utimesSync(oldFile, oldDate, oldDate);
+    utimesSync(recentFile, recentDate, recentDate);
+
+    pruneArtifacts(dir, 7, now);
+
+    const remaining = readdirSync(cyclesDir);
+    expect(remaining).toContain('recent-run.json');
+    expect(remaining).not.toContain('old-run.json');
+  });
+
+  it('does nothing when cycles directory does not exist for pruning', () => {
+    const dir = '/tmp/nonexistent-pirate-claw-test-' + Date.now();
+    expect(() => pruneArtifacts(dir, 7)).not.toThrow();
+  });
+
+  it('formats completed cycle markdown with duration and timestamps', () => {
+    const md = formatCycleMarkdown({
+      type: 'reconcile',
+      status: 'completed',
+      startedAt: '2026-04-05T10:00:00.000Z',
+      completedAt: '2026-04-05T10:00:02.500Z',
+      durationMs: 2500,
+    });
+
+    expect(md).toContain('# reconcile cycle');
+    expect(md).toContain('**Status**: completed');
+    expect(md).toContain('**Duration**: 2500ms');
+    expect(md).toContain('**Started**: 2026-04-05T10:00:00.000Z');
+    expect(md).toContain('**Completed**: 2026-04-05T10:00:02.500Z');
+  });
+});


### PR DESCRIPTION
## Summary

- delivery ticket: `P4.05 Add Runtime JSON/Markdown Artifacts And 7-Day Retention`
- ticket file: `docs/02-delivery/phase-04/ticket-05-add-runtime-artifacts-and-retention.md`
- stacked base branch: `agents/p4-04-add-shared-runtime-lock-and-overlap-skip-semantics`
- internal review: completed at `2026-04-05T10:08:20.862Z`

## External AI Review

- outcome: `patched`
- reviewed commit: `29b34348a721`
- current branch head: `e5413c60a60c`
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- vendors: `coderabbit`, `qodo`

### Actions Taken

- `e5413c60a60c` [coderabbit,qodo] fix: harden cycle result callback and make pruning best-effort [P4.05]