### PR TITLE
fix: improve config validation guidance [P7.05]

### DIFF
--- a/docs/02-delivery/phase-07/ticket-05-config-validation-ux.md
+++ b/docs/02-delivery/phase-07/ticket-05-config-validation-ux.md
@@ -28,3 +28,5 @@ Flexible config forms are only helpful if failures are understandable. Operators
 - `Why this path:` tightening the current config-loader error surface is the smallest acceptable way to support the new ergonomic forms without forcing operators to reverse-engineer parser expectations.
 - `Alternative considered:` replacing the entire config-loader validation layer with a new schema library was rejected because this ticket only commits to better operator feedback, not a validator rewrite.
 - `Deferred:` schema visualization, localized messaging, and broader CLI error redesign remain outside this ticket.
+- `Implementation note:` the improvements stayed inside the existing config-loader functions, but Phase 07-specific errors now point at the precise config path and suggest accepted compact forms instead of only reporting generic object/type failures.
+- `Validation note:` coverage now asserts the new suggestion text for malformed `tv.defaults`, malformed `tv.shows` entries, and env-backed Transmission credential misconfiguration so the operator-facing messages do not silently regress.

--- a/src/config.ts
+++ b/src/config.ts
@@ -180,7 +180,13 @@ function validateCompactTvDefaults(
   input: unknown,
   path: string,
 ): CompactTvDefaults {
-  const defaults = expectRecord(input, `${path} tv defaults`);
+  if (!isRecord(input)) {
+    throw new ConfigError(
+      `Config file "${path} tv defaults" must be an object with "resolutions" and "codecs", for example { "resolutions": ["1080p"], "codecs": ["x265"] }.`,
+    );
+  }
+
+  const defaults = input;
 
   return {
     resolutions: requireNormalizedAllowedStringArray(
@@ -204,7 +210,7 @@ function requireCompactTvShows(
 ): CompactTvShowEntry[] {
   if (!Array.isArray(input) || input.length === 0) {
     throw new ConfigError(
-      `Config file "${path} tv" has invalid "shows"; expected a non-empty array of show entries (string names or objects).`,
+      `Config file "${path} tv shows" must be a non-empty array like ["Example Show"] or [{ "name": "Example Show" }].`,
     );
   }
 
@@ -239,7 +245,13 @@ function validateCompactTvShowEntry(
     return { name: expectString(input, path) };
   }
 
-  const entry = expectRecord(input, path);
+  if (!isRecord(input)) {
+    throw new ConfigError(
+      `Config file "${path}" must be a string show name or an object with "name", optional "matchPattern", optional "resolutions", and optional "codecs".`,
+    );
+  }
+
+  const entry = input;
 
   return {
     name: requireString(entry, 'name', path),
@@ -352,7 +364,7 @@ function resolveTransmissionSecret(
   }
 
   throw new ConfigError(
-    `Config file "${path}" must be a non-empty string or come from ${envKey}.`,
+    `Config file "${path}" must be a non-empty string or come from ${envKey} in the process environment or a .env file next to the config file.`,
   );
 }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -428,7 +428,9 @@ describe('validateConfig', () => {
         },
       }),
     ).toThrow(
-      new ConfigError('Config file "config tv defaults" must be an object.'),
+      new ConfigError(
+        'Config file "config tv defaults" must be an object with "resolutions" and "codecs", for example { "resolutions": ["1080p"], "codecs": ["x265"] }.',
+      ),
     );
   });
 
@@ -455,6 +457,25 @@ describe('validateConfig', () => {
     );
   });
 
+  it('fails when a compact tv show entry is neither a string nor an object', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        tv: {
+          defaults: {
+            resolutions: ['1080p'],
+            codecs: ['x265'],
+          },
+          shows: [42],
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config tv shows[0]" must be a string show name or an object with "name", optional "matchPattern", optional "resolutions", and optional "codecs".',
+      ),
+    );
+  });
+
   it('fails when transmission credentials are missing inline and in env', () => {
     expect(() =>
       validateConfig(
@@ -469,7 +490,7 @@ describe('validateConfig', () => {
       ),
     ).toThrow(
       new ConfigError(
-        'Config file "config transmission username" must be a non-empty string or come from PIRATE_CLAW_TRANSMISSION_USERNAME.',
+        'Config file "config transmission username" must be a non-empty string or come from PIRATE_CLAW_TRANSMISSION_USERNAME in the process environment or a .env file next to the config file.',
       ),
     );
   });


### PR DESCRIPTION
## Summary

- delivery ticket: `P7.05 Config Validation UX`
- ticket file: `docs/02-delivery/phase-07/ticket-05-config-validation-ux.md`
- stacked base branch: `agents/p7-04-env-backed-transmission-secrets`
- internal review: completed at `2026-04-06T15:46:02.226Z`

## External AI Review

- outcome: `clean`
- reviewed commit: `cf098b5a3ba4`
- current branch head: `cf098b5a3ba4`
- vendors: `coderabbit`