### PR TITLE
feat: add per-media-type download directory config [P8.01]

### DIFF
--- a/docs/02-delivery/phase-08/implementation-plan.md
+++ b/docs/02-delivery/phase-08/implementation-plan.md
@@ -1,0 +1,50 @@
+# Phase 08 Implementation Plan
+
+Phase 08 adds per-media-type Transmission download directories, passing the resolved `downloadDir` at queue time.
+
+## Epic
+
+- `Phase 08 Media Placement`
+
+Follow the shared guidance in [`docs/02-delivery/phase-implementation-guidance.md`](../phase-implementation-guidance.md) when shaping or revising tickets for this phase.
+
+## Ticket Order
+
+1. `P8.01 Per-Media-Type Download Directory Config`
+2. `P8.02 Queue-Time Download Directory Resolution`
+3. `P8.03 Docs And Example Config Update`
+
+## Ticket Files
+
+- `ticket-01-per-media-type-download-directory-config.md`
+- `ticket-02-queue-time-download-directory-resolution.md`
+- `ticket-03-docs-and-example-config-update.md`
+
+## Exit Condition
+
+Torrents queued from movie feeds use the configured movie download directory. Torrents queued from TV feeds use the configured TV download directory. When no per-type directory is configured, behavior is identical to the pre-Phase-08 baseline. Docs and example config reflect the new surface.
+
+## Review Rules
+
+Review and merge in ticket order.
+
+Do not start the next ticket until:
+
+- the previous tests are green
+- the behavior change is explained in the ticket and rationale
+- the phase-level defaults and deferrals remain unchanged
+
+## Explicit Deferrals
+
+These are intentionally out of scope for Phase 08:
+
+- Pirate-Claw-side post-completion file moves or renaming
+- per-feed custom download directories beyond the two media types
+- directory validation or creation via Transmission RPC
+
+## Stop Conditions
+
+Pause for review if:
+
+- the `downloadDir` precedence logic forces changes to the label-routing fallback path
+- the config change requires a migration for existing `transmission.downloadDir` users

--- a/docs/02-delivery/phase-08/ticket-01-per-media-type-download-directory-config.md
+++ b/docs/02-delivery/phase-08/ticket-01-per-media-type-download-directory-config.md
@@ -19,3 +19,7 @@ Add `transmission.downloadDirs` to the config type and validation so operators c
 ## Exit Condition
 
 `validateConfig` accepts `transmission.downloadDirs` with movie and/or tv fields, rejects invalid shapes, and the parsed `TransmissionConfig` carries the new fields through to consumers.
+
+## Rationale
+
+`downloadDirs` is validated as a separate optional object on `TransmissionConfig` rather than replacing the existing `downloadDir` field. This preserves backward compatibility — operators with a single global `downloadDir` continue to work unchanged. The per-type fields use the same `movie` / `tv` media-type vocabulary already established by `FeedConfig.mediaType`. Unknown keys inside `downloadDirs` are rejected at config load time to catch typos early.

--- a/docs/02-delivery/phase-08/ticket-01-per-media-type-download-directory-config.md
+++ b/docs/02-delivery/phase-08/ticket-01-per-media-type-download-directory-config.md
@@ -1,0 +1,21 @@
+# P8.01 Per-Media-Type Download Directory Config
+
+## Goal
+
+Add `transmission.downloadDirs` to the config type and validation so operators can specify per-media-type download directories.
+
+## Scope
+
+- Add `downloadDirs?: { movie?: string; tv?: string }` to `TransmissionConfig`
+- Validate `transmission.downloadDirs` in the config loader with path-aware error messages
+- Both fields are optional; when omitted, existing behavior is unchanged
+- Add config validation tests for the new fields
+
+## Out Of Scope
+
+- Passing the resolved directory at queue time (P8.02)
+- Docs/example config update (P8.03)
+
+## Exit Condition
+
+`validateConfig` accepts `transmission.downloadDirs` with movie and/or tv fields, rejects invalid shapes, and the parsed `TransmissionConfig` carries the new fields through to consumers.

--- a/docs/02-delivery/phase-08/ticket-02-queue-time-download-directory-resolution.md
+++ b/docs/02-delivery/phase-08/ticket-02-queue-time-download-directory-resolution.md
@@ -1,0 +1,28 @@
+# P8.02 Queue-Time Download Directory Resolution
+
+## Goal
+
+Resolve the effective `downloadDir` per submission based on media type and pass it in the Transmission RPC `torrent-add` call.
+
+## Scope
+
+- Add `downloadDir?: string` to `SubmitDownloadInput`
+- Update `buildSubmitRequestBody` to prefer `input.downloadDir` over `config.downloadDir`
+- Resolve effective `downloadDir` in the pipeline runner: per-type dir wins over global dir, which wins over omission (Transmission default)
+- Add transmission adapter tests for per-submission `downloadDir`
+- Add pipeline test covering per-media-type directory resolution
+
+## Precedence
+
+1. `transmission.downloadDirs.movie` or `transmission.downloadDirs.tv` (per media type)
+2. `transmission.downloadDir` (global fallback)
+3. omitted (Transmission built-in default)
+
+## Out Of Scope
+
+- Config type or validation changes (P8.01)
+- Docs update (P8.03)
+
+## Exit Condition
+
+A torrent submission for a movie feed includes the movie-specific `downloadDir` in the RPC call. A TV feed submission includes the TV-specific directory. When neither is configured, existing behavior is preserved.

--- a/docs/02-delivery/phase-08/ticket-03-docs-and-example-config-update.md
+++ b/docs/02-delivery/phase-08/ticket-03-docs-and-example-config-update.md
@@ -1,0 +1,20 @@
+# P8.03 Docs And Example Config Update
+
+## Goal
+
+Update user-facing docs and the example config to reflect the new per-media-type download directory feature.
+
+## Scope
+
+- Add `transmission.downloadDirs` to `pirate-claw.config.example.json`
+- Update `README.md` configuration section with the new fields and precedence
+- Update `docs/00-overview/start-here.md` delivered surface to include media placement
+- Update `docs/00-overview/roadmap.md` Phase 08 status to implemented
+
+## Out Of Scope
+
+- Code changes (covered by P8.01 and P8.02)
+
+## Exit Condition
+
+An operator reading the README and example config can discover and configure per-media-type download directories without looking at source code.

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,7 @@ export type TransmissionConfig = {
   username: string;
   password: string;
   downloadDir?: string;
+  downloadDirs?: { movie?: string; tv?: string };
 };
 
 export type RuntimeConfig = {
@@ -346,6 +347,35 @@ function validateTransmission(
       input.downloadDir === undefined
         ? undefined
         : expectString(input.downloadDir, `${path} transmission downloadDir`),
+    downloadDirs: validateDownloadDirs(
+      input.downloadDirs,
+      `${path} transmission downloadDirs`,
+    ),
+  };
+}
+
+function validateDownloadDirs(
+  input: unknown,
+  path: string,
+): { movie?: string; tv?: string } | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  const dirs = expectRecord(input, path);
+
+  const allowed = new Set(['movie', 'tv']);
+  for (const key of Object.keys(dirs)) {
+    if (!allowed.has(key)) {
+      throw new ConfigError(
+        `Config file "${path}" has unknown key "${key}"; expected only "movie" and/or "tv".`,
+      );
+    }
+  }
+
+  return {
+    movie: optionalString(dirs.movie, `${path} movie`),
+    tv: optionalString(dirs.tv, `${path} tv`),
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -374,8 +374,12 @@ function validateDownloadDirs(
   }
 
   return {
-    movie: optionalString(dirs.movie, `${path} movie`),
-    tv: optionalString(dirs.tv, `${path} tv`),
+    ...(dirs.movie !== undefined
+      ? { movie: optionalString(dirs.movie, `${path} movie`) }
+      : {}),
+    ...(dirs.tv !== undefined
+      ? { tv: optionalString(dirs.tv, `${path} tv`) }
+      : {}),
   };
 }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -532,6 +532,115 @@ describe('validateConfig', () => {
       await Bun.$`rm -rf ${directory}`;
     }
   });
+
+  it('accepts transmission.downloadDirs with movie and tv paths', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      transmission: {
+        url: 'http://localhost:9091/transmission/rpc',
+        username: 'user',
+        password: 'pass',
+        downloadDirs: { movie: '/data/movies', tv: '/data/tv' },
+      },
+    });
+
+    expect(config.transmission.downloadDirs).toEqual({
+      movie: '/data/movies',
+      tv: '/data/tv',
+    });
+  });
+
+  it('accepts transmission.downloadDirs with only movie', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      transmission: {
+        url: 'http://localhost:9091/transmission/rpc',
+        username: 'user',
+        password: 'pass',
+        downloadDirs: { movie: '/data/movies' },
+      },
+    });
+
+    expect(config.transmission.downloadDirs).toEqual({
+      movie: '/data/movies',
+    });
+  });
+
+  it('accepts transmission.downloadDirs with only tv', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      transmission: {
+        url: 'http://localhost:9091/transmission/rpc',
+        username: 'user',
+        password: 'pass',
+        downloadDirs: { tv: '/data/tv' },
+      },
+    });
+
+    expect(config.transmission.downloadDirs).toEqual({
+      tv: '/data/tv',
+    });
+  });
+
+  it('omits transmission.downloadDirs when not configured', () => {
+    const config = validateConfig(createMinimalConfig());
+
+    expect(config.transmission.downloadDirs).toBeUndefined();
+  });
+
+  it('fails when transmission.downloadDirs is not an object', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+          downloadDirs: 'not-an-object',
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config transmission downloadDirs" must be an object.',
+      ),
+    );
+  });
+
+  it('fails when transmission.downloadDirs has unknown keys', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+          downloadDirs: { movie: '/data/movies', music: '/data/music' },
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config transmission downloadDirs" has unknown key "music"; expected only "movie" and/or "tv".',
+      ),
+    );
+  });
+
+  it('fails when transmission.downloadDirs movie value is not a string', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+          downloadDirs: { movie: 42 },
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config transmission downloadDirs movie" must be a non-empty string.',
+      ),
+    );
+  });
 });
 
 function createMinimalConfig() {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -641,6 +641,24 @@ describe('validateConfig', () => {
       ),
     );
   });
+
+  it('fails when transmission.downloadDirs tv value is not a string', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+          downloadDirs: { tv: 42 },
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config transmission downloadDirs tv" must be a non-empty string.',
+      ),
+    );
+  });
 });
 
 function createMinimalConfig() {


### PR DESCRIPTION
## Summary

- delivery ticket: `P8.01 Per-Media-Type Download Directory Config`
- ticket file: `docs/02-delivery/phase-08/ticket-01-per-media-type-download-directory-config.md`
- stacked base branch: `main`
- internal review: completed at `2026-04-07T17:38:47.604Z`

## External AI Review

- outcome: `patched`
- reviewed commit: `6362cf595f10`
- current branch head: `1ede94fc4abe`
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Actions Taken

- `1ede94fc4abe` [coderabbit,greptile] fix: omit undefined downloadDirs keys, add symmetric tv validation test
