### PR TITLE
feat: add transmission label routing with fallback [P5.02]

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ Before running:
 4. If authentication is enabled, copy the same username and password into `pirate-claw.config.json`.
 5. If Transmission restricts allowed addresses, keep `127.0.0.1` or `localhost` allowed.
 
+At queue time, Pirate Claw attempts to send Transmission labels based on media type:
+
+- `movie` for movie feeds
+- `tv` for TV feeds
+
+If the configured Transmission instance rejects label arguments, Pirate Claw logs a warning and retries the same submission without labels.
+
 ## Real-World Feed Notes
 
 The current build is tuned to work against:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Example:
   "movies": {
     "years": [2026],
     "resolutions": ["1080p"],
-    "codecs": ["x265"]
+    "codecs": ["x265"],
+    "codecPolicy": "prefer"
   },
   "transmission": {
     "url": "http://localhost:9091/transmission/rpc",
@@ -132,8 +133,11 @@ Current behavior:
 
 - queueable torrent URLs come from RSS `enclosure.url` when present
 - `<link>` remains a fallback when no enclosure URL exists
-- movie items can still match when year and resolution fit policy even if codec is missing
+- movie items default to `movies.codecPolicy: "prefer"`, so they can still match when year and resolution fit policy even if codec is missing
 - explicit preferred codecs still outrank otherwise equivalent unknown-codec movie releases
+
+`movies.codecPolicy` accepts `"prefer"` or `"require"`.
+Use `"require"` to reject movie releases that do not expose an allowed codec in the title.
 
 ## Local Runtime Files
 

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -114,6 +114,10 @@ Goal:
 - add media-type routing labels on Transmission submissions
 - preserve queueing with warning+fallback when labels are unsupported
 
+Current status:
+
+- P5.01 movie codec policy mode is implemented in delivery work; label routing remains pending
+
 Committed scope:
 
 - `movies.codecPolicy: "prefer" | "require"`

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -116,7 +116,7 @@ Goal:
 
 Current status:
 
-- P5.01 movie codec policy mode is implemented in delivery work; label routing remains pending
+- P5.01 movie codec policy mode and P5.02 label-routing fallback are implemented in delivery work
 
 Committed scope:
 

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -10,7 +10,7 @@ Its job is to answer three questions quickly:
 
 ## Current Repo State
 
-Pirate Claw is implemented through Phase 04.
+Pirate Claw is implemented through Phase 04, with Phase 05 ticket P5.01 active in delivery work.
 
 Current delivered surface:
 
@@ -34,6 +34,7 @@ Current product boundary:
 - per-feed polling cadence with persistent poll state
 - shared runtime lock prevents overlapping cycles
 - machine-readable and human-readable cycle artifacts with bounded retention
+- movie codec policy mode via `movies.codecPolicy` (`prefer` by default, `require` for strict matching)
 
 Still deferred:
 

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -35,6 +35,7 @@ Current product boundary:
 - shared runtime lock prevents overlapping cycles
 - machine-readable and human-readable cycle artifacts with bounded retention
 - movie codec policy mode via `movies.codecPolicy` (`prefer` by default, `require` for strict matching)
+- queue-time Transmission `movie` / `tv` labels with warning+retry fallback when labels are unsupported
 
 Still deferred:
 

--- a/docs/02-delivery/phase-05/ticket-01-rationale.md
+++ b/docs/02-delivery/phase-05/ticket-01-rationale.md
@@ -1,0 +1,7 @@
+# Ticket 01 Rationale
+
+- Red first: `movies.codecPolicy: "require"` should stop codec-unknown movie releases from matching, and the resulting `skipped_no_match` outcome should say why.
+- Why this path: extending `MoviePolicy` with a defaulted enum and threading a single movie-specific no-match message through the pipeline is the smallest acceptable slice that changes operator behavior without redesigning matcher or repository status types.
+- Alternative considered: returning a broader discriminated decision object from every matcher was rejected because only the movie strict-policy path needs a new no-match explanation in this ticket.
+- Deferred: TV codec policy, per-feed policy overrides, Transmission label routing, and any richer no-match taxonomy beyond the strict movie codec messages.
+- Verification: `bun test test/config.test.ts test/movie-match.test.ts test/pipeline.test.ts` and `bun run ci`.

--- a/docs/02-delivery/phase-05/ticket-02-rationale.md
+++ b/docs/02-delivery/phase-05/ticket-02-rationale.md
@@ -1,0 +1,6 @@
+# Ticket 02 Rationale
+
+- Red first: queueing should still succeed when Transmission rejects `labels`, with a warning explaining the unlabeled fallback.
+- Why this path: adding optional label support at the downloader boundary and deriving fixed `movie` / `tv` labels from the matched media type is the smallest acceptable slice that delivers routing metadata without redesigning config or placement policy.
+- Alternative considered: adding configurable per-feed label values in this ticket was rejected because it would widen scope beyond the fixed media-type labels committed for Phase 05.
+- Deferred: per-feed custom labels, hard-fail behavior for unsupported labels, downloader-side placement ownership, and richer label policy beyond the fixed media-type mapping.

--- a/pirate-claw.config.example.json
+++ b/pirate-claw.config.example.json
@@ -21,7 +21,8 @@
   "movies": {
     "years": [2026],
     "resolutions": ["1080p"],
-    "codecs": ["x265"]
+    "codecs": ["x265"],
+    "codecPolicy": "prefer"
   },
   "transmission": {
     "url": "http://localhost:9091/transmission/rpc",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,11 +100,14 @@ export async function runCli(argv: string[]): Promise<number> {
       const resolvedConfigPath = resolveConfigPath(configPath);
       const config = await loadConfig(resolvedConfigPath);
       const database = openDatabase();
+      const log = console.log;
 
       try {
         ensureSchema(database);
         const repository = createRepository(database);
-        const downloader = createTransmissionDownloader(config.transmission);
+        const downloader = createTransmissionDownloader(config.transmission, {
+          warn: log,
+        });
 
         const controller = new AbortController();
         const onSignal = () => controller.abort();
@@ -157,6 +160,7 @@ export async function runCli(argv: string[]): Promise<number> {
           },
           options: daemonOptionsFromConfig(config.runtime),
           signal: controller.signal,
+          log,
           onCycleResult: (result) => {
             writeCycleArtifact(artifactDir, result);
             pruneArtifacts(artifactDir, artifactRetentionDays);

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ export type MoviePolicy = {
   years: number[];
   resolutions: string[];
   codecs: string[];
+  codecPolicy: 'prefer' | 'require';
 };
 
 export type TransmissionConfig = {
@@ -162,7 +163,27 @@ function validateMoviePolicy(
       `${path} movies`,
       supportedCodecs,
     ),
+    codecPolicy: requireMovieCodecPolicy(rule, `${path} movies codecPolicy`),
   };
+}
+
+function requireMovieCodecPolicy(
+  input: Record<string, unknown>,
+  path: string,
+): 'prefer' | 'require' {
+  const value = input.codecPolicy;
+
+  if (value === undefined) {
+    return 'prefer';
+  }
+
+  if (value === 'prefer' || value === 'require') {
+    return value;
+  }
+
+  throw new ConfigError(
+    `Config file "${path}" has invalid value; expected one of "prefer", "require".`,
+  );
 }
 
 function validateTransmission(

--- a/src/movie-match.ts
+++ b/src/movie-match.ts
@@ -10,6 +10,11 @@ export type MovieMatchResult = {
   item: NormalizedFeedItem;
 };
 
+export const MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE =
+  'Movie codec is required by policy but missing from release title.';
+export const MOVIE_CODEC_POLICY_REQUIRE_DISALLOWED_MESSAGE =
+  'Movie codec is required by policy and release codec is not allowed.';
+
 const MOVIE_POLICY_RULE_NAME = 'movies';
 
 export function matchMovieItem(
@@ -37,6 +42,34 @@ export function matchMovieItem(
   };
 }
 
+export function getMovieNoMatchReason(
+  item: NormalizedFeedItem,
+  policy: MoviePolicy,
+): string | undefined {
+  const { year, resolution, codec } = item;
+
+  if (
+    item.mediaType !== 'movie' ||
+    year === undefined ||
+    resolution === undefined ||
+    !policy.years.includes(year) ||
+    !policy.resolutions.includes(resolution) ||
+    policy.codecPolicy !== 'require'
+  ) {
+    return undefined;
+  }
+
+  if (codec === undefined) {
+    return MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE;
+  }
+
+  if (!policy.codecs.includes(codec)) {
+    return MOVIE_CODEC_POLICY_REQUIRE_DISALLOWED_MESSAGE;
+  }
+
+  return undefined;
+}
+
 function buildIdentityKey(item: NormalizedFeedItem): string {
   return `movie:${item.normalizedTitle.trim().toLowerCase()}|${item.year ?? ''}`;
 }
@@ -51,7 +84,7 @@ function matchesMovieQuality(
   }
 
   if (codec === undefined) {
-    return policy.codecs.length > 0;
+    return policy.codecPolicy === 'prefer' && policy.codecs.length > 0;
   }
 
   return matchesAllowedQuality(

--- a/src/pipeline-runner.ts
+++ b/src/pipeline-runner.ts
@@ -109,6 +109,7 @@ export async function submitCandidate(
 ): Promise<void> {
   const submission = await downloader.submit({
     downloadUrl: input.feedItem.downloadUrl,
+    labels: getSubmissionLabels(input.match.item.mediaType),
   });
 
   if (submission.ok) {
@@ -128,6 +129,10 @@ export async function submitCandidate(
     status: 'failed',
     message: submission.message,
   });
+}
+
+function getSubmissionLabels(mediaType: 'tv' | 'movie'): string[] {
+  return [mediaType];
 }
 
 function groupByIdentity(

--- a/src/pipeline-runner.ts
+++ b/src/pipeline-runner.ts
@@ -36,12 +36,12 @@ export function createPipelineCoordinator(input: {
   downloader: Downloader;
 }) {
   return {
-    recordNoMatch(feedItemId: number): void {
+    recordNoMatch(feedItemId: number, message?: string): void {
       input.repository.recordFeedItemOutcome({
         runId: input.run.id,
         feedItemId,
         status: 'skipped_no_match',
-        message: 'No matching rule or policy.',
+        message: message ?? 'No matching rule or policy.',
       });
     },
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,7 +1,7 @@
 import type { AppConfig, FeedConfig } from './config';
 import { fetchFeed, type RawFeedItem } from './feed';
-import { matchMovieItem } from './movie-match';
-import { normalizeFeedItem } from './normalize';
+import { getMovieNoMatchReason, matchMovieItem } from './movie-match';
+import { normalizeFeedItem, type NormalizedFeedItem } from './normalize';
 import {
   createPipelineCoordinator,
   type MatchedFeedItem,
@@ -11,7 +11,6 @@ import type {
   CandidateLifecycleStatus,
   CandidateMatchRecord,
   CandidateStateRecord,
-  FeedItemRecord,
   Repository,
 } from './repository';
 import type { Downloader, TorrentSnapshot } from './transmission';
@@ -50,10 +49,17 @@ export async function runPipeline(input: {
 
       for (const item of items) {
         const feedItem = input.repository.recordFeedItem(run.id, item);
-        const match = matchFeedItem(feedItem, input.config, feed);
+        const normalized = normalizeFeedItem({
+          mediaType: feed.mediaType,
+          rawTitle: feedItem.rawTitle,
+        });
+        const match = matchFeedItem(normalized, input.config);
 
         if (!match) {
-          coordinator.recordNoMatch(feedItem.id);
+          coordinator.recordNoMatch(
+            feedItem.id,
+            getFeedItemNoMatchReason(normalized, input.config),
+          );
           continue;
         }
 
@@ -168,20 +174,25 @@ export async function reconcileCandidates(input: {
 }
 
 function matchFeedItem(
-  feedItem: FeedItemRecord,
+  normalized: NormalizedFeedItem,
   config: AppConfig,
-  feed: FeedConfig,
 ): CandidateMatchRecord | undefined {
-  const normalized = normalizeFeedItem({
-    mediaType: feed.mediaType,
-    rawTitle: feedItem.rawTitle,
-  });
-
   if (normalized.mediaType === 'tv') {
     return matchTvItem(normalized, config.tv)[0];
   }
 
   return matchMovieItem(normalized, config.movies);
+}
+
+function getFeedItemNoMatchReason(
+  normalized: NormalizedFeedItem,
+  config: AppConfig,
+): string | undefined {
+  if (normalized.mediaType === 'movie') {
+    return getMovieNoMatchReason(normalized, config.movies);
+  }
+
+  return undefined;
 }
 
 function createEmptyReconcileCounts(): Record<

--- a/src/transmission.ts
+++ b/src/transmission.ts
@@ -24,6 +24,7 @@ export type SubmissionFailure = {
   ok: false;
   code: SubmissionFailureCode;
   message: string;
+  rpcResult?: string;
 };
 
 export type SubmissionResult = SubmissionSuccess | SubmissionFailure;
@@ -55,12 +56,19 @@ export type Downloader = {
   lookupTorrents?(input: LookupTorrentsInput): Promise<LookupTorrentsResult>;
 };
 
+export type DownloaderOptions = {
+  warn?: (message: string) => void;
+};
+
 export function createTransmissionDownloader(
   config: TransmissionConfig,
+  options: DownloaderOptions = {},
 ): Downloader {
+  const warn = options.warn ?? console.warn;
+
   return {
     submit(input) {
-      return submitToTransmission(config, input);
+      return submitToTransmission(config, input, warn);
     },
     lookupTorrents(input) {
       return lookupTorrentsInTransmission(config, input);
@@ -71,6 +79,7 @@ export function createTransmissionDownloader(
 async function submitToTransmission(
   config: TransmissionConfig,
   input: SubmitDownloadInput,
+  warn: (message: string) => void,
 ): Promise<SubmissionResult> {
   const firstResponse = await sendSubmitRpcRequest(config, input);
 
@@ -83,7 +92,7 @@ async function submitToTransmission(
     return result;
   }
 
-  console.warn(
+  warn(
     'Transmission rejected label arguments; retrying submission without labels.',
   );
 
@@ -340,8 +349,9 @@ function shouldRetryWithoutLabels(
     input.labels.length > 0 &&
     !result.ok &&
     result.code === 'rpc_error' &&
-    /labels?/i.test(result.message) &&
-    /(invalid|unknown|unsupported|unrecognized)/i.test(result.message)
+    typeof result.rpcResult === 'string' &&
+    /labels?/i.test(result.rpcResult) &&
+    /(invalid|unknown|unsupported|unrecognized)/i.test(result.rpcResult)
   );
 }
 
@@ -383,6 +393,7 @@ function parseSubmissionResult(parsed: unknown): SubmissionResult {
       ok: false,
       code: 'rpc_error',
       message: `Transmission rejected torrent submission: ${parsed.result}.`,
+      rpcResult: parsed.result,
     };
   }
 
@@ -422,6 +433,7 @@ function parseLookupTorrentsResult(parsed: unknown): LookupTorrentsResult {
       ok: false,
       code: 'rpc_error',
       message: `Transmission rejected torrent lookup: ${parsed.result}.`,
+      rpcResult: parsed.result,
     };
   }
 

--- a/src/transmission.ts
+++ b/src/transmission.ts
@@ -2,6 +2,7 @@ import type { TransmissionConfig } from './config';
 
 export type SubmitDownloadInput = {
   downloadUrl: string;
+  labels?: string[];
 };
 
 export type SubmissionSuccess = {
@@ -71,63 +72,32 @@ async function submitToTransmission(
   config: TransmissionConfig,
   input: SubmitDownloadInput,
 ): Promise<SubmissionResult> {
-  const firstResponse = await sendRpcRequest(
-    config,
-    buildSubmitRequestBody(config, input),
-  );
+  const firstResponse = await sendSubmitRpcRequest(config, input);
 
   if (!firstResponse.ok) {
     return firstResponse.error;
   }
+  const result = await parseSubmissionResponse(firstResponse.response);
 
-  let response = firstResponse.response;
-
-  if (response.status === 409) {
-    const sessionId = response.headers.get('x-transmission-session-id');
-
-    if (!sessionId) {
-      return {
-        ok: false,
-        code: 'session_error',
-        message:
-          'Transmission session negotiation failed: missing X-Transmission-Session-Id header.',
-      };
-    }
-
-    const retryResponse = await sendRpcRequest(
-      config,
-      buildSubmitRequestBody(config, input),
-      sessionId,
-    );
-
-    if (!retryResponse.ok) {
-      return retryResponse.error;
-    }
-
-    response = retryResponse.response;
+  if (!shouldRetryWithoutLabels(input, result)) {
+    return result;
   }
 
-  if (!response.ok) {
-    return {
-      ok: false,
-      code: 'http_error',
-      message: `Transmission RPC request failed with HTTP ${response.status}.`,
-    };
+  console.warn(
+    'Transmission rejected label arguments; retrying submission without labels.',
+  );
+
+  const fallbackResponse = await sendSubmitRpcRequest(
+    config,
+    { ...input, labels: undefined },
+    firstResponse.sessionId,
+  );
+
+  if (!fallbackResponse.ok) {
+    return fallbackResponse.error;
   }
 
-  let parsed: unknown;
-
-  try {
-    parsed = await response.json();
-  } catch {
-    return {
-      ok: false,
-      code: 'invalid_response',
-      message: 'Transmission RPC response was not valid JSON.',
-    };
-  }
-
-  return parseSubmissionResult(parsed);
+  return parseSubmissionResponse(fallbackResponse.response);
 }
 
 async function lookupTorrentsInTransmission(
@@ -230,6 +200,72 @@ async function sendRpcRequest(
   }
 }
 
+async function sendSubmitRpcRequest(
+  config: TransmissionConfig,
+  input: SubmitDownloadInput,
+  sessionId?: string,
+): Promise<
+  | {
+      ok: true;
+      response: Response;
+      sessionId?: string;
+    }
+  | {
+      ok: false;
+      error: SubmissionFailure;
+    }
+> {
+  const firstResponse = await sendRpcRequest(
+    config,
+    buildSubmitRequestBody(config, input),
+    sessionId,
+  );
+
+  if (!firstResponse.ok) {
+    return firstResponse;
+  }
+
+  if (firstResponse.response.status !== 409) {
+    return {
+      ok: true,
+      response: firstResponse.response,
+      sessionId,
+    };
+  }
+
+  const negotiatedSessionId = firstResponse.response.headers.get(
+    'x-transmission-session-id',
+  );
+
+  if (!negotiatedSessionId) {
+    return {
+      ok: false,
+      error: {
+        ok: false,
+        code: 'session_error',
+        message:
+          'Transmission session negotiation failed: missing X-Transmission-Session-Id header.',
+      },
+    };
+  }
+
+  const retryResponse = await sendRpcRequest(
+    config,
+    buildSubmitRequestBody(config, input),
+    negotiatedSessionId,
+  );
+
+  if (!retryResponse.ok) {
+    return retryResponse;
+  }
+
+  return {
+    ok: true,
+    response: retryResponse.response,
+    sessionId: negotiatedSessionId,
+  };
+}
+
 function buildHeaders(
   config: TransmissionConfig,
   sessionId?: string,
@@ -254,6 +290,7 @@ function buildSubmitRequestBody(
   arguments: {
     filename: string;
     'download-dir'?: string;
+    labels?: string[];
   };
 } {
   return {
@@ -261,8 +298,51 @@ function buildSubmitRequestBody(
     arguments: {
       filename: input.downloadUrl,
       ...(config.downloadDir ? { 'download-dir': config.downloadDir } : {}),
+      ...(input.labels && input.labels.length > 0
+        ? { labels: input.labels }
+        : {}),
     },
   };
+}
+
+async function parseSubmissionResponse(
+  response: Response,
+): Promise<SubmissionResult> {
+  if (!response.ok) {
+    return {
+      ok: false,
+      code: 'http_error',
+      message: `Transmission RPC request failed with HTTP ${response.status}.`,
+    };
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = await response.json();
+  } catch {
+    return {
+      ok: false,
+      code: 'invalid_response',
+      message: 'Transmission RPC response was not valid JSON.',
+    };
+  }
+
+  return parseSubmissionResult(parsed);
+}
+
+function shouldRetryWithoutLabels(
+  input: SubmitDownloadInput,
+  result: SubmissionResult,
+): boolean {
+  return (
+    Array.isArray(input.labels) &&
+    input.labels.length > 0 &&
+    !result.ok &&
+    result.code === 'rpc_error' &&
+    /labels?/i.test(result.message) &&
+    /(invalid|unknown|unsupported|unrecognized)/i.test(result.message)
+  );
 }
 
 function buildLookupRequestBody(input: LookupTorrentsInput): {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -151,6 +151,64 @@ describe('pirate-claw run', () => {
     expect(transmissionServer.requestCount).toBe(6);
   });
 
+  it('warns and retries without labels when Transmission rejects label arguments', async () => {
+    const directory = await mkdtemp();
+    const feedServer = startSingleMovieItemFeedServer();
+    const transmissionServer = startLabelRejectingTransmissionServer();
+    const configPath = join(directory, 'pirate-claw.config.json');
+
+    await Bun.write(
+      configPath,
+      JSON.stringify(
+        {
+          feeds: [
+            {
+              name: 'Movie Feed',
+              url: `${feedServer.url}/movie.rss`,
+              mediaType: 'movie',
+            },
+          ],
+          tv: [],
+          movies: {
+            years: [2024],
+            resolutions: ['2160p', '1080p'],
+            codecs: ['x265'],
+            codecPolicy: 'prefer',
+          },
+          transmission: {
+            url: `${transmissionServer.url}/transmission/rpc`,
+            username: 'user',
+            password: 'pass',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const run = await runSimpleCommand(directory, 'run');
+
+    expect(run.exitCode).toBe(0);
+    expect(run.stdout).toContain('queued: 1');
+    expect(run.stderr).toContain(
+      'Transmission rejected label arguments; retrying submission without labels.',
+    );
+    expect(transmissionServer.requestBodies).toHaveLength(2);
+    expect(transmissionServer.requestBodies[0]).toEqual({
+      method: 'torrent-add',
+      arguments: {
+        filename: 'https://example.test/downloads/example-movie.torrent',
+        labels: ['movie'],
+      },
+    });
+    expect(transmissionServer.requestBodies[1]).toEqual({
+      method: 'torrent-add',
+      arguments: {
+        filename: 'https://example.test/downloads/example-movie.torrent',
+      },
+    });
+  });
+
   it('exits with a readable error when config is missing a required section', async () => {
     const directory = await mkdtemp();
     const configPath = `${directory}/missing-sections.json`;
@@ -921,6 +979,36 @@ function startFeedServer(): { url: string } {
   return { url: server.url.origin };
 }
 
+function startSingleMovieItemFeedServer(): { url: string } {
+  const server = Bun.serve({
+    port: 0,
+    hostname: '127.0.0.1',
+    routes: {
+      '/movie.rss': new Response(
+        `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Movie Feed</title>
+    <item>
+      <title>Example.Movie.2024.1080p.WEB.x265-GROUP</title>
+      <link>https://example.test/releases/example-movie</link>
+      <guid>https://example.test/releases/example-movie</guid>
+      <pubDate>Sat, 05 Apr 2026 12:00:00 GMT</pubDate>
+      <enclosure url="https://example.test/downloads/example-movie.torrent" type="application/x-bittorrent" />
+    </item>
+  </channel>
+</rss>`,
+        {
+          headers: { 'content-type': 'application/rss+xml; charset=utf-8' },
+        },
+      ),
+    },
+  });
+
+  servers.push(server);
+  return { url: server.url.origin };
+}
+
 function startTransmissionServer(): { url: string; requestCount: number } {
   const state = { requestCount: 0 };
   const server = Bun.serve({
@@ -972,6 +1060,71 @@ function startTransmissionServer(): { url: string; requestCount: number } {
     url: server.url.origin,
     get requestCount() {
       return state.requestCount;
+    },
+  };
+}
+
+function startLabelRejectingTransmissionServer(): {
+  url: string;
+  requestBodies: Array<{
+    method?: string;
+    arguments?: { filename?: string; labels?: string[] };
+  }>;
+} {
+  const state = {
+    requestBodies: [] as Array<{
+      method?: string;
+      arguments?: { filename?: string; labels?: string[] };
+    }>,
+  };
+  const server = Bun.serve({
+    port: 0,
+    hostname: '127.0.0.1',
+    routes: {
+      '/transmission/rpc': async (request: Request) => {
+        const sessionId = request.headers.get('x-transmission-session-id');
+
+        if (!sessionId) {
+          return new Response(null, {
+            status: 409,
+            headers: {
+              'x-transmission-session-id': 'session-123',
+            },
+          });
+        }
+
+        const body = (await request.json()) as {
+          method?: string;
+          arguments?: { filename?: string; labels?: string[] };
+        };
+        state.requestBodies.push(body);
+
+        if (body.arguments?.labels) {
+          return Response.json({
+            result: 'invalid or unknown argument: labels',
+            arguments: {},
+          });
+        }
+
+        return Response.json({
+          result: 'success',
+          arguments: {
+            'torrent-added': {
+              id: 42,
+              hashString: 'hash-42',
+              name: 'Queued Torrent',
+            },
+          },
+        });
+      },
+    },
+  });
+
+  servers.push(server);
+  return {
+    url: server.url.origin,
+    get requestBodies() {
+      return [...state.requestBodies];
     },
   };
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -39,6 +39,39 @@ describe('validateConfig', () => {
     expect(config.tv[0]?.codecs).toEqual(['x265', 'x264']);
     expect(config.movies.resolutions).toEqual(['2160p', '1080p']);
     expect(config.movies.codecs).toEqual(['x265']);
+    expect(config.movies.codecPolicy).toBe('prefer');
+  });
+
+  it('parses movies.codecPolicy when set to require', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      movies: {
+        years: [2024],
+        resolutions: ['1080p'],
+        codecs: ['x265'],
+        codecPolicy: 'require',
+      },
+    });
+
+    expect(config.movies.codecPolicy).toBe('require');
+  });
+
+  it('fails with a precise movies.codecPolicy path when the value is unsupported', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        movies: {
+          years: [2024],
+          resolutions: ['1080p'],
+          codecs: ['x265'],
+          codecPolicy: 'strict',
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config movies codecPolicy" has invalid value; expected one of "prefer", "require".',
+      ),
+    );
   });
 
   it('fails with a precise tv codecs path when a codec is unsupported', () => {
@@ -290,6 +323,7 @@ function createMinimalConfig() {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     },
     transmission: {
       url: 'http://localhost:9091/transmission/rpc',

--- a/test/movie-match.test.ts
+++ b/test/movie-match.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 
 import type { MoviePolicy } from '../src/config';
-import { matchMovieItem } from '../src/movie-match';
+import {
+  getMovieNoMatchReason,
+  matchMovieItem,
+  MOVIE_CODEC_POLICY_REQUIRE_DISALLOWED_MESSAGE,
+  MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE,
+} from '../src/movie-match';
 import { normalizeFeedItem } from '../src/normalize';
 
 describe('matchMovieItem', () => {
@@ -14,6 +19,7 @@ describe('matchMovieItem', () => {
       years: [2025, 2024],
       resolutions: ['2160p', '1080p'],
       codecs: ['x265', 'x264'],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(item, policy)).toEqual({
@@ -34,6 +40,7 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(item, policy)).toEqual({
@@ -54,6 +61,7 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(item, policy)).toEqual({
@@ -78,6 +86,7 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['2160p', '1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(webRelease, policy)?.identityKey).toBe(
@@ -97,6 +106,7 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(item, policy)?.identityKey).toBe(
@@ -117,6 +127,7 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265', 'x264'],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(explicitCodec, policy)?.identityKey).toBe(
@@ -140,11 +151,48 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265', 'x264'],
+      codecPolicy: 'prefer',
     };
 
     expect(
       matchMovieItem(lowerPreferenceCodec, policy)?.score ?? 0,
     ).toBeGreaterThan(matchMovieItem(unknownCodec, policy)?.score ?? 0);
+  });
+
+  it('rejects codec-unknown movies when codecPolicy is require', () => {
+    const item = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: 'Example.Movie.2024.1080p.WEB-GROUP',
+    });
+    const policy: MoviePolicy = {
+      years: [2024],
+      resolutions: ['1080p'],
+      codecs: ['x265'],
+      codecPolicy: 'require',
+    };
+
+    expect(matchMovieItem(item, policy)).toBeUndefined();
+    expect(getMovieNoMatchReason(item, policy)).toBe(
+      MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE,
+    );
+  });
+
+  it('reports a strict-policy reason when the movie codec is not allowed', () => {
+    const item = normalizeFeedItem({
+      mediaType: 'movie',
+      rawTitle: 'Example.Movie.2024.1080p.WEB.x264-GROUP',
+    });
+    const policy: MoviePolicy = {
+      years: [2024],
+      resolutions: ['1080p'],
+      codecs: ['x265'],
+      codecPolicy: 'require',
+    };
+
+    expect(matchMovieItem(item, policy)).toBeUndefined();
+    expect(getMovieNoMatchReason(item, policy)).toBe(
+      MOVIE_CODEC_POLICY_REQUIRE_DISALLOWED_MESSAGE,
+    );
   });
 
   it.each([
@@ -202,6 +250,7 @@ describe('matchMovieItem', () => {
         years: [2024],
         resolutions: ['1080p'],
         codecs: ['x265'],
+        codecPolicy: 'prefer',
       };
 
       expect(matchMovieItem(item, policy)).toBeUndefined();
@@ -217,6 +266,7 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(item, policy)).toBeUndefined();
@@ -231,6 +281,7 @@ describe('matchMovieItem', () => {
       years: [2024],
       resolutions: ['1080p'],
       codecs: [],
+      codecPolicy: 'prefer',
     };
 
     expect(matchMovieItem(item, policy)).toBeUndefined();

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 
 import { type AppConfig, DEFAULT_RUNTIME_CONFIG } from '../src/config';
 import { FeedError } from '../src/feed';
+import { MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE } from '../src/movie-match';
 import { retryFailedCandidates, runPipeline } from '../src/pipeline';
 import {
   createRepository,
@@ -177,6 +178,59 @@ describe('runPipeline', () => {
       queuedAt: '2026-03-30T00:10:00.000Z',
     });
   });
+
+  it('records a strict codec-policy no-match reason for codec-unknown movie releases', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+
+    const result = await runPipeline({
+      config: createConfig({
+        feeds: [
+          {
+            name: 'Movie Feed',
+            url: 'https://example.test/movie.rss',
+            mediaType: 'movie',
+          },
+        ],
+        tv: [],
+        movies: {
+          years: [2024],
+          resolutions: ['1080p'],
+          codecs: ['x265'],
+          codecPolicy: 'require',
+        },
+      }),
+      repository,
+      downloader: {
+        submit: async () => ({
+          ok: true as const,
+          status: 'queued' as const,
+        }),
+      },
+      fetchFeed: async () => [
+        {
+          feedName: 'Movie Feed',
+          guidOrLink: 'https://example.test/releases/example-movie-no-codec',
+          rawTitle: 'Example.Movie.2024.1080p.WEB-GROUP',
+          publishedAt: '2026-03-30T00:00:00.000Z',
+          downloadUrl:
+            'https://example.test/downloads/example-movie-no-codec.torrent',
+        },
+      ],
+    });
+
+    expect(result.counts).toEqual({
+      queued: 0,
+      failed: 0,
+      skipped_duplicate: 0,
+      skipped_no_match: 1,
+    });
+    expect(repository.listFeedItemOutcomes(result.runId)).toMatchObject([
+      {
+        status: 'skipped_no_match',
+        message: MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE,
+      },
+    ]);
+  });
 });
 
 describe('retryFailedCandidates', () => {
@@ -323,6 +377,7 @@ function createConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       years: [2024],
       resolutions: ['1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     },
     transmission: {
       url: 'http://localhost:9091/transmission/rpc',

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -573,6 +573,7 @@ function requireMovieMatch(rawTitle: string) {
       years: [2024],
       resolutions: ['2160p', '1080p'],
       codecs: ['x265'],
+      codecPolicy: 'prefer',
     },
   );
 

--- a/test/transmission.test.ts
+++ b/test/transmission.test.ts
@@ -131,140 +131,133 @@ describe('Transmission adapter', () => {
     const requests: CapturedRequest[] = [];
     let requestCount = 0;
     const warnings: string[] = [];
-    const originalWarn = console.warn;
-    console.warn = (message?: unknown) => warnings.push(String(message ?? ''));
+    const server = startTransmissionServer(async (request) => {
+      requests.push(await captureRequest(request));
+      requestCount += 1;
 
-    try {
-      const server = startTransmissionServer(async (request) => {
-        requests.push(await captureRequest(request));
-        requestCount += 1;
-
-        if (requestCount === 1) {
-          return new Response(null, {
-            status: 409,
-            headers: {
-              'x-transmission-session-id': 'session-123',
-            },
-          });
-        }
-
-        const body = requests.at(-1)?.json as {
-          arguments?: { labels?: string[] };
-        };
-
-        if (body.arguments?.labels) {
-          return Response.json({
-            result: 'invalid or unknown argument: labels',
-            arguments: {},
-          });
-        }
-
-        return Response.json({
-          result: 'success',
-          arguments: {
-            'torrent-added': {
-              id: 7,
-              hashString: 'abcdef123456',
-              name: 'Example Movie',
-            },
+      if (requestCount === 1) {
+        return new Response(null, {
+          status: 409,
+          headers: {
+            'x-transmission-session-id': 'session-123',
           },
         });
-      });
-      const downloader = createTransmissionDownloader(
-        createTransmissionConfig(server.url.origin, '/downloads/movies'),
-      );
+      }
 
-      const result = await downloader.submit({
-        downloadUrl: 'https://download.example.test/movie/example.torrent',
+      const body = requests.at(-1)?.json as {
+        arguments?: { labels?: string[] };
+      };
+
+      if (body.arguments?.labels) {
+        return Response.json({
+          result: 'invalid or unknown argument: labels',
+          arguments: {},
+        });
+      }
+
+      return Response.json({
+        result: 'success',
+        arguments: {
+          'torrent-added': {
+            id: 7,
+            hashString: 'abcdef123456',
+            name: 'Example Movie',
+          },
+        },
+      });
+    });
+    const downloader = createTransmissionDownloader(
+      createTransmissionConfig(server.url.origin, '/downloads/movies'),
+      {
+        warn: (message) => warnings.push(message),
+      },
+    );
+
+    const result = await downloader.submit({
+      downloadUrl: 'https://download.example.test/movie/example.torrent',
+      labels: ['movie'],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: 'queued',
+      torrentId: 7,
+      torrentName: 'Example Movie',
+      torrentHash: 'abcdef123456',
+    });
+    expect(warnings).toEqual([
+      'Transmission rejected label arguments; retrying submission without labels.',
+    ]);
+    expect(requests).toHaveLength(3);
+    expect(requests[1]!.json).toEqual({
+      method: 'torrent-add',
+      arguments: {
+        filename: 'https://download.example.test/movie/example.torrent',
+        'download-dir': '/downloads/movies',
         labels: ['movie'],
-      });
-
-      expect(result).toEqual({
-        ok: true,
-        status: 'queued',
-        torrentId: 7,
-        torrentName: 'Example Movie',
-        torrentHash: 'abcdef123456',
-      });
-      expect(warnings).toEqual([
-        'Transmission rejected label arguments; retrying submission without labels.',
-      ]);
-      expect(requests).toHaveLength(3);
-      expect(requests[1]!.json).toEqual({
-        method: 'torrent-add',
-        arguments: {
-          filename: 'https://download.example.test/movie/example.torrent',
-          'download-dir': '/downloads/movies',
-          labels: ['movie'],
-        },
-      });
-      expect(requests[2]!.json).toEqual({
-        method: 'torrent-add',
-        arguments: {
-          filename: 'https://download.example.test/movie/example.torrent',
-          'download-dir': '/downloads/movies',
-        },
-      });
-    } finally {
-      console.warn = originalWarn;
-    }
+      },
+    });
+    expect(requests[2]!.json).toEqual({
+      method: 'torrent-add',
+      arguments: {
+        filename: 'https://download.example.test/movie/example.torrent',
+        'download-dir': '/downloads/movies',
+      },
+    });
   });
 
   it('returns the original structured failure when label fallback also fails', async () => {
     let requestCount = 0;
     const warnings: string[] = [];
-    const originalWarn = console.warn;
-    console.warn = (message?: unknown) => warnings.push(String(message ?? ''));
+    const server = startTransmissionServer(async (request) => {
+      requestCount += 1;
 
-    try {
-      const server = startTransmissionServer(async (request) => {
-        requestCount += 1;
+      if (requestCount === 1) {
+        return new Response(null, {
+          status: 409,
+          headers: {
+            'x-transmission-session-id': 'session-123',
+          },
+        });
+      }
 
-        if (requestCount === 1) {
-          return new Response(null, {
-            status: 409,
-            headers: {
-              'x-transmission-session-id': 'session-123',
-            },
-          });
-        }
+      const body = (await request.json()) as {
+        arguments?: { labels?: string[] };
+      };
 
-        const body = (await request.json()) as {
-          arguments?: { labels?: string[] };
-        };
-
-        if (body.arguments?.labels) {
-          return Response.json({
-            result: 'invalid or unknown argument: labels',
-            arguments: {},
-          });
-        }
-
+      if (body.arguments?.labels) {
         return Response.json({
-          result: 'torrent rejected by policy',
+          result: 'invalid or unknown argument: labels',
           arguments: {},
         });
-      });
-      const downloader = createTransmissionDownloader(
-        createTransmissionConfig(server.url.origin),
-      );
+      }
 
-      const result = await downloader.submit({
-        downloadUrl: 'https://download.example.test/movie/example.torrent',
-        labels: ['movie'],
+      return Response.json({
+        result: 'torrent rejected by policy',
+        arguments: {},
       });
+    });
+    const downloader = createTransmissionDownloader(
+      createTransmissionConfig(server.url.origin),
+      {
+        warn: (message) => warnings.push(message),
+      },
+    );
 
-      expectFailure(
-        result,
-        'rpc_error',
-        'Transmission rejected torrent submission: torrent rejected by policy.',
-      );
-      expect(warnings).toEqual([
-        'Transmission rejected label arguments; retrying submission without labels.',
-      ]);
-    } finally {
-      console.warn = originalWarn;
-    }
+    const result = await downloader.submit({
+      downloadUrl: 'https://download.example.test/movie/example.torrent',
+      labels: ['movie'],
+    });
+
+    expectFailure(
+      result,
+      'rpc_error',
+      'Transmission rejected torrent submission: torrent rejected by policy.',
+      'torrent rejected by policy',
+    );
+    expect(warnings).toEqual([
+      'Transmission rejected label arguments; retrying submission without labels.',
+    ]);
   });
 
   it('returns a structured failure when Transmission rejects the RPC call', async () => {
@@ -574,10 +567,14 @@ function expectFailure(
   result: unknown,
   code: SubmissionFailureCode,
   message: string,
+  rpcResult?: string,
 ): asserts result is SubmissionFailure {
-  expect(result).toEqual({
-    ok: false,
-    code,
-    message,
-  });
+  expect(result).toEqual(
+    expect.objectContaining({
+      ok: false,
+      code,
+      message,
+      ...(rpcResult ? { rpcResult } : {}),
+    }),
+  );
 }

--- a/test/transmission.test.ts
+++ b/test/transmission.test.ts
@@ -80,6 +80,193 @@ describe('Transmission adapter', () => {
     });
   });
 
+  it('submits queue-time labels when provided', async () => {
+    const requests: CapturedRequest[] = [];
+    let requestCount = 0;
+    const server = startTransmissionServer(async (request) => {
+      requests.push(await captureRequest(request));
+      requestCount += 1;
+
+      if (requestCount === 1) {
+        return new Response(null, {
+          status: 409,
+          headers: {
+            'x-transmission-session-id': 'session-123',
+          },
+        });
+      }
+
+      return Response.json({
+        result: 'success',
+        arguments: {
+          'torrent-added': {
+            id: 7,
+            hashString: 'abcdef123456',
+            name: 'Example Movie',
+          },
+        },
+      });
+    });
+    const downloader = createTransmissionDownloader(
+      createTransmissionConfig(server.url.origin, '/downloads/movies'),
+    );
+
+    const result = await downloader.submit({
+      downloadUrl: 'https://download.example.test/movie/example.torrent',
+      labels: ['movie'],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(requests[1]!.json).toEqual({
+      method: 'torrent-add',
+      arguments: {
+        filename: 'https://download.example.test/movie/example.torrent',
+        'download-dir': '/downloads/movies',
+        labels: ['movie'],
+      },
+    });
+  });
+
+  it('retries without labels when Transmission rejects label arguments', async () => {
+    const requests: CapturedRequest[] = [];
+    let requestCount = 0;
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown) => warnings.push(String(message ?? ''));
+
+    try {
+      const server = startTransmissionServer(async (request) => {
+        requests.push(await captureRequest(request));
+        requestCount += 1;
+
+        if (requestCount === 1) {
+          return new Response(null, {
+            status: 409,
+            headers: {
+              'x-transmission-session-id': 'session-123',
+            },
+          });
+        }
+
+        const body = requests.at(-1)?.json as {
+          arguments?: { labels?: string[] };
+        };
+
+        if (body.arguments?.labels) {
+          return Response.json({
+            result: 'invalid or unknown argument: labels',
+            arguments: {},
+          });
+        }
+
+        return Response.json({
+          result: 'success',
+          arguments: {
+            'torrent-added': {
+              id: 7,
+              hashString: 'abcdef123456',
+              name: 'Example Movie',
+            },
+          },
+        });
+      });
+      const downloader = createTransmissionDownloader(
+        createTransmissionConfig(server.url.origin, '/downloads/movies'),
+      );
+
+      const result = await downloader.submit({
+        downloadUrl: 'https://download.example.test/movie/example.torrent',
+        labels: ['movie'],
+      });
+
+      expect(result).toEqual({
+        ok: true,
+        status: 'queued',
+        torrentId: 7,
+        torrentName: 'Example Movie',
+        torrentHash: 'abcdef123456',
+      });
+      expect(warnings).toEqual([
+        'Transmission rejected label arguments; retrying submission without labels.',
+      ]);
+      expect(requests).toHaveLength(3);
+      expect(requests[1]!.json).toEqual({
+        method: 'torrent-add',
+        arguments: {
+          filename: 'https://download.example.test/movie/example.torrent',
+          'download-dir': '/downloads/movies',
+          labels: ['movie'],
+        },
+      });
+      expect(requests[2]!.json).toEqual({
+        method: 'torrent-add',
+        arguments: {
+          filename: 'https://download.example.test/movie/example.torrent',
+          'download-dir': '/downloads/movies',
+        },
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it('returns the original structured failure when label fallback also fails', async () => {
+    let requestCount = 0;
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message?: unknown) => warnings.push(String(message ?? ''));
+
+    try {
+      const server = startTransmissionServer(async (request) => {
+        requestCount += 1;
+
+        if (requestCount === 1) {
+          return new Response(null, {
+            status: 409,
+            headers: {
+              'x-transmission-session-id': 'session-123',
+            },
+          });
+        }
+
+        const body = (await request.json()) as {
+          arguments?: { labels?: string[] };
+        };
+
+        if (body.arguments?.labels) {
+          return Response.json({
+            result: 'invalid or unknown argument: labels',
+            arguments: {},
+          });
+        }
+
+        return Response.json({
+          result: 'torrent rejected by policy',
+          arguments: {},
+        });
+      });
+      const downloader = createTransmissionDownloader(
+        createTransmissionConfig(server.url.origin),
+      );
+
+      const result = await downloader.submit({
+        downloadUrl: 'https://download.example.test/movie/example.torrent',
+        labels: ['movie'],
+      });
+
+      expectFailure(
+        result,
+        'rpc_error',
+        'Transmission rejected torrent submission: torrent rejected by policy.',
+      );
+      expect(warnings).toEqual([
+        'Transmission rejected label arguments; retrying submission without labels.',
+      ]);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
   it('returns a structured failure when Transmission rejects the RPC call', async () => {
     const server = startTransmissionServer((request) => {
       const sessionId = request.headers.get('x-transmission-session-id');


### PR DESCRIPTION
## Summary

- delivery ticket: `P5.02 Add Transmission Label Routing With Fallback`
- ticket file: `docs/02-delivery/phase-05/ticket-02-add-transmission-label-routing-with-fallback.md`
- stacked base branch: `agents/p5-01-add-movie-codec-policy-mode`
- internal review: completed at `2026-04-05T13:28:00.383Z`

## External AI Review

- outcome: `patched`
- reviewed commit: `112fd4a2b360`
- current branch head: `b21ed4b83c41`
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- vendors: `coderabbit`, `qodo`

### Actions Taken

- `b21ed4b83c41` [qodo] fix: address AI review feedback [P5.02]