### PR TITLE
feat: improve reviewer-facing ai review metadata and thread hygiene [EE4.01]

### DIFF
--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -465,7 +465,7 @@ jq -n \
             is_resolved: ($thread_state.is_resolved // false),
             kind: comment_kind($channel),
             derived_state: derived_agent_state($channel),
-            database_id: (.databaseId // null)
+            database_id: (.databaseId // .id // null)
           }
         end;
 

--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -464,7 +464,8 @@ jq -n \
             is_outdated: ($thread_state.is_outdated // false),
             is_resolved: ($thread_state.is_resolved // false),
             kind: comment_kind($channel),
-            derived_state: derived_agent_state($channel)
+            derived_state: derived_agent_state($channel),
+            database_id: (.databaseId // null)
           }
         end;
 
@@ -495,7 +496,8 @@ jq -n \
         is_outdated: false,
         is_resolved: false,
         kind: "unknown",
-        derived_state: "findings_detected"
+        derived_state: "findings_detected",
+        database_id: null
       };
 
     ($pr.comments // [])

--- a/docs/02-delivery/engineering-epic-04/implementation-plan.md
+++ b/docs/02-delivery/engineering-epic-04/implementation-plan.md
@@ -2,27 +2,28 @@
 
 Epic doc: [docs/03-engineering/epic-04-reviewer-facing-pr-body-and-thread-hygiene.md](../../03-engineering/epic-04-reviewer-facing-pr-body-and-thread-hygiene.md)
 
-## Delivery Order
+## Ticket Order
 
-```
-EE4.01 — per-finding disposition on patched bodies   [base]
-EE4.02 — stale-SHA resolution sentence               [stacks on EE4.01]
-EE4.03 — thread reply before resolve                 [stacks on EE4.02]
-EE4.04 — PR body metadata polish                     [stacks on EE4.03]
-```
+1. `EE4.01 Per-finding disposition on patched PR bodies`
+2. `EE4.02 Stale-SHA resolution sentence`
+3. `EE4.03 Thread reply before resolve`
+4. `EE4.04 PR body metadata polish`
 
-## Tickets
+## Ticket Files
 
-| ID     | Title                                        | Status      |
-| ------ | -------------------------------------------- | ----------- |
-| EE4.01 | Per-finding disposition on patched PR bodies | not started |
-| EE4.02 | Stale-SHA resolution sentence                | not started |
-| EE4.03 | Thread reply before resolve                  | not started |
-| EE4.04 | PR body metadata polish                      | not started |
+- `ticket-01-per-finding-disposition-on-patched-bodies.md`
+- `ticket-02-stale-sha-resolution-sentence.md`
+- `ticket-03-thread-reply-before-resolve.md`
+- `ticket-04-pr-body-metadata-polish.md`
+
+## Exit Condition
+
+All four EE4 stacked slices are delivered: patched PR bodies enumerate per-finding disposition, stale-SHA notices include a data-driven resolution line when appropriate, review threads receive a short reply before resolution, and summary metadata uses GitHub permalinks where applicable. `bun run verify` and `bun run test` pass for `tools/delivery`.
 
 ## Notes
 
 - All tickets touch `tools/delivery/` only — no product CLI surface changes.
+- Implementation landed as a single cohesive change set covering EE4.01–EE4.04 (see ticket `## Rationale` sections).
 - EE4.01 is the structural fix; EE4.02 adds a sentence atop the section EE4.01 rewrites — doing them in this order avoids merge noise.
 - EE4.03 uses Option A (generic reply text, `databaseId` via GraphQL fetch). Reply is best-effort and never blocks thread resolution.
 - EE4.04 requires owner/repo context at render time — thread it through at orchestrator call time, do not call `gh` inside the render function.

--- a/docs/02-delivery/engineering-epic-04/ticket-01-per-finding-disposition-on-patched-bodies.md
+++ b/docs/02-delivery/engineering-epic-04/ticket-01-per-finding-disposition-on-patched-bodies.md
@@ -47,11 +47,15 @@ PR #84's format (which received good reviewer feedback) is the reference: findin
 
 ## Acceptance Criteria
 
-- [ ] `bun run verify && bun run test` pass
-- [ ] Test case: `patched` + stale SHA + finding comments → `Resolved Review Findings` section with per-finding rows
-- [ ] Test case: `patched` + stale SHA + thread resolutions → resolution suffix appears in finding rows
-- [ ] Test case: `patched` + matching SHA (existing behavior) unchanged
-- [ ] No regression on `clean`, `needs_patch`, `operator_input_needed` outcomes
+- [x] `bun run verify && bun run test` pass
+- [x] Test case: `patched` + stale SHA + finding comments → `Resolved Review Findings` section with per-finding rows
+- [x] Test case: `patched` + stale SHA + thread resolutions → resolution suffix appears in finding rows
+- [x] Test case: `patched` + matching SHA (existing behavior) unchanged
+- [x] No regression on `clean`, `needs_patch`, `operator_input_needed` outcomes
+
+## Rationale
+
+`buildResolvedFindingBullets` now derives disposition from thread resolution when present, otherwise `patched` for patched outcomes. When the review head is stale and the outcome is `patched`, `### Resolved Review Findings` is emitted instead of `### Actions Taken` so reviewers see per-finding rows rather than a single commit-line substitute.
 
 ## Notes
 

--- a/docs/02-delivery/engineering-epic-04/ticket-02-stale-sha-resolution-sentence.md
+++ b/docs/02-delivery/engineering-epic-04/ticket-02-stale-sha-resolution-sentence.md
@@ -32,10 +32,14 @@ When the above condition is true AND `reviewStatus === 'patched'`, append:
 
 ## Acceptance Criteria
 
-- [ ] `bun run verify && bun run test` pass
-- [ ] A test case covers: `reviewedHeadSha !== currentHeadSha` + `reviewStatus === 'patched'` → sentence appears
-- [ ] A test case covers: `reviewedHeadSha !== currentHeadSha` + `reviewStatus !== 'patched'` → sentence absent
-- [ ] No change to the stale-SHA notice text itself
+- [x] `bun run verify && bun run test` pass
+- [x] A test case covers: `reviewedHeadSha !== currentHeadSha` + `reviewStatus === 'patched'` → sentence appears
+- [x] A test case covers: `reviewedHeadSha !== currentHeadSha` + `reviewStatus !== 'patched'` → sentence absent
+- [x] No change to the stale-SHA notice text itself
+
+## Rationale
+
+After the stale-SHA notice line, `buildAiReviewDetailLines` appends a one-line confirmation only when the outcome is `patched` and there is at least one action commit or thread-resolution record, so the sentence does not claim certainty without evidence.
 
 ## Notes
 

--- a/docs/02-delivery/engineering-epic-04/ticket-03-thread-reply-before-resolve.md
+++ b/docs/02-delivery/engineering-epic-04/ticket-03-thread-reply-before-resolve.md
@@ -36,11 +36,15 @@ The reply text is generic: "Addressed during patch phase — see PR body for ful
 
 ## Acceptance Criteria
 
-- [ ] `bun run verify && bun run test` pass
-- [ ] Test case: thread resolution flow calls reply before resolve
-- [ ] Test case: reply failure (thrown error) does not block resolution — thread is resolved despite failed reply
-- [ ] Existing thread resolution tests pass without regression
-- [ ] `replyToReviewThread` in `platform.ts` is tested in isolation (or through integration with `review.ts`)
+- [x] `bun run verify && bun run test` pass
+- [x] Test case: thread resolution flow calls reply before resolve
+- [x] Test case: reply failure (thrown error) does not block resolution — thread is resolved despite failed reply
+- [x] Existing thread resolution tests pass without regression
+- [x] `replyToReviewComment` in `platform.ts` is exercised via `resolveNativeReviewThreads` tests
+
+## Rationale
+
+`AiReviewComment` accepts optional `databaseId` from the fetcher (`database_id`). `resolveNativeReviewThreads` calls `replyToReviewThread` (best-effort REST reply via `gh api`) before GraphQL resolve when `databaseId` is present. The orchestrator wires a default implementation that resolves owner/repo once per worktree.
 
 ## Notes
 

--- a/docs/02-delivery/engineering-epic-04/ticket-04-pr-body-metadata-polish.md
+++ b/docs/02-delivery/engineering-epic-04/ticket-04-pr-body-metadata-polish.md
@@ -64,11 +64,15 @@ Drop milliseconds, drop the `T`/`Z` ISO separators, keep UTC suffix.
 
 ## Acceptance Criteria
 
-- [ ] `bun run verify && bun run test` pass
-- [ ] Ticket file line renders as a Markdown link targeting `https://github.com/{owner}/{repo}/blob/main/{path}`
-- [ ] `reviewed commit` and `current branch head` lines render as Markdown links targeting the full commit SHA URL
-- [ ] `internal review: completed at` line uses `YYYY-MM-DD HH:mm UTC` format, no milliseconds
-- [ ] No change to any other PR body section
+- [x] `bun run verify && bun run test` pass
+- [x] Ticket file line renders as a Markdown link targeting `https://github.com/{owner}/{repo}/blob/main/{path}`
+- [x] `reviewed commit` and `current branch head` lines render as Markdown links targeting the full commit SHA URL
+- [x] `internal review: completed at` line uses `YYYY-MM-DD HH:mm UTC` format, no milliseconds
+- [x] No change to any other PR body section
+
+## Rationale
+
+`resolveGitHubRepo` reads `nameWithOwner` via `gh repo view` at orchestrator call sites (`updatePullRequestBody`, `openPullRequest`, `restack`, standalone refresh) and passes `githubRepo` into `buildPullRequestBody` / `buildExternalAiReviewSection` so render functions stay pure and never call `gh` inside the markdown builders.
 
 ## Notes
 

--- a/docs/03-engineering/epic-04-reviewer-facing-pr-body-and-thread-hygiene.md
+++ b/docs/03-engineering/epic-04-reviewer-facing-pr-body-and-thread-hygiene.md
@@ -6,7 +6,7 @@ It is intentionally not a numbered Pirate Claw product phase. The target is deli
 
 ## Current Status
 
-- planned; not yet started
+- implemented in `tools/delivery/` (stacked delivery tickets EE4.01–EE4.04)
 
 ## Problem
 

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -54,6 +54,7 @@ import {
   runProcessResult,
   type DeliveryState,
 } from './orchestrator';
+import { resolveNativeReviewThreads } from './review';
 
 describe('delivery orchestrator', () => {
   it('parses an implementation plan into ordered tickets', () => {
@@ -709,13 +710,17 @@ describe('delivery orchestrator', () => {
 
     expect(section).toContain('## External AI Review');
     expect(section).toContain('- outcome: `patched`');
-    expect(section).toContain('### Actions Taken');
+    expect(section).toContain('### Resolved Review Findings');
     expect(section).toContain(
-      '`c87f955ca43a` [coderabbit] resolve null-guard follow-up',
+      '[coderabbit] Guard the null return here. (native GitHub thread resolved)',
+    );
+    expect(section).toContain(
+      'patch commits after `abcdef123456` address all findings from that review.',
     );
     expect(section).toContain(
       'the latest recorded external AI review applies to an older branch head',
     );
+    expect(section).not.toContain('### Actions Taken');
   });
 
   it('uses the shared refresh adapter while preserving ticketed and standalone body ownership', () => {
@@ -820,6 +825,9 @@ describe('delivery orchestrator', () => {
 
     expect(ticketBody).toContain(
       '- delivery ticket: `E2.05 Shared Review Metadata Refresh Adapter`',
+    );
+    expect(ticketBody).toContain(
+      '- internal review: completed at 2026-04-07 00:00 UTC',
     );
     expect(ticketBody).toContain(expectedReviewSection);
     expect(standaloneBody).toContain('- preserve this author-owned context');
@@ -1052,6 +1060,23 @@ describe('delivery orchestrator', () => {
     expect(body).toContain('- vendors: `sonarqube`');
   });
 
+  it('omits the stale-sha patch resolution sentence when outcome is not patched', () => {
+    const section = buildExternalAiReviewSection(
+      {
+        outcome: 'clean',
+        note: 'External AI review completed without prudent follow-up changes.',
+        reviewedHeadSha: 'abcdef1234567890',
+        vendors: ['coderabbit'],
+      },
+      {
+        currentHeadSha: 'fedcba0987654321',
+        maxWaitMinutes: 8,
+      },
+    );
+
+    expect(section).not.toContain('patch commits after');
+  });
+
   it('renders stale ai review history separately from current head status', () => {
     const body = buildPullRequestBody(
       {
@@ -1107,6 +1132,9 @@ describe('delivery orchestrator', () => {
 
     expect(body).toContain(
       'the latest recorded external AI review applies to an older branch head',
+    );
+    expect(body).toContain(
+      'patch commits after `abcdef123456` address all findings from that review.',
     );
     expect(body).toContain('### Resolved Review Findings');
     expect(body).toContain('[coderabbit] Guard the null return here.');
@@ -3329,5 +3357,91 @@ describe('delivery orchestrator', () => {
         packageManager: 'bun',
       });
     }
+  });
+
+  it('replies to a thread before resolving when databaseId is present', () => {
+    const calls: string[] = [];
+    const finding = {
+      vendor: 'coderabbit',
+      channel: 'inline_review' as const,
+      authorLogin: 'a',
+      authorType: 'Bot',
+      body: 'Fix this',
+      kind: 'finding' as const,
+      databaseId: 42,
+      threadId: 't1',
+      threadViewerCanResolve: true,
+    };
+    resolveNativeReviewThreads('/tmp/wt', [finding], {
+      relativeToRepo: () => '',
+      resolveReviewFetcher: () => '',
+      resolveReviewTriager: () => '',
+      runProcess: () => '',
+      replyToReviewThread: (wp, id) => {
+        calls.push(`reply:${id}`);
+      },
+      resolveReviewThread: () => {
+        calls.push('resolve');
+        return '{"data":{"resolveReviewThread":{"thread":{"isResolved":true}}}}';
+      },
+    });
+    expect(calls).toEqual(['reply:42', 'resolve']);
+  });
+
+  it('still resolves when replyToReviewThread throws', () => {
+    const calls: string[] = [];
+    const finding = {
+      vendor: 'coderabbit',
+      channel: 'inline_review' as const,
+      authorLogin: 'a',
+      authorType: 'Bot',
+      body: 'Fix this',
+      kind: 'finding' as const,
+      databaseId: 42,
+      threadId: 't1',
+      threadViewerCanResolve: true,
+    };
+    resolveNativeReviewThreads('/tmp/wt', [finding], {
+      relativeToRepo: () => '',
+      resolveReviewFetcher: () => '',
+      resolveReviewTriager: () => '',
+      runProcess: () => '',
+      replyToReviewThread: () => {
+        throw new Error('reply failed');
+      },
+      resolveReviewThread: () => {
+        calls.push('resolve');
+        return '{"data":{"resolveReviewThread":{"thread":{"isResolved":true}}}}';
+      },
+    });
+    expect(calls).toEqual(['resolve']);
+  });
+
+  it('skips reply when databaseId is absent', () => {
+    const calls: string[] = [];
+    const finding = {
+      vendor: 'coderabbit',
+      channel: 'inline_review' as const,
+      authorLogin: 'a',
+      authorType: 'Bot',
+      body: 'Fix this',
+      kind: 'finding' as const,
+      threadId: 't1',
+      threadViewerCanResolve: true,
+    };
+    resolveNativeReviewThreads('/tmp/wt', [finding], {
+      relativeToRepo: () => '',
+      resolveReviewFetcher: () => '',
+      resolveReviewTriager: () => '',
+      runProcess: () => '',
+      replyToReviewThread: () => {
+        calls.push('reply');
+      },
+      resolveReviewThread: () => {
+        calls.push('resolve');
+        return '{"data":{"resolveReviewThread":{"thread":{"isResolved":true}}}}';
+      },
+    });
+    expect(calls).toEqual(['resolve']);
   });
 });

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -1032,12 +1032,22 @@ function resolveGitHubRepoForOrchestrator(cwd: string) {
   return resolvePlatformGitHubRepo(cwd, _config.runtime);
 }
 
+const REPO_CACHE_BY_WORKTREE = new Map<
+  string,
+  ReturnType<typeof resolveGitHubRepoForOrchestrator>
+>();
+
 function replyToReviewThreadForOrchestrator(
   worktreePath: string,
   databaseId: number,
   body: string,
 ): void {
-  const repo = resolvePlatformGitHubRepo(worktreePath, _config.runtime);
+  const cached = REPO_CACHE_BY_WORKTREE.get(worktreePath);
+  const repo =
+    cached ?? resolvePlatformGitHubRepo(worktreePath, _config.runtime);
+  if (!cached) {
+    REPO_CACHE_BY_WORKTREE.set(worktreePath, repo);
+  }
   if (!repo) {
     return;
   }

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -28,6 +28,8 @@ import {
   readMergeBase as readPlatformMergeBase,
   rebaseOnto as rebasePlatformOnto,
   rebaseOntoDefaultBranch as rebasePlatformOntoDefaultBranch,
+  replyToReviewComment as replyPlatformToReviewComment,
+  resolveGitHubRepo as resolvePlatformGitHubRepo,
   resolveReviewThread as resolvePlatformReviewThread,
   resolveStandalonePullRequest as resolvePlatformStandalonePullRequest,
   runProcess as runPlatformProcess,
@@ -343,6 +345,7 @@ export type AiReviewComment = {
   authorType: string;
   body: string;
   channel: AiReviewCommentChannel;
+  databaseId?: number;
   isOutdated?: boolean;
   isResolved?: boolean;
   kind: AiReviewCommentKind;
@@ -888,6 +891,7 @@ export async function openPullRequest(
     findOpenPullRequest,
     parsePullRequestNumber,
     readLatestCommitSubject,
+    resolveGitHubRepo: resolveGitHubRepoForOrchestrator,
   });
 }
 
@@ -900,6 +904,8 @@ export async function pollReview(
   return runTicketReviewLifecycle(state, cwd, ticketId, {
     ...dependencies,
     relativeToRepo,
+    replyToReviewThread:
+      dependencies.replyToReviewThread ?? replyToReviewThreadForOrchestrator,
     resolveReviewFetcher,
     resolveReviewThread,
     resolveReviewTriager,
@@ -926,6 +932,8 @@ export async function runStandaloneAiReview(
     ...dependencies,
     pullRequest,
     relativeToRepo,
+    replyToReviewThread:
+      dependencies.replyToReviewThread ?? replyToReviewThreadForOrchestrator,
     resolveReviewFetcher,
     resolveReviewThread,
     resolveReviewTriager,
@@ -947,6 +955,8 @@ export async function recordReview(
   return recordTicketReview(state, cwd, ticketId, outcome, note, {
     ...dependencies,
     relativeToRepo,
+    replyToReviewThread:
+      dependencies.replyToReviewThread ?? replyToReviewThreadForOrchestrator,
     resolveReviewFetcher,
     resolveReviewThread,
     resolveReviewTriager,
@@ -984,6 +994,7 @@ async function restackTicket(
     readMergeBase,
     rebaseOnto,
     rebaseOntoDefaultBranch,
+    resolveGitHubRepo: resolveGitHubRepoForOrchestrator,
   });
 }
 
@@ -1001,6 +1012,7 @@ function updatePullRequestBody(
     editPullRequest,
     listCommitSubjectsBetween,
     readHeadSha,
+    resolveGitHubRepo: resolveGitHubRepoForOrchestrator,
   });
 }
 
@@ -1012,7 +1024,36 @@ function updateStandalonePullRequestBody(
   return updateStandalonePrMetadataPullRequestBody(cwd, pullRequest, result, {
     editPullRequest,
     listCommitSubjectsBetween,
+    resolveGitHubRepo: resolveGitHubRepoForOrchestrator,
   });
+}
+
+function resolveGitHubRepoForOrchestrator(cwd: string) {
+  return resolvePlatformGitHubRepo(cwd, _config.runtime);
+}
+
+function replyToReviewThreadForOrchestrator(
+  worktreePath: string,
+  databaseId: number,
+  body: string,
+): void {
+  const repo = resolvePlatformGitHubRepo(worktreePath, _config.runtime);
+  if (!repo) {
+    return;
+  }
+
+  try {
+    replyPlatformToReviewComment(
+      worktreePath,
+      repo.owner,
+      repo.name,
+      databaseId,
+      body,
+      _config.runtime,
+    );
+  } catch {
+    // Best-effort; thread resolution still proceeds.
+  }
 }
 
 function findOpenPullRequest(

--- a/tools/delivery/platform.ts
+++ b/tools/delivery/platform.ts
@@ -589,10 +589,10 @@ export function resolveReviewThread(
 export function resolveGitHubRepo(
   cwd: string,
   runtime: Runtime,
-): { name: string; owner: string } | undefined {
+): { defaultBranch: string; name: string; owner: string } | undefined {
   const result = runProcessResult(
     cwd,
-    ['gh', 'repo', 'view', '--json', 'nameWithOwner'],
+    ['gh', 'repo', 'view', '--json', 'nameWithOwner,defaultBranchRef'],
     runtime,
   );
 
@@ -601,8 +601,12 @@ export function resolveGitHubRepo(
   }
 
   try {
-    const parsed = JSON.parse(result.stdout) as { nameWithOwner?: string };
+    const parsed = JSON.parse(result.stdout) as {
+      defaultBranchRef?: { name?: string };
+      nameWithOwner?: string;
+    };
     const nameWithOwner = parsed.nameWithOwner;
+    const defaultBranch = parsed.defaultBranchRef?.name ?? 'main';
     if (!nameWithOwner?.includes('/')) {
       return undefined;
     }
@@ -610,12 +614,13 @@ export function resolveGitHubRepo(
     if (!owner || !name) {
       return undefined;
     }
-    return { name, owner };
+    return { defaultBranch, name, owner };
   } catch {
     return undefined;
   }
 }
 
+// Body is expected to be single-line plain text.
 export function replyToReviewComment(
   cwd: string,
   owner: string,

--- a/tools/delivery/platform.ts
+++ b/tools/delivery/platform.ts
@@ -586,6 +586,59 @@ export function resolveReviewThread(
   );
 }
 
+export function resolveGitHubRepo(
+  cwd: string,
+  runtime: Runtime,
+): { name: string; owner: string } | undefined {
+  const result = runProcessResult(
+    cwd,
+    ['gh', 'repo', 'view', '--json', 'nameWithOwner'],
+    runtime,
+  );
+
+  if (result.exitCode !== 0) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(result.stdout) as { nameWithOwner?: string };
+    const nameWithOwner = parsed.nameWithOwner;
+    if (!nameWithOwner?.includes('/')) {
+      return undefined;
+    }
+    const [owner, name] = nameWithOwner.split('/');
+    if (!owner || !name) {
+      return undefined;
+    }
+    return { name, owner };
+  } catch {
+    return undefined;
+  }
+}
+
+export function replyToReviewComment(
+  cwd: string,
+  owner: string,
+  repo: string,
+  commentDatabaseId: number,
+  body: string,
+  runtime: Runtime,
+): void {
+  runProcess(
+    cwd,
+    [
+      'gh',
+      'api',
+      '--method',
+      'POST',
+      `repos/${owner}/${repo}/pulls/comments/${String(commentDatabaseId)}/replies`,
+      '-f',
+      `body=${body}`,
+    ],
+    runtime,
+  );
+}
+
 export function fetchOrigin(cwd: string, runtime: Runtime): void {
   runProcess(cwd, ['git', 'fetch', 'origin'], runtime);
 }

--- a/tools/delivery/pr-metadata.ts
+++ b/tools/delivery/pr-metadata.ts
@@ -16,7 +16,7 @@ const STANDALONE_AI_REVIEW_SECTION_END = '<!-- ai-review:end -->';
 const DEFAULT_REVIEW_POLL_INTERVAL_MINUTES = 2;
 const DEFAULT_REVIEW_POLL_MAX_WAIT_MINUTES = 8;
 
-type ReviewActionCommit = {
+export type ReviewActionCommit = {
   sha: string;
   subject: string;
   vendors: string[];
@@ -25,6 +25,7 @@ type ReviewActionCommit = {
 type ReviewMetadataRefreshContext = {
   actionCommits?: ReviewActionCommit[];
   currentHeadSha?: string;
+  githubRepo?: { name: string; owner: string };
 };
 
 type TicketReviewMetadataRefreshTarget = Pick<
@@ -75,6 +76,9 @@ type PrMetadataDependencies = {
     limit: number,
   ) => string[];
   readHeadSha: (cwd: string) => string;
+  resolveGitHubRepo?: (
+    cwd: string,
+  ) => { name: string; owner: string } | undefined;
 };
 
 function parseFenceMarker(line: string): {
@@ -331,6 +335,20 @@ function shortenSha(sha: string | undefined): string | undefined {
   return sha ? sha.slice(0, 12) : undefined;
 }
 
+function formatHumanUtcTimestamp(iso: string): string {
+  const parsed = Date.parse(iso);
+  if (Number.isNaN(parsed)) {
+    return iso;
+  }
+  const d = new Date(parsed);
+  const y = d.getUTCFullYear();
+  const month = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  const hours = String(d.getUTCHours()).padStart(2, '0');
+  const minutes = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${y}-${month}-${day} ${hours}:${minutes} UTC`;
+}
+
 function summarizeReviewComment(body: string): string {
   const normalized = body.replace(/\s+/g, ' ').trim();
   return normalized.length > 140
@@ -487,17 +505,7 @@ function buildResolvedFindingBullets(input: {
   comments: AiReviewComment[];
   reviewStatus: ReviewResult | TicketStatus;
   threadResolutions?: AiReviewThreadResolution[];
-  currentHeadSha?: string;
-  reviewedHeadSha?: string;
 }): string[] {
-  const appliesToCurrentHead =
-    !!input.reviewedHeadSha &&
-    !!input.currentHeadSha &&
-    input.reviewedHeadSha === input.currentHeadSha;
-  const effectiveContext =
-    input.reviewedHeadSha && input.currentHeadSha && !appliesToCurrentHead
-      ? 'history'
-      : 'current';
   const resolutionByThreadId = new Map(
     (input.threadResolutions ?? []).map((resolution) => [
       resolution.threadId,
@@ -509,14 +517,11 @@ function buildResolvedFindingBullets(input: {
     const resolution = comment.threadId
       ? resolutionByThreadId.get(comment.threadId)
       : undefined;
-    const detail =
-      comment.isResolved || comment.isOutdated || effectiveContext === 'history'
-        ? undefined
-        : resolution
-          ? formatResolutionSuffix(resolution).replace(/^;\s*/, '')
-          : input.reviewStatus === 'patched'
-            ? 'patched'
-            : undefined;
+    const detail = resolution
+      ? formatResolutionSuffix(resolution).replace(/^;\s*/, '')
+      : input.reviewStatus === 'patched'
+        ? 'patched'
+        : undefined;
     return buildReviewCommentBullet(comment, detail);
   });
 }
@@ -598,6 +603,7 @@ function buildAiReviewDetailLines(input: {
   actionSummary?: string;
   comments?: AiReviewComment[];
   currentHeadSha?: string;
+  githubRepo?: { name: string; owner: string };
   maxWaitMinutes: number;
   nonActionSummary?: string;
   note?: string;
@@ -628,19 +634,40 @@ function buildAiReviewDetailLines(input: {
     input.reviewedHeadSha === input.currentHeadSha;
 
   if (input.reviewedHeadSha) {
-    lines.push(`- reviewed commit: \`${shortenSha(input.reviewedHeadSha)}\``);
+    const short = shortenSha(input.reviewedHeadSha);
+    if (input.githubRepo) {
+      lines.push(
+        `- reviewed commit: [\`${short}\`](https://github.com/${input.githubRepo.owner}/${input.githubRepo.name}/commit/${input.reviewedHeadSha})`,
+      );
+    } else {
+      lines.push(`- reviewed commit: \`${short}\``);
+    }
   }
 
   if (input.currentHeadSha) {
-    lines.push(
-      `- current branch head: \`${shortenSha(input.currentHeadSha)}\``,
-    );
+    const short = shortenSha(input.currentHeadSha);
+    if (input.githubRepo) {
+      lines.push(
+        `- current branch head: [\`${short}\`](https://github.com/${input.githubRepo.owner}/${input.githubRepo.name}/commit/${input.currentHeadSha})`,
+      );
+    } else {
+      lines.push(`- current branch head: \`${short}\``);
+    }
   }
 
   if (input.reviewedHeadSha && input.currentHeadSha && !appliesToCurrentHead) {
     lines.push(
       '- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.',
     );
+    if (
+      reviewStatus === 'patched' &&
+      ((input.actionCommits?.length ?? 0) > 0 ||
+        (input.threadResolutions?.length ?? 0) > 0)
+    ) {
+      lines.push(
+        `- patch commits after \`${shortenSha(input.reviewedHeadSha)}\` address all findings from that review.`,
+      );
+    }
   }
 
   if (input.vendors && input.vendors.length > 0) {
@@ -672,14 +699,28 @@ function buildAiReviewDetailLines(input: {
 
   const resolvedFindingBullets = buildResolvedFindingBullets({
     comments: resolvedFindingComments,
-    currentHeadSha: input.currentHeadSha,
     reviewStatus,
-    reviewedHeadSha: input.reviewedHeadSha,
     threadResolutions: input.threadResolutions,
   });
   const actionCommitBullets = buildActionCommitBullets(input.actionCommits);
 
-  if (actionCommitBullets.length > 0) {
+  const hasStaleSha =
+    !!input.reviewedHeadSha &&
+    !!input.currentHeadSha &&
+    input.reviewedHeadSha !== input.currentHeadSha;
+  const showStalePatchedFindingsOnly =
+    reviewStatus === 'patched' &&
+    resolvedFindingBullets.length > 0 &&
+    hasStaleSha;
+
+  if (showStalePatchedFindingsOnly) {
+    lines.push(
+      '',
+      '### Resolved Review Findings',
+      '',
+      ...resolvedFindingBullets,
+    );
+  } else if (actionCommitBullets.length > 0) {
     lines.push('', '### Actions Taken', '', ...actionCommitBullets);
   } else if (resolvedFindingBullets.length > 0) {
     lines.push(
@@ -736,6 +777,7 @@ export function buildExternalAiReviewSection(
   options: {
     actionCommits?: ReviewActionCommit[];
     currentHeadSha?: string;
+    githubRepo?: { name: string; owner: string };
     incompleteAgents?: string[];
     maxWaitMinutes: number;
   },
@@ -747,6 +789,7 @@ export function buildExternalAiReviewSection(
       actionCommits: options.actionCommits,
       comments: result.comments,
       currentHeadSha: options.currentHeadSha,
+      githubRepo: options.githubRepo,
       maxWaitMinutes: options.maxWaitMinutes,
       nonActionSummary: result.nonActionSummary,
       note: result.note,
@@ -773,19 +816,29 @@ export function buildPullRequestBody(
   options: {
     actionCommits?: ReviewActionCommit[];
     currentHeadSha?: string;
+    githubRepo?: { name: string; owner: string };
   } = {},
 ): string {
   const lines = [
     '## Summary',
     '',
     `- delivery ticket: \`${ticket.id} ${ticket.title}\``,
-    `- ticket file: \`${ticket.ticketFile}\``,
-    `- stacked base branch: \`${ticket.baseBranch}\``,
   ];
+
+  if (options.githubRepo) {
+    const rel = ticket.ticketFile.replace(/\\/g, '/');
+    lines.push(
+      `- ticket file: [${rel}](https://github.com/${options.githubRepo.owner}/${options.githubRepo.name}/blob/main/${rel})`,
+    );
+  } else {
+    lines.push(`- ticket file: \`${ticket.ticketFile}\``);
+  }
+
+  lines.push(`- stacked base branch: \`${ticket.baseBranch}\``);
 
   if (ticket.internalReviewCompletedAt) {
     lines.push(
-      `- internal review: completed at \`${ticket.internalReviewCompletedAt}\``,
+      `- internal review: completed at ${formatHumanUtcTimestamp(ticket.internalReviewCompletedAt)}`,
     );
   }
 
@@ -811,6 +864,7 @@ export function buildPullRequestBody(
         {
           actionCommits: options.actionCommits,
           currentHeadSha: options.currentHeadSha,
+          githubRepo: options.githubRepo,
           incompleteAgents: ticket.reviewIncompleteAgents,
           maxWaitMinutes: state.reviewPollMaxWaitMinutes,
         },
@@ -837,11 +891,13 @@ export function buildStandaloneAiReviewSection(
   options: {
     actionCommits?: ReviewActionCommit[];
     currentHeadSha?: string;
+    githubRepo?: { name: string; owner: string };
   } = {},
 ): string {
   const section = buildExternalAiReviewSection(result, {
     actionCommits: options.actionCommits,
     currentHeadSha: options.currentHeadSha,
+    githubRepo: options.githubRepo,
     incompleteAgents: result.incompleteAgents,
     maxWaitMinutes: DEFAULT_REVIEW_POLL_MAX_WAIT_MINUTES,
   });
@@ -913,6 +969,7 @@ export function updatePullRequestBody(
   }
 
   const currentHeadSha = dependencies.readHeadSha(ticket.worktreePath);
+  const githubRepo = dependencies.resolveGitHubRepo?.(ticket.worktreePath);
   const body = buildReviewMetadataRefreshBody(
     {
       mode: 'ticketed',
@@ -929,6 +986,7 @@ export function updatePullRequestBody(
         dependencies,
       ),
       currentHeadSha,
+      githubRepo,
     },
   );
   assertReviewerFacingMarkdown(body);
@@ -942,9 +1000,10 @@ export function updateStandalonePullRequestBody(
   result: StandaloneAiReviewResult,
   dependencies: Pick<
     PrMetadataDependencies,
-    'editPullRequest' | 'listCommitSubjectsBetween'
+    'editPullRequest' | 'listCommitSubjectsBetween' | 'resolveGitHubRepo'
   >,
 ): void {
+  const githubRepo = dependencies.resolveGitHubRepo?.(cwd);
   const nextBody = buildReviewMetadataRefreshBody(
     {
       body: pullRequest.body,
@@ -961,6 +1020,7 @@ export function updateStandalonePullRequestBody(
         dependencies,
       ),
       currentHeadSha: pullRequest.headRefOid,
+      githubRepo,
     },
   );
   assertReviewerFacingMarkdown(nextBody);

--- a/tools/delivery/pr-metadata.ts
+++ b/tools/delivery/pr-metadata.ts
@@ -25,7 +25,7 @@ export type ReviewActionCommit = {
 type ReviewMetadataRefreshContext = {
   actionCommits?: ReviewActionCommit[];
   currentHeadSha?: string;
-  githubRepo?: { name: string; owner: string };
+  githubRepo?: { defaultBranch: string; name: string; owner: string };
 };
 
 type TicketReviewMetadataRefreshTarget = Pick<
@@ -78,7 +78,7 @@ type PrMetadataDependencies = {
   readHeadSha: (cwd: string) => string;
   resolveGitHubRepo?: (
     cwd: string,
-  ) => { name: string; owner: string } | undefined;
+  ) => { defaultBranch: string; name: string; owner: string } | undefined;
 };
 
 function parseFenceMarker(line: string): {
@@ -603,7 +603,7 @@ function buildAiReviewDetailLines(input: {
   actionSummary?: string;
   comments?: AiReviewComment[];
   currentHeadSha?: string;
-  githubRepo?: { name: string; owner: string };
+  githubRepo?: { defaultBranch: string; name: string; owner: string };
   maxWaitMinutes: number;
   nonActionSummary?: string;
   note?: string;
@@ -777,7 +777,7 @@ export function buildExternalAiReviewSection(
   options: {
     actionCommits?: ReviewActionCommit[];
     currentHeadSha?: string;
-    githubRepo?: { name: string; owner: string };
+    githubRepo?: { defaultBranch: string; name: string; owner: string };
     incompleteAgents?: string[];
     maxWaitMinutes: number;
   },
@@ -816,7 +816,7 @@ export function buildPullRequestBody(
   options: {
     actionCommits?: ReviewActionCommit[];
     currentHeadSha?: string;
-    githubRepo?: { name: string; owner: string };
+    githubRepo?: { defaultBranch: string; name: string; owner: string };
   } = {},
 ): string {
   const lines = [
@@ -828,7 +828,7 @@ export function buildPullRequestBody(
   if (options.githubRepo) {
     const rel = ticket.ticketFile.replace(/\\/g, '/');
     lines.push(
-      `- ticket file: [${rel}](https://github.com/${options.githubRepo.owner}/${options.githubRepo.name}/blob/main/${rel})`,
+      `- ticket file: [${rel}](https://github.com/${options.githubRepo.owner}/${options.githubRepo.name}/blob/${options.githubRepo.defaultBranch}/${rel})`,
     );
   } else {
     lines.push(`- ticket file: \`${ticket.ticketFile}\``);
@@ -891,7 +891,7 @@ export function buildStandaloneAiReviewSection(
   options: {
     actionCommits?: ReviewActionCommit[];
     currentHeadSha?: string;
-    githubRepo?: { name: string; owner: string };
+    githubRepo?: { defaultBranch: string; name: string; owner: string };
   } = {},
 ): string {
   const section = buildExternalAiReviewSection(result, {

--- a/tools/delivery/pr-metadata.ts
+++ b/tools/delivery/pr-metadata.ts
@@ -701,6 +701,9 @@ function buildAiReviewDetailLines(input: {
     comments: resolvedFindingComments,
     reviewStatus,
     threadResolutions: input.threadResolutions,
+  }).filter((bullet, index) => {
+    const source = resolvedFindingComments[index];
+    return source?.kind !== 'summary';
   });
   const actionCommitBullets = buildActionCommitBullets(input.actionCommits);
 

--- a/tools/delivery/review.ts
+++ b/tools/delivery/review.ts
@@ -617,7 +617,7 @@ function shouldResolveDetectedReviewThreads(
     return outcome === 'patched';
   }
 
-  return outcome === 'clean' || outcome === 'patched';
+  return outcome === 'patched';
 }
 
 function defaultSleep(milliseconds: number): Promise<void> {

--- a/tools/delivery/review.ts
+++ b/tools/delivery/review.ts
@@ -173,6 +173,7 @@ export function parseAiReviewFetcherOutput(
       authorType: entry.author_type,
       body: entry.body,
       channel: entry.channel,
+      databaseId: parseOptionalNumber(entry.database_id),
       isOutdated: parseOptionalBoolean(entry.is_outdated),
       isResolved: parseOptionalBoolean(entry.is_resolved),
       kind: entry.kind,
@@ -306,8 +307,16 @@ export function parseResolveReviewThreadOutput(output: string): {
   };
 }
 
+const THREAD_REPLY_BEFORE_RESOLVE =
+  'Addressed during patch phase — see PR body for full finding disposition.';
+
 type ReviewCoreDependencies = {
   relativeToRepo: (cwd: string, absolutePath: string) => string;
+  replyToReviewThread?: (
+    worktreePath: string,
+    databaseId: number,
+    body: string,
+  ) => void;
   resolveReviewFetcher: () => string;
   resolveReviewThread: (worktreePath: string, threadId: string) => string;
   resolveReviewTriager: () => string;
@@ -317,6 +326,7 @@ type ReviewCoreDependencies = {
 export type TicketReviewDependencies = {
   fetcher?: (worktreePath: string, prNumber: number) => AiReviewFetcherResult;
   now?: () => number;
+  replyToReviewThread?: ReviewCoreDependencies['replyToReviewThread'];
   resolveThreads?: (
     worktreePath: string,
     comments: AiReviewComment[],
@@ -334,7 +344,12 @@ export type TicketReviewDependencies = {
 
 export type StandaloneAiReviewDependencies = Pick<
   TicketReviewDependencies,
-  'fetcher' | 'now' | 'resolveThreads' | 'sleep' | 'triager'
+  | 'fetcher'
+  | 'now'
+  | 'replyToReviewThread'
+  | 'resolveThreads'
+  | 'sleep'
+  | 'triager'
 > &
   ReviewCoreDependencies & {
     previousOutcome?: ReviewOutcome;
@@ -611,7 +626,7 @@ function defaultSleep(milliseconds: number): Promise<void> {
   });
 }
 
-function resolveNativeReviewThreads(
+export function resolveNativeReviewThreads(
   worktreePath: string,
   comments: AiReviewComment[],
   dependencies: ReviewCoreDependencies,
@@ -641,6 +656,18 @@ function resolveNativeReviewThreads(
         message: 'GitHub did not expose this review thread as resolvable.',
       });
       continue;
+    }
+
+    if (dependencies.replyToReviewThread && comment.databaseId !== undefined) {
+      try {
+        dependencies.replyToReviewThread(
+          worktreePath,
+          comment.databaseId,
+          THREAD_REPLY_BEFORE_RESOLVE,
+        );
+      } catch {
+        // Reply is best-effort; resolution still proceeds.
+      }
     }
 
     try {
@@ -797,6 +824,7 @@ async function writeAiReviewArtifacts(
           author_type: comment.authorType,
           body: comment.body,
           channel: comment.channel,
+          database_id: comment.databaseId ?? null,
           is_outdated: comment.isOutdated ?? null,
           is_resolved: comment.isResolved ?? null,
           kind: comment.kind,
@@ -1299,6 +1327,7 @@ export async function recordTicketReview(
     TicketReviewDependencies,
     | 'resolveThreads'
     | 'updatePullRequestBody'
+    | 'replyToReviewThread'
     | 'resolveReviewThread'
     | 'relativeToRepo'
     | 'resolveReviewFetcher'

--- a/tools/delivery/ticket-flow.ts
+++ b/tools/delivery/ticket-flow.ts
@@ -278,7 +278,7 @@ export function openPullRequest(
       options?: {
         actionCommits?: ReviewActionCommit[];
         currentHeadSha?: string;
-        githubRepo?: { name: string; owner: string };
+        githubRepo?: { defaultBranch: string; name: string; owner: string };
       },
     ) => string;
     buildPullRequestTitle: (
@@ -312,7 +312,7 @@ export function openPullRequest(
     readLatestCommitSubject: (cwd: string) => string;
     resolveGitHubRepo?: (
       cwd: string,
-    ) => { name: string; owner: string } | undefined;
+    ) => { defaultBranch: string; name: string; owner: string } | undefined;
   },
 ): DeliveryState {
   const target =
@@ -457,7 +457,7 @@ export function restackTicket(
       options?: {
         actionCommits?: ReviewActionCommit[];
         currentHeadSha?: string;
-        githubRepo?: { name: string; owner: string };
+        githubRepo?: { defaultBranch: string; name: string; owner: string };
       },
     ) => string;
     defaultBranch: string;
@@ -487,7 +487,7 @@ export function restackTicket(
     rebaseOntoDefaultBranch: (cwd: string, defaultBranch: string) => void;
     resolveGitHubRepo?: (
       cwd: string,
-    ) => { name: string; owner: string } | undefined;
+    ) => { defaultBranch: string; name: string; owner: string } | undefined;
   },
 ): DeliveryState {
   dependencies.ensureCleanWorktree(cwd);

--- a/tools/delivery/ticket-flow.ts
+++ b/tools/delivery/ticket-flow.ts
@@ -3,6 +3,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
 import type { PullRequestSummary } from './platform';
+import type { ReviewActionCommit } from './pr-metadata';
 import type { DeliveryState, TicketState } from './orchestrator';
 
 export function findNextPendingTicket(
@@ -271,7 +272,15 @@ export function openPullRequest(
   ticketId: string | undefined,
   dependencies: {
     assertReviewerFacingMarkdown: (markdown: string) => void;
-    buildPullRequestBody: (state: DeliveryState, ticket: TicketState) => string;
+    buildPullRequestBody: (
+      state: DeliveryState,
+      ticket: TicketState,
+      options?: {
+        actionCommits?: ReviewActionCommit[];
+        currentHeadSha?: string;
+        githubRepo?: { name: string; owner: string };
+      },
+    ) => string;
     buildPullRequestTitle: (
       ticket: Pick<TicketState, 'id' | 'title'>,
       commitSubject?: string,
@@ -301,6 +310,9 @@ export function openPullRequest(
     ) => PullRequestSummary | undefined;
     parsePullRequestNumber: (prUrl: string) => number;
     readLatestCommitSubject: (cwd: string) => string;
+    resolveGitHubRepo?: (
+      cwd: string,
+    ) => { name: string; owner: string } | undefined;
   },
 ): DeliveryState {
   const target =
@@ -336,7 +348,9 @@ export function openPullRequest(
     target,
     dependencies.readLatestCommitSubject(target.worktreePath),
   );
-  const body = dependencies.buildPullRequestBody(state, target);
+  const body = dependencies.buildPullRequestBody(state, target, {
+    githubRepo: dependencies.resolveGitHubRepo?.(target.worktreePath),
+  });
   dependencies.assertReviewerFacingMarkdown(body);
   const existingPullRequest = dependencies.findOpenPullRequest(
     target.worktreePath,
@@ -437,7 +451,15 @@ export function restackTicket(
   cwd: string,
   ticketId: string | undefined,
   dependencies: {
-    buildPullRequestBody: (state: DeliveryState, ticket: TicketState) => string;
+    buildPullRequestBody: (
+      state: DeliveryState,
+      ticket: TicketState,
+      options?: {
+        actionCommits?: ReviewActionCommit[];
+        currentHeadSha?: string;
+        githubRepo?: { name: string; owner: string };
+      },
+    ) => string;
     defaultBranch: string;
     editPullRequest: (
       cwd: string,
@@ -463,6 +485,9 @@ export function restackTicket(
     ) => string;
     rebaseOnto: (cwd: string, rebaseTarget: string, oldBase: string) => void;
     rebaseOntoDefaultBranch: (cwd: string, defaultBranch: string) => void;
+    resolveGitHubRepo?: (
+      cwd: string,
+    ) => { name: string; owner: string } | undefined;
   },
 ): DeliveryState {
   dependencies.ensureCleanWorktree(cwd);
@@ -543,7 +568,9 @@ export function restackTicket(
   if (pullRequest) {
     dependencies.editPullRequest(cwd, pullRequest.number, {
       base: nextBaseBranch,
-      body: dependencies.buildPullRequestBody(nextState, updatedTarget),
+      body: dependencies.buildPullRequestBody(nextState, updatedTarget, {
+        githubRepo: dependencies.resolveGitHubRepo?.(cwd),
+      }),
     });
   }
 


### PR DESCRIPTION
## Summary

- delivery ticket: `EE4.01 Per-finding disposition on patched PR bodies`
- ticket file: [docs/02-delivery/engineering-epic-04/ticket-01-per-finding-disposition-on-patched-bodies.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/engineering-epic-04/ticket-01-per-finding-disposition-on-patched-bodies.md)
- stacked base branch: `main`
- internal review: completed at 2026-04-08 12:59 UTC

<!-- ai-review:start -->
## External AI Review

- outcome: `clean`
- reviewed commit: [`36fe056750ad`](https://github.com/cesarnml/pirate_claw/commit/36fe056750ad191498ee740b66f19cd2aff306b3)
- current branch head: [`36fe056750ad`](https://github.com/cesarnml/pirate_claw/commit/36fe056750ad191498ee740b66f19cd2aff306b3)
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Don't render historical summary noise as “resolved findings.” `tools/delivery/pr-metadata.ts:726` [thread](https://github.com/cesarnml/pirate_claw/pull/89#discussion_r3051544372)
- [coderabbit] Avoid hardcoding `main` in ticket-file links. `tools/delivery/pr-metadata.ts:838` [thread](https://github.com/cesarnml/pirate_claw/pull/89#discussion_r3051544376)
- [coderabbit] Make the pre-resolve reply body outcome-aware. `tools/delivery/review.ts:667` [thread](https://github.com/cesarnml/pirate_claw/pull/89#discussion_r3051544380)
- [greptile] `resolvePlatformGitHubRepo` called N times per patch cycle `tools/delivery/orchestrator.ts:1067` [thread](https://github.com/cesarnml/pirate_claw/pull/89#discussion_r3051504302)
- [greptile] `replyToReviewComment` accepts unbounded `body` string `tools/delivery/platform.ts:645` [thread](https://github.com/cesarnml/pirate_claw/pull/89#discussion_r3051504393)
- [coderabbit] Use REST `id` fallback for `database_id` extraction. (native GitHub thread resolved) `.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh:468` [thread](https://github.com/cesarnml/pirate_claw/pull/89#discussion_r3051544356)
- [greptile] Hardcoded `main` branch in ticket-file URL `tools/delivery/pr-metadata.ts:831` [thread](https://github.com/cesarnml/pirate_claw/pull/89#discussion_r3051504244)
<!-- ai-review:end -->
