### PR TITLE
feat: add runtime.apiPort config and HTTP listener lifecycle [P9.01]

### DIFF
--- a/docs/02-delivery/phase-09/ticket-01-config-and-daemon-http-listener-lifecycle.md
+++ b/docs/02-delivery/phase-09/ticket-01-config-and-daemon-http-listener-lifecycle.md
@@ -23,3 +23,15 @@ Add `runtime.apiPort` to config and wire a `Bun.serve()` HTTP listener into the 
 ## Exit Condition
 
 Config validation accepts/rejects `runtime.apiPort` correctly. The daemon starts an HTTP listener on the configured port that responds to any request with a 404 JSON body. The listener stops cleanly when the daemon receives SIGINT/SIGTERM. When `apiPort` is omitted, no listener starts and the daemon behaves identically to pre-Phase-09.
+
+## Rationale
+
+**Design choice: `fetch` handler injection.** Rather than starting `Bun.serve()` inside the CLI command handler and passing a server object into the daemon loop, the fetch handler is injected as an optional function into `runDaemonLoop`. This keeps the daemon module testable without real network sockets in most tests — only the server lifecycle tests need port 0.
+
+**Port validation.** `optionalPositiveInteger` validates range 1–65535 and rejects floats, zero, negatives, and strings. Port 0 is excluded from config validation (it's not a real user-facing port) but is used in tests to get an OS-assigned ephemeral port.
+
+**Null-check vs truthiness.** The server start condition uses `options.apiPort != null` instead of truthiness to avoid the `apiPort: 0` falsy-zero trap, which was caught by the initial test run.
+
+**Stub 404 handler.** `createApiFetch()` in `src/api.ts` returns a single function that responds 404 for all routes. This is the seam where P9.02/P9.03 will add real routing.
+
+**Early-abort server stop.** The shutdown path handles both the normal signal-abort case (after timers are created) and the pre-aborted case (signal already aborted before timers). Both paths call `server.stop()` to avoid leaking the listener.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,3 @@
+export function createApiFetch(): (request: Request) => Response {
+  return () => Response.json({ error: 'not found' }, { status: 404 });
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -183,7 +183,7 @@ export async function runCli(argv: string[]): Promise<number> {
             writeCycleArtifact(artifactDir, result);
             pruneArtifacts(artifactDir, artifactRetentionDays);
           },
-          fetch: config.runtime.apiPort ? createApiFetch() : undefined,
+          fetch: config.runtime.apiPort != null ? createApiFetch() : undefined,
         });
       } finally {
         database.close();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 
 import { join } from 'node:path';
 
+import { createApiFetch } from './api';
 import { ConfigError, loadConfig, resolveConfigPath } from './config';
 import { daemonOptionsFromConfig, runDaemonLoop } from './daemon';
 import {
@@ -182,6 +183,7 @@ export async function runCli(argv: string[]): Promise<number> {
             writeCycleArtifact(artifactDir, result);
             pruneArtifacts(artifactDir, artifactRetentionDays);
           },
+          fetch: config.runtime.apiPort ? createApiFetch() : undefined,
         });
       } finally {
         database.close();

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,7 @@ export type RuntimeConfig = {
   reconcileIntervalMinutes: number;
   artifactDir: string;
   artifactRetentionDays: number;
+  apiPort?: number;
 };
 
 export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
@@ -605,6 +606,10 @@ function validateRuntime(input: unknown, path: string): RuntimeConfig {
         runtime.artifactRetentionDays,
         `${path} runtime artifactRetentionDays`,
       ) ?? DEFAULT_RUNTIME_CONFIG.artifactRetentionDays,
+    apiPort: optionalPositiveInteger(
+      runtime.apiPort,
+      `${path} runtime apiPort`,
+    ),
   };
 }
 
@@ -626,6 +631,30 @@ function optionalPositiveNumber(
   ) {
     throw new ConfigError(
       `Config file "${path}" must be a finite positive number (max ${MAX_INTERVAL_MINUTES}).`,
+    );
+  }
+
+  return input;
+}
+
+const MAX_PORT = 65_535;
+
+function optionalPositiveInteger(
+  input: unknown,
+  path: string,
+): number | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  if (
+    typeof input !== 'number' ||
+    !Number.isInteger(input) ||
+    input < 1 ||
+    input > MAX_PORT
+  ) {
+    throw new ConfigError(
+      `Config file "${path}" must be a positive integer (1–${MAX_PORT}).`,
     );
   }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -39,6 +39,7 @@ export async function runDaemonLoop(input: {
   if (options.apiPort != null && input.fetch) {
     server = Bun.serve({
       port: options.apiPort,
+      hostname: '127.0.0.1',
       fetch: input.fetch,
     });
     log(`api listening on port ${server.port}`);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -30,6 +30,12 @@ export async function runDaemonLoop(input: {
 
   let server: ReturnType<typeof Bun.serve> | undefined;
 
+  if (options.apiPort != null && !input.fetch) {
+    throw new Error(
+      `runDaemonLoop requires a fetch handler when apiPort (${options.apiPort}) is set.`,
+    );
+  }
+
   if (options.apiPort != null && input.fetch) {
     server = Bun.serve({
       port: options.apiPort,

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4,12 +4,14 @@ import type { CycleResult } from './runtime-artifacts';
 export type DaemonOptions = {
   runIntervalMs: number;
   reconcileIntervalMs: number;
+  apiPort?: number;
 };
 
 export function daemonOptionsFromConfig(runtime: RuntimeConfig): DaemonOptions {
   return {
     runIntervalMs: runtime.runIntervalMinutes * 60 * 1000,
     reconcileIntervalMs: runtime.reconcileIntervalMinutes * 60 * 1000,
+    apiPort: runtime.apiPort,
   };
 }
 
@@ -20,10 +22,21 @@ export async function runDaemonLoop(input: {
   signal: AbortSignal;
   log?: (message: string) => void;
   onCycleResult?: (result: CycleResult) => void;
+  fetch?: (request: Request) => Response | Promise<Response>;
 }): Promise<void> {
   const { runCycle, reconcileCycle, options, signal } = input;
   const log = input.log ?? console.log;
   let busy = false;
+
+  let server: ReturnType<typeof Bun.serve> | undefined;
+
+  if (options.apiPort != null && input.fetch) {
+    server = Bun.serve({
+      port: options.apiPort,
+      fetch: input.fetch,
+    });
+    log(`api listening on port ${server.port}`);
+  }
 
   const emitCycleResult = (result: CycleResult): void => {
     if (!input.onCycleResult) return;
@@ -73,6 +86,10 @@ export async function runDaemonLoop(input: {
   await guardedCycle('reconcile', reconcileCycle);
 
   if (signal.aborted) {
+    if (server) {
+      server.stop();
+      log('api stopped');
+    }
     log('daemon stopped');
     return;
   }
@@ -95,6 +112,11 @@ export async function runDaemonLoop(input: {
 
   clearInterval(runTimer);
   clearInterval(reconcileTimer);
+
+  if (server) {
+    server.stop();
+    log('api stopped');
+  }
 
   if (inFlight) {
     await inFlight;

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test';
+
+import { createApiFetch } from '../src/api';
+
+describe('createApiFetch', () => {
+  it('returns 404 for any request', () => {
+    const handler = createApiFetch();
+    const response = handler(new Request('http://localhost/anything'));
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns JSON error body', async () => {
+    const handler = createApiFetch();
+    const response = handler(new Request('http://localhost/anything'));
+    const body = await response.json();
+
+    expect(body).toEqual({ error: 'not found' });
+  });
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -347,6 +347,66 @@ describe('validateConfig', () => {
     );
   });
 
+  it('accepts a valid runtime.apiPort integer', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      runtime: { apiPort: 3000 },
+    });
+
+    expect(config.runtime.apiPort).toBe(3000);
+  });
+
+  it('leaves runtime.apiPort undefined when omitted', () => {
+    const config = validateConfig(createMinimalConfig());
+
+    expect(config.runtime.apiPort).toBeUndefined();
+  });
+
+  it('fails when runtime.apiPort is zero', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        runtime: { apiPort: 0 },
+      }),
+    ).toThrow(/apiPort.*must be a positive integer/);
+  });
+
+  it('fails when runtime.apiPort is negative', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        runtime: { apiPort: -1 },
+      }),
+    ).toThrow(/apiPort.*must be a positive integer/);
+  });
+
+  it('fails when runtime.apiPort is a float', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        runtime: { apiPort: 3000.5 },
+      }),
+    ).toThrow(/apiPort.*must be a positive integer/);
+  });
+
+  it('fails when runtime.apiPort exceeds 65535', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        runtime: { apiPort: 70000 },
+      }),
+    ).toThrow(/apiPort.*must be a positive integer/);
+  });
+
+  it('fails when runtime.apiPort is a string', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        runtime: { apiPort: '3000' },
+      }),
+    ).toThrow(/apiPort.*must be a positive integer/);
+  });
+
   it('parses optional pollIntervalMinutes on feeds', () => {
     const config = validateConfig({
       ...createMinimalConfig(),

--- a/test/daemon.test.ts
+++ b/test/daemon.test.ts
@@ -313,4 +313,96 @@ describe('daemon', () => {
     expect(options.runIntervalMs).toBe(15 * 60 * 1000);
     expect(options.reconcileIntervalMs).toBe(2 * 60 * 1000);
   });
+
+  it('passes apiPort through daemonOptionsFromConfig', () => {
+    const options = daemonOptionsFromConfig({
+      runIntervalMinutes: 15,
+      reconcileIntervalMinutes: 2,
+      artifactDir: '.pirate-claw/runtime',
+      artifactRetentionDays: 7,
+      apiPort: 8080,
+    });
+
+    expect(options.apiPort).toBe(8080);
+  });
+
+  it('starts an HTTP server when apiPort and fetch are provided', async () => {
+    const log: string[] = [];
+    const controller = new AbortController();
+
+    await runDaemonLoop({
+      runCycle: async () => {
+        controller.abort();
+      },
+      reconcileCycle: async () => {},
+      options: {
+        runIntervalMs: 600_000,
+        reconcileIntervalMs: 600_000,
+        apiPort: 0,
+      },
+      signal: controller.signal,
+      log: (msg) => log.push(msg),
+      fetch: () => Response.json({ ok: true }),
+    });
+
+    expect(log.some((m) => m.startsWith('api listening on port'))).toBe(true);
+    expect(log).toContain('api stopped');
+    expect(log).toContain('daemon stopped');
+  });
+
+  it('does not start an HTTP server when apiPort is omitted', async () => {
+    const log: string[] = [];
+    const controller = new AbortController();
+
+    await runDaemonLoop({
+      runCycle: async () => {
+        controller.abort();
+      },
+      reconcileCycle: async () => {},
+      options: { runIntervalMs: 600_000, reconcileIntervalMs: 600_000 },
+      signal: controller.signal,
+      log: (msg) => log.push(msg),
+    });
+
+    expect(log.every((m) => !m.includes('api listening'))).toBe(true);
+    expect(log.every((m) => !m.includes('api stopped'))).toBe(true);
+  });
+
+  it('stops the HTTP server on signal shutdown', async () => {
+    const log: string[] = [];
+    const controller = new AbortController();
+    let serverPort: number | undefined;
+
+    await runDaemonLoop({
+      runCycle: async () => {
+        // capture port from log
+        const portMsg = log.find((m) => m.startsWith('api listening on port'));
+        if (portMsg) {
+          serverPort = Number(portMsg.replace('api listening on port ', ''));
+        }
+        controller.abort();
+      },
+      reconcileCycle: async () => {},
+      options: {
+        runIntervalMs: 600_000,
+        reconcileIntervalMs: 600_000,
+        apiPort: 0,
+      },
+      signal: controller.signal,
+      log: (msg) => log.push(msg),
+      fetch: () => Response.json({ ok: true }),
+    });
+
+    expect(serverPort).toBeDefined();
+    expect(log).toContain('api stopped');
+
+    // server should be stopped — fetch should fail
+    try {
+      await fetch(`http://localhost:${serverPort}/test`);
+      // If this succeeds, the server wasn't properly stopped
+      expect(true).toBe(false);
+    } catch {
+      // Expected: connection refused
+    }
+  });
 });

--- a/test/daemon.test.ts
+++ b/test/daemon.test.ts
@@ -368,6 +368,23 @@ describe('daemon', () => {
     expect(log.every((m) => !m.includes('api stopped'))).toBe(true);
   });
 
+  it('throws when apiPort is set without a fetch handler', async () => {
+    const controller = new AbortController();
+
+    await expect(
+      runDaemonLoop({
+        runCycle: async () => {},
+        reconcileCycle: async () => {},
+        options: {
+          runIntervalMs: 600_000,
+          reconcileIntervalMs: 600_000,
+          apiPort: 0,
+        },
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow(/requires a fetch handler/);
+  });
+
   it('stops the HTTP server on signal shutdown', async () => {
     const log: string[] = [];
     const controller = new AbortController();


### PR DESCRIPTION
## Summary

- delivery ticket: `P9.01 Config And Daemon HTTP Listener Lifecycle`
- ticket file: `docs/02-delivery/phase-09/ticket-01-config-and-daemon-http-listener-lifecycle.md`
- stacked base branch: `main`
- internal review: completed at `2026-04-07T19:59:01.922Z`

## External AI Review

- outcome: `patched`
- reviewed commit: `641c0fdf0bf7`
- current branch head: `e2ce3b4`
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Actions Taken

- `749b2fdaed54` [coderabbit] fix: fail fast when apiPort is set without fetch handler [P9.01]
- `e2ce3b4` [greptile] fix: bind Bun.serve to 127.0.0.1 to prevent exposing daemon API on all network interfaces
- `e2ce3b4` [greptile] fix: use apiPort != null instead of truthiness check in cli.ts for consistency with daemon.ts