### PR TITLE
feat: resolve per-media-type download directory at queue time [P8.02]

### DIFF
--- a/docs/02-delivery/phase-08/ticket-02-queue-time-download-directory-resolution.md
+++ b/docs/02-delivery/phase-08/ticket-02-queue-time-download-directory-resolution.md
@@ -26,3 +26,7 @@ Resolve the effective `downloadDir` per submission based on media type and pass 
 ## Exit Condition
 
 A torrent submission for a movie feed includes the movie-specific `downloadDir` in the RPC call. A TV feed submission includes the TV-specific directory. When neither is configured, existing behavior is preserved.
+
+## Rationale
+
+Per-submission `downloadDir` was added to `SubmitDownloadInput` and the `buildSubmitRequestBody` function now prefers it over `config.downloadDir`. The precedence chain (per-type → global → omitted) is resolved through a `createDownloadDirResolver` function in pipeline.ts that reads `TransmissionConfig`. The resolver is injected into the pipeline coordinator as a function, avoiding a direct coupling between the pipeline-runner module and config types. The `retryFailedCandidates` path also receives the resolver so that retries honor per-media-type directories.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -81,6 +81,7 @@ export async function runCli(argv: string[]): Promise<number> {
         const result = await retryFailedCandidates({
           repository: createRepository(database),
           downloader: createTransmissionDownloader(config.transmission),
+          transmissionConfig: config.transmission,
         });
 
         console.log(formatRunSummary(result));

--- a/src/pipeline-runner.ts
+++ b/src/pipeline-runner.ts
@@ -34,6 +34,7 @@ export function createPipelineCoordinator(input: {
   run: RunRecord;
   repository: Repository;
   downloader: Downloader;
+  resolveDownloadDir?: (mediaType: 'tv' | 'movie') => string | undefined;
 }) {
   return {
     recordNoMatch(feedItemId: number, message?: string): void {
@@ -70,12 +71,17 @@ export function createPipelineCoordinator(input: {
           continue;
         }
 
-        await submitCandidate(input.repository, input.downloader, {
-          runId: input.run.id,
-          feedItemId: winner.feedItem.id,
-          feedItem: winner.feedItem,
-          match: winner.match,
-        });
+        await submitCandidate(
+          input.repository,
+          input.downloader,
+          {
+            runId: input.run.id,
+            feedItemId: winner.feedItem.id,
+            feedItem: winner.feedItem,
+            match: winner.match,
+          },
+          input.resolveDownloadDir,
+        );
       }
     },
 
@@ -83,12 +89,17 @@ export function createPipelineCoordinator(input: {
       candidates: CandidateStateRecord[],
     ): Promise<void> {
       for (const candidate of candidates) {
-        await submitCandidate(input.repository, input.downloader, {
-          runId: input.run.id,
-          feedItemId: candidate.lastFeedItemId,
-          feedItem: createRawFeedItem(candidate),
-          match: createCandidateMatchRecord(candidate),
-        });
+        await submitCandidate(
+          input.repository,
+          input.downloader,
+          {
+            runId: input.run.id,
+            feedItemId: candidate.lastFeedItemId,
+            feedItem: createRawFeedItem(candidate),
+            match: createCandidateMatchRecord(candidate),
+          },
+          input.resolveDownloadDir,
+        );
       }
     },
 
@@ -106,9 +117,11 @@ export async function submitCandidate(
   repository: Repository,
   downloader: Downloader,
   input: SubmissionInput,
+  resolveDownloadDir?: (mediaType: 'tv' | 'movie') => string | undefined,
 ): Promise<void> {
   const submission = await downloader.submit({
     downloadUrl: input.feedItem.downloadUrl,
+    downloadDir: resolveDownloadDir?.(input.match.item.mediaType),
     labels: getSubmissionLabels(input.match.item.mediaType),
   });
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,4 +1,4 @@
-import type { AppConfig, FeedConfig } from './config';
+import type { AppConfig, FeedConfig, TransmissionConfig } from './config';
 import { fetchFeed, type RawFeedItem } from './feed';
 import { getMovieNoMatchReason, matchMovieItem } from './movie-match';
 import { normalizeFeedItem, type NormalizedFeedItem } from './normalize';
@@ -39,6 +39,7 @@ export async function runPipeline(input: {
     run,
     repository: input.repository,
     downloader: input.downloader,
+    resolveDownloadDir: createDownloadDirResolver(input.config.transmission),
   });
 
   try {
@@ -78,12 +79,16 @@ export async function runPipeline(input: {
 export async function retryFailedCandidates(input: {
   repository: Repository;
   downloader: Downloader;
+  transmissionConfig?: TransmissionConfig;
 }): Promise<RunPipelineResult> {
   const run = input.repository.startRun();
   const coordinator = createPipelineCoordinator({
     run,
     repository: input.repository,
     downloader: input.downloader,
+    resolveDownloadDir: input.transmissionConfig
+      ? createDownloadDirResolver(input.transmissionConfig)
+      : undefined,
   });
 
   try {
@@ -250,4 +255,11 @@ function deriveLifecycleStatus(
   }
 
   return 'queued';
+}
+
+function createDownloadDirResolver(
+  transmission: TransmissionConfig,
+): (mediaType: 'tv' | 'movie') => string | undefined {
+  return (mediaType) =>
+    transmission.downloadDirs?.[mediaType] ?? transmission.downloadDir;
 }

--- a/src/transmission.ts
+++ b/src/transmission.ts
@@ -2,6 +2,7 @@ import type { TransmissionConfig } from './config';
 
 export type SubmitDownloadInput = {
   downloadUrl: string;
+  downloadDir?: string;
   labels?: string[];
 };
 
@@ -302,11 +303,13 @@ function buildSubmitRequestBody(
     labels?: string[];
   };
 } {
+  const effectiveDir = input.downloadDir ?? config.downloadDir;
+
   return {
     method: 'torrent-add',
     arguments: {
       filename: input.downloadUrl,
-      ...(config.downloadDir ? { 'download-dir': config.downloadDir } : {}),
+      ...(effectiveDir ? { 'download-dir': effectiveDir } : {}),
       ...(input.labels && input.labels.length > 0
         ? { labels: input.labels }
         : {}),

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -8,6 +8,7 @@ import { type AppConfig, DEFAULT_RUNTIME_CONFIG } from '../src/config';
 import { FeedError } from '../src/feed';
 import { MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE } from '../src/movie-match';
 import { retryFailedCandidates, runPipeline } from '../src/pipeline';
+import type { SubmitDownloadInput } from '../src/transmission';
 import {
   createRepository,
   ensureSchema,
@@ -230,6 +231,48 @@ describe('runPipeline', () => {
         message: MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE,
       },
     ]);
+  });
+
+  it('passes per-media-type downloadDir to downloader submit', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+    const submissions: SubmitDownloadInput[] = [];
+
+    await runPipeline({
+      config: createConfig({
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+          downloadDir: '/downloads/default',
+          downloadDirs: { tv: '/downloads/tv', movie: '/downloads/movies' },
+        },
+      }),
+      repository,
+      downloader: {
+        submit: async (input) => {
+          submissions.push(input);
+          return {
+            ok: true as const,
+            status: 'queued' as const,
+            torrentId: 7,
+            torrentName: 'Example Show S01E02',
+            torrentHash: 'abcdef123456',
+          };
+        },
+      },
+      fetchFeed: async () => [
+        {
+          feedName: 'TV Feed',
+          guidOrLink: 'https://example.test/releases/example-show',
+          rawTitle: 'Example.Show.S01E02.1080p.WEB.x265-GROUP',
+          publishedAt: '2026-03-30T00:00:00.000Z',
+          downloadUrl: 'https://example.test/downloads/example-show.torrent',
+        },
+      ],
+    });
+
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0]!.downloadDir).toBe('/downloads/tv');
   });
 });
 

--- a/test/transmission.test.ts
+++ b/test/transmission.test.ts
@@ -440,6 +440,95 @@ describe('Transmission adapter', () => {
     );
   });
 
+  it('prefers per-submission downloadDir over config downloadDir', async () => {
+    const requests: CapturedRequest[] = [];
+    let requestCount = 0;
+    const server = startTransmissionServer(async (request) => {
+      requests.push(await captureRequest(request));
+      requestCount += 1;
+
+      if (requestCount === 1) {
+        return new Response(null, {
+          status: 409,
+          headers: {
+            'x-transmission-session-id': 'session-123',
+          },
+        });
+      }
+
+      return Response.json({
+        result: 'success',
+        arguments: {
+          'torrent-added': {
+            id: 7,
+            hashString: 'abcdef123456',
+            name: 'Example Movie',
+          },
+        },
+      });
+    });
+    const downloader = createTransmissionDownloader(
+      createTransmissionConfig(server.url.origin, '/downloads/default'),
+    );
+
+    await downloader.submit({
+      downloadUrl: 'https://download.example.test/movie/example.torrent',
+      downloadDir: '/downloads/movies',
+    });
+
+    expect(requests[1]!.json).toEqual({
+      method: 'torrent-add',
+      arguments: {
+        filename: 'https://download.example.test/movie/example.torrent',
+        'download-dir': '/downloads/movies',
+      },
+    });
+  });
+
+  it('falls back to config downloadDir when per-submission downloadDir is omitted', async () => {
+    const requests: CapturedRequest[] = [];
+    let requestCount = 0;
+    const server = startTransmissionServer(async (request) => {
+      requests.push(await captureRequest(request));
+      requestCount += 1;
+
+      if (requestCount === 1) {
+        return new Response(null, {
+          status: 409,
+          headers: {
+            'x-transmission-session-id': 'session-123',
+          },
+        });
+      }
+
+      return Response.json({
+        result: 'success',
+        arguments: {
+          'torrent-added': {
+            id: 7,
+            hashString: 'abcdef123456',
+            name: 'Example Movie',
+          },
+        },
+      });
+    });
+    const downloader = createTransmissionDownloader(
+      createTransmissionConfig(server.url.origin, '/downloads/default'),
+    );
+
+    await downloader.submit({
+      downloadUrl: 'https://download.example.test/movie/example.torrent',
+    });
+
+    expect(requests[1]!.json).toEqual({
+      method: 'torrent-add',
+      arguments: {
+        filename: 'https://download.example.test/movie/example.torrent',
+        'download-dir': '/downloads/default',
+      },
+    });
+  });
+
   it('looks up torrent lifecycle details through torrent-get', async () => {
     const requests: CapturedRequest[] = [];
     let requestCount = 0;


### PR DESCRIPTION
## Summary

- delivery ticket: `P8.02 Queue-Time Download Directory Resolution`
- ticket file: `docs/02-delivery/phase-08/ticket-02-queue-time-download-directory-resolution.md`
- stacked base branch: `agents/p8-01-per-media-type-download-directory-config`
- internal review: completed at `2026-04-07T17:57:03.959Z`

## External AI Review

- outcome: `clean`
- reviewed commit: `40970053069f`
- current branch head: `40970053069f`
- vendors: `coderabbit`, `sonarqube`
