### PR TITLE
docs: update user-facing docs and example config for media placement [P8.03]

### DIFF
--- a/.agents/skills/son-of-anton-ethos/SKILL.md
+++ b/.agents/skills/son-of-anton-ethos/SKILL.md
@@ -28,6 +28,15 @@ Do not stop merely because:
 
 Those are normal orchestrator milestones, not permission checkpoints.
 
+## Pre-Flight Sequencing
+
+Before creating any ticket branches or worktrees for a phase:
+
+1. Commit the delivery plan and all ticket docs to the default branch first.
+2. Only then create ticket branches from the default branch tip.
+
+This avoids the rebase-dance where ticket worktrees are missing the plan docs they depend on.
+
 ## Required Behavior
 
 1. Re-read the required repo docs and handoff artifacts at each ticket boundary.
@@ -39,13 +48,29 @@ Those are normal orchestrator milestones, not permission checkpoints.
    - update the ticket rationale when behavior or implementation choices changed
    - record internal review
    - open or refresh the PR
-   - run the orchestrator's AI-review polling flow
+   - run the orchestrator's AI-review polling flow (see [AI Review Polling](#ai-review-polling) below)
    - patch prudent review findings when required
    - refresh PR state
    - advance to the next ticket
 5. During external waits, read ahead into the next ticket and nearby seams if helpful.
 6. Do not write ahead across ticket boundaries.
 7. Keep going after `advance` without asking for permission again unless a real blocker exists.
+
+## AI Review Polling
+
+During the `poll-review` window, be sabai-sabai. The developer uses this time to review earlier stacked PRs. Token usage is minimal while sleeping between polls.
+
+When results land, actually read them:
+
+- **Inline review comments** are the signal. CodeRabbit and Greptile post their actionable findings as inline code-level review threads (`pulls/{number}/comments` API), not as PR-level issue comments.
+- **Summary PR comments** (issue_comment channel) from CodeRabbit and Greptile are orchestration noise — they announce that a review started or post a walkthrough. Do not treat them as the review itself.
+- **Qodo** posts a single actionable PR comment that summarizes all findings. It is the easiest vendor output for an agent to parse, but its free tier is limited. Treat Qodo comments as actionable when present.
+- **SonarQube** posts a Quality Gate summary as a PR comment and may annotate via GitHub Checks. The PR comment is the primary signal.
+- After the polling window, cross-reference the fetcher's structured output against the raw inline comments API (`pulls/{number}/comments`). Do not treat the fetcher's `findingsCount` or `detected` flag as the sole source of truth — the fetcher's detection can lag behind actual comment delivery.
+
+### Docs-Only PRs
+
+Skip the external AI review polling window for docs-only PRs (no code changes). Static analysis and security scanning have nothing to find in markdown edits. Consistency and correctness findings on docs (like phase-status text drift) should be caught during implementation, not outsourced to a review bot. Record `clean` immediately and advance.
 
 ## Stop Conditions
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pirate Claw is a local CLI for pulling media candidates from RSS feeds, matching them against your rules, and queueing approved downloads in Transmission.
 
-Phases 01-07 of the current product roadmap are implemented on `main`. The currently documented engineering epics through Epic 03 are also implemented on `main`. Further product-surface or delivery-tooling expansion now requires a new planning pass and new approved phase/epic docs.
+Phases 01-08 of the current product roadmap are implemented on `main`. The currently documented engineering epics through Epic 03 are also implemented on `main`. Further product-surface or delivery-tooling expansion now requires a new planning pass and new approved phase/epic docs.
 
 It currently supports:
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ High-level config shape:
 - `feeds`: RSS sources to inspect (optional `pollIntervalMinutes` per feed)
 - `tv`: either the legacy per-show rule array or a compact `defaults + shows` object
 - `movies`: global movie intake policy
-- `transmission`: local Transmission RPC settings
+- `transmission`: local Transmission RPC settings (optional `downloadDirs` for per-media-type download directories)
 - `runtime`: daemon scheduling and artifact settings (optional, all fields have defaults)
 
 Example:
@@ -116,7 +116,11 @@ Example:
     "codecPolicy": "prefer"
   },
   "transmission": {
-    "url": "http://localhost:9091/transmission/rpc"
+    "url": "http://localhost:9091/transmission/rpc",
+    "downloadDirs": {
+      "movie": "/data/movies",
+      "tv": "/data/tv"
+    }
   },
   "runtime": {
     "runIntervalMinutes": 30,

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -218,7 +218,7 @@ Goal:
 
 Current status:
 
-- planned, not yet implemented
+- implemented on `main`
 
 Committed scope:
 

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -10,7 +10,7 @@ Its job is to answer three questions quickly:
 
 ## Current Repo State
 
-Pirate Claw is implemented through Phase 07.
+Pirate Claw is implemented through Phase 08.
 
 Current delivered surface:
 

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -27,6 +27,7 @@ Current delivered surface:
 - runtime artifacts under `.pirate-claw/runtime/cycles/` with 7-day retention
 - movie codec policy mode via `movies.codecPolicy` (`prefer` by default, `require` for strict matching)
 - queue-time Transmission `movie` / `tv` labels with warning+retry fallback when labels are unsupported
+- per-media-type Transmission download directories via `transmission.downloadDirs`
 
 Current product boundary:
 

--- a/docs/02-delivery/phase-08/implementation-plan.md
+++ b/docs/02-delivery/phase-08/implementation-plan.md
@@ -1,0 +1,50 @@
+# Phase 08 Implementation Plan
+
+Phase 08 adds per-media-type Transmission download directories, passing the resolved `downloadDir` at queue time.
+
+## Epic
+
+- `Phase 08 Media Placement`
+
+Follow the shared guidance in [`docs/02-delivery/phase-implementation-guidance.md`](../phase-implementation-guidance.md) when shaping or revising tickets for this phase.
+
+## Ticket Order
+
+1. `P8.01 Per-Media-Type Download Directory Config`
+2. `P8.02 Queue-Time Download Directory Resolution`
+3. `P8.03 Docs And Example Config Update`
+
+## Ticket Files
+
+- `ticket-01-per-media-type-download-directory-config.md`
+- `ticket-02-queue-time-download-directory-resolution.md`
+- `ticket-03-docs-and-example-config-update.md`
+
+## Exit Condition
+
+Torrents queued from movie feeds use the configured movie download directory. Torrents queued from TV feeds use the configured TV download directory. When no per-type directory is configured, behavior is identical to the pre-Phase-08 baseline. Docs and example config reflect the new surface.
+
+## Review Rules
+
+Review and merge in ticket order.
+
+Do not start the next ticket until:
+
+- the previous tests are green
+- the behavior change is explained in the ticket and rationale
+- the phase-level defaults and deferrals remain unchanged
+
+## Explicit Deferrals
+
+These are intentionally out of scope for Phase 08:
+
+- Pirate-Claw-side post-completion file moves or renaming
+- per-feed custom download directories beyond the two media types
+- directory validation or creation via Transmission RPC
+
+## Stop Conditions
+
+Pause for review if:
+
+- the `downloadDir` precedence logic forces changes to the label-routing fallback path
+- the config change requires a migration for existing `transmission.downloadDir` users

--- a/docs/02-delivery/phase-08/ticket-01-per-media-type-download-directory-config.md
+++ b/docs/02-delivery/phase-08/ticket-01-per-media-type-download-directory-config.md
@@ -19,3 +19,7 @@ Add `transmission.downloadDirs` to the config type and validation so operators c
 ## Exit Condition
 
 `validateConfig` accepts `transmission.downloadDirs` with movie and/or tv fields, rejects invalid shapes, and the parsed `TransmissionConfig` carries the new fields through to consumers.
+
+## Rationale
+
+`downloadDirs` is validated as a separate optional object on `TransmissionConfig` rather than replacing the existing `downloadDir` field. This preserves backward compatibility — operators with a single global `downloadDir` continue to work unchanged. The per-type fields use the same `movie` / `tv` media-type vocabulary already established by `FeedConfig.mediaType`. Unknown keys inside `downloadDirs` are rejected at config load time to catch typos early.

--- a/docs/02-delivery/phase-08/ticket-01-per-media-type-download-directory-config.md
+++ b/docs/02-delivery/phase-08/ticket-01-per-media-type-download-directory-config.md
@@ -1,0 +1,21 @@
+# P8.01 Per-Media-Type Download Directory Config
+
+## Goal
+
+Add `transmission.downloadDirs` to the config type and validation so operators can specify per-media-type download directories.
+
+## Scope
+
+- Add `downloadDirs?: { movie?: string; tv?: string }` to `TransmissionConfig`
+- Validate `transmission.downloadDirs` in the config loader with path-aware error messages
+- Both fields are optional; when omitted, existing behavior is unchanged
+- Add config validation tests for the new fields
+
+## Out Of Scope
+
+- Passing the resolved directory at queue time (P8.02)
+- Docs/example config update (P8.03)
+
+## Exit Condition
+
+`validateConfig` accepts `transmission.downloadDirs` with movie and/or tv fields, rejects invalid shapes, and the parsed `TransmissionConfig` carries the new fields through to consumers.

--- a/docs/02-delivery/phase-08/ticket-02-queue-time-download-directory-resolution.md
+++ b/docs/02-delivery/phase-08/ticket-02-queue-time-download-directory-resolution.md
@@ -26,3 +26,7 @@ Resolve the effective `downloadDir` per submission based on media type and pass 
 ## Exit Condition
 
 A torrent submission for a movie feed includes the movie-specific `downloadDir` in the RPC call. A TV feed submission includes the TV-specific directory. When neither is configured, existing behavior is preserved.
+
+## Rationale
+
+Per-submission `downloadDir` was added to `SubmitDownloadInput` and the `buildSubmitRequestBody` function now prefers it over `config.downloadDir`. The precedence chain (per-type → global → omitted) is resolved through a `createDownloadDirResolver` function in pipeline.ts that reads `TransmissionConfig`. The resolver is injected into the pipeline coordinator as a function, avoiding a direct coupling between the pipeline-runner module and config types. The `retryFailedCandidates` path also receives the resolver so that retries honor per-media-type directories.

--- a/docs/02-delivery/phase-08/ticket-02-queue-time-download-directory-resolution.md
+++ b/docs/02-delivery/phase-08/ticket-02-queue-time-download-directory-resolution.md
@@ -1,0 +1,28 @@
+# P8.02 Queue-Time Download Directory Resolution
+
+## Goal
+
+Resolve the effective `downloadDir` per submission based on media type and pass it in the Transmission RPC `torrent-add` call.
+
+## Scope
+
+- Add `downloadDir?: string` to `SubmitDownloadInput`
+- Update `buildSubmitRequestBody` to prefer `input.downloadDir` over `config.downloadDir`
+- Resolve effective `downloadDir` in the pipeline runner: per-type dir wins over global dir, which wins over omission (Transmission default)
+- Add transmission adapter tests for per-submission `downloadDir`
+- Add pipeline test covering per-media-type directory resolution
+
+## Precedence
+
+1. `transmission.downloadDirs.movie` or `transmission.downloadDirs.tv` (per media type)
+2. `transmission.downloadDir` (global fallback)
+3. omitted (Transmission built-in default)
+
+## Out Of Scope
+
+- Config type or validation changes (P8.01)
+- Docs update (P8.03)
+
+## Exit Condition
+
+A torrent submission for a movie feed includes the movie-specific `downloadDir` in the RPC call. A TV feed submission includes the TV-specific directory. When neither is configured, existing behavior is preserved.

--- a/docs/02-delivery/phase-08/ticket-03-docs-and-example-config-update.md
+++ b/docs/02-delivery/phase-08/ticket-03-docs-and-example-config-update.md
@@ -18,3 +18,7 @@ Update user-facing docs and the example config to reflect the new per-media-type
 ## Exit Condition
 
 An operator reading the README and example config can discover and configure per-media-type download directories without looking at source code.
+
+## Rationale
+
+The example config uses explicit paths (`/data/movies`, `/data/tv`) to make the feature discoverable without reading source code. The README inline JSON example mirrors the example config so operators see correct syntax in both places. The `docs/README.md` delivery index, `start-here.md` delivered surface list, and `roadmap.md` Phase 08 status are updated to reflect the implemented state.

--- a/docs/02-delivery/phase-08/ticket-03-docs-and-example-config-update.md
+++ b/docs/02-delivery/phase-08/ticket-03-docs-and-example-config-update.md
@@ -1,0 +1,20 @@
+# P8.03 Docs And Example Config Update
+
+## Goal
+
+Update user-facing docs and the example config to reflect the new per-media-type download directory feature.
+
+## Scope
+
+- Add `transmission.downloadDirs` to `pirate-claw.config.example.json`
+- Update `README.md` configuration section with the new fields and precedence
+- Update `docs/00-overview/start-here.md` delivered surface to include media placement
+- Update `docs/00-overview/roadmap.md` Phase 08 status to implemented
+
+## Out Of Scope
+
+- Code changes (covered by P8.01 and P8.02)
+
+## Exit Condition
+
+An operator reading the README and example config can discover and configure per-media-type download directories without looking at source code.

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ Execution plans, issue conventions, and ticket breakdowns.
 - `phase-06/implementation-plan.md`: Synology runbook delivery plan
 - `phase-06/synology-runbook.md`: canonical operator-facing Synology runbook (validated)
 - `phase-07/implementation-plan.md`: config ergonomics delivery plan
+- `phase-08/implementation-plan.md`: media placement delivery plan
 
 ### `03-engineering`
 

--- a/pirate-claw.config.example.json
+++ b/pirate-claw.config.example.json
@@ -32,7 +32,11 @@
     "codecPolicy": "prefer"
   },
   "transmission": {
-    "url": "http://localhost:9091/transmission/rpc"
+    "url": "http://localhost:9091/transmission/rpc",
+    "downloadDirs": {
+      "movie": "/data/movies",
+      "tv": "/data/tv"
+    }
   },
   "runtime": {
     "runIntervalMinutes": 30,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -81,6 +81,7 @@ export async function runCli(argv: string[]): Promise<number> {
         const result = await retryFailedCandidates({
           repository: createRepository(database),
           downloader: createTransmissionDownloader(config.transmission),
+          transmissionConfig: config.transmission,
         });
 
         console.log(formatRunSummary(result));

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,7 @@ export type TransmissionConfig = {
   username: string;
   password: string;
   downloadDir?: string;
+  downloadDirs?: { movie?: string; tv?: string };
 };
 
 export type RuntimeConfig = {
@@ -346,6 +347,35 @@ function validateTransmission(
       input.downloadDir === undefined
         ? undefined
         : expectString(input.downloadDir, `${path} transmission downloadDir`),
+    downloadDirs: validateDownloadDirs(
+      input.downloadDirs,
+      `${path} transmission downloadDirs`,
+    ),
+  };
+}
+
+function validateDownloadDirs(
+  input: unknown,
+  path: string,
+): { movie?: string; tv?: string } | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  const dirs = expectRecord(input, path);
+
+  const allowed = new Set(['movie', 'tv']);
+  for (const key of Object.keys(dirs)) {
+    if (!allowed.has(key)) {
+      throw new ConfigError(
+        `Config file "${path}" has unknown key "${key}"; expected only "movie" and/or "tv".`,
+      );
+    }
+  }
+
+  return {
+    movie: optionalString(dirs.movie, `${path} movie`),
+    tv: optionalString(dirs.tv, `${path} tv`),
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -374,8 +374,12 @@ function validateDownloadDirs(
   }
 
   return {
-    movie: optionalString(dirs.movie, `${path} movie`),
-    tv: optionalString(dirs.tv, `${path} tv`),
+    ...(dirs.movie !== undefined
+      ? { movie: optionalString(dirs.movie, `${path} movie`) }
+      : {}),
+    ...(dirs.tv !== undefined
+      ? { tv: optionalString(dirs.tv, `${path} tv`) }
+      : {}),
   };
 }
 

--- a/src/pipeline-runner.ts
+++ b/src/pipeline-runner.ts
@@ -34,6 +34,7 @@ export function createPipelineCoordinator(input: {
   run: RunRecord;
   repository: Repository;
   downloader: Downloader;
+  resolveDownloadDir?: (mediaType: 'tv' | 'movie') => string | undefined;
 }) {
   return {
     recordNoMatch(feedItemId: number, message?: string): void {
@@ -70,12 +71,17 @@ export function createPipelineCoordinator(input: {
           continue;
         }
 
-        await submitCandidate(input.repository, input.downloader, {
-          runId: input.run.id,
-          feedItemId: winner.feedItem.id,
-          feedItem: winner.feedItem,
-          match: winner.match,
-        });
+        await submitCandidate(
+          input.repository,
+          input.downloader,
+          {
+            runId: input.run.id,
+            feedItemId: winner.feedItem.id,
+            feedItem: winner.feedItem,
+            match: winner.match,
+          },
+          input.resolveDownloadDir,
+        );
       }
     },
 
@@ -83,12 +89,17 @@ export function createPipelineCoordinator(input: {
       candidates: CandidateStateRecord[],
     ): Promise<void> {
       for (const candidate of candidates) {
-        await submitCandidate(input.repository, input.downloader, {
-          runId: input.run.id,
-          feedItemId: candidate.lastFeedItemId,
-          feedItem: createRawFeedItem(candidate),
-          match: createCandidateMatchRecord(candidate),
-        });
+        await submitCandidate(
+          input.repository,
+          input.downloader,
+          {
+            runId: input.run.id,
+            feedItemId: candidate.lastFeedItemId,
+            feedItem: createRawFeedItem(candidate),
+            match: createCandidateMatchRecord(candidate),
+          },
+          input.resolveDownloadDir,
+        );
       }
     },
 
@@ -106,9 +117,11 @@ export async function submitCandidate(
   repository: Repository,
   downloader: Downloader,
   input: SubmissionInput,
+  resolveDownloadDir?: (mediaType: 'tv' | 'movie') => string | undefined,
 ): Promise<void> {
   const submission = await downloader.submit({
     downloadUrl: input.feedItem.downloadUrl,
+    downloadDir: resolveDownloadDir?.(input.match.item.mediaType),
     labels: getSubmissionLabels(input.match.item.mediaType),
   });
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,4 +1,4 @@
-import type { AppConfig, FeedConfig } from './config';
+import type { AppConfig, FeedConfig, TransmissionConfig } from './config';
 import { fetchFeed, type RawFeedItem } from './feed';
 import { getMovieNoMatchReason, matchMovieItem } from './movie-match';
 import { normalizeFeedItem, type NormalizedFeedItem } from './normalize';
@@ -39,6 +39,7 @@ export async function runPipeline(input: {
     run,
     repository: input.repository,
     downloader: input.downloader,
+    resolveDownloadDir: createDownloadDirResolver(input.config.transmission),
   });
 
   try {
@@ -78,12 +79,16 @@ export async function runPipeline(input: {
 export async function retryFailedCandidates(input: {
   repository: Repository;
   downloader: Downloader;
+  transmissionConfig?: TransmissionConfig;
 }): Promise<RunPipelineResult> {
   const run = input.repository.startRun();
   const coordinator = createPipelineCoordinator({
     run,
     repository: input.repository,
     downloader: input.downloader,
+    resolveDownloadDir: input.transmissionConfig
+      ? createDownloadDirResolver(input.transmissionConfig)
+      : undefined,
   });
 
   try {
@@ -250,4 +255,11 @@ function deriveLifecycleStatus(
   }
 
   return 'queued';
+}
+
+function createDownloadDirResolver(
+  transmission: TransmissionConfig,
+): (mediaType: 'tv' | 'movie') => string | undefined {
+  return (mediaType) =>
+    transmission.downloadDirs?.[mediaType] ?? transmission.downloadDir;
 }

--- a/src/transmission.ts
+++ b/src/transmission.ts
@@ -2,6 +2,7 @@ import type { TransmissionConfig } from './config';
 
 export type SubmitDownloadInput = {
   downloadUrl: string;
+  downloadDir?: string;
   labels?: string[];
 };
 
@@ -302,11 +303,13 @@ function buildSubmitRequestBody(
     labels?: string[];
   };
 } {
+  const effectiveDir = input.downloadDir ?? config.downloadDir;
+
   return {
     method: 'torrent-add',
     arguments: {
       filename: input.downloadUrl,
-      ...(config.downloadDir ? { 'download-dir': config.downloadDir } : {}),
+      ...(effectiveDir ? { 'download-dir': effectiveDir } : {}),
       ...(input.labels && input.labels.length > 0
         ? { labels: input.labels }
         : {}),

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -532,6 +532,115 @@ describe('validateConfig', () => {
       await Bun.$`rm -rf ${directory}`;
     }
   });
+
+  it('accepts transmission.downloadDirs with movie and tv paths', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      transmission: {
+        url: 'http://localhost:9091/transmission/rpc',
+        username: 'user',
+        password: 'pass',
+        downloadDirs: { movie: '/data/movies', tv: '/data/tv' },
+      },
+    });
+
+    expect(config.transmission.downloadDirs).toEqual({
+      movie: '/data/movies',
+      tv: '/data/tv',
+    });
+  });
+
+  it('accepts transmission.downloadDirs with only movie', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      transmission: {
+        url: 'http://localhost:9091/transmission/rpc',
+        username: 'user',
+        password: 'pass',
+        downloadDirs: { movie: '/data/movies' },
+      },
+    });
+
+    expect(config.transmission.downloadDirs).toEqual({
+      movie: '/data/movies',
+    });
+  });
+
+  it('accepts transmission.downloadDirs with only tv', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      transmission: {
+        url: 'http://localhost:9091/transmission/rpc',
+        username: 'user',
+        password: 'pass',
+        downloadDirs: { tv: '/data/tv' },
+      },
+    });
+
+    expect(config.transmission.downloadDirs).toEqual({
+      tv: '/data/tv',
+    });
+  });
+
+  it('omits transmission.downloadDirs when not configured', () => {
+    const config = validateConfig(createMinimalConfig());
+
+    expect(config.transmission.downloadDirs).toBeUndefined();
+  });
+
+  it('fails when transmission.downloadDirs is not an object', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+          downloadDirs: 'not-an-object',
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config transmission downloadDirs" must be an object.',
+      ),
+    );
+  });
+
+  it('fails when transmission.downloadDirs has unknown keys', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+          downloadDirs: { movie: '/data/movies', music: '/data/music' },
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config transmission downloadDirs" has unknown key "music"; expected only "movie" and/or "tv".',
+      ),
+    );
+  });
+
+  it('fails when transmission.downloadDirs movie value is not a string', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+          downloadDirs: { movie: 42 },
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config transmission downloadDirs movie" must be a non-empty string.',
+      ),
+    );
+  });
 });
 
 function createMinimalConfig() {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -641,6 +641,24 @@ describe('validateConfig', () => {
       ),
     );
   });
+
+  it('fails when transmission.downloadDirs tv value is not a string', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+          downloadDirs: { tv: 42 },
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config transmission downloadDirs tv" must be a non-empty string.',
+      ),
+    );
+  });
 });
 
 function createMinimalConfig() {

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -274,6 +274,55 @@ describe('runPipeline', () => {
     expect(submissions).toHaveLength(1);
     expect(submissions[0]!.downloadDir).toBe('/downloads/tv');
   });
+
+  it('passes per-media-type downloadDir for movie feed items', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+    const submissions: SubmitDownloadInput[] = [];
+
+    await runPipeline({
+      config: createConfig({
+        feeds: [
+          {
+            name: 'Movie Feed',
+            url: 'https://example.test/movies.rss',
+            mediaType: 'movie',
+          },
+        ],
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+          downloadDir: '/downloads/default',
+          downloadDirs: { tv: '/downloads/tv', movie: '/downloads/movies' },
+        },
+      }),
+      repository,
+      downloader: {
+        submit: async (input) => {
+          submissions.push(input);
+          return {
+            ok: true as const,
+            status: 'queued' as const,
+            torrentId: 8,
+            torrentName: 'Great Movie 2024',
+            torrentHash: 'movie123hash',
+          };
+        },
+      },
+      fetchFeed: async () => [
+        {
+          feedName: 'Movie Feed',
+          guidOrLink: 'https://example.test/releases/great-movie',
+          rawTitle: 'Great.Movie.2024.1080p.WEB.x265-GROUP',
+          publishedAt: '2026-03-30T00:00:00.000Z',
+          downloadUrl: 'https://example.test/downloads/great-movie.torrent',
+        },
+      ],
+    });
+
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0]!.downloadDir).toBe('/downloads/movies');
+  });
 });
 
 describe('retryFailedCandidates', () => {

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -8,6 +8,7 @@ import { type AppConfig, DEFAULT_RUNTIME_CONFIG } from '../src/config';
 import { FeedError } from '../src/feed';
 import { MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE } from '../src/movie-match';
 import { retryFailedCandidates, runPipeline } from '../src/pipeline';
+import type { SubmitDownloadInput } from '../src/transmission';
 import {
   createRepository,
   ensureSchema,
@@ -230,6 +231,48 @@ describe('runPipeline', () => {
         message: MOVIE_CODEC_POLICY_REQUIRE_MISSING_MESSAGE,
       },
     ]);
+  });
+
+  it('passes per-media-type downloadDir to downloader submit', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+    const submissions: SubmitDownloadInput[] = [];
+
+    await runPipeline({
+      config: createConfig({
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+          downloadDir: '/downloads/default',
+          downloadDirs: { tv: '/downloads/tv', movie: '/downloads/movies' },
+        },
+      }),
+      repository,
+      downloader: {
+        submit: async (input) => {
+          submissions.push(input);
+          return {
+            ok: true as const,
+            status: 'queued' as const,
+            torrentId: 7,
+            torrentName: 'Example Show S01E02',
+            torrentHash: 'abcdef123456',
+          };
+        },
+      },
+      fetchFeed: async () => [
+        {
+          feedName: 'TV Feed',
+          guidOrLink: 'https://example.test/releases/example-show',
+          rawTitle: 'Example.Show.S01E02.1080p.WEB.x265-GROUP',
+          publishedAt: '2026-03-30T00:00:00.000Z',
+          downloadUrl: 'https://example.test/downloads/example-show.torrent',
+        },
+      ],
+    });
+
+    expect(submissions).toHaveLength(1);
+    expect(submissions[0]!.downloadDir).toBe('/downloads/tv');
   });
 });
 

--- a/test/transmission.test.ts
+++ b/test/transmission.test.ts
@@ -440,6 +440,95 @@ describe('Transmission adapter', () => {
     );
   });
 
+  it('prefers per-submission downloadDir over config downloadDir', async () => {
+    const requests: CapturedRequest[] = [];
+    let requestCount = 0;
+    const server = startTransmissionServer(async (request) => {
+      requests.push(await captureRequest(request));
+      requestCount += 1;
+
+      if (requestCount === 1) {
+        return new Response(null, {
+          status: 409,
+          headers: {
+            'x-transmission-session-id': 'session-123',
+          },
+        });
+      }
+
+      return Response.json({
+        result: 'success',
+        arguments: {
+          'torrent-added': {
+            id: 7,
+            hashString: 'abcdef123456',
+            name: 'Example Movie',
+          },
+        },
+      });
+    });
+    const downloader = createTransmissionDownloader(
+      createTransmissionConfig(server.url.origin, '/downloads/default'),
+    );
+
+    await downloader.submit({
+      downloadUrl: 'https://download.example.test/movie/example.torrent',
+      downloadDir: '/downloads/movies',
+    });
+
+    expect(requests[1]!.json).toEqual({
+      method: 'torrent-add',
+      arguments: {
+        filename: 'https://download.example.test/movie/example.torrent',
+        'download-dir': '/downloads/movies',
+      },
+    });
+  });
+
+  it('falls back to config downloadDir when per-submission downloadDir is omitted', async () => {
+    const requests: CapturedRequest[] = [];
+    let requestCount = 0;
+    const server = startTransmissionServer(async (request) => {
+      requests.push(await captureRequest(request));
+      requestCount += 1;
+
+      if (requestCount === 1) {
+        return new Response(null, {
+          status: 409,
+          headers: {
+            'x-transmission-session-id': 'session-123',
+          },
+        });
+      }
+
+      return Response.json({
+        result: 'success',
+        arguments: {
+          'torrent-added': {
+            id: 7,
+            hashString: 'abcdef123456',
+            name: 'Example Movie',
+          },
+        },
+      });
+    });
+    const downloader = createTransmissionDownloader(
+      createTransmissionConfig(server.url.origin, '/downloads/default'),
+    );
+
+    await downloader.submit({
+      downloadUrl: 'https://download.example.test/movie/example.torrent',
+    });
+
+    expect(requests[1]!.json).toEqual({
+      method: 'torrent-add',
+      arguments: {
+        filename: 'https://download.example.test/movie/example.torrent',
+        'download-dir': '/downloads/default',
+      },
+    });
+  });
+
   it('looks up torrent lifecycle details through torrent-get', async () => {
     const requests: CapturedRequest[] = [];
     let requestCount = 0;


### PR DESCRIPTION
## Summary

Docs-only ticket completing Phase 08 (Media Placement). Updates all user-facing surfaces to reflect the new `downloadDirs` config.

## Changes

- **`pirate-claw.config.example.json`** — Added `downloadDirs: { movie, tv }` to the transmission section
- **`README.md`** — Added feature to "It currently supports" list, updated inline config example and description
- **`docs/00-overview/start-here.md`** — Added `downloadDirs` to delivered surface list
- **`docs/00-overview/roadmap.md`** — Phase 08 status → "implemented on main"
- **`docs/README.md`** — Added phase-08 delivery plan entry

## Testing

Docs-only — no code changes. Format, typecheck, lint, and spellcheck all pass.

## Stacked On

- PR #78 (`P8.02`)
- PR #77 (`P8.01`)