### PR TITLE
docs: add daemon HTTP API documentation and update Phase 09 status [P9.04]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pirate Claw is a local CLI for pulling media candidates from RSS feeds, matching them against your rules, and queueing approved downloads in Transmission.
 
-Phases 01-08 of the current product roadmap are implemented on `main`. The currently documented engineering epics through Epic 03 are also implemented on `main`. Further product-surface or delivery-tooling expansion now requires a new planning pass and new approved phase/epic docs.
+Phases 01-09 of the current product roadmap are implemented on `main`. The currently documented engineering epics through Epic 03 are also implemented on `main`. Further product-surface or delivery-tooling expansion now requires a new planning pass and new approved phase/epic docs.
 
 It currently supports:
 
@@ -16,6 +16,7 @@ It currently supports:
 - status inspection and retry of failed submissions
 - effective config inspection through `pirate-claw config show`
 - env-backed Transmission credentials via process env or `.env`
+- read-only daemon HTTP API for external consumers when `runtime.apiPort` is configured
 
 ## Commands
 
@@ -77,7 +78,7 @@ High-level config shape:
 - `tv`: either the legacy per-show rule array or a compact `defaults + shows` object
 - `movies`: global movie intake policy
 - `transmission`: local Transmission RPC settings (optional `downloadDirs` for per-media-type download directories)
-- `runtime`: daemon scheduling and artifact settings (optional, all fields have defaults)
+- `runtime`: daemon scheduling and artifact settings (optional, all fields have defaults; `apiPort` enables the HTTP API)
 
 Example:
 
@@ -126,7 +127,8 @@ Example:
     "runIntervalMinutes": 30,
     "reconcileIntervalMinutes": 1,
     "artifactDir": ".pirate-claw/runtime",
-    "artifactRetentionDays": 7
+    "artifactRetentionDays": 7,
+    "apiPort": 3000
   }
 }
 ```
@@ -196,6 +198,54 @@ Run the daemon for continuous scheduled operation:
 ```
 
 The daemon runs in the foreground, executing run cycles every 30 minutes and reconcile cycles every 1 minute. Stop with `Ctrl+C`.
+
+## Daemon HTTP API
+
+When `runtime.apiPort` is set in the config, the daemon starts a read-only HTTP JSON API alongside the normal scheduling loop:
+
+```json
+{
+  "runtime": {
+    "apiPort": 3000
+  }
+}
+```
+
+When `runtime.apiPort` is omitted, no HTTP listener starts.
+
+### Endpoints
+
+| Endpoint              | Description                                                |
+| --------------------- | ---------------------------------------------------------- |
+| `GET /api/health`     | Uptime, start time, and last run/reconcile cycle snapshots |
+| `GET /api/status`     | Recent run summaries from the local database               |
+| `GET /api/candidates` | All tracked candidate state records                        |
+| `GET /api/shows`      | TV candidates grouped by show → season → episode           |
+| `GET /api/movies`     | Movie candidates sorted by title                           |
+| `GET /api/feeds`      | Feed config with poll state and `isDue` status             |
+| `GET /api/config`     | Effective config with Transmission credentials redacted    |
+
+### Example
+
+```bash
+curl http://localhost:3000/api/health
+```
+
+```json
+{
+  "uptime": 3600000,
+  "startedAt": "2026-04-08T12:00:00.000Z",
+  "lastRunCycle": {
+    "status": "completed",
+    "startedAt": "...",
+    "completedAt": "...",
+    "durationMs": 1234
+  },
+  "lastReconcileCycle": null
+}
+```
+
+All endpoints are read-only. No endpoint mutates daemon state. There is no authentication in this version — it is designed for private NAS networks.
 
 ## Current Scope
 

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -243,13 +243,16 @@ Goal:
 
 Current status:
 
-- planned, not yet implemented
+- implemented on `main`
 
 Committed scope:
 
-- lightweight HTTP listener in the daemon on a configurable port
-- read-only endpoints: `/api/status`, `/api/candidates`, `/api/shows`, `/api/config`
+- lightweight HTTP listener in the daemon on a configurable port (`runtime.apiPort`)
+- read-only endpoints: `/api/health`, `/api/status`, `/api/candidates`, `/api/shows`, `/api/movies`, `/api/feeds`, `/api/config`
 - no authentication in v1 (private NAS network)
+- TV candidates with missing season/episode are skipped rather than synthesized
+- feed `isDue` logic reuses the shared `isDueFeed` helper for consistency with the scheduler
+- Transmission credentials redacted in `/api/config`
 
 Explicitly deferred:
 
@@ -260,6 +263,7 @@ Explicitly deferred:
 Working notes:
 
 - `docs/01-product/phase-09-daemon-http-api.md`
+- `docs/02-delivery/phase-09/implementation-plan.md`
 
 ## Phase 10: Read-Only SvelteKit Dashboard
 
@@ -330,8 +334,8 @@ These items emerged during ideation and are explicitly deferred beyond Phase 11:
 
 ## Current Planning Posture
 
-- product phases `01`-`07` and engineering epics `01`-`03` are complete on `main`
-- product phases `08`-`11` are planned with approved product docs but do not yet have delivery implementation plans or ticket decompositions
+- product phases `01`-`09` and engineering epics `01`-`03` are complete on `main`
+- product phases `10`-`11` are planned with approved product docs but do not yet have delivery implementation plans or ticket decompositions
 - each new phase requires an explicit planning pass, approved ticket decomposition, and developer sign-off before implementation starts
 - smaller bounded changes can still proceed as standalone PR work without inventing a new phase
 
@@ -347,4 +351,4 @@ Working notes:
 - promote durable technical choices into ADRs
 - numbered phases are planning buckets, not a promise of strict implementation sequence when dependencies allow independent work
 
-Last verified against `README.md` and active delivery plans: 2026-04-07.
+Last verified against `README.md` and active delivery plans: 2026-04-08.

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -10,7 +10,7 @@ Its job is to answer three questions quickly:
 
 ## Current Repo State
 
-Pirate Claw is implemented through Phase 08.
+Pirate Claw is implemented through Phase 09.
 
 Current delivered surface:
 
@@ -40,6 +40,7 @@ Current product boundary:
 - per-feed polling cadence with persistent poll state
 - shared runtime lock prevents overlapping cycles
 - machine-readable and human-readable cycle artifacts with bounded retention
+- read-only daemon HTTP API (`/api/health`, `/api/status`, `/api/candidates`, `/api/shows`, `/api/movies`, `/api/feeds`, `/api/config`) when `runtime.apiPort` is configured
 
 Still deferred:
 
@@ -50,7 +51,7 @@ Still deferred:
 - Synology archiving
 - ingestion redesign beyond the local SQLite model
 
-Last verified against `README.md` and CLI commands: 2026-04-07.
+Last verified against `README.md` and CLI commands: 2026-04-08.
 
 Current planning focus:
 

--- a/docs/02-delivery/phase-09/ticket-04-docs-and-example-config-update.md
+++ b/docs/02-delivery/phase-09/ticket-04-docs-and-example-config-update.md
@@ -19,3 +19,11 @@ Update user-facing docs and example config to document the new `runtime.apiPort`
 ## Exit Condition
 
 An operator reading the README can understand how to enable the daemon HTTP API, what endpoints are available, and what JSON shapes to expect. The example config shows the `apiPort` field. Start-here and roadmap reflect Phase 09 as delivered.
+
+## Rationale
+
+- Added `runtime.apiPort` to example config with value `3000` as a sensible development default.
+- README receives a full "Daemon HTTP API" section with endpoint table, example curl/response, and guidance on when the listener starts. Placed between the daemon usage section and the current scope section.
+- start-here.md updated from "through Phase 08" to "through Phase 09" and the delivered surface list includes all 7 API endpoints.
+- roadmap.md Phase 09 moves from "planned, not yet implemented" to "implemented on main" with the full committed scope including review-driven refinements (skip incomplete TV candidates, reuse isDueFeed, credential redaction).
+- docs/README.md index gets `phase-09/implementation-plan.md` entry.

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ Execution plans, issue conventions, and ticket breakdowns.
 - `phase-06/synology-runbook.md`: canonical operator-facing Synology runbook (validated)
 - `phase-07/implementation-plan.md`: config ergonomics delivery plan
 - `phase-08/implementation-plan.md`: media placement delivery plan
+- `phase-09/implementation-plan.md`: daemon HTTP API delivery plan
 
 ### `03-engineering`
 

--- a/pirate-claw.config.example.json
+++ b/pirate-claw.config.example.json
@@ -42,6 +42,7 @@
     "runIntervalMinutes": 30,
     "reconcileIntervalMinutes": 1,
     "artifactDir": ".pirate-claw/runtime",
-    "artifactRetentionDays": 7
+    "artifactRetentionDays": 7,
+    "apiPort": 3000
   }
 }


### PR DESCRIPTION
## Summary

- delivery ticket: `P9.04 Docs And Example Config Update`
- ticket file: `docs/02-delivery/phase-09/ticket-04-docs-and-example-config-update.md`
- stacked base branch: `agents/p9-03-shows-movies-feeds-and-config-endpoints`
- internal review: completed at `2026-04-07T20:52:59.147Z`

## External AI Review

- outcome: `clean`
- current branch head: `085a4f3e0450`
- no prudent follow-up changes were required.
