### PR TITLE
fix: harden ai review reporting follow-ups

### DIFF
--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -267,7 +267,7 @@ jq -n \
       | ($body | test("review started|review in progress|currently reviewing|i am reviewing|i'\''m reviewing|analyzing this pr|analysis in progress|starting review|check back in a few minutes|processing new changes in this pr"));
 
     def greptile_reviewed_sha:
-      (body_text | capture("commit/(?<sha>[0-9a-fA-F]{7,40})")?.sha // "" | ascii_downcase);
+      (try (body_text | capture("commit/(?<sha>[0-9a-fA-F]{7,40})").sha) catch "" | ascii_downcase);
 
     def looks_like_current_greptile_started_text:
       (body_text | normalize_text) as $body

--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -266,24 +266,6 @@ jq -n \
       (body_text | normalize_text) as $body
       | ($body | test("review started|review in progress|currently reviewing|i am reviewing|i'\''m reviewing|analyzing this pr|analysis in progress|starting review|check back in a few minutes|processing new changes in this pr"));
 
-    def greptile_reviewed_sha:
-      (try (body_text | capture("commit/(?<sha>[0-9a-fA-F]{7,40})").sha) catch "" | ascii_downcase);
-
-    def looks_like_current_greptile_started_text:
-      (body_text | normalize_text) as $body
-      | (vendor_name) as $vendor
-      | if $vendor != "greptile" then
-          false
-        elif ($body | test("last reviewed commit|re-trigger greptile|retrigger greptile|reviews \\(")) | not then
-          false
-        else
-          (greptile_reviewed_sha) as $reviewed
-          | (current_head_sha) as $current
-          | ($reviewed | length) > 0
-            and ($current | length) > 0
-            and ($current | startswith($reviewed))
-        end;
-
     def looks_like_summary_noise_text:
       (body_text | normalize_text) as $body
       | ($body | test("review summary by|code review by|walkthroughs|file changes|looking for bugs\\?|finishing touches|summary of changes|rule violations|bugs \\("));

--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -264,7 +264,7 @@ jq -n \
 
     def looks_like_started_text:
       (body_text | normalize_text) as $body
-      | ($body | test("review started|review in progress|currently reviewing|i am reviewing|i'\''m reviewing|analyzing this pr|analysis in progress|starting review|check back in a few minutes|processing new changes in this pr"));
+      | ($body | test("review started|review in progress|currently reviewing|i am reviewing|i'\''m reviewing|analyzing this pr|analysis in progress|starting review|check back in a few minutes|processing new changes in this pr|last reviewed commit|re-trigger greptile|retrigger greptile|reviews \\("));
 
     def looks_like_summary_noise_text:
       (body_text | normalize_text) as $body

--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -264,7 +264,25 @@ jq -n \
 
     def looks_like_started_text:
       (body_text | normalize_text) as $body
-      | ($body | test("review started|review in progress|currently reviewing|i am reviewing|i'\''m reviewing|analyzing this pr|analysis in progress|starting review|check back in a few minutes|processing new changes in this pr|last reviewed commit|re-trigger greptile|retrigger greptile|reviews \\("));
+      | ($body | test("review started|review in progress|currently reviewing|i am reviewing|i'\''m reviewing|analyzing this pr|analysis in progress|starting review|check back in a few minutes|processing new changes in this pr"));
+
+    def greptile_reviewed_sha:
+      (body_text | capture("commit/(?<sha>[0-9a-fA-F]{7,40})")?.sha // "" | ascii_downcase);
+
+    def looks_like_current_greptile_started_text:
+      (body_text | normalize_text) as $body
+      | (vendor_name) as $vendor
+      | if $vendor != "greptile" then
+          false
+        elif ($body | test("last reviewed commit|re-trigger greptile|retrigger greptile|reviews \\(")) | not then
+          false
+        else
+          (greptile_reviewed_sha) as $reviewed
+          | (current_head_sha) as $current
+          | ($reviewed | length) > 0
+            and ($current | length) > 0
+            and ($current | startswith($reviewed))
+        end;
 
     def looks_like_summary_noise_text:
       (body_text | normalize_text) as $body

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -196,6 +196,7 @@ Goal:
 Planning note:
 
 - this is a separate engineering epic, not a product phase, and should be planned under `docs/03-engineering/` or a later dedicated engineering roadmap note
+- current tracked epic: `docs/03-engineering/epic-01-pr-body-reporting-unification.md`
 
 ## Planning Rules
 

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -72,6 +72,7 @@ The orchestrator owns process mechanics:
 - blocking advancement until review has been explicitly recorded or auto-recorded as `clean` after the final polling check
 - refreshing the current PR body from recorded ai-cr follow-up notes immediately before advancing to the next ticket
 - resolving native GitHub inline review threads for patched AI-review findings when the saved review artifact exposes a resolvable thread identity
+- normalizing reviewer-facing external AI-review PR body reporting through one shared cleanup/rendering path for ticket-linked and standalone PRs
 
 It does **not** own AI-review detection heuristics or triage judgment.
 
@@ -253,6 +254,7 @@ PR descriptions are maintained as delivery metadata, not one-shot text.
 - `record-review ... patched` also makes a best-effort attempt to resolve mapped native GitHub inline review threads for patched findings
 - `poll-review` auto-records `clean` when no `ai-code-review` feedback is detected by the final check and refreshes the PR body immediately
 - PR-body AI-review notes now distinguish current-head review from stale-history review when the reviewed SHA no longer matches the branch head
+- ticket-linked and standalone PR refreshes now share the same reviewer-facing external-review section builder plus cleanup rules for duplicate/stale review scaffolding
 - `advance` refreshes the PR body from that recorded review state, then marks the ticket done and optionally starts the next one
 
 This matters because the repo squash-merges PRs onto `main`, so the PR body needs to mention prudent ai-cr follow-up work before the stack moves on.

--- a/docs/03-engineering/epic-01-pr-body-reporting-unification.md
+++ b/docs/03-engineering/epic-01-pr-body-reporting-unification.md
@@ -1,0 +1,40 @@
+# Epic 01: PR Body Reporting Unification
+
+This engineering epic tracks cleanup of the delivery orchestrator's reviewer-facing PR body reporting.
+
+It is intentionally not a numbered Pirate Claw product phase. The target is maintainer workflow architecture, not new CLI or runtime behavior.
+
+## Goal
+
+Unify the external AI-review PR body reporting path so ticket-linked PRs and standalone PRs reuse the same reviewer-facing section builder and cleanup logic.
+
+The practical bug behind this epic was simple: standalone PRs could accumulate stale manual `## External AI Review` prose above the managed review block, while ticket-linked PRs followed a different body-refresh path.
+
+## In Scope
+
+- one shared reviewer-facing `## External AI Review` section builder
+- one shared PR-body cleanup/normalization path for external review reporting
+- refactoring ticket-linked and standalone orchestrator flows to call the shared logic
+- regression coverage for the duplicate-section failure mode seen on PR `#59`
+
+## Out Of Scope
+
+- AI-review polling redesign
+- vendor fetcher changes beyond compatibility with the shared body helpers
+- artifact storage redesign
+- thread-resolution redesign
+- broader review-pipeline modularization beyond PR body reporting
+
+## Locked Decisions
+
+- standalone PRs keep author-owned summary/body content outside the managed review section
+- this epic is "PR body only", not "PR body plus thread resolution" and not a general AI-review architecture rewrite
+- further ticket-linked vs standalone review-pipeline drift should be captured as follow-up work rather than widening this epic by default
+
+## Intended Outcome
+
+After this epic lands:
+
+- ticket-linked and standalone PRs render the same reviewer-facing external review section for the same recorded review state
+- standalone PR refreshes remove stale duplicate `## External AI Review` scaffolding instead of appending beside it
+- reviewer-facing PR body cleanup rules live behind one orchestrator seam instead of diverging by flow type

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ Execution plans, issue conventions, and ticket breakdowns.
 
 Cross-cutting engineering rules that apply beyond a single phase.
 
+- `epic-01-pr-body-reporting-unification.md`: shared reviewer-facing PR body reporting cleanup for ticket-linked and standalone orchestrator flows
 - `sqlite-schema.md`: current local SQLite tables, identities, and persistence invariants
 - `son-of-anton.md`: the dev-facing doctrine for this repo's AI-assisted delivery workflow
 - `snyk-workflow-rationale.md`: rationale for adding Snyk-based security scanning to CI

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -651,6 +651,19 @@ describe('delivery orchestrator', () => {
     ).toContain('- outcome: `clean`');
   });
 
+  it('preserves incomplete agents in standalone review sections', () => {
+    const body = buildStandaloneAiReviewSection({
+      outcome: 'clean',
+      note: 'External AI review completed without prudent follow-up changes.',
+      incompleteAgents: ['coderabbit', 'greptile'],
+      vendors: ['coderabbit', 'greptile'],
+    });
+
+    expect(body).toContain(
+      '- incomplete agents at timeout: `coderabbit, greptile`',
+    );
+  });
+
   it('renders the same external review section content for ticketed and standalone flows', () => {
     const section = buildExternalAiReviewSection(
       {

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 
 import {
   assertReviewerFacingMarkdown,
+  buildExternalAiReviewSection,
   buildStandaloneAiReviewSection,
   buildReviewPollCheckMinutes,
   buildPullRequestBody,
@@ -573,6 +574,44 @@ describe('delivery orchestrator', () => {
     expect(deduped).not.toContain('old-2');
   });
 
+  it('removes stale manual external review prose when refreshing standalone review metadata', () => {
+    const merged = mergeStandaloneAiReviewSection(
+      [
+        '## Summary',
+        '- add stacked closeout support',
+        '',
+        '## External AI Review',
+        '',
+        '- original outcome on reviewed head: `operator_input_needed`',
+        '- reviewed commit: `df8c35128bd2`',
+        '- current branch head: `f238a1f`',
+        '- vendors: `coderabbit`',
+        '',
+        '### Patched Follow-Up',
+        '',
+        '- [coderabbit] Persist replacement PR metadata before continuing.',
+        '',
+        '<!-- ai-review:start -->',
+        'old managed block',
+        '<!-- ai-review:end -->',
+      ].join('\n'),
+      buildStandaloneAiReviewSection({
+        outcome: 'clean',
+        note: 'External AI review completed without prudent follow-up changes.',
+        reviewedHeadSha: '80026dbdebbb18fa6017dc522c2a0fc916927367',
+        vendors: ['coderabbit', 'greptile'],
+      }),
+    );
+
+    expect(merged.match(/^## External AI Review$/gm)?.length ?? 0).toBe(1);
+    expect(merged).not.toContain('original outcome on reviewed head');
+    expect(merged).not.toContain('Patched Follow-Up');
+    expect(merged).toContain('## Summary');
+    expect(merged).toContain('- add stacked closeout support');
+    expect(merged).toContain('<!-- ai-review:start -->');
+    expect(merged).toContain('`coderabbit`, `greptile`');
+  });
+
   it('renders final standalone ai review outcomes accurately', () => {
     expect(
       buildStandaloneAiReviewSection({
@@ -610,6 +649,60 @@ describe('delivery orchestrator', () => {
         vendors: ['qodo'],
       }),
     ).toContain('- outcome: `clean`');
+  });
+
+  it('renders the same external review section content for ticketed and standalone flows', () => {
+    const section = buildExternalAiReviewSection(
+      {
+        outcome: 'patched',
+        note: 'Patched the prudent AI review follow-up.',
+        reviewedHeadSha: 'abcdef1234567890',
+        comments: [
+          {
+            vendor: 'coderabbit',
+            channel: 'inline_review',
+            authorLogin: 'coderabbitai',
+            authorType: 'Bot',
+            body: 'Guard the null return here.',
+            kind: 'finding',
+            path: 'src/example.ts',
+            line: 42,
+            threadId: 'thread_example_1',
+            url: 'https://example.test/comment/1',
+          },
+        ],
+        threadResolutions: [
+          {
+            status: 'resolved',
+            threadId: 'thread_example_1',
+            url: 'https://example.test/comment/1',
+            vendor: 'coderabbit',
+          },
+        ],
+        vendors: ['coderabbit'],
+      },
+      {
+        actionCommits: [
+          {
+            sha: 'c87f955ca43a1234',
+            subject: 'resolve null-guard follow-up',
+            vendors: ['coderabbit'],
+          },
+        ],
+        currentHeadSha: 'fedcba0987654321',
+        maxWaitMinutes: 8,
+      },
+    );
+
+    expect(section).toContain('## External AI Review');
+    expect(section).toContain('- outcome: `patched`');
+    expect(section).toContain('### Actions Taken');
+    expect(section).toContain(
+      '`c87f955ca43a` [coderabbit] resolve null-guard follow-up',
+    );
+    expect(section).toContain(
+      'the latest recorded external AI review applies to an older branch head',
+    );
   });
 
   it('keeps standalone pr bodies free of artifact paths', () => {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -4257,6 +4257,7 @@ export function buildStandaloneAiReviewSection(
     | 'artifactJsonPath'
     | 'artifactTextPath'
     | 'comments'
+    | 'incompleteAgents'
     | 'note'
     | 'nonActionSummary'
     | 'outcome'
@@ -4272,6 +4273,7 @@ export function buildStandaloneAiReviewSection(
   const section = buildExternalAiReviewSection(result, {
     actionCommits: options.actionCommits,
     currentHeadSha: options.currentHeadSha,
+    incompleteAgents: result.incompleteAgents,
     maxWaitMinutes: DEFAULT_REVIEW_POLL_MAX_WAIT_MINUTES,
   });
 

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -3232,6 +3232,97 @@ function stripBannedPrBodySections(body: string): string {
     .trimEnd();
 }
 
+function stripExternalAiReviewSections(body: string): string {
+  const lines = body.split('\n');
+  const kept: string[] = [];
+  let index = 0;
+  let activeFence: { char: '`' | '~'; length: number } | undefined;
+
+  while (index < lines.length) {
+    const line = lines[index]!;
+    const fenceMarker = parseFenceMarker(line);
+    if (fenceMarker) {
+      if (!activeFence) {
+        activeFence = { char: fenceMarker.char, length: fenceMarker.length };
+      } else if (
+        fenceMarker.char === activeFence.char &&
+        fenceMarker.length >= activeFence.length &&
+        fenceMarker.trailing.trim().length === 0
+      ) {
+        activeFence = undefined;
+      }
+      kept.push(line);
+      index += 1;
+      continue;
+    }
+    if (activeFence) {
+      kept.push(line);
+      index += 1;
+      continue;
+    }
+
+    const heading = parseMarkdownHeadingAt(lines, index);
+    if (
+      !heading ||
+      heading.title.trim().toLowerCase() !== 'external ai review'
+    ) {
+      kept.push(lines[index]!);
+      index += 1;
+      continue;
+    }
+
+    index += heading.lineCount;
+    while (index < lines.length) {
+      const nextLine = lines[index]!;
+      const nextFenceMarker = parseFenceMarker(nextLine);
+      if (nextFenceMarker) {
+        if (!activeFence) {
+          activeFence = {
+            char: nextFenceMarker.char,
+            length: nextFenceMarker.length,
+          };
+        } else if (
+          nextFenceMarker.char === activeFence.char &&
+          nextFenceMarker.length >= activeFence.length &&
+          nextFenceMarker.trailing.trim().length === 0
+        ) {
+          activeFence = undefined;
+        }
+        index += 1;
+        continue;
+      }
+      if (activeFence) {
+        index += 1;
+        continue;
+      }
+      const nextHeading = parseMarkdownHeadingAt(lines, index);
+      if (nextHeading && nextHeading.level <= heading.level) {
+        break;
+      }
+      index += 1;
+    }
+  }
+
+  return kept
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd();
+}
+
+function normalizeReviewerFacingPullRequestBody(
+  body: string,
+  options: {
+    stripExternalAiReviewSections?: boolean;
+  } = {},
+): string {
+  const sanitized = stripBannedPrBodySections(body);
+  const withoutExternalReview = options.stripExternalAiReviewSections
+    ? stripExternalAiReviewSections(sanitized)
+    : sanitized;
+
+  return `${withoutExternalReview.trimEnd()}\n`;
+}
+
 function collectActionVendors(
   comments: AiReviewComment[] | undefined,
   vendors: string[] | undefined,
@@ -3723,32 +3814,31 @@ export function buildPullRequestBody(
     ticket.status === 'needs_patch' ||
     ticket.status === 'operator_input_needed'
   ) {
-    lines.push('', '## External AI Review', '');
     lines.push(
-      ...buildAiReviewDetailLines({
-        actionSummary: ticket.reviewActionSummary,
-        actionCommits: options.actionCommits,
-        comments: ticket.reviewComments,
-        currentHeadSha: options.currentHeadSha,
-        maxWaitMinutes: state.reviewPollMaxWaitMinutes,
-        nonActionSummary: ticket.reviewNonActionSummary,
-        note: ticket.reviewNote,
-        outcome: ticket.reviewOutcome,
-        reviewedHeadSha: ticket.reviewHeadSha,
-        status: ticket.status,
-        threadResolutions: ticket.reviewThreadResolutions,
-        vendors: ticket.reviewVendors,
-      }),
+      '',
+      buildExternalAiReviewSection(
+        {
+          actionSummary: ticket.reviewActionSummary,
+          comments: ticket.reviewComments,
+          note: ticket.reviewNote,
+          nonActionSummary: ticket.reviewNonActionSummary,
+          outcome: ticket.reviewOutcome,
+          reviewedHeadSha: ticket.reviewHeadSha,
+          status: ticket.status,
+          threadResolutions: ticket.reviewThreadResolutions,
+          vendors: ticket.reviewVendors,
+        },
+        {
+          actionCommits: options.actionCommits,
+          currentHeadSha: options.currentHeadSha,
+          incompleteAgents: ticket.reviewIncompleteAgents,
+          maxWaitMinutes: state.reviewPollMaxWaitMinutes,
+        },
+      ),
     );
-
-    if (ticket.reviewIncompleteAgents?.length) {
-      lines.push(
-        `- incomplete agents at timeout: \`${ticket.reviewIncompleteAgents.join(', ')}\``,
-      );
-    }
   }
 
-  return stripBannedPrBodySections(lines.join('\n'));
+  return normalizeReviewerFacingPullRequestBody(lines.join('\n'));
 }
 
 export function buildPullRequestTitle(
@@ -4179,29 +4269,63 @@ export function buildStandaloneAiReviewSection(
     currentHeadSha?: string;
   } = {},
 ): string {
-  const lines = [
+  const section = buildExternalAiReviewSection(result, {
+    actionCommits: options.actionCommits,
+    currentHeadSha: options.currentHeadSha,
+    maxWaitMinutes: DEFAULT_REVIEW_POLL_MAX_WAIT_MINUTES,
+  });
+
+  return [
     STANDALONE_AI_REVIEW_SECTION_START,
-    '## External AI Review',
-    '',
-  ];
+    section,
+    STANDALONE_AI_REVIEW_SECTION_END,
+  ].join('\n');
+}
+
+export function buildExternalAiReviewSection(
+  result: {
+    actionSummary?: string;
+    comments?: AiReviewComment[];
+    note?: string;
+    nonActionSummary?: string;
+    outcome?: ReviewResult;
+    reviewedHeadSha?: string;
+    status?: TicketStatus;
+    threadResolutions?: AiReviewThreadResolution[];
+    vendors?: string[];
+  },
+  options: {
+    actionCommits?: ReviewActionCommit[];
+    currentHeadSha?: string;
+    incompleteAgents?: string[];
+    maxWaitMinutes: number;
+  },
+): string {
+  const lines = ['## External AI Review', ''];
   lines.push(
     ...buildAiReviewDetailLines({
       actionSummary: result.actionSummary,
       actionCommits: options.actionCommits,
       comments: result.comments,
       currentHeadSha: options.currentHeadSha,
-      maxWaitMinutes: DEFAULT_REVIEW_POLL_MAX_WAIT_MINUTES,
+      maxWaitMinutes: options.maxWaitMinutes,
       nonActionSummary: result.nonActionSummary,
       note: result.note,
       outcome: result.outcome,
       reviewedHeadSha: result.reviewedHeadSha,
+      status: result.status,
       threadResolutions: result.threadResolutions,
       vendors: result.vendors,
     }),
   );
 
-  lines.push(STANDALONE_AI_REVIEW_SECTION_END);
-  return stripBannedPrBodySections(lines.join('\n'));
+  if (options.incompleteAgents && options.incompleteAgents.length > 0) {
+    lines.push(
+      `- incomplete agents at timeout: \`${options.incompleteAgents.join(', ')}\``,
+    );
+  }
+
+  return lines.join('\n');
 }
 
 export function mergeStandaloneAiReviewSection(
@@ -4213,12 +4337,18 @@ export function mergeStandaloneAiReviewSection(
     'g',
   );
   const bodyWithoutAiReviewSections = body.replace(pattern, '').trimEnd();
+  const normalizedBody = normalizeReviewerFacingPullRequestBody(
+    bodyWithoutAiReviewSections,
+    {
+      stripExternalAiReviewSections: true,
+    },
+  ).trimEnd();
   const mergedBody =
-    bodyWithoutAiReviewSections.length > 0
-      ? `${bodyWithoutAiReviewSections}\n\n${section}\n`
+    normalizedBody.length > 0
+      ? `${normalizedBody}\n\n${section}\n`
       : `${section}\n`;
 
-  return `${stripBannedPrBodySections(mergedBody).trimEnd()}\n`;
+  return normalizeReviewerFacingPullRequestBody(mergedBody);
 }
 
 function updateStandalonePullRequestBody(


### PR DESCRIPTION
## Summary
- add Greptile support to the standalone AI-review fetch/normalize flow alongside CodeRabbit and Qodo
- harden standalone review-state handling so stale Greptile status comments and already-patched native review threads do not keep PR reporting in a misleading state
- unify ticket-linked and standalone `## External AI Review` PR body reporting behind one shared renderer and cleanup path, including the duplicate-section regression seen on PR #59

<!-- ai-review:start -->
## External AI Review

- outcome: `clean`
- reviewed commit: `171786df6792`
- current branch head: `171786df6792`
- vendors: `coderabbit`, `greptile`
<!-- ai-review:end -->
