### PR TITLE
refactor: share review metadata refresh [E2.05]

### DIFF
--- a/docs/02-delivery/engineering-epic-02/ticket-05-shared-review-metadata-refresh-adapter.md
+++ b/docs/02-delivery/engineering-epic-02/ticket-05-shared-review-metadata-refresh-adapter.md
@@ -39,3 +39,4 @@ This ticket does not change polling or review-state recording semantics. It only
 - `Why this path:` the adapter boundary is small and reviewable because the rendering primitives already exist; the work is mostly about centralizing composition without flattening the intentional differences.
 - `Alternative considered:` forcing one fully identical PR-body builder for both modes was rejected because standalone PRs must preserve author-owned content while ticket-linked PRs must keep delivery metadata.
 - `Deferred:` top-level command cleanup and final doc convergence remain for the last ticket.
+- `Implemented seam:` ticket-linked and standalone refresh paths now share one recorded-review metadata adapter that feeds the same reviewer-facing external review section context into each mode while preserving stacked summary fields for ticketed PRs and author-owned body content outside the managed AI-review block for standalone PRs.

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -8,6 +8,7 @@ import {
   buildExternalAiReviewSection,
   buildStandaloneAiReviewSection,
   buildReviewPollCheckMinutes,
+  buildReviewMetadataRefreshBody,
   buildPullRequestBody,
   buildPullRequestTitle,
   buildTicketHandoff,
@@ -717,6 +718,116 @@ describe('delivery orchestrator', () => {
     expect(section).toContain(
       'the latest recorded external AI review applies to an older branch head',
     );
+  });
+
+  it('uses the shared refresh adapter while preserving ticketed and standalone body ownership', () => {
+    const reviewState = {
+      actionSummary: 'Patched the null-guard regression and tightened tests.',
+      comments: [
+        {
+          vendor: 'coderabbit',
+          channel: 'inline_review' as const,
+          authorLogin: 'coderabbitai',
+          authorType: 'Bot',
+          body: 'Guard the null return here.',
+          kind: 'finding' as const,
+          path: 'src/example.ts',
+          line: 42,
+          threadId: 'thread_example_1',
+          url: 'https://example.test/comment/1',
+        },
+      ],
+      note: 'Patched the prudent AI review follow-up.',
+      outcome: 'patched' as const,
+      reviewedHeadSha: 'abcdef1234567890',
+      threadResolutions: [
+        {
+          status: 'resolved' as const,
+          threadId: 'thread_example_1',
+          url: 'https://example.test/comment/1',
+          vendor: 'coderabbit',
+        },
+      ],
+      vendors: ['coderabbit'],
+    };
+    const refreshContext = {
+      actionCommits: [
+        {
+          sha: 'c87f955ca43a1234',
+          subject: 'resolve null-guard follow-up',
+          vendors: ['coderabbit'],
+        },
+      ],
+      currentHeadSha: 'fedcba0987654321',
+    };
+    const expectedReviewSection = buildExternalAiReviewSection(reviewState, {
+      ...refreshContext,
+      maxWaitMinutes: 8,
+    });
+
+    const ticketBody = buildReviewMetadataRefreshBody(
+      {
+        mode: 'ticketed',
+        state: {
+          planKey: 'engineering-epic-02',
+          planPath:
+            'docs/02-delivery/engineering-epic-02/implementation-plan.md',
+          statePath: '.agents/delivery/engineering-epic-02/state.json',
+          reviewsDirPath: '.agents/delivery/engineering-epic-02/reviews',
+          handoffsDirPath: '.agents/delivery/engineering-epic-02/handoffs',
+          reviewPollIntervalMinutes: 2,
+          reviewPollMaxWaitMinutes: 8,
+          tickets: [],
+        },
+        ticket: {
+          id: 'E2.05',
+          title: 'Shared Review Metadata Refresh Adapter',
+          ticketFile:
+            'docs/02-delivery/engineering-epic-02/ticket-05-shared-review-metadata-refresh-adapter.md',
+          baseBranch: 'agents/e2-04-shared-clean-and-timeout-recording-core',
+          internalReviewCompletedAt: '2026-04-07T00:00:00.000Z',
+          reviewActionSummary: reviewState.actionSummary,
+          reviewIncompleteAgents: undefined,
+          reviewComments: reviewState.comments,
+          reviewHeadSha: reviewState.reviewedHeadSha,
+          reviewNonActionSummary: undefined,
+          reviewNote: reviewState.note,
+          reviewOutcome: reviewState.outcome,
+          reviewThreadResolutions: reviewState.threadResolutions,
+          reviewVendors: reviewState.vendors,
+          status: 'reviewed',
+        },
+      },
+      refreshContext,
+    );
+
+    const standaloneBody = buildReviewMetadataRefreshBody(
+      {
+        mode: 'standalone',
+        body: [
+          '## Summary',
+          '- preserve this author-owned context',
+          '',
+          '## Notes',
+          '- keep this section too',
+        ].join('\n'),
+        result: {
+          ...reviewState,
+          prNumber: 32,
+          prUrl: 'https://example.test/pull/32',
+        },
+      },
+      refreshContext,
+    );
+
+    expect(ticketBody).toContain(
+      '- delivery ticket: `E2.05 Shared Review Metadata Refresh Adapter`',
+    );
+    expect(ticketBody).toContain(expectedReviewSection);
+    expect(standaloneBody).toContain('- preserve this author-owned context');
+    expect(standaloneBody).toContain('- keep this section too');
+    expect(standaloneBody).toContain(expectedReviewSection);
+    expect(standaloneBody).toContain('<!-- ai-review:start -->');
   });
 
   it('keeps standalone pr bodies free of artifact paths', () => {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -455,6 +455,42 @@ export type StandaloneAiReviewResult = {
   vendors: string[];
 };
 
+type ReviewMetadataRefreshContext = {
+  actionCommits?: ReviewActionCommit[];
+  currentHeadSha?: string;
+};
+
+type TicketReviewMetadataRefreshTarget = Pick<
+  TicketState,
+  | 'id'
+  | 'title'
+  | 'ticketFile'
+  | 'baseBranch'
+  | 'internalReviewCompletedAt'
+  | 'reviewActionSummary'
+  | 'reviewIncompleteAgents'
+  | 'reviewComments'
+  | 'reviewHeadSha'
+  | 'status'
+  | 'reviewOutcome'
+  | 'reviewNote'
+  | 'reviewNonActionSummary'
+  | 'reviewThreadResolutions'
+  | 'reviewVendors'
+>;
+
+type ReviewMetadataRefreshBodyOptions =
+  | {
+      mode: 'standalone';
+      body: string;
+      result: StandaloneAiReviewResult;
+    }
+  | {
+      mode: 'ticketed';
+      state: DeliveryState;
+      ticket: TicketReviewMetadataRefreshTarget;
+    };
+
 type StandaloneAiReviewDependencies = Pick<
   PollReviewDependencies,
   'fetcher' | 'now' | 'resolveThreads' | 'sleep' | 'triager'
@@ -3909,27 +3945,7 @@ function buildAiReviewDetailLines(input: {
 
 export function buildPullRequestBody(
   state: DeliveryState,
-  ticket: Pick<
-    TicketState,
-    | 'id'
-    | 'title'
-    | 'ticketFile'
-    | 'baseBranch'
-    | 'internalReviewCompletedAt'
-    | 'reviewActionSummary'
-    | 'reviewIncompleteAgents'
-    | 'reviewComments'
-    | 'reviewHeadSha'
-    | 'reviewIncompleteAgents'
-    | 'reviewComments'
-    | 'reviewHeadSha'
-    | 'status'
-    | 'reviewOutcome'
-    | 'reviewNote'
-    | 'reviewNonActionSummary'
-    | 'reviewThreadResolutions'
-    | 'reviewVendors'
-  >,
+  ticket: TicketReviewMetadataRefreshTarget,
   options: {
     actionCommits?: ReviewActionCommit[];
     currentHeadSha?: string;
@@ -3979,6 +3995,20 @@ export function buildPullRequestBody(
   }
 
   return normalizeReviewerFacingPullRequestBody(lines.join('\n'));
+}
+
+export function buildReviewMetadataRefreshBody(
+  options: ReviewMetadataRefreshBodyOptions,
+  context: ReviewMetadataRefreshContext = {},
+): string {
+  if (options.mode === 'ticketed') {
+    return buildPullRequestBody(options.state, options.ticket, context);
+  }
+
+  return mergeStandaloneAiReviewSection(
+    options.body,
+    buildStandaloneAiReviewSection(options.result, context),
+  );
 }
 
 export function buildPullRequestTitle(
@@ -4368,16 +4398,23 @@ function updatePullRequestBody(
   }
 
   const currentHeadSha = readHeadSha(ticket.worktreePath);
-  const body = buildPullRequestBody(state, ticket, {
-    actionCommits: listReviewActionCommits(
-      ticket.worktreePath,
-      ticket.reviewHeadSha,
+  const body = buildReviewMetadataRefreshBody(
+    {
+      mode: 'ticketed',
+      state,
+      ticket,
+    },
+    {
+      actionCommits: listReviewActionCommits(
+        ticket.worktreePath,
+        ticket.reviewHeadSha,
+        currentHeadSha,
+        ticket.reviewComments,
+        ticket.reviewVendors,
+      ),
       currentHeadSha,
-      ticket.reviewComments,
-      ticket.reviewVendors,
-    ),
-    currentHeadSha,
-  });
+    },
+  );
   assertReviewerFacingMarkdown(body);
 
   runProcess(ticket.worktreePath, [
@@ -4498,9 +4535,13 @@ function updateStandalonePullRequestBody(
   pullRequest: StandalonePullRequest,
   result: StandaloneAiReviewResult,
 ): void {
-  const nextBody = mergeStandaloneAiReviewSection(
-    pullRequest.body,
-    buildStandaloneAiReviewSection(result, {
+  const nextBody = buildReviewMetadataRefreshBody(
+    {
+      body: pullRequest.body,
+      mode: 'standalone',
+      result,
+    },
+    {
       actionCommits: listReviewActionCommits(
         cwd,
         result.reviewedHeadSha,
@@ -4509,7 +4550,7 @@ function updateStandalonePullRequestBody(
         result.vendors,
       ),
       currentHeadSha: pullRequest.headRefOid,
-    }),
+    },
   );
   assertReviewerFacingMarkdown(nextBody);
 


### PR DESCRIPTION
## Summary

- delivery ticket: `E2.05 Shared Review Metadata Refresh Adapter`
- ticket file: `docs/02-delivery/engineering-epic-02/ticket-05-shared-review-metadata-refresh-adapter.md`
- stacked base branch: `agents/e2-04-shared-clean-and-timeout-recording-core`
- internal review: completed at `2026-04-06T21:29:54.447Z`

## External AI Review

- outcome: `clean`
- reviewed commit: `6090e10c8696`
- current branch head: `6090e10c8696`
- vendors: `coderabbit`
