### PR TITLE
feat(api): add shows, movies, feeds, and config endpoints [P9.03]

### DIFF
--- a/docs/02-delivery/phase-09/ticket-03-shows-movies-feeds-and-config-endpoints.md
+++ b/docs/02-delivery/phase-09/ticket-03-shows-movies-feeds-and-config-endpoints.md
@@ -27,13 +27,13 @@ Wire `GET /api/shows`, `GET /api/movies`, `GET /api/feeds`, and `GET /api/config
 
 ## Exit Condition
 
-`curl http://localhost:<port>/api/shows` returns a JSON breakdown of TV shows with season/episode structure. `curl http://localhost:<port>/api/movies` returns a JSON list of movie candidates grouped by title. `curl http://localhost:<port>/api/feeds` returns feed status with last polled and next due times. `curl http://localhost:<port>/api/config` returns the full effective config with credentials redacted. No endpoint mutates daemon state.
+`curl http://localhost:<port>/api/shows` returns a JSON breakdown of TV shows with season/episode structure. `curl http://localhost:<port>/api/movies` returns a JSON list of movie candidates grouped by title. `curl http://localhost:<port>/api/feeds` returns feed status with last polled time and an `isDue` boolean. `curl http://localhost:<port>/api/config` returns the full effective config with nested `transmission.username` and `transmission.password` redacted. No endpoint mutates daemon state.
 
 ## Rationale
 
-- **Show grouping**: `buildShowBreakdowns` groups TV candidates by `normalizedTitle` → season → episodes, providing a structured hierarchy that mirrors how users think about TV content (show → season → episode).
+- **Show grouping**: `buildShowBreakdowns` groups TV candidates by `normalizedTitle` → season → episodes, providing a structured hierarchy that mirrors how users think about TV content (show → season → episode). TV candidates with missing season or episode are skipped rather than synthesized as 0, to avoid collision with real specials (S00).
 - **Movie grouping**: `buildMovieBreakdowns` filters candidates to movies only and maps to a flat list since movies lack the season/episode hierarchy.
-- **Feed status with poll state**: `buildFeedStatuses` combines static feed config with persisted poll state timestamps and computes `isDue` based on the configured `pollIntervalMinutes`, giving operators a single view of feed health.
-- **Credential redaction**: `redactConfig` uses a shallow spread copy to replace known credential fields (`transmissionPassword`, `transmissionUsername`) with `'[redacted]'` without mutating the original config object. Shallow copy is sufficient because we only redact top-level string fields.
+- **Feed status with poll state**: `buildFeedStatuses` combines static feed config with persisted poll state timestamps and computes an `isDue` boolean by delegating to the shared `isDueFeed()` helper from `poll-state.ts`, keeping the API and daemon scheduler in lockstep.
+- **Credential redaction**: `redactConfig` uses a shallow spread copy to replace nested `transmission.username` and `transmission.password` with `'[redacted]'` without mutating the original config object.
 - **Dependency injection expansion**: `ApiFetchDeps` grew to include `config`, `pollStatePath`, and `loadPollState` alongside the existing `repository` and `health`. This keeps the fetch handler fully testable with stubs — no file I/O or real config needed in tests.
 - **No router library**: URL pathname matching remains a simple `switch` statement. Seven routes do not justify a dependency.

--- a/docs/02-delivery/phase-09/ticket-03-shows-movies-feeds-and-config-endpoints.md
+++ b/docs/02-delivery/phase-09/ticket-03-shows-movies-feeds-and-config-endpoints.md
@@ -28,3 +28,12 @@ Wire `GET /api/shows`, `GET /api/movies`, `GET /api/feeds`, and `GET /api/config
 ## Exit Condition
 
 `curl http://localhost:<port>/api/shows` returns a JSON breakdown of TV shows with season/episode structure. `curl http://localhost:<port>/api/movies` returns a JSON list of movie candidates grouped by title. `curl http://localhost:<port>/api/feeds` returns feed status with last polled and next due times. `curl http://localhost:<port>/api/config` returns the full effective config with credentials redacted. No endpoint mutates daemon state.
+
+## Rationale
+
+- **Show grouping**: `buildShowBreakdowns` groups TV candidates by `normalizedTitle` → season → episodes, providing a structured hierarchy that mirrors how users think about TV content (show → season → episode).
+- **Movie grouping**: `buildMovieBreakdowns` filters candidates to movies only and maps to a flat list since movies lack the season/episode hierarchy.
+- **Feed status with poll state**: `buildFeedStatuses` combines static feed config with persisted poll state timestamps and computes `isDue` based on the configured `pollIntervalMinutes`, giving operators a single view of feed health.
+- **Credential redaction**: `redactConfig` uses a shallow spread copy to replace known credential fields (`transmissionPassword`, `transmissionUsername`) with `'[redacted]'` without mutating the original config object. Shallow copy is sufficient because we only redact top-level string fields.
+- **Dependency injection expansion**: `ApiFetchDeps` grew to include `config`, `pollStatePath`, and `loadPollState` alongside the existing `repository` and `health`. This keeps the fetch handler fully testable with stubs — no file I/O or real config needed in tests.
+- **No router library**: URL pathname matching remains a simple `switch` statement. Seven routes do not justify a dependency.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,7 @@
+import type { AppConfig, FeedConfig, RuntimeConfig } from './config';
+import type { PollState } from './poll-state';
+import type { CandidateStateRecord, Repository } from './repository';
 import type { CycleResult } from './runtime-artifacts';
-import type { Repository } from './repository';
 
 export type CycleSnapshot = {
   status: CycleResult['status'];
@@ -43,6 +45,9 @@ export function recordCycleInHealth(
 export type ApiFetchDeps = {
   repository: Repository;
   health: HealthState;
+  config: AppConfig;
+  pollStatePath: string;
+  loadPollState: (path: string) => PollState;
 };
 
 export function createApiFetch(
@@ -52,7 +57,7 @@ export function createApiFetch(
     return () => Response.json({ error: 'not found' }, { status: 404 });
   }
 
-  const { repository, health } = deps;
+  const { repository, health, config, pollStatePath, loadPollState } = deps;
 
   return (request: Request) => {
     const url = new URL(request.url);
@@ -93,6 +98,197 @@ export function createApiFetch(
       }
     }
 
+    if (url.pathname === '/api/shows') {
+      try {
+        const candidates = repository.listCandidateStates();
+        return Response.json({ shows: buildShowBreakdowns(candidates) });
+      } catch {
+        return Response.json(
+          { error: 'internal server error' },
+          { status: 500 },
+        );
+      }
+    }
+
+    if (url.pathname === '/api/movies') {
+      try {
+        const candidates = repository.listCandidateStates();
+        return Response.json({ movies: buildMovieBreakdowns(candidates) });
+      } catch {
+        return Response.json(
+          { error: 'internal server error' },
+          { status: 500 },
+        );
+      }
+    }
+
+    if (url.pathname === '/api/feeds') {
+      try {
+        const pollState = loadPollState(pollStatePath);
+        return Response.json({
+          feeds: buildFeedStatuses(config.feeds, pollState, config.runtime),
+        });
+      } catch {
+        return Response.json(
+          { error: 'internal server error' },
+          { status: 500 },
+        );
+      }
+    }
+
+    if (url.pathname === '/api/config') {
+      return Response.json(redactConfig(config));
+    }
+
     return Response.json({ error: 'not found' }, { status: 404 });
+  };
+}
+
+// --- Show breakdowns ---
+
+export type ShowEpisode = {
+  episode: number;
+  identityKey: string;
+  status: string;
+  lifecycleStatus?: string;
+  queuedAt?: string;
+};
+
+export type ShowSeason = {
+  season: number;
+  episodes: ShowEpisode[];
+};
+
+export type ShowBreakdown = {
+  normalizedTitle: string;
+  seasons: ShowSeason[];
+};
+
+export function buildShowBreakdowns(
+  candidates: CandidateStateRecord[],
+): ShowBreakdown[] {
+  const tvCandidates = candidates.filter((c) => c.mediaType === 'tv');
+
+  const showMap = new Map<string, Map<number, ShowEpisode[]>>();
+
+  for (const c of tvCandidates) {
+    const title = c.normalizedTitle;
+    if (!showMap.has(title)) {
+      showMap.set(title, new Map());
+    }
+    const seasonMap = showMap.get(title)!;
+    const season = c.season ?? 0;
+    if (!seasonMap.has(season)) {
+      seasonMap.set(season, []);
+    }
+    seasonMap.get(season)!.push({
+      episode: c.episode ?? 0,
+      identityKey: c.identityKey,
+      status: c.status,
+      lifecycleStatus: c.lifecycleStatus,
+      queuedAt: c.queuedAt,
+    });
+  }
+
+  const shows: ShowBreakdown[] = [];
+  for (const [title, seasonMap] of showMap) {
+    const seasons: ShowSeason[] = [];
+    for (const [season, episodes] of seasonMap) {
+      episodes.sort((a, b) => a.episode - b.episode);
+      seasons.push({ season, episodes });
+    }
+    seasons.sort((a, b) => a.season - b.season);
+    shows.push({ normalizedTitle: title, seasons });
+  }
+
+  return shows.sort((a, b) =>
+    a.normalizedTitle.localeCompare(b.normalizedTitle),
+  );
+}
+
+// --- Movie breakdowns ---
+
+export type MovieBreakdown = {
+  normalizedTitle: string;
+  year?: number;
+  resolution?: string;
+  codec?: string;
+  identityKey: string;
+  status: string;
+  lifecycleStatus?: string;
+  queuedAt?: string;
+};
+
+export function buildMovieBreakdowns(
+  candidates: CandidateStateRecord[],
+): MovieBreakdown[] {
+  return candidates
+    .filter((c) => c.mediaType === 'movie')
+    .map((c) => ({
+      normalizedTitle: c.normalizedTitle,
+      year: c.year,
+      resolution: c.resolution,
+      codec: c.codec,
+      identityKey: c.identityKey,
+      status: c.status,
+      lifecycleStatus: c.lifecycleStatus,
+      queuedAt: c.queuedAt,
+    }))
+    .sort((a, b) => a.normalizedTitle.localeCompare(b.normalizedTitle));
+}
+
+// --- Feed statuses ---
+
+export type FeedStatus = {
+  name: string;
+  url: string;
+  mediaType: string;
+  pollIntervalMinutes: number;
+  lastPolledAt: string | null;
+  isDue: boolean;
+};
+
+export function buildFeedStatuses(
+  feeds: FeedConfig[],
+  pollState: PollState,
+  runtime: RuntimeConfig,
+): FeedStatus[] {
+  const now = Date.now();
+
+  return feeds.map((feed) => {
+    const record = pollState.feeds[feed.name];
+    const intervalMinutes =
+      feed.pollIntervalMinutes ?? runtime.runIntervalMinutes;
+    const lastPolledAt = record?.lastPolledAt ?? null;
+
+    let isDue = true;
+    if (lastPolledAt) {
+      const lastPolled = Date.parse(lastPolledAt);
+      if (!Number.isNaN(lastPolled)) {
+        isDue = now - lastPolled >= intervalMinutes * 60 * 1000;
+      }
+    }
+
+    return {
+      name: feed.name,
+      url: feed.url,
+      mediaType: feed.mediaType,
+      pollIntervalMinutes: intervalMinutes,
+      lastPolledAt,
+      isDue,
+    };
+  });
+}
+
+// --- Config redaction ---
+
+export function redactConfig(config: AppConfig): AppConfig {
+  return {
+    ...config,
+    transmission: {
+      ...config.transmission,
+      username: '[redacted]',
+      password: '[redacted]',
+    },
   };
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,5 @@
 import type { AppConfig, FeedConfig, RuntimeConfig } from './config';
+import { isDueFeed } from './poll-state';
 import type { PollState } from './poll-state';
 import type { CandidateStateRecord, Repository } from './repository';
 import type { CycleResult } from './runtime-artifacts';
@@ -137,7 +138,14 @@ export function createApiFetch(
     }
 
     if (url.pathname === '/api/config') {
-      return Response.json(redactConfig(config));
+      try {
+        return Response.json(redactConfig(config));
+      } catch {
+        return Response.json(
+          { error: 'internal server error' },
+          { status: 500 },
+        );
+      }
     }
 
     return Response.json({ error: 'not found' }, { status: 404 });
@@ -172,17 +180,21 @@ export function buildShowBreakdowns(
   const showMap = new Map<string, Map<number, ShowEpisode[]>>();
 
   for (const c of tvCandidates) {
+    if (c.season === undefined || c.episode === undefined) {
+      continue;
+    }
+
     const title = c.normalizedTitle;
     if (!showMap.has(title)) {
       showMap.set(title, new Map());
     }
     const seasonMap = showMap.get(title)!;
-    const season = c.season ?? 0;
+    const season = c.season;
     if (!seasonMap.has(season)) {
       seasonMap.set(season, []);
     }
     seasonMap.get(season)!.push({
-      episode: c.episode ?? 0,
+      episode: c.episode,
       identityKey: c.identityKey,
       status: c.status,
       lifecycleStatus: c.lifecycleStatus,
@@ -242,7 +254,7 @@ export function buildMovieBreakdowns(
 export type FeedStatus = {
   name: string;
   url: string;
-  mediaType: string;
+  mediaType: 'tv' | 'movie';
   pollIntervalMinutes: number;
   lastPolledAt: string | null;
   isDue: boolean;
@@ -252,22 +264,13 @@ export function buildFeedStatuses(
   feeds: FeedConfig[],
   pollState: PollState,
   runtime: RuntimeConfig,
+  now: number = Date.now(),
 ): FeedStatus[] {
-  const now = Date.now();
-
   return feeds.map((feed) => {
     const record = pollState.feeds[feed.name];
     const intervalMinutes =
       feed.pollIntervalMinutes ?? runtime.runIntervalMinutes;
     const lastPolledAt = record?.lastPolledAt ?? null;
-
-    let isDue = true;
-    if (lastPolledAt) {
-      const lastPolled = Date.parse(lastPolledAt);
-      if (!Number.isNaN(lastPolled)) {
-        isDue = now - lastPolled >= intervalMinutes * 60 * 1000;
-      }
-    }
 
     return {
       name: feed.name,
@@ -275,7 +278,7 @@ export function buildFeedStatuses(
       mediaType: feed.mediaType,
       pollIntervalMinutes: intervalMinutes,
       lastPolledAt,
-      isDue,
+      isDue: isDueFeed(feed, pollState, runtime, now),
     };
   });
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -187,7 +187,13 @@ export async function runCli(argv: string[]): Promise<number> {
             pruneArtifacts(artifactDir, artifactRetentionDays);
           },
           fetch: config.runtime.apiPort
-            ? createApiFetch({ repository, health })
+            ? createApiFetch({
+                repository,
+                health,
+                config,
+                pollStatePath,
+                loadPollState,
+              })
             : undefined,
         });
       } finally {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -2,11 +2,17 @@ import { describe, expect, it } from 'bun:test';
 
 import {
   type ApiFetchDeps,
+  buildFeedStatuses,
+  buildMovieBreakdowns,
+  buildShowBreakdowns,
   createApiFetch,
   createHealthState,
   recordCycleInHealth,
+  redactConfig,
 } from '../src/api';
-import type { Repository } from '../src/repository';
+import type { AppConfig } from '../src/config';
+import type { PollState } from '../src/poll-state';
+import type { CandidateStateRecord, Repository } from '../src/repository';
 import type { CycleResult } from '../src/runtime-artifacts';
 
 function stubRepository(overrides: Partial<Repository> = {}): Repository {
@@ -28,10 +34,45 @@ function stubRepository(overrides: Partial<Repository> = {}): Repository {
   } as Repository;
 }
 
+function stubConfig(): AppConfig {
+  return {
+    feeds: [
+      {
+        name: 'TV Feed',
+        url: 'https://example.test/tv.rss',
+        mediaType: 'tv',
+      },
+    ],
+    tv: [{ name: 'Example Show', resolutions: ['1080p'], codecs: ['x265'] }],
+    movies: {
+      years: [2024],
+      resolutions: ['1080p'],
+      codecs: ['x265'],
+      codecPolicy: 'prefer',
+    },
+    transmission: {
+      url: 'http://localhost:9091/transmission/rpc',
+      username: 'user',
+      password: 'pass',
+    },
+    runtime: {
+      runIntervalMinutes: 30,
+      reconcileIntervalMinutes: 1,
+      artifactDir: '.pirate-claw/runtime',
+      artifactRetentionDays: 7,
+    },
+  };
+}
+
+const emptyPollState: PollState = { feeds: {} };
+
 function createDeps(overrides: Partial<Repository> = {}): ApiFetchDeps {
   return {
     repository: stubRepository(overrides),
     health: createHealthState(),
+    config: stubConfig(),
+    pollStatePath: '/nonexistent/poll-state.json',
+    loadPollState: () => emptyPollState,
   };
 }
 
@@ -255,5 +296,296 @@ describe('recordCycleInHealth', () => {
 
     expect(health.lastRunCycle!.status).toBe('failed');
     expect(health.lastRunCycle!.startedAt).toBe('2026-01-01T00:01:00Z');
+  });
+});
+
+// --- P9.03 endpoint tests ---
+
+function tvCandidate(
+  overrides: Partial<CandidateStateRecord> = {},
+): CandidateStateRecord {
+  return {
+    identityKey: 'tv-key',
+    mediaType: 'tv',
+    status: 'queued',
+    ruleName: 'Test Show',
+    score: 100,
+    reasons: [],
+    rawTitle: 'Test.Show.S01E01',
+    normalizedTitle: 'test show',
+    season: 1,
+    episode: 1,
+    feedName: 'feed',
+    guidOrLink: 'http://example.test/1',
+    publishedAt: '2026-01-01T00:00:00Z',
+    downloadUrl: 'http://example.test/dl/1',
+    firstSeenRunId: 1,
+    lastSeenRunId: 1,
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function movieCandidate(
+  overrides: Partial<CandidateStateRecord> = {},
+): CandidateStateRecord {
+  return {
+    identityKey: 'movie-key',
+    mediaType: 'movie',
+    status: 'queued',
+    ruleName: 'Test Movie',
+    score: 100,
+    reasons: [],
+    rawTitle: 'Test.Movie.2024',
+    normalizedTitle: 'test movie',
+    year: 2024,
+    resolution: '1080p',
+    codec: 'x265',
+    feedName: 'feed',
+    guidOrLink: 'http://example.test/2',
+    publishedAt: '2026-01-01T00:00:00Z',
+    downloadUrl: 'http://example.test/dl/2',
+    firstSeenRunId: 1,
+    lastSeenRunId: 1,
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('GET /api/shows', () => {
+  it('returns grouped TV show breakdowns', async () => {
+    const candidates = [
+      tvCandidate({ identityKey: 'k1', season: 1, episode: 1 }),
+      tvCandidate({ identityKey: 'k2', season: 1, episode: 2 }),
+      tvCandidate({
+        identityKey: 'k3',
+        season: 2,
+        episode: 1,
+      }),
+    ];
+    const deps = createDeps({
+      listCandidateStates: () => candidates as never,
+    });
+    const handler = createApiFetch(deps);
+    const response = handler(new Request('http://localhost/api/shows'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.shows).toHaveLength(1);
+    expect(body.shows[0].normalizedTitle).toBe('test show');
+    expect(body.shows[0].seasons).toHaveLength(2);
+    expect(body.shows[0].seasons[0].season).toBe(1);
+    expect(body.shows[0].seasons[0].episodes).toHaveLength(2);
+    expect(body.shows[0].seasons[1].season).toBe(2);
+  });
+
+  it('excludes movie candidates', async () => {
+    const candidates = [
+      tvCandidate({ identityKey: 'k1' }),
+      movieCandidate({ identityKey: 'k2' }),
+    ];
+    const deps = createDeps({
+      listCandidateStates: () => candidates as never,
+    });
+    const handler = createApiFetch(deps);
+    const response = handler(new Request('http://localhost/api/shows'));
+    const body = await response.json();
+
+    expect(body.shows).toHaveLength(1);
+  });
+});
+
+describe('GET /api/movies', () => {
+  it('returns movie breakdowns', async () => {
+    const candidates = [movieCandidate()];
+    const deps = createDeps({
+      listCandidateStates: () => candidates as never,
+    });
+    const handler = createApiFetch(deps);
+    const response = handler(new Request('http://localhost/api/movies'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.movies).toHaveLength(1);
+    expect(body.movies[0].normalizedTitle).toBe('test movie');
+    expect(body.movies[0].year).toBe(2024);
+  });
+
+  it('excludes TV candidates', async () => {
+    const candidates = [
+      tvCandidate({ identityKey: 'k1' }),
+      movieCandidate({ identityKey: 'k2' }),
+    ];
+    const deps = createDeps({
+      listCandidateStates: () => candidates as never,
+    });
+    const handler = createApiFetch(deps);
+    const response = handler(new Request('http://localhost/api/movies'));
+    const body = await response.json();
+
+    expect(body.movies).toHaveLength(1);
+  });
+});
+
+describe('GET /api/feeds', () => {
+  it('returns feed statuses with poll timing', async () => {
+    const pollState: PollState = {
+      feeds: { 'TV Feed': { lastPolledAt: '2026-01-01T00:00:00Z' } },
+    };
+    const deps = createDeps();
+    deps.loadPollState = () => pollState;
+    const handler = createApiFetch(deps);
+    const response = handler(new Request('http://localhost/api/feeds'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.feeds).toHaveLength(1);
+    expect(body.feeds[0].name).toBe('TV Feed');
+    expect(body.feeds[0].lastPolledAt).toBe('2026-01-01T00:00:00Z');
+    expect(typeof body.feeds[0].isDue).toBe('boolean');
+    expect(body.feeds[0].pollIntervalMinutes).toBe(30);
+  });
+
+  it('returns isDue true when never polled', async () => {
+    const deps = createDeps();
+    deps.loadPollState = () => ({ feeds: {} });
+    const handler = createApiFetch(deps);
+    const response = handler(new Request('http://localhost/api/feeds'));
+    const body = await response.json();
+
+    expect(body.feeds[0].isDue).toBe(true);
+    expect(body.feeds[0].lastPolledAt).toBeNull();
+  });
+});
+
+describe('GET /api/config', () => {
+  it('returns config with redacted credentials', async () => {
+    const deps = createDeps();
+    const handler = createApiFetch(deps);
+    const response = handler(new Request('http://localhost/api/config'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.transmission.username).toBe('[redacted]');
+    expect(body.transmission.password).toBe('[redacted]');
+    expect(body.transmission.url).toBe(
+      'http://localhost:9091/transmission/rpc',
+    );
+  });
+
+  it('does not mutate the original config object', async () => {
+    const deps = createDeps();
+    const handler = createApiFetch(deps);
+    handler(new Request('http://localhost/api/config'));
+
+    expect(deps.config.transmission.username).toBe('user');
+    expect(deps.config.transmission.password).toBe('pass');
+  });
+});
+
+describe('buildShowBreakdowns', () => {
+  it('sorts shows by title and seasons/episodes by number', () => {
+    const candidates = [
+      tvCandidate({
+        identityKey: 'k1',
+        normalizedTitle: 'z show',
+        season: 2,
+        episode: 3,
+      }),
+      tvCandidate({
+        identityKey: 'k2',
+        normalizedTitle: 'a show',
+        season: 1,
+        episode: 2,
+      }),
+      tvCandidate({
+        identityKey: 'k3',
+        normalizedTitle: 'a show',
+        season: 1,
+        episode: 1,
+      }),
+    ];
+
+    const shows = buildShowBreakdowns(candidates as never);
+
+    expect(shows[0].normalizedTitle).toBe('a show');
+    expect(shows[0].seasons[0].episodes[0].episode).toBe(1);
+    expect(shows[0].seasons[0].episodes[1].episode).toBe(2);
+    expect(shows[1].normalizedTitle).toBe('z show');
+  });
+});
+
+describe('buildMovieBreakdowns', () => {
+  it('sorts movies by title', () => {
+    const candidates = [
+      movieCandidate({ identityKey: 'k1', normalizedTitle: 'z movie' }),
+      movieCandidate({ identityKey: 'k2', normalizedTitle: 'a movie' }),
+    ];
+
+    const movies = buildMovieBreakdowns(candidates as never);
+
+    expect(movies[0].normalizedTitle).toBe('a movie');
+    expect(movies[1].normalizedTitle).toBe('z movie');
+  });
+});
+
+describe('buildFeedStatuses', () => {
+  it('marks feed as due when poll interval exceeded', () => {
+    const feeds = [
+      {
+        name: 'Feed',
+        url: 'http://example.test/rss',
+        mediaType: 'tv' as const,
+      },
+    ];
+    const pollState: PollState = {
+      feeds: {
+        Feed: { lastPolledAt: new Date(Date.now() - 999999999).toISOString() },
+      },
+    };
+    const runtime = {
+      runIntervalMinutes: 30,
+      reconcileIntervalMinutes: 1,
+      artifactDir: '',
+      artifactRetentionDays: 7,
+    };
+
+    const statuses = buildFeedStatuses(feeds, pollState, runtime);
+
+    expect(statuses[0].isDue).toBe(true);
+  });
+
+  it('marks feed as not due when recently polled', () => {
+    const feeds = [
+      {
+        name: 'Feed',
+        url: 'http://example.test/rss',
+        mediaType: 'tv' as const,
+      },
+    ];
+    const pollState: PollState = {
+      feeds: { Feed: { lastPolledAt: new Date().toISOString() } },
+    };
+    const runtime = {
+      runIntervalMinutes: 30,
+      reconcileIntervalMinutes: 1,
+      artifactDir: '',
+      artifactRetentionDays: 7,
+    };
+
+    const statuses = buildFeedStatuses(feeds, pollState, runtime);
+
+    expect(statuses[0].isDue).toBe(false);
+  });
+});
+
+describe('redactConfig', () => {
+  it('redacts transmission username and password', () => {
+    const config = stubConfig();
+    const redacted = redactConfig(config);
+
+    expect(redacted.transmission.username).toBe('[redacted]');
+    expect(redacted.transmission.password).toBe('[redacted]');
+    expect(config.transmission.username).toBe('user');
   });
 });

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -513,6 +513,25 @@ describe('buildShowBreakdowns', () => {
     expect(shows[0].seasons[0].episodes[1].episode).toBe(2);
     expect(shows[1].normalizedTitle).toBe('z show');
   });
+
+  it('skips TV candidates with missing season or episode', () => {
+    const candidates = [
+      tvCandidate({ identityKey: 'k1', season: 1, episode: 1 }),
+      { ...tvCandidate({ identityKey: 'k2' }), season: undefined, episode: 3 },
+      { ...tvCandidate({ identityKey: 'k3' }), season: 2, episode: undefined },
+      {
+        ...tvCandidate({ identityKey: 'k4' }),
+        season: undefined,
+        episode: undefined,
+      },
+    ];
+
+    const shows = buildShowBreakdowns(candidates as never);
+
+    expect(shows).toHaveLength(1);
+    expect(shows[0].seasons[0].episodes).toHaveLength(1);
+    expect(shows[0].seasons[0].episodes[0].identityKey).toBe('k1');
+  });
 });
 
 describe('buildMovieBreakdowns', () => {


### PR DESCRIPTION
## Summary

- delivery ticket: `P9.03 Shows, Movies, Feeds, And Config Endpoints`
- ticket file: `docs/02-delivery/phase-09/ticket-03-shows-movies-feeds-and-config-endpoints.md`
- stacked base branch: `agents/p9-02-status-health-and-candidates-endpoints`

## External AI Review

- outcome: `patched`
- reviewed commit: `bfbf8aa061d2`
- current branch head: `6617159c6dc7`
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Actions Taken

- `6617159c6dc7` [coderabbit,greptile] fix(api): patch review findings for P9.03

### No-Action Rationale

- Left 1 unclear comment(s) for manual judgment.
