### PR TITLE
feat: candidates list view with sort, empty/error states, TV show links [P10.02]

### DIFF
--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,0 +1,45 @@
+export type CandidateStatus =
+	| 'queued'
+	| 'skipped'
+	| 'rejected'
+	| 'duplicate'
+	| 'reconciled'
+	| 'downloading'
+	| 'completed'
+	| 'failed';
+
+export type CandidateLifecycleStatus = 'active' | 'seeding' | 'stopped' | 'error';
+
+export type CandidateStateRecord = {
+	identityKey: string;
+	mediaType: 'movie' | 'tv';
+	status: CandidateStatus;
+	queuedAt?: string;
+	lifecycleStatus?: CandidateLifecycleStatus;
+	reconciledAt?: string;
+	transmissionTorrentId?: number;
+	transmissionTorrentName?: string;
+	transmissionTorrentHash?: string;
+	transmissionStatusCode?: number;
+	transmissionPercentDone?: number;
+	transmissionDoneDate?: string;
+	transmissionDownloadDir?: string;
+	ruleName: string;
+	score: number;
+	reasons: string[];
+	rawTitle: string;
+	normalizedTitle: string;
+	season?: number;
+	episode?: number;
+	year?: number;
+	resolution?: string;
+	codec?: string;
+	feedName: string;
+	guidOrLink: string;
+	publishedAt: string;
+	downloadUrl: string;
+	firstSeenRunId: number;
+	lastSeenRunId: number;
+	lastFeedItemId?: number;
+	updatedAt: string;
+};

--- a/web/src/routes/candidates/+page.server.ts
+++ b/web/src/routes/candidates/+page.server.ts
@@ -1,0 +1,12 @@
+import { apiFetch } from '$lib/server/api';
+import type { CandidateStateRecord } from '$lib/types';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+	try {
+		const data = await apiFetch<{ candidates: CandidateStateRecord[] }>('/api/candidates');
+		return { candidates: data.candidates, error: null };
+	} catch {
+		return { candidates: [] as CandidateStateRecord[], error: 'Could not reach the API.' };
+	}
+};

--- a/web/src/routes/candidates/+page.svelte
+++ b/web/src/routes/candidates/+page.svelte
@@ -1,2 +1,97 @@
-<h1 class="text-2xl font-semibold">Candidates</h1>
-<p class="mt-2 text-gray-400">Candidates table coming in P10.02.</p>
+<script lang="ts">
+	import type { PageData } from './$types';
+	import type { CandidateStateRecord } from '$lib/types';
+
+	let { data }: { data: PageData } = $props();
+
+	type SortKey = 'mediaType' | 'status';
+	let sortKey = $state<SortKey>('status');
+	let sortAsc = $state(true);
+
+	function toggleSort(key: SortKey) {
+		if (sortKey === key) {
+			sortAsc = !sortAsc;
+		} else {
+			sortKey = key;
+			sortAsc = true;
+		}
+	}
+
+	function showSlug(c: CandidateStateRecord) {
+		return encodeURIComponent(c.normalizedTitle);
+	}
+
+	const sorted = $derived(
+		[...data.candidates].sort((a, b) => {
+			const av = a[sortKey] ?? '';
+			const bv = b[sortKey] ?? '';
+			const cmp = String(av).localeCompare(String(bv));
+			return sortAsc ? cmp : -cmp;
+		}),
+	);
+
+	function arrow(key: SortKey) {
+		if (sortKey !== key) return '';
+		return sortAsc ? ' ↑' : ' ↓';
+	}
+</script>
+
+<h1 class="mb-4 text-2xl font-semibold">Candidates</h1>
+
+{#if data.error}
+	<p class="text-red-400" role="alert">{data.error}</p>
+{:else if data.candidates.length === 0}
+	<p class="text-gray-400">No candidates found.</p>
+{:else}
+	<div class="overflow-x-auto">
+		<table class="w-full table-auto border-collapse text-sm">
+			<thead>
+				<tr class="border-b border-gray-700 text-left text-gray-400">
+					<th class="py-2 pr-4">Title</th>
+					<th
+						class="cursor-pointer py-2 pr-4 hover:text-white"
+						onclick={() => toggleSort('mediaType')}
+					>
+						Type{arrow('mediaType')}
+					</th>
+					<th class="py-2 pr-4">Rule</th>
+					<th class="py-2 pr-4">Resolution</th>
+					<th
+						class="cursor-pointer py-2 pr-4 hover:text-white"
+						onclick={() => toggleSort('status')}
+					>
+						Status{arrow('status')}
+					</th>
+					<th class="py-2 pr-4">Queued At</th>
+					<th class="py-2">Updated At</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each sorted as candidate (candidate.identityKey)}
+					<tr class="border-b border-gray-800 hover:bg-gray-800/40">
+						<td class="py-2 pr-4 font-medium">
+							{#if candidate.mediaType === 'tv'}
+								<a href="/shows/{showSlug(candidate)}" class="text-blue-400 hover:underline">
+									{candidate.normalizedTitle}
+								</a>
+							{:else}
+								{candidate.normalizedTitle}
+							{/if}
+						</td>
+						<td class="py-2 pr-4 text-gray-300">{candidate.mediaType}</td>
+						<td class="py-2 pr-4 text-gray-300">{candidate.ruleName}</td>
+						<td class="py-2 pr-4 text-gray-300">{candidate.resolution ?? '—'}</td>
+						<td class="py-2 pr-4">
+							<span class="rounded px-1.5 py-0.5 text-xs font-semibold">{candidate.status}</span>
+							{#if candidate.lifecycleStatus}
+								<span class="ml-1 text-xs text-gray-500">({candidate.lifecycleStatus})</span>
+							{/if}
+						</td>
+						<td class="py-2 pr-4 text-gray-400">{candidate.queuedAt ?? '—'}</td>
+						<td class="py-2 text-gray-400">{candidate.updatedAt}</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
+{/if}

--- a/web/src/routes/candidates/+page.svelte
+++ b/web/src/routes/candidates/+page.svelte
@@ -21,6 +21,17 @@
 		return encodeURIComponent(c.normalizedTitle);
 	}
 
+	const statusColors: Record<string, string> = {
+		queued: 'bg-gray-700 text-gray-200',
+		skipped: 'bg-gray-600 text-gray-300',
+		rejected: 'bg-red-900 text-red-300',
+		duplicate: 'bg-yellow-900 text-yellow-300',
+		reconciled: 'bg-green-900 text-green-300',
+		downloading: 'bg-blue-900 text-blue-300',
+		completed: 'bg-green-800 text-green-200',
+		failed: 'bg-red-800 text-red-200',
+	};
+
 	const sorted = $derived(
 		[...data.candidates].sort((a, b) => {
 			const av = a[sortKey] ?? '';
@@ -49,18 +60,26 @@
 				<tr class="border-b border-gray-700 text-left text-gray-400">
 					<th class="py-2 pr-4">Title</th>
 					<th
-						class="cursor-pointer py-2 pr-4 hover:text-white"
-						onclick={() => toggleSort('mediaType')}
+						class="py-2 pr-4"
+						aria-sort={sortKey === 'mediaType' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
 					>
-						Type{arrow('mediaType')}
+						<button
+							type="button"
+							class="cursor-pointer text-left text-gray-400 hover:text-white"
+							onclick={() => toggleSort('mediaType')}
+						>Type{arrow('mediaType')}</button>
 					</th>
 					<th class="py-2 pr-4">Rule</th>
 					<th class="py-2 pr-4">Resolution</th>
 					<th
-						class="cursor-pointer py-2 pr-4 hover:text-white"
-						onclick={() => toggleSort('status')}
+						class="py-2 pr-4"
+						aria-sort={sortKey === 'status' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
 					>
-						Status{arrow('status')}
+						<button
+							type="button"
+							class="cursor-pointer text-left text-gray-400 hover:text-white"
+							onclick={() => toggleSort('status')}
+						>Status{arrow('status')}</button>
 					</th>
 					<th class="py-2 pr-4">Queued At</th>
 					<th class="py-2">Updated At</th>
@@ -82,7 +101,10 @@
 						<td class="py-2 pr-4 text-gray-300">{candidate.ruleName}</td>
 						<td class="py-2 pr-4 text-gray-300">{candidate.resolution ?? '—'}</td>
 						<td class="py-2 pr-4">
-							<span class="rounded px-1.5 py-0.5 text-xs font-semibold">{candidate.status}</span>
+
+								<span
+									class="rounded px-1.5 py-0.5 text-xs font-semibold {statusColors[candidate.status] ?? 'bg-gray-700 text-gray-200'}"
+								>{candidate.status}</span>
 							{#if candidate.lifecycleStatus}
 								<span class="ml-1 text-xs text-gray-500">({candidate.lifecycleStatus})</span>
 							{/if}

--- a/web/src/routes/candidates/candidates.test.ts
+++ b/web/src/routes/candidates/candidates.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Page from './+page.svelte';
+import type { CandidateStateRecord } from '$lib/types';
+
+const mockCandidate: CandidateStateRecord = {
+	identityKey: 'key-1',
+	mediaType: 'tv',
+	status: 'queued',
+	queuedAt: '2024-01-01T00:00:00Z',
+	ruleName: 'hd-tv',
+	score: 10,
+	reasons: ['matched'],
+	rawTitle: 'The Show S01E01',
+	normalizedTitle: 'The Show',
+	season: 1,
+	episode: 1,
+	resolution: '1080p',
+	feedName: 'feed-a',
+	guidOrLink: 'https://example.com',
+	publishedAt: '2024-01-01T00:00:00Z',
+	downloadUrl: 'https://example.com/dl',
+	firstSeenRunId: 1,
+	lastSeenRunId: 1,
+	updatedAt: '2024-01-01T01:00:00Z',
+};
+
+describe('/candidates', () => {
+	it('renders table with candidate data', () => {
+		render(Page, { data: { candidates: [mockCandidate], error: null } });
+		expect(screen.getByText('The Show')).toBeInTheDocument();
+		expect(screen.getByText('tv')).toBeInTheDocument();
+		expect(screen.getByText('hd-tv')).toBeInTheDocument();
+		expect(screen.getByText('1080p')).toBeInTheDocument();
+		expect(screen.getByText('queued')).toBeInTheDocument();
+		// TV candidate title links to show detail
+		const link = screen.getByRole('link', { name: 'The Show' });
+		expect(link).toHaveAttribute('href', '/shows/The%20Show');
+	});
+
+	it('renders empty state when no candidates', () => {
+		render(Page, { data: { candidates: [], error: null } });
+		expect(screen.getByText('No candidates found.')).toBeInTheDocument();
+	});
+
+	it('renders error state when API is unreachable', () => {
+		render(Page, { data: { candidates: [], error: 'Could not reach the API.' } });
+		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
+	});
+});

--- a/web/src/routes/candidates/candidates.test.ts
+++ b/web/src/routes/candidates/candidates.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import Page from './+page.svelte';
 import type { CandidateStateRecord } from '$lib/types';


### PR DESCRIPTION
## Summary

- delivery ticket: `P10.02 Candidates List View`
- ticket file: `docs/02-delivery/phase-10/ticket-02-candidates-list.md`
- stacked base branch: `agents/p10-01-scaffold-sveltekit-app-tooling-nav-shell-dockerfile`
- internal review: completed at `2026-04-08T08:01:49.533Z`

## External AI Review

- outcome: `patched`
- reviewed commit: `5701efe6c1d7`
- current branch head: `6d88b81ab5dd`
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Actions Taken

- `6d88b81ab5dd` [coderabbit,greptile] fix: accessible sort headers, status badge colors, remove unused import [P10.02]
