### PR TITLE
feat: add health, status, and candidates API endpoints [P9.02]

### DIFF
--- a/docs/02-delivery/phase-09/ticket-02-status-and-candidates-endpoints.md
+++ b/docs/02-delivery/phase-09/ticket-02-status-and-candidates-endpoints.md
@@ -25,3 +25,13 @@ Wire `GET /api/health`, `GET /api/status`, and `GET /api/candidates` into the da
 ## Exit Condition
 
 `curl http://localhost:<port>/api/health` returns daemon uptime and last cycle snapshots. `curl http://localhost:<port>/api/status` returns a JSON array of recent runs with counts. `curl http://localhost:<port>/api/candidates` returns a JSON array of candidate state records. All endpoints work while the daemon is running its normal cycle loop.
+
+## Rationale
+
+**Health state tracking via `onCycleResult`.** Rather than adding new daemon plumbing, the existing `onCycleResult` callback is the insertion point for health tracking. `recordCycleInHealth` is called in the same callback alongside artifact writes. The `HealthState` object is mutable and shared with the fetch handler — this is safe because Bun is single-threaded and the health state only has last-cycle snapshots (no arrays to grow).
+
+**`createApiFetch` dependency injection.** The fetch handler accepts an optional `ApiFetchDeps` object containing the repository and health state. When no deps are provided (P9.01 stub path), it returns a bare 404 handler. This preserves backward compatibility and keeps tests simple — unit tests stub the repository interface, no real database needed.
+
+**URL-pathname routing.** Routes use `new URL(request.url).pathname` for matching instead of a router library. Three routes don't justify a dependency.
+
+**Uptime as milliseconds.** The health endpoint returns `uptime` in milliseconds (integer) rather than seconds. Millisecond precision matches `durationMs` in cycle snapshots and avoids floating-point rounding.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,3 +1,84 @@
-export function createApiFetch(): (request: Request) => Response {
-  return () => Response.json({ error: 'not found' }, { status: 404 });
+import type { CycleResult } from './runtime-artifacts';
+import type { Repository } from './repository';
+
+export type CycleSnapshot = {
+  status: CycleResult['status'];
+  startedAt: string;
+  completedAt: string;
+  durationMs: number;
+};
+
+export type HealthState = {
+  startedAt: string;
+  lastRunCycle: CycleSnapshot | null;
+  lastReconcileCycle: CycleSnapshot | null;
+};
+
+export function createHealthState(): HealthState {
+  return {
+    startedAt: new Date().toISOString(),
+    lastRunCycle: null,
+    lastReconcileCycle: null,
+  };
+}
+
+export function recordCycleInHealth(
+  health: HealthState,
+  result: CycleResult,
+): void {
+  const snapshot: CycleSnapshot = {
+    status: result.status,
+    startedAt: result.startedAt,
+    completedAt: result.completedAt,
+    durationMs: result.durationMs,
+  };
+
+  if (result.type === 'run') {
+    health.lastRunCycle = snapshot;
+  } else if (result.type === 'reconcile') {
+    health.lastReconcileCycle = snapshot;
+  }
+}
+
+export type ApiFetchDeps = {
+  repository: Repository;
+  health: HealthState;
+};
+
+export function createApiFetch(
+  deps?: ApiFetchDeps,
+): (request: Request) => Response {
+  if (!deps) {
+    return () => Response.json({ error: 'not found' }, { status: 404 });
+  }
+
+  const { repository, health } = deps;
+
+  return (request: Request) => {
+    const url = new URL(request.url);
+
+    if (url.pathname === '/api/health') {
+      const uptimeMs = Date.now() - new Date(health.startedAt).getTime();
+      return Response.json({
+        uptime: uptimeMs,
+        startedAt: health.startedAt,
+        lastRunCycle: health.lastRunCycle,
+        lastReconcileCycle: health.lastReconcileCycle,
+      });
+    }
+
+    if (url.pathname === '/api/status') {
+      return Response.json({
+        runs: repository.listRecentRunSummaries(),
+      });
+    }
+
+    if (url.pathname === '/api/candidates') {
+      return Response.json({
+        candidates: repository.listCandidateStates(),
+      });
+    }
+
+    return Response.json({ error: 'not found' }, { status: 404 });
+  };
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -68,15 +68,29 @@ export function createApiFetch(
     }
 
     if (url.pathname === '/api/status') {
-      return Response.json({
-        runs: repository.listRecentRunSummaries(),
-      });
+      try {
+        return Response.json({
+          runs: repository.listRecentRunSummaries(),
+        });
+      } catch {
+        return Response.json(
+          { error: 'internal server error' },
+          { status: 500 },
+        );
+      }
     }
 
     if (url.pathname === '/api/candidates') {
-      return Response.json({
-        candidates: repository.listCandidateStates(),
-      });
+      try {
+        return Response.json({
+          candidates: repository.listCandidateStates(),
+        });
+      } catch {
+        return Response.json(
+          { error: 'internal server error' },
+          { status: 500 },
+        );
+      }
     }
 
     return Response.json({ error: 'not found' }, { status: 404 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 
 import { join } from 'node:path';
 
-import { createApiFetch } from './api';
+import { createApiFetch, createHealthState, recordCycleInHealth } from './api';
 import { ConfigError, loadConfig, resolveConfigPath } from './config';
 import { daemonOptionsFromConfig, runDaemonLoop } from './daemon';
 import {
@@ -139,6 +139,8 @@ export async function runCli(argv: string[]): Promise<number> {
 
         const { artifactDir, artifactRetentionDays } = config.runtime;
 
+        const health = createHealthState();
+
         await runDaemonLoop({
           runCycle: async () => {
             let pollState = loadPollState(pollStatePath);
@@ -180,10 +182,13 @@ export async function runCli(argv: string[]): Promise<number> {
           signal: controller.signal,
           log,
           onCycleResult: (result) => {
+            recordCycleInHealth(health, result);
             writeCycleArtifact(artifactDir, result);
             pruneArtifacts(artifactDir, artifactRetentionDays);
           },
-          fetch: config.runtime.apiPort ? createApiFetch() : undefined,
+          fetch: config.runtime.apiPort
+            ? createApiFetch({ repository, health })
+            : undefined,
         });
       } finally {
         database.close();

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,20 +1,229 @@
 import { describe, expect, it } from 'bun:test';
 
-import { createApiFetch } from '../src/api';
+import {
+  type ApiFetchDeps,
+  createApiFetch,
+  createHealthState,
+  recordCycleInHealth,
+} from '../src/api';
+import type { Repository } from '../src/repository';
+import type { CycleResult } from '../src/runtime-artifacts';
+
+function stubRepository(overrides: Partial<Repository> = {}): Repository {
+  return {
+    recordRun: () => ({ id: 1, startedAt: '', status: 'running' }),
+    completeRun: () => {},
+    recordFeedItem: () => 1,
+    recordFeedItemOutcome: () => {},
+    recordCandidateOutcome: () => ({}) as never,
+    getCandidateState: () => undefined,
+    updateCandidateReconciliation: () => ({}) as never,
+    retryCandidate: () => ({}) as never,
+    listFeedItemOutcomes: () => [],
+    listRecentRunSummaries: () => [],
+    listCandidateStates: () => [],
+    listReconcilableCandidates: () => [],
+    listRetryableCandidates: () => [],
+    ...overrides,
+  } as Repository;
+}
+
+function createDeps(overrides: Partial<Repository> = {}): ApiFetchDeps {
+  return {
+    repository: stubRepository(overrides),
+    health: createHealthState(),
+  };
+}
 
 describe('createApiFetch', () => {
-  it('returns 404 for any request', () => {
+  it('returns 404 for any request when no deps provided', () => {
     const handler = createApiFetch();
     const response = handler(new Request('http://localhost/anything'));
 
     expect(response.status).toBe(404);
   });
 
-  it('returns JSON error body', async () => {
+  it('returns JSON error body when no deps provided', async () => {
     const handler = createApiFetch();
     const response = handler(new Request('http://localhost/anything'));
     const body = await response.json();
 
     expect(body).toEqual({ error: 'not found' });
+  });
+
+  it('returns 404 for unknown routes', async () => {
+    const deps = createDeps();
+    const handler = createApiFetch(deps);
+    const response = handler(new Request('http://localhost/unknown'));
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'not found' });
+  });
+});
+
+describe('GET /api/health', () => {
+  it('returns uptime and startedAt', async () => {
+    const deps = createDeps();
+    const handler = createApiFetch(deps);
+    const response = handler(new Request('http://localhost/api/health'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.startedAt).toBe(deps.health.startedAt);
+    expect(typeof body.uptime).toBe('number');
+    expect(body.uptime).toBeGreaterThanOrEqual(0);
+    expect(body.lastRunCycle).toBeNull();
+    expect(body.lastReconcileCycle).toBeNull();
+  });
+
+  it('includes cycle snapshots after cycles run', async () => {
+    const deps = createDeps();
+    const handler = createApiFetch(deps);
+
+    const runResult: CycleResult = {
+      type: 'run',
+      status: 'completed',
+      startedAt: '2026-01-01T00:00:00Z',
+      completedAt: '2026-01-01T00:00:05Z',
+      durationMs: 5000,
+    };
+    recordCycleInHealth(deps.health, runResult);
+
+    const response = handler(new Request('http://localhost/api/health'));
+    const body = await response.json();
+
+    expect(body.lastRunCycle).toEqual({
+      status: 'completed',
+      startedAt: '2026-01-01T00:00:00Z',
+      completedAt: '2026-01-01T00:00:05Z',
+      durationMs: 5000,
+    });
+    expect(body.lastReconcileCycle).toBeNull();
+  });
+});
+
+describe('GET /api/status', () => {
+  it('returns recent run summaries', async () => {
+    const runs = [
+      {
+        id: 1,
+        startedAt: '2026-01-01T00:00:00Z',
+        status: 'completed' as const,
+        completedAt: '2026-01-01T00:00:05Z',
+        counts: {
+          queued: 2,
+          skipped_duplicate: 1,
+          skipped_no_match: 0,
+          failed: 0,
+        },
+      },
+    ];
+    const deps = createDeps({ listRecentRunSummaries: () => runs });
+    const handler = createApiFetch(deps);
+    const response = handler(new Request('http://localhost/api/status'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.runs).toEqual(runs);
+  });
+});
+
+describe('GET /api/candidates', () => {
+  it('returns candidate state records', async () => {
+    const candidates = [
+      {
+        identityKey: 'test-key',
+        mediaType: 'tv' as const,
+        status: 'queued' as const,
+        ruleName: 'Test Show',
+        score: 100,
+        reasons: ['reason1'],
+        rawTitle: 'Test.Show.S01E01',
+        normalizedTitle: 'test show',
+        season: 1,
+        episode: 1,
+        feedName: 'test-feed',
+        guidOrLink: 'http://example.test/1',
+        publishedAt: '2026-01-01T00:00:00Z',
+        downloadUrl: 'http://example.test/dl/1',
+        firstSeenRunId: 1,
+        lastSeenRunId: 1,
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ];
+    const deps = createDeps({ listCandidateStates: () => candidates as never });
+    const handler = createApiFetch(deps);
+    const response = handler(new Request('http://localhost/api/candidates'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.candidates).toEqual(candidates);
+  });
+});
+
+describe('recordCycleInHealth', () => {
+  it('records run cycle snapshot', () => {
+    const health = createHealthState();
+    const result: CycleResult = {
+      type: 'run',
+      status: 'completed',
+      startedAt: '2026-01-01T00:00:00Z',
+      completedAt: '2026-01-01T00:00:05Z',
+      durationMs: 5000,
+    };
+
+    recordCycleInHealth(health, result);
+
+    expect(health.lastRunCycle).toEqual({
+      status: 'completed',
+      startedAt: '2026-01-01T00:00:00Z',
+      completedAt: '2026-01-01T00:00:05Z',
+      durationMs: 5000,
+    });
+    expect(health.lastReconcileCycle).toBeNull();
+  });
+
+  it('records reconcile cycle snapshot', () => {
+    const health = createHealthState();
+    const result: CycleResult = {
+      type: 'reconcile',
+      status: 'failed',
+      startedAt: '2026-01-01T00:00:00Z',
+      completedAt: '2026-01-01T00:00:02Z',
+      durationMs: 2000,
+      error: 'boom',
+    };
+
+    recordCycleInHealth(health, result);
+
+    expect(health.lastRunCycle).toBeNull();
+    expect(health.lastReconcileCycle).toEqual({
+      status: 'failed',
+      startedAt: '2026-01-01T00:00:00Z',
+      completedAt: '2026-01-01T00:00:02Z',
+      durationMs: 2000,
+    });
+  });
+
+  it('overwrites previous snapshot with latest', () => {
+    const health = createHealthState();
+    recordCycleInHealth(health, {
+      type: 'run',
+      status: 'completed',
+      startedAt: '2026-01-01T00:00:00Z',
+      completedAt: '2026-01-01T00:00:05Z',
+      durationMs: 5000,
+    });
+    recordCycleInHealth(health, {
+      type: 'run',
+      status: 'failed',
+      startedAt: '2026-01-01T00:01:00Z',
+      completedAt: '2026-01-01T00:01:02Z',
+      durationMs: 2000,
+      error: 'oops',
+    });
+
+    expect(health.lastRunCycle!.status).toBe('failed');
+    expect(health.lastRunCycle!.startedAt).toBe('2026-01-01T00:01:00Z');
   });
 });

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -161,6 +161,36 @@ describe('GET /api/candidates', () => {
   });
 });
 
+describe('GET /api/status — error handling', () => {
+  it('returns 500 JSON error when repository throws', async () => {
+    const deps = createDeps({
+      listRecentRunSummaries: () => {
+        throw new Error('db error');
+      },
+    });
+    const handler = createApiFetch(deps);
+    const response = handler(new Request('http://localhost/api/status'));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'internal server error' });
+  });
+});
+
+describe('GET /api/candidates — error handling', () => {
+  it('returns 500 JSON error when repository throws', async () => {
+    const deps = createDeps({
+      listCandidateStates: () => {
+        throw new Error('db error');
+      },
+    });
+    const handler = createApiFetch(deps);
+    const response = handler(new Request('http://localhost/api/candidates'));
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'internal server error' });
+  });
+});
+
 describe('recordCycleInHealth', () => {
   it('records run cycle snapshot', () => {
     const health = createHealthState();


### PR DESCRIPTION
## Summary

- delivery ticket: `P9.02 Status, Health, And Candidates Endpoints`
- ticket file: `docs/02-delivery/phase-09/ticket-02-status-and-candidates-endpoints.md`
- stacked base branch: `agents/p9-01-config-and-daemon-http-listener-lifecycle`
- internal review: completed at `2026-04-07T20:13:33.313Z`

## External AI Review

- outcome: `patched`
- reviewed commit: `1ed9bd274785`
- current branch head: `0af64374ae37`
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Actions Taken

- `0af64374ae37` [greptile] fix: add try/catch error handling and tests for status/candidates endpoints [P9.02]
