### PR TITLE
refactor: extract commit-link metadata helper [EE4.04]

### DIFF
--- a/tools/delivery/pr-metadata.ts
+++ b/tools/delivery/pr-metadata.ts
@@ -339,7 +339,7 @@ function buildGitHubCommitLink(input: {
   githubRepo: { defaultBranch: string; name: string; owner: string };
   sha: string;
 }): string {
-  const short = shortenSha(input.sha);
+  const short = input.sha.slice(0, 12);
   return `[\`${short}\`](https://github.com/${input.githubRepo.owner}/${input.githubRepo.name}/commit/${input.sha})`;
 }
 

--- a/tools/delivery/pr-metadata.ts
+++ b/tools/delivery/pr-metadata.ts
@@ -335,6 +335,14 @@ function shortenSha(sha: string | undefined): string | undefined {
   return sha ? sha.slice(0, 12) : undefined;
 }
 
+function buildGitHubCommitLink(input: {
+  githubRepo: { defaultBranch: string; name: string; owner: string };
+  sha: string;
+}): string {
+  const short = shortenSha(input.sha);
+  return `[\`${short}\`](https://github.com/${input.githubRepo.owner}/${input.githubRepo.name}/commit/${input.sha})`;
+}
+
 function formatHumanUtcTimestamp(iso: string): string {
   const parsed = Date.parse(iso);
   if (Number.isNaN(parsed)) {
@@ -644,24 +652,30 @@ function buildAiReviewDetailLines(input: {
     input.reviewedHeadSha === input.currentHeadSha;
 
   if (input.reviewedHeadSha) {
-    const short = shortenSha(input.reviewedHeadSha);
     if (input.githubRepo) {
       lines.push(
-        `- reviewed commit: [\`${short}\`](https://github.com/${input.githubRepo.owner}/${input.githubRepo.name}/commit/${input.reviewedHeadSha})`,
+        `- reviewed commit: ${buildGitHubCommitLink({
+          githubRepo: input.githubRepo,
+          sha: input.reviewedHeadSha,
+        })}`,
       );
     } else {
-      lines.push(`- reviewed commit: \`${short}\``);
+      lines.push(`- reviewed commit: \`${shortenSha(input.reviewedHeadSha)}\``);
     }
   }
 
   if (input.currentHeadSha) {
-    const short = shortenSha(input.currentHeadSha);
     if (input.githubRepo) {
       lines.push(
-        `- current branch head: [\`${short}\`](https://github.com/${input.githubRepo.owner}/${input.githubRepo.name}/commit/${input.currentHeadSha})`,
+        `- current branch head: ${buildGitHubCommitLink({
+          githubRepo: input.githubRepo,
+          sha: input.currentHeadSha,
+        })}`,
       );
     } else {
-      lines.push(`- current branch head: \`${short}\``);
+      lines.push(
+        `- current branch head: \`${shortenSha(input.currentHeadSha)}\``,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

- delivery ticket: `EE4.04 PR body metadata polish`
- ticket file: [docs/02-delivery/engineering-epic-04/ticket-04-pr-body-metadata-polish.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/engineering-epic-04/ticket-04-pr-body-metadata-polish.md)
- stacked base branch: `agents/ee4-03-thread-reply-before-resolve`
- internal review: completed at 2026-04-08 13:33 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`386cc988fbee`](https://github.com/cesarnml/pirate_claw/commit/386cc988fbeefe688db7f21e220bf689d4ed4474)
- current branch head: [`c9b50e96afae`](https://github.com/cesarnml/pirate_claw/commit/c9b50e96afae34fa469aa2f8137e9a5c4b6b28c4)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `386cc988fbee` address all findings from that review.
- vendors: `coderabbit`, `greptile`

### Resolved Review Findings

- [greptile] `shortenSha` return type leaks `undefined` into template literal (native GitHub thread resolved) `tools/delivery/pr-metadata.ts:344` [thread](https://github.com/cesarnml/pirate_claw/pull/92#discussion_r3051706086)
- [coderabbit] Configuration used (patched) [thread](https://github.com/cesarnml/pirate_claw/pull/92#issuecomment-4206618977)
- [greptile] No security concerns identified. (patched) [thread](https://github.com/cesarnml/pirate_claw/pull/92#issuecomment-4206646195)
