### PR TITLE
feat: add config show command [P7.03]

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -2,3 +2,43 @@
 # Keep this file intentionally minimal for now: Qodo is a supported external
 # review agent in this repo, and this file gives us a stable place for future
 # opinionated repo-level tweaks without relying only on portal settings.
+#
+# Pin the key GitHub App automation defaults explicitly so repo behavior does
+# not depend solely on upstream or portal-side defaults.
+#
+# Source:
+# - https://docs.qodo.ai/v1/configuration/configuration-file
+# - https://raw.githubusercontent.com/qodo-ai/pr-agent/main/pr_agent/settings/configuration.toml
+#
+# Keep this file minimal. Qodo's docs recommend overriding only the settings
+# you actually want to pin at the repo level.
+
+[config]
+publish_output = true
+publish_output_progress = true
+disable_auto_feedback = false
+
+[github]
+deployment_type = "user"
+base_url = "https://api.github.com"
+publish_inline_comments_fallback_with_verification = true
+try_fix_invalid_inline_comments = true
+app_name = "pr-agent"
+ignore_bot_pr = true
+
+[github_app]
+bot_user = "github-actions[bot]"
+override_deployment_type = true
+handle_pr_actions = ["opened", "reopened", "ready_for_review"]
+pr_commands = [
+  "/describe --pr_description.final_update_message=false",
+  "/review",
+  "/improve",
+]
+handle_push_trigger = false
+push_trigger_ignore_bot_commits = true
+push_trigger_ignore_merge_commits = true
+push_trigger_wait_for_initial_review = true
+push_trigger_pending_tasks_backlog = true
+push_trigger_pending_tasks_ttl = 300
+push_commands = ["/describe", "/review"]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,14 @@ Example:
       "resolutions": ["720p"],
       "codecs": ["x265"]
     },
-    "shows": ["Beyond the Gates"]
+    "shows": [
+      "Beyond the Gates",
+      {
+        "name": "The Daily Show",
+        "matchPattern": "daily show",
+        "resolutions": ["1080p"]
+      }
+    ]
   },
   "movies": {
     "years": [2026],
@@ -113,7 +120,8 @@ Example:
 The compact TV form reduces repetition when most tracked shows share one quality policy:
 
 - `tv.defaults` defines the shared `resolutions` and `codecs`
-- `tv.shows` lists show names that inherit those defaults
+- `tv.shows` may contain plain show names that inherit those defaults
+- `tv.shows` may also contain objects with local `matchPattern`, `resolutions`, or `codecs` overrides
 - the older `tv: [{ ... }]` array shape still works unchanged
 
 ## Transmission Setup

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It currently supports:
 - `pirate-claw status`
 - `pirate-claw retry-failed`
 - `pirate-claw reconcile`
+- `pirate-claw config show`
 
 ## Quick Start
 
@@ -51,6 +52,12 @@ Reconcile tracked torrents from Transmission with:
 
 ```bash
 ./bin/pirate-claw reconcile --config ./pirate-claw.config.json
+```
+
+Inspect the fully normalized effective config with:
+
+```bash
+./bin/pirate-claw config show --config ./pirate-claw.config.json
 ```
 
 ## Configuration

--- a/docs/02-delivery/phase-07/ticket-02-tv-per-show-overrides.md
+++ b/docs/02-delivery/phase-07/ticket-02-tv-per-show-overrides.md
@@ -29,3 +29,5 @@ Compact TV config is only useful if it still handles exceptions cleanly. Some sh
 - `Why this path:` mixed `tv.shows` entries preserve the compact happy path while giving exceptions a local escape hatch, which is the smallest acceptable extension beyond P7.01.
 - `Alternative considered:` introducing named profiles in the same ticket was rejected because it adds an extra indirection layer before the compact/default model is proven useful.
 - `Deferred:` profile systems, config rendering, env-backed secrets, and richer validation guidance remain separate tickets.
+- `Implementation note:` mixed compact entries are normalized into the same `TvRule[]` output as P7.01, so downstream matcher and runtime code still does not need to distinguish compact config variants.
+- `Validation note:` the checked-in example and README now show both inherited string entries and bounded per-show object overrides so operators can see the intended shape directly.

--- a/docs/02-delivery/phase-07/ticket-03-config-normalization-visibility.md
+++ b/docs/02-delivery/phase-07/ticket-03-config-normalization-visibility.md
@@ -29,3 +29,5 @@ More flexible config ingestion increases the need for visibility. Operators shou
 - `Why this path:` one bounded config-inspection command is the smallest acceptable way to make flexible config ingestion auditable without redesigning status or runtime artifacts.
 - `Alternative considered:` surfacing the normalized config only through daemon artifacts was rejected because operators need an on-demand inspection path even when the daemon is not running.
 - `Deferred:` interactive config tooling, broader schema introspection, and validation-polish work beyond the command itself remain outside this ticket.
+- `Implementation note:` `pirate-claw config show` reuses the existing `loadConfig` normalization path and prints the resulting `AppConfig` as stable pretty JSON, which avoided introducing a second config-rendering model.
+- `Validation note:` CLI coverage now exercises compact TV defaults plus per-show overrides through the public command so this visibility path stays aligned with the runtime loader rather than only with unit-level config tests.

--- a/pirate-claw.config.example.json
+++ b/pirate-claw.config.example.json
@@ -16,7 +16,14 @@
       "resolutions": ["720p"],
       "codecs": ["x265"]
     },
-    "shows": ["Beyond the Gates"]
+    "shows": [
+      "Beyond the Gates",
+      {
+        "name": "The Daily Show",
+        "matchPattern": "daily show",
+        "resolutions": ["1080p"]
+      }
+    ]
   },
   "movies": {
     "years": [2026],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,22 @@ export async function runCli(argv: string[]): Promise<number> {
   const [command, ...rest] = argv;
 
   try {
+    if (command === 'config') {
+      const [subcommand, ...configArgs] = rest;
+
+      if (subcommand === 'show') {
+        const configPath = parseConfigPath(configArgs);
+        const resolvedConfigPath = resolveConfigPath(configPath);
+        const config = await loadConfig(resolvedConfigPath);
+
+        console.log(JSON.stringify(config, null, 2));
+        return 0;
+      }
+
+      console.error('Unknown config command. Available commands: "show".');
+      return 1;
+    }
+
     if (command === 'run') {
       const configPath = parseConfigPath(rest);
       const resolvedConfigPath = resolveConfigPath(configPath);
@@ -192,7 +208,7 @@ export async function runCli(argv: string[]): Promise<number> {
     }
 
     console.error(
-      'Unknown command. Available commands: "run", "daemon", "status", "retry-failed", "reconcile".',
+      'Unknown command. Available commands: "run", "daemon", "status", "retry-failed", "reconcile", "config".',
     );
     return 1;
   } catch (error) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,13 @@ type CompactTvDefaults = {
   codecs: string[];
 };
 
+type CompactTvShowEntry = {
+  name: string;
+  matchPattern?: string;
+  resolutions?: string[];
+  codecs?: string[];
+};
+
 export type MoviePolicy = {
   years: number[];
   resolutions: string[];
@@ -114,7 +121,9 @@ function validateTvConfig(input: unknown, path: string): TvRule[] {
   const defaults = validateCompactTvDefaults(tv.defaults, path);
   const shows = requireCompactTvShows(tv.shows, path);
 
-  return shows.map((name) => validateCompactTvRule(name, defaults));
+  return shows.map((entry, index) =>
+    validateCompactTvRule(entry, defaults, `${path} tv shows[${index}]`),
+  );
 }
 
 function validateFeed(input: unknown, path: string, index: number): FeedConfig {
@@ -181,26 +190,73 @@ function validateCompactTvDefaults(
   };
 }
 
-function requireCompactTvShows(input: unknown, path: string): string[] {
+function requireCompactTvShows(
+  input: unknown,
+  path: string,
+): CompactTvShowEntry[] {
   if (!Array.isArray(input) || input.length === 0) {
     throw new ConfigError(
-      `Config file "${path} tv" has invalid "shows"; expected a non-empty array of show names.`,
+      `Config file "${path} tv" has invalid "shows"; expected a non-empty array of show entries (string names or objects).`,
     );
   }
 
   return input.map((entry, index) =>
-    expectString(entry, `${path} tv shows[${index}]`),
+    validateCompactTvShowEntry(entry, `${path} tv shows[${index}]`),
   );
 }
 
 function validateCompactTvRule(
-  name: string,
+  entry: CompactTvShowEntry,
   defaults: CompactTvDefaults,
+  path: string,
 ): TvRule {
   return {
-    name,
-    resolutions: [...defaults.resolutions],
-    codecs: [...defaults.codecs],
+    name: entry.name,
+    matchPattern: validateOptionalMatchPattern(
+      entry.matchPattern,
+      `${path} matchPattern`,
+    ),
+    resolutions: entry.resolutions
+      ? [...entry.resolutions]
+      : [...defaults.resolutions],
+    codecs: entry.codecs ? [...entry.codecs] : [...defaults.codecs],
+  };
+}
+
+function validateCompactTvShowEntry(
+  input: unknown,
+  path: string,
+): CompactTvShowEntry {
+  if (typeof input === 'string') {
+    return { name: expectString(input, path) };
+  }
+
+  const entry = expectRecord(input, path);
+
+  return {
+    name: requireString(entry, 'name', path),
+    matchPattern:
+      entry.matchPattern === undefined
+        ? undefined
+        : expectString(entry.matchPattern, `${path} matchPattern`),
+    resolutions:
+      entry.resolutions === undefined
+        ? undefined
+        : requireNormalizedAllowedStringArray(
+            entry,
+            'resolutions',
+            path,
+            supportedResolutions,
+          ),
+    codecs:
+      entry.codecs === undefined
+        ? undefined
+        : requireNormalizedAllowedStringArray(
+            entry,
+            'codecs',
+            path,
+            supportedCodecs,
+          ),
   };
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -501,6 +501,134 @@ describe('pirate-claw status', () => {
   });
 });
 
+describe('pirate-claw config show', () => {
+  afterEach(async () => {
+    while (openDatabases.length > 0) {
+      openDatabases.pop()?.close();
+    }
+
+    while (servers.length > 0) {
+      servers.pop()?.stop(true);
+    }
+
+    while (tempDirs.length > 0) {
+      const directory = tempDirs.pop();
+
+      if (directory) {
+        await Bun.$`rm -rf ${directory}`;
+      }
+    }
+  });
+
+  it('prints the normalized config for compact tv input', async () => {
+    const directory = await mkdtemp();
+    const configPath = join(directory, 'pirate-claw.config.json');
+
+    await Bun.write(
+      configPath,
+      JSON.stringify(
+        {
+          feeds: [
+            {
+              name: 'TV Feed',
+              url: 'https://example.test/tv.rss',
+              mediaType: 'tv',
+            },
+          ],
+          tv: {
+            defaults: {
+              resolutions: ['1080P'],
+              codecs: ['X265'],
+            },
+            shows: [
+              'Default Show',
+              {
+                name: 'Override Show',
+                matchPattern: 'override show',
+                resolutions: ['720p'],
+              },
+            ],
+          },
+          movies: {
+            years: [2024],
+            resolutions: ['1080p'],
+            codecs: ['x265'],
+          },
+          transmission: {
+            url: 'http://localhost:9091/transmission/rpc',
+            username: 'user',
+            password: 'pass',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    const result = await runSimpleCommand(
+      directory,
+      'config',
+      'show',
+      '--config',
+      configPath,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(JSON.parse(result.stdout)).toEqual({
+      feeds: [
+        {
+          name: 'TV Feed',
+          url: 'https://example.test/tv.rss',
+          mediaType: 'tv',
+        },
+      ],
+      tv: [
+        {
+          name: 'Default Show',
+          resolutions: ['1080p'],
+          codecs: ['x265'],
+        },
+        {
+          name: 'Override Show',
+          matchPattern: 'override show',
+          resolutions: ['720p'],
+          codecs: ['x265'],
+        },
+      ],
+      movies: {
+        years: [2024],
+        resolutions: ['1080p'],
+        codecs: ['x265'],
+        codecPolicy: 'prefer',
+      },
+      transmission: {
+        url: 'http://localhost:9091/transmission/rpc',
+        username: 'user',
+        password: 'pass',
+      },
+      runtime: {
+        runIntervalMinutes: 30,
+        reconcileIntervalMinutes: 1,
+        artifactDir: '.pirate-claw/runtime',
+        artifactRetentionDays: 7,
+      },
+    });
+  });
+
+  it('fails with a readable error for unknown config subcommands', async () => {
+    const directory = await mkdtemp();
+
+    const result = await runSimpleCommand(directory, 'config', 'wat');
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain(
+      'Unknown config command. Available commands: "show".',
+    );
+  });
+});
+
 describe('pirate-claw retry-failed', () => {
   afterEach(async () => {
     while (openDatabases.length > 0) {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -33,6 +33,49 @@ describe('validateConfig', () => {
     ]);
   });
 
+  it('supports mixed compact tv show entries with per-show overrides', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      tv: {
+        defaults: {
+          resolutions: ['1080P'],
+          codecs: ['X265'],
+        },
+        shows: [
+          'Default Show',
+          {
+            name: 'Pattern Override Show',
+            matchPattern: 'pattern-override',
+          },
+          {
+            name: 'Quality Override Show',
+            resolutions: ['720p'],
+            codecs: ['x264'],
+          },
+        ],
+      },
+    });
+
+    expect(config.tv).toEqual([
+      {
+        name: 'Default Show',
+        resolutions: ['1080p'],
+        codecs: ['x265'],
+      },
+      {
+        name: 'Pattern Override Show',
+        matchPattern: 'pattern-override',
+        resolutions: ['1080p'],
+        codecs: ['x265'],
+      },
+      {
+        name: 'Quality Override Show',
+        resolutions: ['720p'],
+        codecs: ['x264'],
+      },
+    ]);
+  });
+
   it('keeps the legacy tv rule array shape working unchanged', () => {
     const config = validateConfig(createMinimalConfig());
 
@@ -350,6 +393,29 @@ describe('validateConfig', () => {
       }),
     ).toThrow(
       new ConfigError('Config file "config tv defaults" must be an object.'),
+    );
+  });
+
+  it('fails when a compact tv object entry omits the show name', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        tv: {
+          defaults: {
+            resolutions: ['1080p'],
+            codecs: ['x265'],
+          },
+          shows: [
+            {
+              resolutions: ['720p'],
+            },
+          ],
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config tv shows[0] name" must be a non-empty string.',
+      ),
     );
   });
 });


### PR DESCRIPTION
## Summary

- delivery ticket: `P7.03 Config Normalization Visibility`
- ticket file: `docs/02-delivery/phase-07/ticket-03-config-normalization-visibility.md`
- stacked base branch: `agents/p7-02-tv-per-show-overrides`
- internal review: completed at `2026-04-06T15:28:19.974Z`

## External AI Review

- outcome: `clean`
- reviewed commit: `233ebe2c16c5`
- current branch head: `233ebe2c16c5`
- vendors: `coderabbit`