### PR TITLE
feat: config view with section-per-group rendering, error state [P10.04]

### DIFF
--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -61,3 +61,48 @@ export type ShowBreakdown = {
 	normalizedTitle: string;
 	seasons: ShowSeason[];
 };
+
+export type FeedConfig = {
+	name: string;
+	url: string;
+	mediaType: 'tv' | 'movie';
+	parserHints?: Record<string, unknown>;
+	pollIntervalMinutes?: number;
+};
+
+export type TvRule = {
+	name: string;
+	matchPattern?: string;
+	resolutions: string[];
+	codecs: string[];
+};
+
+export type MoviePolicy = {
+	years: number[];
+	resolutions: string[];
+	codecs: string[];
+	codecPolicy: 'prefer' | 'require';
+};
+
+export type TransmissionConfig = {
+	url: string;
+	username: string;
+	password: string;
+	downloadDir?: string;
+	downloadDirs?: { movie?: string; tv?: string };
+};
+
+export type RuntimeConfig = {
+	runIntervalMinutes: number;
+	reconcileIntervalMinutes: number;
+	artifactDir: string;
+	artifactRetentionDays: number;
+	apiPort?: number;
+};
+
+export type AppConfig = {
+	feeds: FeedConfig[];
+	tv: TvRule[];
+	movies: MoviePolicy;
+	transmission: TransmissionConfig;
+	runtime: RuntimeConfig;

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -6,7 +6,8 @@ export const load: PageServerLoad = async () => {
 	try {
 		const config = await apiFetch<AppConfig>('/api/config');
 		return { config, error: null };
-	} catch {
+	} catch (err) {
+		console.error('[config] failed to load config:', err);
 		return { config: null as AppConfig | null, error: 'Could not reach the API.' };
 	}
 };

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -1,0 +1,12 @@
+import { apiFetch } from '$lib/server/api';
+import type { AppConfig } from '$lib/types';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+	try {
+		const config = await apiFetch<AppConfig>('/api/config');
+		return { config, error: null };
+	} catch {
+		return { config: null as AppConfig | null, error: 'Could not reach the API.' };
+	}
+};

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -1,2 +1,146 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	const { data }: { data: PageData } = $props();
+</script>
+
 <h1 class="text-2xl font-semibold">Config</h1>
-<p class="mt-2 text-gray-400">Effective config view coming in P10.04.</p>
+
+{#if data.error}
+	<p class="mt-4 text-red-400" role="alert">{data.error}</p>
+{:else if data.config}
+	{@const config = data.config}
+
+	<section class="mt-6">
+		<h2 class="text-lg font-semibold text-gray-200">Feeds</h2>
+		{#if config.feeds.length === 0}
+			<p class="mt-2 text-gray-400">No feeds configured.</p>
+		{:else}
+			<ul class="mt-2 space-y-3">
+				{#each config.feeds as feed}
+					<li class="rounded bg-gray-800 p-3 text-sm">
+						<div class="font-medium text-gray-100">{feed.name}</div>
+						<div class="mt-1 text-gray-400">
+							<span class="mr-3">Type: {feed.mediaType}</span>
+							{#if feed.pollIntervalMinutes !== undefined}
+								<span class="mr-3">Poll: {feed.pollIntervalMinutes}m</span>
+							{/if}
+							<span class="break-all">URL: {feed.url}</span>
+						</div>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</section>
+
+	<section class="mt-6">
+		<h2 class="text-lg font-semibold text-gray-200">TV Rules</h2>
+		{#if config.tv.length === 0}
+			<p class="mt-2 text-gray-400">No TV rules configured.</p>
+		{:else}
+			<ul class="mt-2 space-y-3">
+				{#each config.tv as rule}
+					<li class="rounded bg-gray-800 p-3 text-sm">
+						<div class="font-medium text-gray-100">{rule.name}</div>
+						<div class="mt-1 text-gray-400">
+							{#if rule.matchPattern}
+								<div>Pattern: <code class="text-gray-300">{rule.matchPattern}</code></div>
+							{/if}
+							<div>Resolutions: {rule.resolutions.join(', ')}</div>
+							<div>Codecs: {rule.codecs.join(', ')}</div>
+						</div>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</section>
+
+	<section class="mt-6">
+		<h2 class="text-lg font-semibold text-gray-200">Movies</h2>
+		<dl class="mt-2 rounded bg-gray-800 p-3 text-sm">
+			<div class="flex gap-2">
+				<dt class="text-gray-400">Years:</dt>
+				<dd class="text-gray-200">{config.movies.years.join(', ')}</dd>
+			</div>
+			<div class="flex gap-2">
+				<dt class="text-gray-400">Resolutions:</dt>
+				<dd class="text-gray-200">{config.movies.resolutions.join(', ')}</dd>
+			</div>
+			<div class="flex gap-2">
+				<dt class="text-gray-400">Codecs:</dt>
+				<dd class="text-gray-200">{config.movies.codecs.join(', ')}</dd>
+			</div>
+			<div class="flex gap-2">
+				<dt class="text-gray-400">Codec policy:</dt>
+				<dd class="text-gray-200">{config.movies.codecPolicy}</dd>
+			</div>
+		</dl>
+	</section>
+
+	<section class="mt-6">
+		<h2 class="text-lg font-semibold text-gray-200">Transmission</h2>
+		<dl class="mt-2 rounded bg-gray-800 p-3 text-sm">
+			<div class="flex gap-2">
+				<dt class="text-gray-400">URL:</dt>
+				<dd class="text-gray-200">{config.transmission.url}</dd>
+			</div>
+			<div class="flex gap-2">
+				<dt class="text-gray-400">Username:</dt>
+				<dd class="text-gray-200">{config.transmission.username}</dd>
+			</div>
+			<div class="flex gap-2">
+				<dt class="text-gray-400">Password:</dt>
+				<dd class="text-gray-200">{config.transmission.password}</dd>
+			</div>
+			{#if config.transmission.downloadDir}
+				<div class="flex gap-2">
+					<dt class="text-gray-400">Download dir:</dt>
+					<dd class="text-gray-200">{config.transmission.downloadDir}</dd>
+				</div>
+			{/if}
+			{#if config.transmission.downloadDirs}
+				{#if config.transmission.downloadDirs.tv}
+					<div class="flex gap-2">
+						<dt class="text-gray-400">TV dir:</dt>
+						<dd class="text-gray-200">{config.transmission.downloadDirs.tv}</dd>
+					</div>
+				{/if}
+				{#if config.transmission.downloadDirs.movie}
+					<div class="flex gap-2">
+						<dt class="text-gray-400">Movie dir:</dt>
+						<dd class="text-gray-200">{config.transmission.downloadDirs.movie}</dd>
+					</div>
+				{/if}
+			{/if}
+		</dl>
+	</section>
+
+	<section class="mt-6">
+		<h2 class="text-lg font-semibold text-gray-200">Runtime</h2>
+		<dl class="mt-2 rounded bg-gray-800 p-3 text-sm">
+			<div class="flex gap-2">
+				<dt class="text-gray-400">Run interval:</dt>
+				<dd class="text-gray-200">{config.runtime.runIntervalMinutes}m</dd>
+			</div>
+			<div class="flex gap-2">
+				<dt class="text-gray-400">Reconcile interval:</dt>
+				<dd class="text-gray-200">{config.runtime.reconcileIntervalMinutes}m</dd>
+			</div>
+			<div class="flex gap-2">
+				<dt class="text-gray-400">Artifact dir:</dt>
+				<dd class="text-gray-200">{config.runtime.artifactDir}</dd>
+			</div>
+			<div class="flex gap-2">
+				<dt class="text-gray-400">Artifact retention:</dt>
+				<dd class="text-gray-200">{config.runtime.artifactRetentionDays} days</dd>
+			</div>
+			{#if config.runtime.apiPort !== undefined}
+				<div class="flex gap-2">
+					<dt class="text-gray-400">API port:</dt>
+					<dd class="text-gray-200">{config.runtime.apiPort}</dd>
+				</div>
+			{/if}
+		</dl>
+	</section>
+{/if}
+

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -90,7 +90,7 @@
 			</div>
 			<div class="flex gap-2">
 				<dt class="text-gray-400">Password:</dt>
-				<dd class="text-gray-200">{config.transmission.password}</dd>
+				<dd class="text-gray-200">••••••••</dd>
 			</div>
 			{#if config.transmission.downloadDir}
 				<div class="flex gap-2">

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -55,4 +55,15 @@ describe('/config', () => {
 		render(Page, { data: { config: null, error: 'Could not reach the API.' } });
 		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
 	});
+
+	it('renders empty state when feeds and tv rules are empty', () => {
+		render(Page, {
+			data: {
+				config: { ...mockConfig, feeds: [], tv: [] },
+				error: null,
+			},
+		});
+		expect(screen.getByText('No feeds configured.')).toBeInTheDocument();
+		expect(screen.getByText('No TV rules configured.')).toBeInTheDocument();
+	});
 });

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Page from './+page.svelte';
+import type { AppConfig } from '$lib/types';
+
+const mockConfig: AppConfig = {
+	feeds: [
+		{
+			name: 'TestFeed',
+			url: 'https://example.com/rss',
+			mediaType: 'tv',
+			pollIntervalMinutes: 30,
+		},
+	],
+	tv: [
+		{
+			name: 'hd-tv',
+			matchPattern: 'The Show',
+			resolutions: ['1080p'],
+			codecs: ['x265'],
+		},
+	],
+	movies: {
+		years: [2024],
+		resolutions: ['1080p'],
+		codecs: ['x265'],
+		codecPolicy: 'prefer',
+	},
+	transmission: {
+		url: 'http://localhost:9091',
+		username: '[redacted]',
+		password: '[redacted]',
+	},
+	runtime: {
+		runIntervalMinutes: 30,
+		reconcileIntervalMinutes: 1,
+		artifactDir: '.pirate-claw/runtime',
+		artifactRetentionDays: 7,
+	},
+};
+
+describe('/config', () => {
+	it('renders config sections with mock data', () => {
+		render(Page, { data: { config: mockConfig, error: null } });
+		expect(screen.getByRole('heading', { name: 'Feeds' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'TV Rules' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Movies' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Transmission' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Runtime' })).toBeInTheDocument();
+		expect(screen.getByText('TestFeed')).toBeInTheDocument();
+		expect(screen.getByText('hd-tv')).toBeInTheDocument();
+	});
+
+	it('renders error state when API is unreachable', () => {
+		render(Page, { data: { config: null, error: 'Could not reach the API.' } });
+		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
+	});
+});


### PR DESCRIPTION
## Summary

- delivery ticket: `P10.04 Config View`
- ticket file: `docs/02-delivery/phase-10/ticket-04-config-view.md`
- stacked base branch: `agents/p10-03-show-detail-view`
- internal review: completed at `2026-04-08T09:29:29.407Z`

## External AI Review

- outcome: `patched`
- reviewed commit: `9e996cbd4642`
- current branch head: `03cabd83eeae`
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Actions Taken

- `03cabd83eeae` [greptile] fix: mask password in UI, add console.error, add empty-state tests [P10.04]
