### PR TITLE
fix: address actionable PR 46 orchestrator feedback

### DIFF
--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -25,6 +25,7 @@ import {
   findTicketByBranch,
   formatNotificationMessage,
   formatReviewWindowMessage,
+  generateRunDeliverInvocation,
   inferPackageManager,
   initOrchestratorConfig,
   loadOrchestratorConfig,
@@ -47,6 +48,7 @@ import {
   resolveReviewTriager,
   summarizeStateDifferences,
   syncStateWithPlan,
+  runProcessResult,
   type DeliveryState,
 } from './orchestrator';
 
@@ -2342,26 +2344,80 @@ describe('delivery orchestrator', () => {
       }
     });
 
-    it('resolves empty config to defaults', () => {
-      const tempDir = '/tmp/resolve-cfg-test';
-      const resolved = resolveOrchestratorConfig({}, tempDir);
-      expect(resolved).toEqual({
-        defaultBranch: 'main',
-        planRoot: 'docs',
-        runtime: 'bun',
-        packageManager: 'npm',
-      });
+    it('throws when config json is not an object', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-cfg-'));
+      try {
+        await writeFile(join(tempDir, 'orchestrator.config.json'), '[]');
+
+        await expect(loadOrchestratorConfig(tempDir)).rejects.toThrow(
+          /must contain a JSON object/,
+        );
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
     });
 
-    it('merges partial config with defaults', () => {
-      const resolved = resolveOrchestratorConfig(
-        { defaultBranch: 'develop', planRoot: 'specifications' },
-        '/tmp/resolve-cfg-merge',
-      );
-      expect(resolved.defaultBranch).toBe('develop');
-      expect(resolved.planRoot).toBe('specifications');
-      expect(resolved.runtime).toBe('bun');
-      expect(resolved.packageManager).toBe('npm');
+    it('throws on blank defaultBranch', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-cfg-'));
+      try {
+        await writeFile(
+          join(tempDir, 'orchestrator.config.json'),
+          JSON.stringify({ defaultBranch: '   ' }),
+        );
+
+        await expect(loadOrchestratorConfig(tempDir)).rejects.toThrow(
+          /Expected a non-blank string/,
+        );
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
+    it('throws on blank planRoot', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-cfg-'));
+      try {
+        await writeFile(
+          join(tempDir, 'orchestrator.config.json'),
+          JSON.stringify({ planRoot: '   ' }),
+        );
+
+        await expect(loadOrchestratorConfig(tempDir)).rejects.toThrow(
+          /Expected a non-blank string/,
+        );
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
+    it('resolves empty config to defaults', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-cfg-resolve-'));
+      try {
+        const resolved = resolveOrchestratorConfig({}, tempDir);
+        expect(resolved).toEqual({
+          defaultBranch: 'main',
+          planRoot: 'docs',
+          runtime: 'bun',
+          packageManager: 'npm',
+        });
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
+    it('merges partial config with defaults', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-cfg-resolve-'));
+      try {
+        const resolved = resolveOrchestratorConfig(
+          { defaultBranch: 'develop', planRoot: 'specifications' },
+          tempDir,
+        );
+        expect(resolved.defaultBranch).toBe('develop');
+        expect(resolved.planRoot).toBe('specifications');
+        expect(resolved.runtime).toBe('bun');
+        expect(resolved.packageManager).toBe('npm');
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
     });
 
     it('infers bun from bun.lock', async () => {
@@ -2450,5 +2506,36 @@ describe('delivery orchestrator', () => {
         });
       }
     });
+  });
+
+  it('renders npm deliver invocations with a separator', () => {
+    expect(generateRunDeliverInvocation('npm')).toBe('npm run deliver --');
+    expect(generateRunDeliverInvocation('bun')).toBe('bun run deliver');
+    expect(generateRunDeliverInvocation('pnpm')).toBe('pnpm run deliver');
+  });
+
+  it('surfaces node spawn startup errors in stderr', () => {
+    initOrchestratorConfig({
+      defaultBranch: 'main',
+      planRoot: 'docs',
+      runtime: 'node',
+      packageManager: 'bun',
+    });
+
+    try {
+      const result = runProcessResult(process.cwd(), [
+        '__codex_missing_binary_for_test__',
+      ]);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('__codex_missing_binary_for_test__');
+    } finally {
+      initOrchestratorConfig({
+        defaultBranch: 'main',
+        planRoot: 'docs',
+        runtime: 'bun',
+        packageManager: 'bun',
+      });
+    }
   });
 });

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -144,10 +144,10 @@ export async function loadOrchestratorConfig(
     return {};
   }
 
-  const raw = JSON.parse(await readFile(configPath, 'utf8')) as Record<
-    string,
-    unknown
-  >;
+  const raw = requireConfigObject(
+    JSON.parse(await readFile(configPath, 'utf8')),
+    'orchestrator.config.json',
+  );
 
   if (
     raw.runtime !== undefined &&
@@ -169,24 +169,20 @@ export async function loadOrchestratorConfig(
     );
   }
 
-  if (
-    raw.defaultBranch !== undefined &&
-    typeof raw.defaultBranch !== 'string'
-  ) {
-    throw new Error(
-      'Invalid defaultBranch in orchestrator.config.json. Expected a string.',
-    );
-  }
-
-  if (raw.planRoot !== undefined && typeof raw.planRoot !== 'string') {
-    throw new Error(
-      'Invalid planRoot in orchestrator.config.json. Expected a string.',
-    );
-  }
+  const defaultBranch = optionalNonBlankString(
+    raw.defaultBranch,
+    'defaultBranch',
+    'orchestrator.config.json',
+  );
+  const planRoot = optionalNonBlankString(
+    raw.planRoot,
+    'planRoot',
+    'orchestrator.config.json',
+  );
 
   return {
-    defaultBranch: raw.defaultBranch as string | undefined,
-    planRoot: raw.planRoot as string | undefined,
+    defaultBranch,
+    planRoot,
     runtime: raw.runtime as OrchestratorConfig['runtime'],
     packageManager: raw.packageManager as OrchestratorConfig['packageManager'],
   };
@@ -207,11 +203,57 @@ export function resolveOrchestratorConfig(
   cwd: string,
 ): ResolvedOrchestratorConfig {
   return {
-    defaultBranch: raw.defaultBranch ?? 'main',
-    planRoot: raw.planRoot ?? 'docs',
+    defaultBranch: raw.defaultBranch?.trim() || 'main',
+    planRoot: raw.planRoot?.trim() || 'docs',
     runtime: raw.runtime ?? 'bun',
     packageManager: raw.packageManager ?? inferPackageManager(cwd),
   };
+}
+
+function requireConfigObject(
+  raw: unknown,
+  sourceLabel: string,
+): Record<string, unknown> {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new Error(`${sourceLabel} must contain a JSON object.`);
+  }
+
+  return raw as Record<string, unknown>;
+}
+
+function optionalNonBlankString(
+  value: unknown,
+  fieldName: string,
+  sourceLabel: string,
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error(
+      `Invalid ${fieldName} in ${sourceLabel}. Expected a string.`,
+    );
+  }
+
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new Error(
+      `Invalid ${fieldName} in ${sourceLabel}. Expected a non-blank string.`,
+    );
+  }
+
+  return normalized;
+}
+
+export function generateRunDeliverInvocation(
+  packageManager: ResolvedOrchestratorConfig['packageManager'],
+): string {
+  if (packageManager === 'npm') {
+    return 'npm run deliver --';
+  }
+
+  return `${packageManager} run deliver`;
 }
 
 export type DeliveryNotificationEvent =
@@ -551,7 +593,7 @@ export async function runDeliveryOrchestrator(
             outcome !== 'operator_input_needed')
         ) {
           throw new Error(
-            `Usage: ${_config.packageManager} run deliver --plan <plan-path> record-review <ticket-id> <clean|patched|operator_input_needed> [note]`,
+            `Usage: ${generateRunDeliverInvocation(_config.packageManager)} --plan <plan-path> record-review <ticket-id> <clean|patched|operator_input_needed> [note]`,
           );
         }
 
@@ -1102,7 +1144,7 @@ async function resolveOptionsForCommand(
 
 function getUsage(): string {
   return [
-    `Usage: ${_config.packageManager} run deliver --plan <plan-path> <command>`,
+    `Usage: ${generateRunDeliverInvocation(_config.packageManager)} --plan <plan-path> <command>`,
     '',
     'Commands:',
     '  ai-review [--pr <number>]',
@@ -4428,7 +4470,7 @@ function runProcess(cwd: string, cmd: string[]): string {
   return result.stdout;
 }
 
-function runProcessResult(
+export function runProcessResult(
   cwd: string,
   cmd: string[],
 ): {
@@ -4459,7 +4501,10 @@ function runProcessResult(
 
   return {
     exitCode: result.status ?? 1,
-    stderr: (result.stderr?.toString() ?? '').trim(),
+    stderr: [result.stderr?.toString() ?? '', result.error?.message ?? '']
+      .filter(Boolean)
+      .join('\n')
+      .trim(),
     stdout: result.stdout?.toString() ?? '',
   };
 }


### PR DESCRIPTION
## Summary

- close the still-actionable CodeRabbit follow-ups from PR #46
- reject non-object or blank-string orchestrator.config.json values for defaultBranch and planRoot
- render runnable npm usage text with npm run deliver -- ...
- preserve Node spawnSync startup errors in orchestrator command failures
- isolate config-resolution tests from host /tmp lockfiles and add coverage for the new guards

## Verification

- bun test tools/delivery/orchestrator.test.ts
- bun run verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation now strictly enforces valid JSON structure and rejects empty or whitespace-only values in critical fields.
  * Process error reporting enhanced with improved error context capture.

* **Tests**
  * Expanded test coverage for configuration validation edge cases and CLI invocation formatting across different package managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->