### PR TITLE
feat: show detail view with season/episode grid, not-found/error states [P10.03]

### DIFF
--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -43,3 +43,21 @@ export type CandidateStateRecord = {
 	lastFeedItemId?: number;
 	updatedAt: string;
 };
+
+export type ShowEpisode = {
+	episode: number;
+	identityKey: string;
+	status: string;
+	lifecycleStatus?: string;
+	queuedAt?: string;
+};
+
+export type ShowSeason = {
+	season: number;
+	episodes: ShowEpisode[];
+};
+
+export type ShowBreakdown = {
+	normalizedTitle: string;
+	seasons: ShowSeason[];
+};

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -47,7 +47,7 @@ export type CandidateStateRecord = {
 export type ShowEpisode = {
 	episode: number;
 	identityKey: string;
-	status: string;
+	status: CandidateStatus;
 	lifecycleStatus?: string;
 	queuedAt?: string;
 };

--- a/web/src/routes/shows/[slug]/+page.server.ts
+++ b/web/src/routes/shows/[slug]/+page.server.ts
@@ -1,5 +1,17 @@
+import { apiFetch } from '$lib/server/api';
+import type { ShowBreakdown } from '$lib/types';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = ({ params }) => {
-	return { slug: decodeURIComponent(params.slug) };
+export const load: PageServerLoad = async ({ params }) => {
+	const title = decodeURIComponent(params.slug);
+	try {
+		const data = await apiFetch<{ shows: ShowBreakdown[] }>('/api/shows');
+		const show = data.shows.find(
+			(s) => s.normalizedTitle.toLowerCase() === title.toLowerCase(),
+		) ?? null;
+		return { show, error: null };
+	} catch {
+		return { show: null as ShowBreakdown | null, error: 'Could not reach the API.' };
+	}
 };
+

--- a/web/src/routes/shows/[slug]/+page.server.ts
+++ b/web/src/routes/shows/[slug]/+page.server.ts
@@ -3,7 +3,7 @@ import type { ShowBreakdown } from '$lib/types';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params }) => {
-	const title = decodeURIComponent(params.slug);
+	const title = params.slug;
 	try {
 		const data = await apiFetch<{ shows: ShowBreakdown[] }>('/api/shows');
 		const show = data.shows.find(

--- a/web/src/routes/shows/[slug]/+page.svelte
+++ b/web/src/routes/shows/[slug]/+page.svelte
@@ -1,7 +1,46 @@
 <script lang="ts">
-	import type { PageProps } from './$types';
-	let { data }: PageProps = $props();
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
 </script>
 
-<h1 class="text-2xl font-semibold">{data.slug}</h1>
-<p class="mt-2 text-gray-400">Show detail coming in P10.03.</p>
+<div class="mb-4">
+	<a href="/candidates" class="text-sm text-gray-400 hover:text-white">← Candidates</a>
+</div>
+
+{#if data.error}
+	<p class="text-red-400" role="alert">{data.error}</p>
+{:else if !data.show}
+	<p class="text-gray-400">Show not found.</p>
+{:else}
+	<h1 class="mb-6 text-2xl font-semibold">{data.show.normalizedTitle}</h1>
+
+	{#each data.show.seasons as season (season.season)}
+		<section class="mb-8">
+			<h2 class="mb-3 text-lg font-medium text-gray-300">Season {season.season}</h2>
+			<table class="w-full table-auto border-collapse text-sm">
+				<thead>
+					<tr class="border-b border-gray-700 text-left text-gray-400">
+						<th class="py-2 pr-4">Episode</th>
+						<th class="py-2 pr-4">Status</th>
+						<th class="py-2">Queued At</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each season.episodes as ep (ep.identityKey)}
+						<tr class="border-b border-gray-800 hover:bg-gray-800/40">
+							<td class="py-2 pr-4 font-medium">E{String(ep.episode).padStart(2, '0')}</td>
+							<td class="py-2 pr-4 text-gray-300">
+								{ep.status}
+								{#if ep.lifecycleStatus}
+									<span class="ml-1 text-xs text-gray-500">({ep.lifecycleStatus})</span>
+								{/if}
+							</td>
+							<td class="py-2 text-gray-400">{ep.queuedAt ?? '—'}</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</section>
+	{/each}
+{/if}

--- a/web/src/routes/shows/[slug]/shows.test.ts
+++ b/web/src/routes/shows/[slug]/shows.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Page from './+page.svelte';
+import type { ShowBreakdown } from '$lib/types';
+
+const mockShow: ShowBreakdown = {
+	normalizedTitle: 'The Show',
+	seasons: [
+		{
+			season: 1,
+			episodes: [
+				{
+					episode: 1,
+					identityKey: 'key-s01e01',
+					status: 'queued',
+					queuedAt: '2024-01-01T00:00:00Z',
+				},
+				{
+					episode: 2,
+					identityKey: 'key-s01e02',
+					status: 'completed',
+					lifecycleStatus: 'seeding',
+				},
+			],
+		},
+	],
+};
+
+describe('/shows/[slug]', () => {
+	it('renders show name and season section', () => {
+		render(Page, { data: { show: mockShow, error: null } });
+		expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('The Show');
+		expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Season 1');
+		expect(screen.getByText('E01')).toBeInTheDocument();
+	});
+
+	it('renders not-found state when show is null', () => {
+		render(Page, { data: { show: null, error: null } });
+		expect(screen.getByText('Show not found.')).toBeInTheDocument();
+	});
+
+	it('renders error state when API is unreachable', () => {
+		render(Page, { data: { show: null, error: 'Could not reach the API.' } });
+		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
+	});
+});


### PR DESCRIPTION
## Summary

- delivery ticket: `P10.03 Show Detail View`
- ticket file: `docs/02-delivery/phase-10/ticket-03-show-detail.md`
- stacked base branch: `agents/p10-02-candidates-list-view`
- internal review: completed at `2026-04-08T08:23:05.984Z`

## External AI Review

- outcome: `patched`
- reviewed commit: `9469295565fe`
- current branch head: `4013b50d82d4`
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Actions Taken

- `4013b50d82d4` [coderabbit,greptile] fix: remove double decodeURIComponent, type ShowEpisode.status as CandidateStatus [P10.03]
