### PR TITLE
feat: add movie codec policy mode [P5.01]

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Example:
   "movies": {
     "years": [2026],
     "resolutions": ["1080p"],
-    "codecs": ["x265"]
+    "codecs": ["x265"],
+    "codecPolicy": "prefer"
   },
   "transmission": {
     "url": "http://localhost:9091/transmission/rpc",
@@ -132,8 +133,11 @@ Current behavior:
 
 - queueable torrent URLs come from RSS `enclosure.url` when present
 - `<link>` remains a fallback when no enclosure URL exists
-- movie items can still match when year and resolution fit policy even if codec is missing
+- movie items default to `movies.codecPolicy: "prefer"`, so they can still match when year and resolution fit policy even if codec is missing
 - explicit preferred codecs still outrank otherwise equivalent unknown-codec movie releases
+
+`movies.codecPolicy` accepts `"prefer"` or `"require"`.
+Use `"require"` to reject movie releases that do not expose an allowed codec in the title.
 
 ## Local Runtime Files
 

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -114,6 +114,10 @@ Goal:
 - add media-type routing labels on Transmission submissions
 - preserve queueing with warning+fallback when labels are unsupported
 
+Current status:
+
+- P5.01 movie codec policy mode is implemented in delivery work; label routing remains pending
+
 Committed scope:
 
 - `movies.codecPolicy: "prefer" | "require"`

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -10,7 +10,7 @@ Its job is to answer three questions quickly:
 
 ## Current Repo State
 
-Pirate Claw is implemented through Phase 04.
+Pirate Claw is implemented through Phase 04, with Phase 05 ticket P5.01 active in delivery work.
 
 Current delivered surface:
 
@@ -34,6 +34,7 @@ Current product boundary:
 - per-feed polling cadence with persistent poll state
 - shared runtime lock prevents overlapping cycles
 - machine-readable and human-readable cycle artifacts with bounded retention
+- movie codec policy mode via `movies.codecPolicy` (`prefer` by default, `require` for strict matching)
 
 Still deferred:
 

--- a/docs/02-delivery/phase-05/ticket-01-rationale.md
+++ b/docs/02-delivery/phase-05/ticket-01-rationale.md
@@ -4,3 +4,4 @@
 - Why this path: extending `MoviePolicy` with a defaulted enum and threading a single movie-specific no-match message through the pipeline is the smallest acceptable slice that changes operator behavior without redesigning matcher or repository status types.
 - Alternative considered: returning a broader discriminated decision object from every matcher was rejected because only the movie strict-policy path needs a new no-match explanation in this ticket.
 - Deferred: TV codec policy, per-feed policy overrides, Transmission label routing, and any richer no-match taxonomy beyond the strict movie codec messages.
+- Verification: `bun test test/config.test.ts test/movie-match.test.ts test/pipeline.test.ts` and `bun run ci`.

--- a/docs/02-delivery/phase-05/ticket-01-rationale.md
+++ b/docs/02-delivery/phase-05/ticket-01-rationale.md
@@ -1,0 +1,6 @@
+# Ticket 01 Rationale
+
+- Red first: `movies.codecPolicy: "require"` should stop codec-unknown movie releases from matching, and the resulting `skipped_no_match` outcome should say why.
+- Why this path: extending `MoviePolicy` with a defaulted enum and threading a single movie-specific no-match message through the pipeline is the smallest acceptable slice that changes operator behavior without redesigning matcher or repository status types.
+- Alternative considered: returning a broader discriminated decision object from every matcher was rejected because only the movie strict-policy path needs a new no-match explanation in this ticket.
+- Deferred: TV codec policy, per-feed policy overrides, Transmission label routing, and any richer no-match taxonomy beyond the strict movie codec messages.

--- a/pirate-claw.config.example.json
+++ b/pirate-claw.config.example.json
@@ -21,7 +21,8 @@
   "movies": {
     "years": [2026],
     "resolutions": ["1080p"],
-    "codecs": ["x265"]
+    "codecs": ["x265"],
+    "codecPolicy": "prefer"
   },
   "transmission": {
     "url": "http://localhost:9091/transmission/rpc",

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ export type MoviePolicy = {
   years: number[];
   resolutions: string[];
   codecs: string[];
+  codecPolicy: 'prefer' | 'require';
 };
 
 export type TransmissionConfig = {
@@ -162,7 +163,27 @@ function validateMoviePolicy(
       `${path} movies`,
       supportedCodecs,
     ),
+    codecPolicy: requireMovieCodecPolicy(rule, `${path} movies codecPolicy`),
   };
+}
+
+function requireMovieCodecPolicy(
+  input: Record<string, unknown>,
+  path: string,
+): 'prefer' | 'require' {
+  const value = input.codecPolicy;
+
+  if (value === undefined) {
+    return 'prefer';
+  }
+
+  if (value === 'prefer' || value === 'require') {
+    return value;
+  }
+
+  throw new ConfigError(
+    `Config file "${path}" has invalid value; expected one of "prefer", "require".`,
+  );
 }
 
 function validateTransmission(

--- a/src/movie-match.ts
+++ b/src/movie-match.ts
@@ -10,6 +10,11 @@ export type MovieMatchResult = {
   item: NormalizedFeedItem;
 };
 
+export const MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE =
+  'Movie codec is required by policy but missing from release title.';
+export const MOVIE_CODEC_POLICY_REQUIRE_DISALLOWED_MESSAGE =
+  'Movie codec is required by policy and release codec is not allowed.';
+
 const MOVIE_POLICY_RULE_NAME = 'movies';
 
 export function matchMovieItem(
@@ -37,6 +42,34 @@ export function matchMovieItem(
   };
 }
 
+export function getMovieNoMatchReason(
+  item: NormalizedFeedItem,
+  policy: MoviePolicy,
+): string | undefined {
+  const { year, resolution, codec } = item;
+
+  if (
+    item.mediaType !== 'movie' ||
+    year === undefined ||
+    resolution === undefined ||
+    !policy.years.includes(year) ||
+    !policy.resolutions.includes(resolution) ||
+    policy.codecPolicy !== 'require'
+  ) {
+    return undefined;
+  }
+
+  if (codec === undefined) {
+    return MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE;
+  }
+
+  if (!policy.codecs.includes(codec)) {
+    return MOVIE_CODEC_POLICY_REQUIRE_DISALLOWED_MESSAGE;
+  }
+
+  return undefined;
+}
+
 function buildIdentityKey(item: NormalizedFeedItem): string {
   return `movie:${item.normalizedTitle.trim().toLowerCase()}|${item.year ?? ''}`;
 }
@@ -51,7 +84,7 @@ function matchesMovieQuality(
   }
 
   if (codec === undefined) {
-    return policy.codecs.length > 0;
+    return policy.codecPolicy === 'prefer' && policy.codecs.length > 0;
   }
 
   return matchesAllowedQuality(

--- a/src/pipeline-runner.ts
+++ b/src/pipeline-runner.ts
@@ -36,12 +36,12 @@ export function createPipelineCoordinator(input: {
   downloader: Downloader;
 }) {
   return {
-    recordNoMatch(feedItemId: number): void {
+    recordNoMatch(feedItemId: number, message?: string): void {
       input.repository.recordFeedItemOutcome({
         runId: input.run.id,
         feedItemId,
         status: 'skipped_no_match',
-        message: 'No matching rule or policy.',
+        message: message ?? 'No matching rule or policy.',
       });
     },
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,6 +1,6 @@
 import type { AppConfig, FeedConfig } from './config';
 import { fetchFeed, type RawFeedItem } from './feed';
-import { matchMovieItem } from './movie-match';
+import { getMovieNoMatchReason, matchMovieItem } from './movie-match';
 import { normalizeFeedItem } from './normalize';
 import {
   createPipelineCoordinator,
@@ -53,7 +53,10 @@ export async function runPipeline(input: {
         const match = matchFeedItem(feedItem, input.config, feed);
 
         if (!match) {
-          coordinator.recordNoMatch(feedItem.id);
+          coordinator.recordNoMatch(
+            feedItem.id,
+            getFeedItemNoMatchReason(feedItem, input.config, feed),
+          );
           continue;
         }
 
@@ -182,6 +185,23 @@ function matchFeedItem(
   }
 
   return matchMovieItem(normalized, config.movies);
+}
+
+function getFeedItemNoMatchReason(
+  feedItem: FeedItemRecord,
+  config: AppConfig,
+  feed: FeedConfig,
+): string | undefined {
+  const normalized = normalizeFeedItem({
+    mediaType: feed.mediaType,
+    rawTitle: feedItem.rawTitle,
+  });
+
+  if (normalized.mediaType === 'movie') {
+    return getMovieNoMatchReason(normalized, config.movies);
+  }
+
+  return undefined;
 }
 
 function createEmptyReconcileCounts(): Record<

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,7 +1,7 @@
 import type { AppConfig, FeedConfig } from './config';
 import { fetchFeed, type RawFeedItem } from './feed';
 import { getMovieNoMatchReason, matchMovieItem } from './movie-match';
-import { normalizeFeedItem } from './normalize';
+import { normalizeFeedItem, type NormalizedFeedItem } from './normalize';
 import {
   createPipelineCoordinator,
   type MatchedFeedItem,
@@ -11,7 +11,6 @@ import type {
   CandidateLifecycleStatus,
   CandidateMatchRecord,
   CandidateStateRecord,
-  FeedItemRecord,
   Repository,
 } from './repository';
 import type { Downloader, TorrentSnapshot } from './transmission';
@@ -50,12 +49,16 @@ export async function runPipeline(input: {
 
       for (const item of items) {
         const feedItem = input.repository.recordFeedItem(run.id, item);
-        const match = matchFeedItem(feedItem, input.config, feed);
+        const normalized = normalizeFeedItem({
+          mediaType: feed.mediaType,
+          rawTitle: feedItem.rawTitle,
+        });
+        const match = matchFeedItem(normalized, input.config);
 
         if (!match) {
           coordinator.recordNoMatch(
             feedItem.id,
-            getFeedItemNoMatchReason(feedItem, input.config, feed),
+            getFeedItemNoMatchReason(normalized, input.config),
           );
           continue;
         }
@@ -171,15 +174,9 @@ export async function reconcileCandidates(input: {
 }
 
 function matchFeedItem(
-  feedItem: FeedItemRecord,
+  normalized: NormalizedFeedItem,
   config: AppConfig,
-  feed: FeedConfig,
 ): CandidateMatchRecord | undefined {
-  const normalized = normalizeFeedItem({
-    mediaType: feed.mediaType,
-    rawTitle: feedItem.rawTitle,
-  });
-
   if (normalized.mediaType === 'tv') {
     return matchTvItem(normalized, config.tv)[0];
   }
@@ -188,15 +185,9 @@ function matchFeedItem(
 }
 
 function getFeedItemNoMatchReason(
-  feedItem: FeedItemRecord,
+  normalized: NormalizedFeedItem,
   config: AppConfig,
-  feed: FeedConfig,
 ): string | undefined {
-  const normalized = normalizeFeedItem({
-    mediaType: feed.mediaType,
-    rawTitle: feedItem.rawTitle,
-  });
-
   if (normalized.mediaType === 'movie') {
     return getMovieNoMatchReason(normalized, config.movies);
   }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -39,6 +39,39 @@ describe('validateConfig', () => {
     expect(config.tv[0]?.codecs).toEqual(['x265', 'x264']);
     expect(config.movies.resolutions).toEqual(['2160p', '1080p']);
     expect(config.movies.codecs).toEqual(['x265']);
+    expect(config.movies.codecPolicy).toBe('prefer');
+  });
+
+  it('parses movies.codecPolicy when set to require', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      movies: {
+        years: [2024],
+        resolutions: ['1080p'],
+        codecs: ['x265'],
+        codecPolicy: 'require',
+      },
+    });
+
+    expect(config.movies.codecPolicy).toBe('require');
+  });
+
+  it('fails with a precise movies.codecPolicy path when the value is unsupported', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        movies: {
+          years: [2024],
+          resolutions: ['1080p'],
+          codecs: ['x265'],
+          codecPolicy: 'strict',
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config movies codecPolicy" has invalid value; expected one of "prefer", "require".',
+      ),
+    );
   });
 
   it('fails with a precise tv codecs path when a codec is unsupported', () => {
@@ -290,6 +323,7 @@ function createMinimalConfig() {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     },
     transmission: {
       url: 'http://localhost:9091/transmission/rpc',

--- a/test/movie-match.test.ts
+++ b/test/movie-match.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 
 import type { MoviePolicy } from '../src/config';
-import { matchMovieItem } from '../src/movie-match';
+import {
+  getMovieNoMatchReason,
+  matchMovieItem,
+  MOVIE_CODEC_POLICY_REQUIRE_DISALLOWED_MESSAGE,
+  MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE,
+} from '../src/movie-match';
 import { normalizeFeedItem } from '../src/normalize';
 
 describe('matchMovieItem', () => {
@@ -14,6 +19,7 @@ describe('matchMovieItem', () => {
       years: [2025, 2024],
       resolutions: ['2160p', '1080p'],
       codecs: ['x265', 'x264'],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(item, policy)).toEqual({
@@ -34,6 +40,7 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(item, policy)).toEqual({
@@ -54,6 +61,7 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(item, policy)).toEqual({
@@ -78,6 +86,7 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['2160p', '1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(webRelease, policy)?.identityKey).toBe(
@@ -97,6 +106,7 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(item, policy)?.identityKey).toBe(
@@ -117,6 +127,7 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265', 'x264'],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(explicitCodec, policy)?.identityKey).toBe(
@@ -140,11 +151,48 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265', 'x264'],
+      codecPolicy: 'prefer',
     };
 
     expect(
       matchMovieItem(lowerPreferenceCodec, policy)?.score ?? 0,
     ).toBeGreaterThan(matchMovieItem(unknownCodec, policy)?.score ?? 0);
+  });
+
+  it('rejects codec-unknown movies when codecPolicy is require', () => {
+    const item = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: 'Example.Movie.2024.1080p.WEB-GROUP',
+    });
+    const policy: MoviePolicy = {
+      years: [2024],
+      resolutions: ['1080p'],
+      codecs: ['x265'],
+      codecPolicy: 'require',
+    };
+
+    expect(matchMovieItem(item, policy)).toBeUndefined();
+    expect(getMovieNoMatchReason(item, policy)).toBe(
+      MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE,
+    );
+  });
+
+  it('reports a strict-policy reason when the movie codec is not allowed', () => {
+    const item = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: 'Example.Movie.2024.1080p.WEB.x264-GROUP',
+    });
+    const policy: MoviePolicy = {
+      years: [2024],
+      resolutions: ['1080p'],
+      codecs: ['x265'],
+      codecPolicy: 'require',
+    };
+
+    expect(matchMovieItem(item, policy)).toBeUndefined();
+    expect(getMovieNoMatchReason(item, policy)).toBe(
+      MOVIE_CODEC_POLICY_REQUIRE_DISALLOWED_MESSAGE,
+    );
   });
 
   it.each([
@@ -202,6 +250,7 @@ describe('matchMovieItem', () => {
         years: [2024],
         resolutions: ['1080p'],
         codecs: ['x265'],
+        codecPolicy: 'prefer',
       };
 
       expect(matchMovieItem(item, policy)).toBeUndefined();
@@ -217,6 +266,7 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(item, policy)).toBeUndefined();
@@ -231,6 +281,7 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['1080p'],
       codecs: [],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(item, policy)).toBeUndefined();

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 
 import { type AppConfig, DEFAULT_RUNTIME_CONFIG } from '../src/config';
 import { FeedError } from '../src/feed';
+import { MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE } from '../src/movie-match';
 import { retryFailedCandidates, runPipeline } from '../src/pipeline';
 import {
   createRepository,
@@ -177,6 +178,59 @@ describe('runPipeline', () => {
       queuedAt: '2026-03-30T00:10:00.000Z',
     });
   });
+
+  it('records a strict codec-policy no-match reason for codec-unknown movie releases', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+
+    const result = await runPipeline({
+      config: createConfig({
+        feeds: [
+          {
+            name: 'Movie Feed',
+            url: 'https://example.test/movie.rss',
+            mediaType: 'movie',
+          },
+        ],
+        tv: [],
+        movies: {
+          years: [2024],
+          resolutions: ['1080p'],
+          codecs: ['x265'],
+          codecPolicy: 'require',
+        },
+      }),
+      repository,
+      downloader: {
+        submit: async () => ({
+          ok: true as const,
+          status: 'queued' as const,
+        }),
+      },
+      fetchFeed: async () => [
+        {
+          feedName: 'Movie Feed',
+          guidOrLink: 'https://example.test/releases/example-movie-no-codec',
+          rawTitle: 'Example.Movie.2024.1080p.WEB-GROUP',
+          publishedAt: '2026-03-30T00:00:00.000Z',
+          downloadUrl:
+            'https://example.test/downloads/example-movie-no-codec.torrent',
+        },
+      ],
+    });
+
+    expect(result.counts).toEqual({
+      queued: 0,
+      failed: 0,
+      skipped_duplicate: 0,
+      skipped_no_match: 1,
+    });
+    expect(repository.listFeedItemOutcomes(result.runId)).toMatchObject([
+      {
+        status: 'skipped_no_match',
+        message: MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE,
+      },
+    ]);
+  });
 });
 
 describe('retryFailedCandidates', () => {
@@ -323,6 +377,7 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     },
     transmission: {
       url: 'http://localhost:9091/transmission/rpc',

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -573,6 +573,7 @@ function requireMovieMatch(rawTitle: string) {
       years: [2024],
       resolutions: ['2160p', '1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     },
   );
 


### PR DESCRIPTION
## Summary

- delivery ticket: `P5.01 Add Movie Codec Policy Mode`
- ticket file: `docs/02-delivery/phase-05/ticket-01-add-movie-codec-policy-mode.md`
- stacked base branch: `main`
- internal review: completed at `2026-04-05T13:14:02.458Z`

## External AI Review

- outcome: `patched`
- reviewed commit: `3b28011b6b25`
- current branch head: `19c155799cb2`
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- vendors: `coderabbit`, `qodo`

### Actions Taken

- `19c155799cb2` [qodo] fix: address AI review feedback [P5.01]