### PR TITLE
feat: support tv per-show overrides [P7.02]

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -2,3 +2,43 @@
 # Keep this file intentionally minimal for now: Qodo is a supported external
 # review agent in this repo, and this file gives us a stable place for future
 # opinionated repo-level tweaks without relying only on portal settings.
+#
+# Pin the key GitHub App automation defaults explicitly so repo behavior does
+# not depend solely on upstream or portal-side defaults.
+#
+# Source:
+# - https://docs.qodo.ai/v1/configuration/configuration-file
+# - https://raw.githubusercontent.com/qodo-ai/pr-agent/main/pr_agent/settings/configuration.toml
+#
+# Keep this file minimal. Qodo's docs recommend overriding only the settings
+# you actually want to pin at the repo level.
+
+[config]
+publish_output = true
+publish_output_progress = true
+disable_auto_feedback = false
+
+[github]
+deployment_type = "user"
+base_url = "https://api.github.com"
+publish_inline_comments_fallback_with_verification = true
+try_fix_invalid_inline_comments = true
+app_name = "pr-agent"
+ignore_bot_pr = true
+
+[github_app]
+bot_user = "github-actions[bot]"
+override_deployment_type = true
+handle_pr_actions = ["opened", "reopened", "ready_for_review"]
+pr_commands = [
+  "/describe --pr_description.final_update_message=false",
+  "/review",
+  "/improve",
+]
+handle_push_trigger = false
+push_trigger_ignore_bot_commits = true
+push_trigger_ignore_merge_commits = true
+push_trigger_wait_for_initial_review = true
+push_trigger_pending_tasks_backlog = true
+push_trigger_pending_tasks_ttl = 300
+push_commands = ["/describe", "/review"]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,14 @@ Example:
       "resolutions": ["720p"],
       "codecs": ["x265"]
     },
-    "shows": ["Beyond the Gates"]
+    "shows": [
+      "Beyond the Gates",
+      {
+        "name": "The Daily Show",
+        "matchPattern": "daily show",
+        "resolutions": ["1080p"]
+      }
+    ]
   },
   "movies": {
     "years": [2026],
@@ -113,7 +120,8 @@ Example:
 The compact TV form reduces repetition when most tracked shows share one quality policy:
 
 - `tv.defaults` defines the shared `resolutions` and `codecs`
-- `tv.shows` lists show names that inherit those defaults
+- `tv.shows` may contain plain show names that inherit those defaults
+- `tv.shows` may also contain objects with local `matchPattern`, `resolutions`, or `codecs` overrides
 - the older `tv: [{ ... }]` array shape still works unchanged
 
 ## Transmission Setup

--- a/docs/02-delivery/phase-07/ticket-02-tv-per-show-overrides.md
+++ b/docs/02-delivery/phase-07/ticket-02-tv-per-show-overrides.md
@@ -29,3 +29,5 @@ Compact TV config is only useful if it still handles exceptions cleanly. Some sh
 - `Why this path:` mixed `tv.shows` entries preserve the compact happy path while giving exceptions a local escape hatch, which is the smallest acceptable extension beyond P7.01.
 - `Alternative considered:` introducing named profiles in the same ticket was rejected because it adds an extra indirection layer before the compact/default model is proven useful.
 - `Deferred:` profile systems, config rendering, env-backed secrets, and richer validation guidance remain separate tickets.
+- `Implementation note:` mixed compact entries are normalized into the same `TvRule[]` output as P7.01, so downstream matcher and runtime code still does not need to distinguish compact config variants.
+- `Validation note:` the checked-in example and README now show both inherited string entries and bounded per-show object overrides so operators can see the intended shape directly.

--- a/pirate-claw.config.example.json
+++ b/pirate-claw.config.example.json
@@ -16,7 +16,14 @@
       "resolutions": ["720p"],
       "codecs": ["x265"]
     },
-    "shows": ["Beyond the Gates"]
+    "shows": [
+      "Beyond the Gates",
+      {
+        "name": "The Daily Show",
+        "matchPattern": "daily show",
+        "resolutions": ["1080p"]
+      }
+    ]
   },
   "movies": {
     "years": [2026],

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,13 @@ type CompactTvDefaults = {
   codecs: string[];
 };
 
+type CompactTvShowEntry = {
+  name: string;
+  matchPattern?: string;
+  resolutions?: string[];
+  codecs?: string[];
+};
+
 export type MoviePolicy = {
   years: number[];
   resolutions: string[];
@@ -114,7 +121,9 @@ function validateTvConfig(input: unknown, path: string): TvRule[] {
   const defaults = validateCompactTvDefaults(tv.defaults, path);
   const shows = requireCompactTvShows(tv.shows, path);
 
-  return shows.map((name) => validateCompactTvRule(name, defaults));
+  return shows.map((entry, index) =>
+    validateCompactTvRule(entry, defaults, `${path} tv shows[${index}]`),
+  );
 }
 
 function validateFeed(input: unknown, path: string, index: number): FeedConfig {
@@ -181,7 +190,10 @@ function validateCompactTvDefaults(
   };
 }
 
-function requireCompactTvShows(input: unknown, path: string): string[] {
+function requireCompactTvShows(
+  input: unknown,
+  path: string,
+): CompactTvShowEntry[] {
   if (!Array.isArray(input) || input.length === 0) {
     throw new ConfigError(
       `Config file "${path} tv" has invalid "shows"; expected a non-empty array of show names.`,
@@ -189,18 +201,62 @@ function requireCompactTvShows(input: unknown, path: string): string[] {
   }
 
   return input.map((entry, index) =>
-    expectString(entry, `${path} tv shows[${index}]`),
+    validateCompactTvShowEntry(entry, `${path} tv shows[${index}]`),
   );
 }
 
 function validateCompactTvRule(
-  name: string,
+  entry: CompactTvShowEntry,
   defaults: CompactTvDefaults,
+  path: string,
 ): TvRule {
   return {
-    name,
-    resolutions: [...defaults.resolutions],
-    codecs: [...defaults.codecs],
+    name: entry.name,
+    matchPattern: validateOptionalMatchPattern(
+      entry.matchPattern,
+      `${path} matchPattern`,
+    ),
+    resolutions: entry.resolutions
+      ? [...entry.resolutions]
+      : [...defaults.resolutions],
+    codecs: entry.codecs ? [...entry.codecs] : [...defaults.codecs],
+  };
+}
+
+function validateCompactTvShowEntry(
+  input: unknown,
+  path: string,
+): CompactTvShowEntry {
+  if (typeof input === 'string') {
+    return { name: expectString(input, path) };
+  }
+
+  const entry = expectRecord(input, path);
+
+  return {
+    name: requireString(entry, 'name', path),
+    matchPattern:
+      entry.matchPattern === undefined
+        ? undefined
+        : expectString(entry.matchPattern, `${path} matchPattern`),
+    resolutions:
+      entry.resolutions === undefined
+        ? undefined
+        : requireNormalizedAllowedStringArray(
+            entry,
+            'resolutions',
+            path,
+            supportedResolutions,
+          ),
+    codecs:
+      entry.codecs === undefined
+        ? undefined
+        : requireNormalizedAllowedStringArray(
+            entry,
+            'codecs',
+            path,
+            supportedCodecs,
+          ),
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -196,7 +196,7 @@ function requireCompactTvShows(
 ): CompactTvShowEntry[] {
   if (!Array.isArray(input) || input.length === 0) {
     throw new ConfigError(
-      `Config file "${path} tv" has invalid "shows"; expected a non-empty array of show names.`,
+      `Config file "${path} tv" has invalid "shows"; expected a non-empty array of show entries (string names or objects).`,
     );
   }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -33,6 +33,49 @@ describe('validateConfig', () => {
     ]);
   });
 
+  it('supports mixed compact tv show entries with per-show overrides', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      tv: {
+        defaults: {
+          resolutions: ['1080P'],
+          codecs: ['X265'],
+        },
+        shows: [
+          'Default Show',
+          {
+            name: 'Pattern Override Show',
+            matchPattern: 'pattern-override',
+          },
+          {
+            name: 'Quality Override Show',
+            resolutions: ['720p'],
+            codecs: ['x264'],
+          },
+        ],
+      },
+    });
+
+    expect(config.tv).toEqual([
+      {
+        name: 'Default Show',
+        resolutions: ['1080p'],
+        codecs: ['x265'],
+      },
+      {
+        name: 'Pattern Override Show',
+        matchPattern: 'pattern-override',
+        resolutions: ['1080p'],
+        codecs: ['x265'],
+      },
+      {
+        name: 'Quality Override Show',
+        resolutions: ['720p'],
+        codecs: ['x264'],
+      },
+    ]);
+  });
+
   it('keeps the legacy tv rule array shape working unchanged', () => {
     const config = validateConfig(createMinimalConfig());
 
@@ -350,6 +393,29 @@ describe('validateConfig', () => {
       }),
     ).toThrow(
       new ConfigError('Config file "config tv defaults" must be an object.'),
+    );
+  });
+
+  it('fails when a compact tv object entry omits the show name', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        tv: {
+          defaults: {
+            resolutions: ['1080p'],
+            codecs: ['x265'],
+          },
+          shows: [
+            {
+              resolutions: ['720p'],
+            },
+          ],
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config tv shows[0] name" must be a non-empty string.',
+      ),
     );
   });
 });


### PR DESCRIPTION
## Summary

- delivery ticket: `P7.02 TV Per-Show Overrides`
- ticket file: `docs/02-delivery/phase-07/ticket-02-tv-per-show-overrides.md`
- stacked base branch: `agents/p7-01-compact-tv-config`
- internal review: completed at `2026-04-06T15:03:26.750Z`

## External AI Review

- outcome: `patched`
- reviewed commit: `2fc8e5120d26`
- current branch head: `5660163e69f4`
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- vendors: `coderabbit`

### Actions Taken

- `944f8c493e7e` [coderabbit] fix: clarify compact tv show validation
- `5660163e69f4` [coderabbit] chore: pin qodo repo config