### PR TITLE
refactor: centralize stale-sha patch-evidence check [EE4.02]

### DIFF
--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -1133,7 +1133,7 @@ describe('delivery orchestrator', () => {
     expect(body).toContain(
       'the latest recorded external AI review applies to an older branch head',
     );
-    expect(body).toContain(
+    expect(body).not.toContain(
       'patch commits after `abcdef123456` address all findings from that review.',
     );
     expect(body).toContain('### Resolved Review Findings');

--- a/tools/delivery/pr-metadata.ts
+++ b/tools/delivery/pr-metadata.ts
@@ -540,10 +540,7 @@ function hasPatchEvidence(input: {
   actionCommits?: ReviewActionCommit[];
   threadResolutions?: AiReviewThreadResolution[];
 }): boolean {
-  return (
-    (input.actionCommits?.length ?? 0) > 0 ||
-    (input.threadResolutions?.length ?? 0) > 0
-  );
+  return (input.actionCommits?.length ?? 0) > 0;
 }
 
 export function assertReviewerFacingMarkdown(body: string): void {

--- a/tools/delivery/pr-metadata.ts
+++ b/tools/delivery/pr-metadata.ts
@@ -536,6 +536,16 @@ function buildActionCommitBullets(
   });
 }
 
+function hasPatchEvidence(input: {
+  actionCommits?: ReviewActionCommit[];
+  threadResolutions?: AiReviewThreadResolution[];
+}): boolean {
+  return (
+    (input.actionCommits?.length ?? 0) > 0 ||
+    (input.threadResolutions?.length ?? 0) > 0
+  );
+}
+
 export function assertReviewerFacingMarkdown(body: string): void {
   const lines = body.split('\n');
   let activeFence: { char: '`' | '~'; length: number } | undefined;
@@ -661,8 +671,10 @@ function buildAiReviewDetailLines(input: {
     );
     if (
       reviewStatus === 'patched' &&
-      ((input.actionCommits?.length ?? 0) > 0 ||
-        (input.threadResolutions?.length ?? 0) > 0)
+      hasPatchEvidence({
+        actionCommits: input.actionCommits,
+        threadResolutions: input.threadResolutions,
+      })
     ) {
       lines.push(
         `- patch commits after \`${shortenSha(input.reviewedHeadSha)}\` address all findings from that review.`,


### PR DESCRIPTION
## Summary

- delivery ticket: `EE4.02 Stale-SHA resolution sentence`
- ticket file: [docs/02-delivery/engineering-epic-04/ticket-02-stale-sha-resolution-sentence.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/engineering-epic-04/ticket-02-stale-sha-resolution-sentence.md)
- stacked base branch: `agents/ee4-01-per-finding-disposition-on-patched-pr-bodies`
- internal review: completed at 2026-04-08 13:14 UTC

<!-- ai-review:start -->
## External AI Review

- outcome: `clean`
- reviewed commit: [`447141903804`](https://github.com/cesarnml/pirate_claw/commit/4471419038043a921aa376af33b7239eca809057)
- current branch head: [`447141903804`](https://github.com/cesarnml/pirate_claw/commit/4471419038043a921aa376af33b7239eca809057)
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Resolved Review Findings

- [greptile] `hasPatchEvidence` causes misleading "patch commits" sentence when only thread resolutions exist `tools/delivery/pr-metadata.ts:544` [thread](https://github.com/cesarnml/pirate_claw/pull/90#discussion_r3051589064)
<!-- ai-review:end -->
