### PR TITLE
chore: normalize thread-reply body formatting [EE4.03]

### DIFF
--- a/tools/delivery/review.ts
+++ b/tools/delivery/review.ts
@@ -310,6 +310,10 @@ export function parseResolveReviewThreadOutput(output: string): {
 const THREAD_REPLY_BEFORE_RESOLVE =
   'Addressed during patch phase — see PR body for full finding disposition.';
 
+function sanitizeThreadReplyBody(body: string): string {
+  return body.replace(/\s+/g, ' ').trim();
+}
+
 type ReviewCoreDependencies = {
   relativeToRepo: (cwd: string, absolutePath: string) => string;
   replyToReviewThread?: (
@@ -663,7 +667,7 @@ export function resolveNativeReviewThreads(
         dependencies.replyToReviewThread(
           worktreePath,
           comment.databaseId,
-          THREAD_REPLY_BEFORE_RESOLVE,
+          sanitizeThreadReplyBody(THREAD_REPLY_BEFORE_RESOLVE),
         );
       } catch {
         // Reply is best-effort; resolution still proceeds.


### PR DESCRIPTION
## Summary

- delivery ticket: `EE4.03 Thread reply before resolve`
- ticket file: [docs/02-delivery/engineering-epic-04/ticket-03-thread-reply-before-resolve.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/engineering-epic-04/ticket-03-thread-reply-before-resolve.md)
- stacked base branch: `agents/ee4-02-stale-sha-resolution-sentence`
- internal review: completed at 2026-04-08 13:21 UTC

## External AI Review

- outcome: `clean`
- current branch head: [`67b20d887dee`](https://github.com/cesarnml/pirate_claw/commit/67b20d887dee2f27eb0321c381820e6813848f51)
- no prudent follow-up changes were required.
- incomplete agents at timeout: `greptile`
