### PR TITLE
refactor: make delivery orchestrator core configurable via orchestrator.config.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 # Repo Rules
 
 - For phase work, first read `docs/00-overview/start-here.md` and `docs/03-engineering/delivery-orchestrator.md`, then surface the orchestrator path before coding.
-- Prefer `bun run deliver --plan ...` over ad hoc implementation.
+- The delivery orchestrator reads `orchestrator.config.json` at the repo root for runtime, package manager, default branch, and plan root. See `docs/03-engineering/delivery-orchestrator.md` for field details and defaults.
+- Prefer `bun run deliver --plan ...` (or the configured package manager's equivalent) over ad hoc implementation.
 - For orchestrated ticket work, the handoff under `.agents/delivery/<plan-key>/handoffs/` is required input alongside the plan and ticket docs.
 - `begin phase` / `implement phase` means run the stacked-ticket workflow until blocked, not just the first ticket.
 - Phase flow: implement, verify, push/open PR, run the configured `ai-code-review` polling window, patch prudent findings if any appear, refresh PR state, then advance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
 # Repo Rules
 
 - For phase work, first read `docs/00-overview/start-here.md` and `docs/03-engineering/delivery-orchestrator.md`, then surface the orchestrator path before coding.
-- The delivery orchestrator reads `orchestrator.config.json` at the repo root for runtime, package manager, default branch, and plan root. See `docs/03-engineering/delivery-orchestrator.md` for field details and defaults.
-- Prefer `bun run deliver --plan ...` (or the configured package manager's equivalent) over ad hoc implementation.
+- The delivery orchestrator reads `orchestrator.config.json` at the repo root for default branch, plan root, runtime internals, and package-manager-aware bootstrap defaults. See `docs/03-engineering/delivery-orchestrator.md` for field details and scope.
+- Prefer `bun run deliver --plan ...` over ad hoc implementation. In this repo, `bun run deliver` remains the supported operator entrypoint even though the orchestrator internals are more configurable.
 - For orchestrated ticket work, the handoff under `.agents/delivery/<plan-key>/handoffs/` is required input alongside the plan and ticket docs.
 - `begin phase` / `implement phase` means run the stacked-ticket workflow until blocked, not just the first ticket.
 - Phase flow: implement, verify, push/open PR, run the configured `ai-code-review` polling window, patch prudent findings if any appear, refresh PR state, then advance.

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -14,6 +14,28 @@ That means:
 
 This keeps the product boundary honest. `src/` remains the Pirate Claw application. The delivery tool is a maintainer workflow helper.
 
+## App-Agnostic Runtime
+
+The orchestrator is runtime-agnostic. It works under Bun and Node via `orchestrator.config.json` at the repo root:
+
+```json
+{
+  "defaultBranch": "main",
+  "planRoot": "docs",
+  "runtime": "bun",
+  "packageManager": "bun"
+}
+```
+
+All fields are optional. When the file is absent, the orchestrator infers sensible defaults:
+
+- `defaultBranch`: `"main"`
+- `planRoot`: `"docs"` (plans live at `{planRoot}/02-delivery/<phase>/implementation-plan.md`)
+- `runtime`: `"bun"` (`"bun"` uses `Bun.spawnSync`, `"node"` uses `child_process.spawnSync`)
+- `packageManager`: inferred from lockfile (`bun.lock` → `"bun"`, `pnpm-lock.yaml` → `"pnpm"`, `yarn.lock` → `"yarn"`, `package-lock.json` → `"npm"`, fallback `"npm"`)
+
+The internal convention below `planRoot` is fixed: `{planRoot}/02-delivery/<phase>/implementation-plan.md`. Only the top-level directory name is configurable.
+
 ## Plan-Driven, Not Phase-Hardcoded
 
 The engine is generic. It does not fundamentally belong to Phase 02.
@@ -39,7 +61,7 @@ The orchestrator owns process mechanics:
 - per-ticket handoff artifacts under `.agents/delivery/<plan-key>/handoffs/`
 - deterministic branch and worktree naming
 - copying a local `.env` into fresh ticket work trees when the invoking worktree has one
-- bootstrapping fresh Bun ticket work trees before implementation starts
+- bootstrapping fresh ticket work trees using the configured package manager before implementation starts
 - stacked PR base chaining
 - idempotent PR open/update behavior for already-pushed ticket branches
 - a 2/4/6/8-minute ai-review polling loop after PR open
@@ -111,7 +133,7 @@ That inference is intentionally conservative. It reconstructs enough state to re
 
 ## Commands
 
-Use the generic command:
+Use the generic command (shown with `bun`; substitute your configured package manager):
 
 ```bash
 bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md status

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -14,9 +14,9 @@ That means:
 
 This keeps the product boundary honest. `src/` remains the Pirate Claw application. The delivery tool is a maintainer workflow helper.
 
-## App-Agnostic Runtime
+## Configurable Core
 
-The orchestrator is runtime-agnostic. It works under Bun and Node via `orchestrator.config.json` at the repo root:
+The orchestrator core now reads `orchestrator.config.json` at the repo root so branch, plan-root, runtime-internal, and bootstrap defaults are not hardcoded:
 
 ```json
 {
@@ -31,10 +31,12 @@ All fields are optional. When the file is absent, the orchestrator infers sensib
 
 - `defaultBranch`: `"main"`
 - `planRoot`: `"docs"` (plans live at `{planRoot}/02-delivery/<phase>/implementation-plan.md`)
-- `runtime`: `"bun"` (`"bun"` uses `Bun.spawnSync`, `"node"` uses `child_process.spawnSync`)
-- `packageManager`: inferred from lockfile (`bun.lock` → `"bun"`, `pnpm-lock.yaml` → `"pnpm"`, `yarn.lock` → `"yarn"`, `package-lock.json` → `"npm"`, fallback `"npm"`)
+- `runtime`: `"bun"` (`"bun"` uses `Bun.spawnSync`, `"node"` uses `child_process.spawnSync` inside the orchestrator implementation)
+- `packageManager`: inferred from lockfile (`bun.lock` → `"bun"`, `pnpm-lock.yaml` → `"pnpm"`, `yarn.lock` → `"yarn"`, `package-lock.json` → `"npm"`, fallback `"npm"`) for worktree bootstrap behavior
 
 The internal convention below `planRoot` is fixed: `{planRoot}/02-delivery/<phase>/implementation-plan.md`. Only the top-level directory name is configurable.
+
+In Pirate Claw itself, the supported operator entrypoint remains `bun run deliver --plan ...`. This change makes the orchestrator core less repo-specific, but it does not turn this repository into a fully validated multi-runtime CLI package.
 
 ## Plan-Driven, Not Phase-Hardcoded
 
@@ -61,7 +63,7 @@ The orchestrator owns process mechanics:
 - per-ticket handoff artifacts under `.agents/delivery/<plan-key>/handoffs/`
 - deterministic branch and worktree naming
 - copying a local `.env` into fresh ticket work trees when the invoking worktree has one
-- bootstrapping fresh ticket work trees using the configured package manager before implementation starts
+- bootstrapping fresh ticket work trees using lockfile-aware package-manager defaults before implementation starts
 - stacked PR base chaining
 - idempotent PR open/update behavior for already-pushed ticket branches
 - a 2/4/6/8-minute ai-review polling loop after PR open
@@ -133,7 +135,7 @@ That inference is intentionally conservative. It reconstructs enough state to re
 
 ## Commands
 
-Use the generic command (shown with `bun`; substitute your configured package manager):
+Use the supported repo command:
 
 ```bash
 bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md status

--- a/scripts/deliver.ts
+++ b/scripts/deliver.ts
@@ -1,7 +1,7 @@
 import { runDeliveryOrchestrator } from '../tools/delivery/orchestrator';
 
 const exitCode = await runDeliveryOrchestrator(
-  Bun.argv.slice(2),
+  process.argv.slice(2),
   process.cwd(),
 );
 process.exit(exitCode);

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -25,6 +25,9 @@ import {
   findTicketByBranch,
   formatNotificationMessage,
   formatReviewWindowMessage,
+  inferPackageManager,
+  initOrchestratorConfig,
+  loadOrchestratorConfig,
   mergeStandaloneAiReviewSection,
   notifyBestEffort,
   openPullRequest,
@@ -37,6 +40,7 @@ import {
   pollReview,
   recordInternalReview,
   recordReview,
+  resolveOrchestratorConfig,
   resolvePlanPathForBranch,
   resolveNotifier,
   resolveReviewFetcher,
@@ -2257,5 +2261,194 @@ describe('delivery orchestrator', () => {
         process.env.AI_CODE_REVIEW_TRIAGER = original;
       }
     }
+  });
+
+  describe('orchestrator config', () => {
+    it('returns defaults when config file is absent', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-cfg-'));
+      try {
+        const config = await loadOrchestratorConfig(tempDir);
+        expect(config).toEqual({});
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
+    it('loads a partial config and preserves specified fields', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-cfg-'));
+      try {
+        await writeFile(
+          join(tempDir, 'orchestrator.config.json'),
+          JSON.stringify({ defaultBranch: 'develop', runtime: 'node' }),
+        );
+
+        const config = await loadOrchestratorConfig(tempDir);
+        expect(config).toEqual({
+          defaultBranch: 'develop',
+          planRoot: undefined,
+          runtime: 'node',
+          packageManager: undefined,
+        });
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
+    it('throws on invalid runtime value', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-cfg-'));
+      try {
+        await writeFile(
+          join(tempDir, 'orchestrator.config.json'),
+          JSON.stringify({ runtime: 'deno' }),
+        );
+
+        await expect(loadOrchestratorConfig(tempDir)).rejects.toThrow(
+          /Invalid runtime "deno"/,
+        );
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
+    it('throws on invalid packageManager value', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-cfg-'));
+      try {
+        await writeFile(
+          join(tempDir, 'orchestrator.config.json'),
+          JSON.stringify({ packageManager: 'cargo' }),
+        );
+
+        await expect(loadOrchestratorConfig(tempDir)).rejects.toThrow(
+          /Invalid packageManager "cargo"/,
+        );
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
+    it('throws on non-string defaultBranch', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-cfg-'));
+      try {
+        await writeFile(
+          join(tempDir, 'orchestrator.config.json'),
+          JSON.stringify({ defaultBranch: 42 }),
+        );
+
+        await expect(loadOrchestratorConfig(tempDir)).rejects.toThrow(
+          /Invalid defaultBranch/,
+        );
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
+    it('resolves empty config to defaults', () => {
+      const tempDir = '/tmp/resolve-cfg-test';
+      const resolved = resolveOrchestratorConfig({}, tempDir);
+      expect(resolved).toEqual({
+        defaultBranch: 'main',
+        planRoot: 'docs',
+        runtime: 'bun',
+        packageManager: 'npm',
+      });
+    });
+
+    it('merges partial config with defaults', () => {
+      const resolved = resolveOrchestratorConfig(
+        { defaultBranch: 'develop', planRoot: 'specifications' },
+        '/tmp/resolve-cfg-merge',
+      );
+      expect(resolved.defaultBranch).toBe('develop');
+      expect(resolved.planRoot).toBe('specifications');
+      expect(resolved.runtime).toBe('bun');
+      expect(resolved.packageManager).toBe('npm');
+    });
+
+    it('infers bun from bun.lock', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-pm-'));
+      try {
+        await writeFile(join(tempDir, 'bun.lock'), '');
+        expect(inferPackageManager(tempDir)).toBe('bun');
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
+    it('infers pnpm from pnpm-lock.yaml', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-pm-'));
+      try {
+        await writeFile(join(tempDir, 'pnpm-lock.yaml'), '');
+        expect(inferPackageManager(tempDir)).toBe('pnpm');
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
+    it('infers yarn from yarn.lock', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-pm-'));
+      try {
+        await writeFile(join(tempDir, 'yarn.lock'), '');
+        expect(inferPackageManager(tempDir)).toBe('yarn');
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
+    it('infers npm from package-lock.json', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-pm-'));
+      try {
+        await writeFile(join(tempDir, 'package-lock.json'), '{}');
+        expect(inferPackageManager(tempDir)).toBe('npm');
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
+    it('falls back to npm when no lockfile is present', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-pm-'));
+      try {
+        expect(inferPackageManager(tempDir)).toBe('npm');
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
+    it('syncStateWithPlan uses configured defaultBranch for first ticket baseBranch', () => {
+      initOrchestratorConfig({
+        defaultBranch: 'develop',
+        planRoot: 'docs',
+        runtime: 'bun',
+        packageManager: 'bun',
+      });
+
+      try {
+        const options = createOptions({
+          planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+        });
+
+        const synced = syncStateWithPlan(
+          undefined,
+          [
+            {
+              id: 'P3.01',
+              title: 'First Ticket',
+              slug: 'first-ticket',
+              ticketFile: 'docs/02-delivery/phase-03/ticket-01-first-ticket.md',
+            },
+          ],
+          '/workspace/test',
+          options,
+        );
+
+        expect(synced.tickets[0]?.baseBranch).toBe('develop');
+      } finally {
+        initOrchestratorConfig({
+          defaultBranch: 'main',
+          planRoot: 'docs',
+          runtime: 'bun',
+          packageManager: 'bun',
+        });
+      }
+    });
   });
 });

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -1,3 +1,4 @@
+import { spawnSync as nodeSpawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { readdir } from 'node:fs/promises';
@@ -99,6 +100,119 @@ type BranchMatch = {
   branch: string;
   source: 'ticket-id' | 'derived';
 };
+
+export type OrchestratorConfig = {
+  defaultBranch?: string;
+  planRoot?: string;
+  runtime?: 'bun' | 'node';
+  packageManager?: 'bun' | 'npm' | 'pnpm' | 'yarn';
+};
+
+export type ResolvedOrchestratorConfig = {
+  defaultBranch: string;
+  planRoot: string;
+  runtime: 'bun' | 'node';
+  packageManager: 'bun' | 'npm' | 'pnpm' | 'yarn';
+};
+
+const VALID_RUNTIMES = ['bun', 'node'] as const;
+const VALID_PACKAGE_MANAGERS = ['bun', 'npm', 'pnpm', 'yarn'] as const;
+
+let _config: ResolvedOrchestratorConfig = {
+  defaultBranch: 'main',
+  planRoot: 'docs',
+  runtime: 'bun',
+  packageManager: 'npm',
+};
+
+export function initOrchestratorConfig(
+  config: ResolvedOrchestratorConfig,
+): void {
+  _config = config;
+}
+
+export function getOrchestratorConfig(): ResolvedOrchestratorConfig {
+  return _config;
+}
+
+export async function loadOrchestratorConfig(
+  cwd: string,
+): Promise<OrchestratorConfig> {
+  const configPath = resolve(cwd, 'orchestrator.config.json');
+
+  if (!existsSync(configPath)) {
+    return {};
+  }
+
+  const raw = JSON.parse(await readFile(configPath, 'utf8')) as Record<
+    string,
+    unknown
+  >;
+
+  if (
+    raw.runtime !== undefined &&
+    !VALID_RUNTIMES.includes(raw.runtime as (typeof VALID_RUNTIMES)[number])
+  ) {
+    throw new Error(
+      `Invalid runtime "${String(raw.runtime)}" in orchestrator.config.json. Expected: ${VALID_RUNTIMES.join(', ')}`,
+    );
+  }
+
+  if (
+    raw.packageManager !== undefined &&
+    !VALID_PACKAGE_MANAGERS.includes(
+      raw.packageManager as (typeof VALID_PACKAGE_MANAGERS)[number],
+    )
+  ) {
+    throw new Error(
+      `Invalid packageManager "${String(raw.packageManager)}" in orchestrator.config.json. Expected: ${VALID_PACKAGE_MANAGERS.join(', ')}`,
+    );
+  }
+
+  if (
+    raw.defaultBranch !== undefined &&
+    typeof raw.defaultBranch !== 'string'
+  ) {
+    throw new Error(
+      'Invalid defaultBranch in orchestrator.config.json. Expected a string.',
+    );
+  }
+
+  if (raw.planRoot !== undefined && typeof raw.planRoot !== 'string') {
+    throw new Error(
+      'Invalid planRoot in orchestrator.config.json. Expected a string.',
+    );
+  }
+
+  return {
+    defaultBranch: raw.defaultBranch as string | undefined,
+    planRoot: raw.planRoot as string | undefined,
+    runtime: raw.runtime as OrchestratorConfig['runtime'],
+    packageManager: raw.packageManager as OrchestratorConfig['packageManager'],
+  };
+}
+
+export function inferPackageManager(
+  cwd: string,
+): ResolvedOrchestratorConfig['packageManager'] {
+  if (existsSync(resolve(cwd, 'bun.lock'))) return 'bun';
+  if (existsSync(resolve(cwd, 'pnpm-lock.yaml'))) return 'pnpm';
+  if (existsSync(resolve(cwd, 'yarn.lock'))) return 'yarn';
+  if (existsSync(resolve(cwd, 'package-lock.json'))) return 'npm';
+  return 'npm';
+}
+
+export function resolveOrchestratorConfig(
+  raw: OrchestratorConfig,
+  cwd: string,
+): ResolvedOrchestratorConfig {
+  return {
+    defaultBranch: raw.defaultBranch ?? 'main',
+    planRoot: raw.planRoot ?? 'docs',
+    runtime: raw.runtime ?? 'bun',
+    packageManager: raw.packageManager ?? inferPackageManager(cwd),
+  };
+}
 
 export type DeliveryNotificationEvent =
   | {
@@ -324,6 +438,9 @@ export async function runDeliveryOrchestrator(
     | undefined;
 
   try {
+    const rawConfig = await loadOrchestratorConfig(cwd);
+    _config = resolveOrchestratorConfig(rawConfig, cwd);
+
     await ensureEnvReady(cwd);
     const notifier = resolveNotifier();
     parsed = parseCliArgs(argv);
@@ -434,7 +551,7 @@ export async function runDeliveryOrchestrator(
             outcome !== 'operator_input_needed')
         ) {
           throw new Error(
-            'Usage: bun run deliver --plan <plan-path> record-review <ticket-id> <clean|patched|operator_input_needed> [note]',
+            `Usage: ${_config.packageManager} run deliver --plan <plan-path> record-review <ticket-id> <clean|patched|operator_input_needed> [note]`,
           );
         }
 
@@ -601,7 +718,7 @@ export function findPrimaryWorktreePath(cwd: string): string | undefined {
   return worktrees.find(
     (worktree) =>
       resolve(worktree.path) !== resolve(cwd) &&
-      worktree.branch === 'refs/heads/main',
+      worktree.branch === `refs/heads/${_config.defaultBranch}`,
   )?.path;
 }
 
@@ -694,7 +811,7 @@ export function syncStateWithPlan(
       );
       const inferredBaseBranch =
         index === 0
-          ? 'main'
+          ? _config.defaultBranch
           : selectBranchValue(
               existingById.get(previousTicket?.id ?? '')?.branch,
               inferredById.get(previousTicket?.id ?? '')?.branch,
@@ -710,7 +827,7 @@ export function syncStateWithPlan(
         branch: resolvedBranch,
         baseBranch:
           index === 0
-            ? 'main'
+            ? _config.defaultBranch
             : selectBranchValue(
                 previous?.baseBranch,
                 inferredTicket?.baseBranch,
@@ -985,7 +1102,7 @@ async function resolveOptionsForCommand(
 
 function getUsage(): string {
   return [
-    'Usage: bun run deliver --plan <plan-path> <command>',
+    `Usage: ${_config.packageManager} run deliver --plan <plan-path> <command>`,
     '',
     'Commands:',
     '  ai-review [--pr <number>]',
@@ -1089,7 +1206,7 @@ export function resolvePlanPathForBranch(
 }
 
 async function listImplementationPlans(cwd: string): Promise<string[]> {
-  const deliveryRoot = resolve(cwd, 'docs/02-delivery');
+  const deliveryRoot = resolve(cwd, _config.planRoot, '02-delivery');
   const entries = await readdir(deliveryRoot, { withFileTypes: true });
 
   return entries
@@ -1219,7 +1336,7 @@ function inferStateFromRepo(
       deriveBranchName(definition);
     const baseBranch =
       index === 0
-        ? 'main'
+        ? _config.defaultBranch
         : (findExistingBranch(branchCatalog, ticketDefinitions[index - 1]!)
             ?.branch ?? deriveBranchName(ticketDefinitions[index - 1]!));
     const branchExists = branchCatalog.includes(branch);
@@ -2851,8 +2968,8 @@ async function restackTicket(
   );
   const previous = targetIndex > 0 ? state.tickets[targetIndex - 1] : undefined;
 
-  let nextBaseBranch = 'main';
-  let rebaseTarget = 'origin/main';
+  let nextBaseBranch = _config.defaultBranch;
+  let rebaseTarget = `origin/${_config.defaultBranch}`;
 
   if (previous) {
     const oldBase = runProcess(cwd, [
@@ -2875,7 +2992,7 @@ async function restackTicket(
 
     runProcess(cwd, ['git', 'rebase', '--onto', rebaseTarget, oldBase]);
   } else {
-    runProcess(cwd, ['git', 'rebase', 'origin/main']);
+    runProcess(cwd, ['git', 'rebase', `origin/${_config.defaultBranch}`]);
   }
 
   const nextState: DeliveryState = {
@@ -4319,17 +4436,31 @@ function runProcessResult(
   stderr: string;
   stdout: string;
 } {
-  const result = Bun.spawnSync(cmd, {
+  if (_config.runtime === 'bun' && typeof globalThis.Bun !== 'undefined') {
+    const result = Bun.spawnSync(cmd, {
+      cwd,
+      stderr: 'pipe',
+      stdout: 'pipe',
+      env: process.env,
+    });
+
+    return {
+      exitCode: result.exitCode,
+      stderr: new TextDecoder().decode(result.stderr).trim(),
+      stdout: new TextDecoder().decode(result.stdout),
+    };
+  }
+
+  const result = nodeSpawnSync(cmd[0]!, cmd.slice(1), {
     cwd,
-    stderr: 'pipe',
-    stdout: 'pipe',
     env: process.env,
+    stdio: ['pipe', 'pipe', 'pipe'],
   });
 
   return {
-    exitCode: result.exitCode,
-    stderr: new TextDecoder().decode(result.stderr).trim(),
-    stdout: new TextDecoder().decode(result.stdout),
+    exitCode: result.status ?? 1,
+    stderr: (result.stderr?.toString() ?? '').trim(),
+    stdout: result.stdout?.toString() ?? '',
   };
 }
 
@@ -4384,16 +4515,31 @@ function sleep(milliseconds: number): Promise<void> {
   );
 }
 
+const LOCK_FILES = [
+  'bun.lock',
+  'pnpm-lock.yaml',
+  'yarn.lock',
+  'package-lock.json',
+] as const;
+
 async function bootstrapWorktreeIfNeeded(worktreePath: string): Promise<void> {
   if (
     !existsSync(resolve(worktreePath, 'package.json')) ||
-    !existsSync(resolve(worktreePath, 'bun.lock')) ||
     existsSync(resolve(worktreePath, 'node_modules'))
   ) {
     return;
   }
 
-  runProcess(worktreePath, ['bun', 'install']);
+  const hasLockfile = LOCK_FILES.some((file) =>
+    existsSync(resolve(worktreePath, file)),
+  );
+
+  if (!hasLockfile) {
+    return;
+  }
+
+  const pm = _config.packageManager;
+  runProcess(worktreePath, [pm, 'install']);
 
   const packageJson = JSON.parse(
     await readFile(resolve(worktreePath, 'package.json'), 'utf8'),
@@ -4402,7 +4548,7 @@ async function bootstrapWorktreeIfNeeded(worktreePath: string): Promise<void> {
   };
 
   if (packageJson.scripts?.['hooks:install']) {
-    runProcess(worktreePath, ['bun', 'run', 'hooks:install']);
+    runProcess(worktreePath, [pm, 'run', 'hooks:install']);
   }
 }
 


### PR DESCRIPTION
## Summary

- Make the delivery orchestrator core configurable via `orchestrator.config.json` (repo root, all fields optional) for `defaultBranch`, `planRoot`, runtime internals (`bun`|`node`), and package-manager-aware worktree bootstrap defaults (`bun`|`npm`|`pnpm`|`yarn`)
- Replace hardcoded `main` and `docs/02-delivery` references with config-backed defaults, add a runtime-switchable process layer (`Bun.spawnSync` or `child_process.spawnSync`), and make worktree bootstrap lockfile-aware
- Keep Pirate Claw's supported operator entrypoint as `bun run deliver --plan ...`; this PR makes the orchestrator internals less repo-specific but does not claim a fully validated multi-runtime CLI surface for this repo
- Add tests covering config loading, validation, lockfile inference, and `defaultBranch` propagation through `syncStateWithPlan`

Existing Pirate Claw behavior is unchanged when `orchestrator.config.json` is absent.

## Test plan

- [x] Existing and new orchestrator tests pass under the repo's supported Bun workflow (`bun test`)
- [x] Pre-push verification passes (format, typecheck, lint, spellcheck)
- [ ] Manual cross-runtime validation remains out of scope for this repo until a non-Bun entrypoint is explicitly supported
