### PR TITLE
feat: dashboard home with daemon health, run history, nav links [P10.05]

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+root = "./test"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pirate-claw": "./bin/pirate-claw"
   },
   "scripts": {
-    "ci": "bun run verify && bun run test",
+    "ci": "bun run verify && bun run test && bun run test:web",
     "deliver": "bun run ./scripts/deliver.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -20,6 +20,7 @@
     "closeout-stack": "bun run ./scripts/closeout-stack.ts",
     "test": "bun test",
     "test:coverage": "bun test --coverage",
+    "test:web": "bun install --cwd web --frozen-lockfile && bun run --cwd web test",
     "typecheck": "tsc --noEmit",
     "verify": "bun run format:check && bun run typecheck && bun run lint && bun run spellcheck"
   },

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -124,9 +124,16 @@ export type RunSummaryRecord = {
 	counts: Record<FeedItemOutcomeStatus, number>;
 };
 
+export type CycleSnapshot = {
+	status: RunStatus;
+	startedAt: string;
+	completedAt?: string;
+	durationMs?: number;
+};
+
 export type DaemonHealth = {
 	uptime: number;
 	startedAt: string;
-	lastRunCycle?: string;
-	lastReconcileCycle?: string;
+	lastRunCycle?: CycleSnapshot;
+	lastReconcileCycle?: CycleSnapshot;
 };

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -106,3 +106,27 @@ export type AppConfig = {
 	movies: MoviePolicy;
 	transmission: TransmissionConfig;
 	runtime: RuntimeConfig;
+};
+
+export type FeedItemOutcomeStatus =
+	| 'queued'
+	| 'failed'
+	| 'skipped_duplicate'
+	| 'skipped_no_match';
+
+export type RunStatus = 'running' | 'completed' | 'failed';
+
+export type RunSummaryRecord = {
+	id: number;
+	startedAt: string;
+	status: RunStatus;
+	completedAt?: string;
+	counts: Record<FeedItemOutcomeStatus, number>;
+};
+
+export type DaemonHealth = {
+	uptime: number;
+	startedAt: string;
+	lastRunCycle?: string;
+	lastReconcileCycle?: string;
+};

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -1,0 +1,20 @@
+import { apiFetch } from '$lib/server/api';
+import type { DaemonHealth, RunSummaryRecord } from '$lib/types';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+	try {
+		const [health, status] = await Promise.all([
+			apiFetch<DaemonHealth>('/api/health'),
+			apiFetch<{ runs: RunSummaryRecord[] }>('/api/status'),
+		]);
+		return { health, runs: status.runs, error: null };
+	} catch (err) {
+		console.error('[dashboard] failed to load health/status:', err);
+		return {
+			health: null as DaemonHealth | null,
+			runs: [] as RunSummaryRecord[],
+			error: 'Could not reach the API.',
+		};
+	}
+};

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,2 +1,95 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	const { data }: { data: PageData } = $props();
+
+	function formatUptime(ms: number): string {
+		const totalSeconds = Math.floor(ms / 1000);
+		const hours = Math.floor(totalSeconds / 3600);
+		const minutes = Math.floor((totalSeconds % 3600) / 60);
+		const seconds = totalSeconds % 60;
+		if (hours > 0) return `${hours}h ${minutes}m ${seconds}s`;
+		if (minutes > 0) return `${minutes}m ${seconds}s`;
+		return `${seconds}s`;
+	}
+
+	function formatDate(iso: string): string {
+		return new Date(iso).toLocaleString();
+	}
+</script>
+
 <h1 class="text-2xl font-semibold">Dashboard</h1>
-<p class="mt-2 text-gray-400">Run summary and candidate stats coming in P10.05.</p>
+
+{#if data.error}
+	<p class="mt-4 text-red-400" role="alert">{data.error}</p>
+{:else if data.health}
+	{@const health = data.health}
+	{@const runs = data.runs}
+
+	<section class="mt-6">
+		<h2 class="text-lg font-semibold text-gray-200">Daemon</h2>
+		<dl class="mt-2 rounded bg-gray-800 p-3 text-sm">
+			<div class="flex gap-2">
+				<dt class="text-gray-400">Uptime:</dt>
+				<dd class="text-gray-200">{formatUptime(health.uptime)}</dd>
+			</div>
+			<div class="flex gap-2">
+				<dt class="text-gray-400">Started at:</dt>
+				<dd class="text-gray-200">{formatDate(health.startedAt)}</dd>
+			</div>
+			{#if health.lastRunCycle}
+				<div class="flex gap-2">
+					<dt class="text-gray-400">Last run cycle:</dt>
+					<dd class="text-gray-200">{formatDate(health.lastRunCycle)}</dd>
+				</div>
+			{/if}
+			{#if health.lastReconcileCycle}
+				<div class="flex gap-2">
+					<dt class="text-gray-400">Last reconcile:</dt>
+					<dd class="text-gray-200">{formatDate(health.lastReconcileCycle)}</dd>
+				</div>
+			{/if}
+		</dl>
+	</section>
+
+	<section class="mt-6">
+		<h2 class="text-lg font-semibold text-gray-200">Recent Runs</h2>
+		{#if runs.length === 0}
+			<p class="mt-2 text-gray-400">No runs recorded yet.</p>
+		{:else}
+			<table class="mt-2 w-full text-left text-sm">
+				<thead>
+					<tr class="border-b border-gray-700 text-gray-400">
+						<th class="py-2 pr-4">ID</th>
+						<th class="py-2 pr-4">Started</th>
+						<th class="py-2 pr-4">Status</th>
+						<th class="py-2 pr-4">Queued</th>
+						<th class="py-2 pr-4">Failed</th>
+						<th class="py-2 pr-4">Skipped</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each runs as run}
+						<tr class="border-b border-gray-800 text-gray-300">
+							<td class="py-2 pr-4 font-mono">{run.id}</td>
+							<td class="py-2 pr-4">{formatDate(run.startedAt)}</td>
+							<td class="py-2 pr-4">{run.status}</td>
+							<td class="py-2 pr-4">{run.counts.queued ?? 0}</td>
+							<td class="py-2 pr-4">{run.counts.failed ?? 0}</td>
+							<td class="py-2 pr-4"
+								>{(run.counts.skipped_duplicate ?? 0) +
+									(run.counts.skipped_no_match ?? 0)}</td
+							>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		{/if}
+	</section>
+
+	<nav class="mt-8 flex gap-4 text-sm">
+		<a href="/candidates" class="text-blue-400 hover:underline">View Candidates</a>
+		<a href="/config" class="text-blue-400 hover:underline">View Config</a>
+	</nav>
+{/if}
+

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -14,7 +14,11 @@
 	}
 
 	function formatDate(iso: string): string {
-		return new Date(iso).toLocaleString();
+		return new Date(iso).toLocaleString('en-US', {
+			dateStyle: 'medium',
+			timeStyle: 'short',
+			timeZone: 'UTC',
+		});
 	}
 </script>
 
@@ -40,13 +44,13 @@
 			{#if health.lastRunCycle}
 				<div class="flex gap-2">
 					<dt class="text-gray-400">Last run cycle:</dt>
-					<dd class="text-gray-200">{formatDate(health.lastRunCycle)}</dd>
+					<dd class="text-gray-200">{formatDate(health.lastRunCycle.startedAt)}</dd>
 				</div>
 			{/if}
 			{#if health.lastReconcileCycle}
 				<div class="flex gap-2">
 					<dt class="text-gray-400">Last reconcile:</dt>
-					<dd class="text-gray-200">{formatDate(health.lastReconcileCycle)}</dd>
+					<dd class="text-gray-200">{formatDate(health.lastReconcileCycle.startedAt)}</dd>
 				</div>
 			{/if}
 		</dl>
@@ -91,5 +95,7 @@
 		<a href="/candidates" class="text-blue-400 hover:underline">View Candidates</a>
 		<a href="/config" class="text-blue-400 hover:underline">View Config</a>
 	</nav>
+{:else}
+	<p class="mt-4 text-gray-400">Loading…</p>
 {/if}
 

--- a/web/src/routes/dashboard.test.ts
+++ b/web/src/routes/dashboard.test.ts
@@ -6,8 +6,8 @@ import type { DaemonHealth, RunSummaryRecord } from '$lib/types';
 const mockHealth: DaemonHealth = {
 	uptime: 3661000,
 	startedAt: '2024-01-01T00:00:00Z',
-	lastRunCycle: '2024-01-01T01:00:00Z',
-	lastReconcileCycle: '2024-01-01T01:00:30Z',
+	lastRunCycle: { status: 'completed', startedAt: '2024-01-01T01:00:00Z' },
+	lastReconcileCycle: { status: 'completed', startedAt: '2024-01-01T01:00:30Z' },
 };
 
 const mockRun: RunSummaryRecord = {

--- a/web/src/routes/dashboard.test.ts
+++ b/web/src/routes/dashboard.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Page from './+page.svelte';
+import type { DaemonHealth, RunSummaryRecord } from '$lib/types';
+
+const mockHealth: DaemonHealth = {
+	uptime: 3661000,
+	startedAt: '2024-01-01T00:00:00Z',
+	lastRunCycle: '2024-01-01T01:00:00Z',
+	lastReconcileCycle: '2024-01-01T01:00:30Z',
+};
+
+const mockRun: RunSummaryRecord = {
+	id: 42,
+	startedAt: '2024-01-01T01:00:00Z',
+	status: 'completed',
+	completedAt: '2024-01-01T01:01:00Z',
+	counts: {
+		queued: 3,
+		failed: 0,
+		skipped_duplicate: 1,
+		skipped_no_match: 5,
+	},
+};
+
+describe('/', () => {
+	it('renders daemon summary and run table with mock data', () => {
+		render(Page, { data: { health: mockHealth, runs: [mockRun], error: null } });
+		expect(screen.getByRole('heading', { name: 'Daemon' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Recent Runs' })).toBeInTheDocument();
+		// uptime: 3661000ms = 1h 1m 1s
+		expect(screen.getByText('1h 1m 1s')).toBeInTheDocument();
+		// run ID appears in table
+		expect(screen.getByText('42')).toBeInTheDocument();
+		// nav links present
+		expect(screen.getByRole('link', { name: 'View Candidates' })).toHaveAttribute(
+			'href',
+			'/candidates',
+		);
+		expect(screen.getByRole('link', { name: 'View Config' })).toHaveAttribute('href', '/config');
+	});
+
+	it('renders error state when API is unreachable', () => {
+		render(Page, { data: { health: null, runs: [], error: 'Could not reach the API.' } });
+		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
+	});
+});


### PR DESCRIPTION
## Summary

- delivery ticket: `P10.05 Dashboard Home`
- ticket file: `docs/02-delivery/phase-10/ticket-05-dashboard-home.md`
- stacked base branch: `agents/p10-04-config-view`
- internal review: completed at `2026-04-08T09:43:42.312Z`

## External AI Review

- outcome: `patched`
- reviewed commit: `6cda740e1a5f`
- current branch head: `7c4deede628e`
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Actions Taken

- `7c4deede628e` [coderabbit,greptile] fix: P10.05 review patches — CycleSnapshot type, UTC formatDate, else fallback [P10.05]
