### PR TITLE
refactor: unify ticketed and standalone ai-review polling lifecycle

### DIFF
--- a/tools/delivery/closeout-stack.test.ts
+++ b/tools/delivery/closeout-stack.test.ts
@@ -30,7 +30,7 @@ function createState(tickets: TicketState[]): DeliveryState {
     reviewsDirPath: '.agents/delivery/phase-01/reviews',
     handoffsDirPath: '.agents/delivery/phase-01/handoffs',
     reviewPollIntervalMinutes: 2,
-    reviewPollMaxWaitMinutes: 8,
+    reviewPollMaxWaitMinutes: 10,
     tickets,
   };
 }

--- a/tools/delivery/notifications.ts
+++ b/tools/delivery/notifications.ts
@@ -1,4 +1,5 @@
 import { buildReviewPollCheckMinutes } from './review';
+import { computeExtendedReviewPollMaxWaitMinutes } from './review-polling-profile';
 import type {
   DeliveryState,
   DeliveryNotificationEvent,
@@ -41,13 +42,6 @@ function findTicketById(
         state.tickets.find(
           (ticket) => ticket.status === 'operator_input_needed',
         ));
-}
-
-function computeExtendedReviewPollMaxWaitMinutes(
-  intervalMinutes: number,
-  maxWaitMinutes: number,
-): number {
-  return maxWaitMinutes + intervalMinutes;
 }
 
 function buildTicketStartedEvent(

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -107,7 +107,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
     });
   });
 
@@ -122,7 +122,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: options.reviewsDirPath,
       handoffsDirPath: options.handoffsDirPath,
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P2.01',
@@ -182,7 +182,7 @@ describe('delivery orchestrator', () => {
         reviewsDirPath: '.agents/delivery/phase-02/reviews',
         handoffsDirPath: '.agents/delivery/phase-02/handoffs',
         reviewPollIntervalMinutes: 2,
-        reviewPollMaxWaitMinutes: 8,
+        reviewPollMaxWaitMinutes: 10,
         tickets: [
           {
             id: 'P2.01',
@@ -327,7 +327,7 @@ describe('delivery orchestrator', () => {
           reviewsDirPath: '.agents/delivery/phase-03/reviews',
           handoffsDirPath: '.agents/delivery/phase-03/handoffs',
           reviewPollIntervalMinutes: 2,
-          reviewPollMaxWaitMinutes: 8,
+          reviewPollMaxWaitMinutes: 10,
           tickets: [
             {
               id: 'P3.01',
@@ -522,7 +522,7 @@ describe('delivery orchestrator', () => {
         prNumber: 32,
         prUrl: 'https://example.test/pull/32',
         reviewPollIntervalMinutes: 2,
-        reviewPollMaxWaitMinutes: 8,
+        reviewPollMaxWaitMinutes: 10,
       }),
     ).toContain('Son of Anton PR #32\nAI review started.');
     expect(
@@ -779,7 +779,7 @@ describe('delivery orchestrator', () => {
           reviewsDirPath: '.agents/delivery/engineering-epic-02/reviews',
           handoffsDirPath: '.agents/delivery/engineering-epic-02/handoffs',
           reviewPollIntervalMinutes: 2,
-          reviewPollMaxWaitMinutes: 8,
+          reviewPollMaxWaitMinutes: 10,
           tickets: [],
         },
         ticket: {
@@ -856,7 +856,7 @@ describe('delivery orchestrator', () => {
         reviewsDirPath: '.agents/delivery/phase-03/reviews',
         handoffsDirPath: '.agents/delivery/phase-03/handoffs',
         reviewPollIntervalMinutes: 2,
-        reviewPollMaxWaitMinutes: 8,
+        reviewPollMaxWaitMinutes: 10,
         tickets: [],
       },
       {
@@ -907,7 +907,7 @@ describe('delivery orchestrator', () => {
         reviewsDirPath: '.agents/delivery/phase-03/reviews',
         handoffsDirPath: '.agents/delivery/phase-03/handoffs',
         reviewPollIntervalMinutes: 2,
-        reviewPollMaxWaitMinutes: 8,
+        reviewPollMaxWaitMinutes: 10,
         tickets: [],
       },
       {
@@ -1086,7 +1086,7 @@ describe('delivery orchestrator', () => {
         reviewsDirPath: '.agents/delivery/phase-03/reviews',
         handoffsDirPath: '.agents/delivery/phase-03/handoffs',
         reviewPollIntervalMinutes: 2,
-        reviewPollMaxWaitMinutes: 8,
+        reviewPollMaxWaitMinutes: 10,
         tickets: [],
       },
       {
@@ -1150,7 +1150,7 @@ describe('delivery orchestrator', () => {
         reviewsDirPath: '.agents/delivery/phase-03/reviews',
         handoffsDirPath: '.agents/delivery/phase-03/handoffs',
         reviewPollIntervalMinutes: 2,
-        reviewPollMaxWaitMinutes: 8,
+        reviewPollMaxWaitMinutes: 10,
         tickets: [
           {
             id: 'P3.01',
@@ -1174,11 +1174,16 @@ describe('delivery orchestrator', () => {
 
     expect(message).toContain('AI Review Window');
     expect(message).toContain(
-      'polling cadence: every 2 minutes up to 8 minutes',
+      'polling cadence: every 2 minutes up to 10 minutes',
     );
-    expect(message).toContain('checks at: 2, 4, 6, 8 minutes after PR open');
+    expect(message).toContain(
+      'checks at: 2, 4, 6, 8, 10 minutes after PR open',
+    );
     expect(message).toContain('first check at: 2026-04-01T10:02:00.000Z');
-    expect(message).toContain('final check at: 2026-04-01T10:08:00.000Z');
+    expect(message).toContain('final check at: 2026-04-01T10:10:00.000Z');
+    expect(message).toContain(
+      'if an AI review agent is still clearly in progress at 10 minutes, the orchestrator performs one final check at 12 minutes',
+    );
     expect(message).toContain('the orchestrator records `clean` and continues');
   });
 
@@ -1190,7 +1195,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -1241,7 +1246,7 @@ describe('delivery orchestrator', () => {
               ...state.tickets[0]!,
               status: 'reviewed',
               reviewNote:
-                'No AI review feedback was detected within the 8-minute polling window.',
+                'No AI review feedback was detected within the 10-minute polling window.',
             },
             state.tickets[1]!,
           ],
@@ -1258,7 +1263,7 @@ describe('delivery orchestrator', () => {
             status: 'reviewed',
             reviewOutcome: 'clean',
             reviewNote:
-              'No AI review feedback was detected within the 8-minute polling window.',
+              'No AI review feedback was detected within the 10-minute polling window.',
           },
           state.tickets[1]!,
         ],
@@ -1305,7 +1310,7 @@ describe('delivery orchestrator', () => {
         reviewsDirPath: '.agents/delivery/phase-03/reviews',
         handoffsDirPath: '.agents/delivery/phase-03/handoffs',
         reviewPollIntervalMinutes: 2,
-        reviewPollMaxWaitMinutes: 8,
+        reviewPollMaxWaitMinutes: 10,
         tickets: [
           {
             id: 'P3.01',
@@ -1329,7 +1334,7 @@ describe('delivery orchestrator', () => {
         reviewsDirPath: '.agents/delivery/phase-03/reviews',
         handoffsDirPath: '.agents/delivery/phase-03/handoffs',
         reviewPollIntervalMinutes: 2,
-        reviewPollMaxWaitMinutes: 8,
+        reviewPollMaxWaitMinutes: 10,
         tickets: [
           {
             id: 'P3.01',
@@ -1376,9 +1381,9 @@ describe('delivery orchestrator', () => {
     }
   });
 
-  it('builds the 2/4/6/8-minute review polling schedule', () => {
-    expect(buildReviewPollCheckMinutes(2, 8)).toEqual([2, 4, 6, 8]);
-    expect(() => buildReviewPollCheckMinutes(0, 8)).toThrow(
+  it('builds the 2/4/6/8/10-minute review polling schedule', () => {
+    expect(buildReviewPollCheckMinutes(2, 10)).toEqual([2, 4, 6, 8, 10]);
+    expect(() => buildReviewPollCheckMinutes(0, 10)).toThrow(
       'Review polling interval and max wait must be positive.',
     );
   });
@@ -1563,7 +1568,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -1664,7 +1669,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -1724,7 +1729,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -1883,7 +1888,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -1982,7 +1987,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -2024,13 +2029,13 @@ describe('delivery orchestrator', () => {
       updatePullRequestBody: async () => undefined,
     });
 
-    expect(sleeps).toEqual([120000, 240000, 360000, 480000, 600000]);
+    expect(sleeps).toEqual([120000, 240000, 360000, 480000, 600000, 720000]);
     expect(nextState.tickets[0]).toMatchObject({
       status: 'done',
       reviewOutcome: 'clean',
       reviewIncompleteAgents: ['coderabbit'],
       reviewNote:
-        'AI review reached the 10-minute limit while waiting on: coderabbit. No actionable findings were captured. Rerun manually if needed.',
+        'AI review reached the 12-minute limit while waiting on: coderabbit. No actionable findings were captured. Rerun manually if needed.',
     });
   });
 
@@ -2042,7 +2047,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -2083,15 +2088,15 @@ describe('delivery orchestrator', () => {
       },
     });
 
-    expect(sleeps).toEqual([120000, 240000, 360000, 480000]);
+    expect(sleeps).toEqual([120000, 240000, 360000, 480000, 600000]);
     expect(nextState.tickets[0]).toMatchObject({
       status: 'done',
       reviewOutcome: 'clean',
       reviewNote:
-        'No AI review feedback was detected within the 8-minute polling window.',
+        'No AI review feedback was detected within the 10-minute polling window.',
     });
     expect(prBodyUpdates).toEqual([
-      'phase-03:No AI review feedback was detected within the 8-minute polling window.',
+      'phase-03:No AI review feedback was detected within the 10-minute polling window.',
     ]);
   });
 
@@ -2103,7 +2108,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -2166,7 +2171,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -2205,7 +2210,7 @@ describe('delivery orchestrator', () => {
       status: 'done',
       reviewOutcome: 'patched',
       reviewNote:
-        'No AI review feedback was detected within the 8-minute polling window. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
+        'No AI review feedback was detected within the 10-minute polling window. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
     });
   });
 
@@ -2217,7 +2222,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -2309,7 +2314,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -2372,7 +2377,7 @@ describe('delivery orchestrator', () => {
     expect(standaloneResult.outcome).toBe('patched');
     expect(nextState.tickets[0]?.reviewOutcome).toBe('patched');
     expect(nextState.tickets[0]?.reviewNote).toBe(
-      'No AI review feedback was detected within the 8-minute polling window. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
+      'No AI review feedback was detected within the 10-minute polling window. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
     );
     expect(standaloneResult.note).toBe(
       'No AI review feedback was detected within the 10-minute polling window. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
@@ -2387,7 +2392,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -2456,7 +2461,7 @@ describe('delivery orchestrator', () => {
       standaloneResult.incompleteAgents,
     );
     expect(nextState.tickets[0]?.reviewNote).toBe(
-      'AI review reached the 10-minute limit while waiting on: coderabbit. No actionable findings were captured. Rerun manually if needed.',
+      'AI review reached the 12-minute limit while waiting on: coderabbit. No actionable findings were captured. Rerun manually if needed.',
     );
     expect(standaloneResult.note).toBe(
       'AI review reached the 12-minute limit while waiting on: coderabbit. No actionable findings were captured. Rerun manually if needed.',
@@ -2681,7 +2686,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -2751,7 +2756,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -2825,7 +2830,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -2871,7 +2876,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -2918,7 +2923,7 @@ describe('delivery orchestrator', () => {
       reviewsDirPath: '.agents/delivery/phase-03/reviews',
       handoffsDirPath: '.agents/delivery/phase-03/handoffs',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
       tickets: [
         {
           id: 'P3.01',
@@ -3034,7 +3039,7 @@ describe('delivery orchestrator', () => {
       prNumber: 33,
       prUrl: 'https://example.test/pull/33',
       reviewPollIntervalMinutes: 2,
-      reviewPollMaxWaitMinutes: 8,
+      reviewPollMaxWaitMinutes: 10,
     });
 
     expect(requests).toHaveLength(1);

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -117,6 +117,16 @@ export {
   resolveReviewPollWindowStart,
 };
 export {
+  type AiReviewLifecycleHooks,
+  DEFAULT_REVIEW_POLLING_PROFILE,
+  type PollForAiReviewResult,
+  type ReviewPollingProfile,
+  computeExtendedReviewPollMaxWaitMinutes,
+  pollForAiReview,
+  resolveDeliveryReviewPollingProfile,
+  runAiReviewLifecycleWithAdapters,
+} from './review';
+export {
   buildTicketHandoff,
   canAdvanceTicket,
   eventsForAdvanceCommand,

--- a/tools/delivery/planning.ts
+++ b/tools/delivery/planning.ts
@@ -3,6 +3,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import { basename, dirname, join, resolve } from 'node:path';
 
 import type { OrchestratorOptions, TicketDefinition } from './orchestrator';
+import { DEFAULT_REVIEW_POLLING_PROFILE } from './review-polling-profile';
 
 export function parsePlan(
   markdown: string,
@@ -76,8 +77,8 @@ export function createOptions(input: {
     statePath: `.agents/delivery/${planKey}/state.json`,
     reviewsDirPath: `.agents/delivery/${planKey}/reviews`,
     handoffsDirPath: `.agents/delivery/${planKey}/handoffs`,
-    reviewPollIntervalMinutes: 2,
-    reviewPollMaxWaitMinutes: 8,
+    reviewPollIntervalMinutes: DEFAULT_REVIEW_POLLING_PROFILE.intervalMinutes,
+    reviewPollMaxWaitMinutes: DEFAULT_REVIEW_POLLING_PROFILE.maxWaitMinutes,
   };
 }
 

--- a/tools/delivery/pr-metadata.ts
+++ b/tools/delivery/pr-metadata.ts
@@ -9,12 +9,11 @@ import type {
   TicketState,
   TicketStatus,
 } from './orchestrator';
+import { DEFAULT_REVIEW_POLLING_PROFILE } from './review-polling-profile';
 
 const MAX_ACTION_COMMITS = 20;
 const STANDALONE_AI_REVIEW_SECTION_START = '<!-- ai-review:start -->';
 const STANDALONE_AI_REVIEW_SECTION_END = '<!-- ai-review:end -->';
-const DEFAULT_REVIEW_POLL_INTERVAL_MINUTES = 2;
-const DEFAULT_REVIEW_POLL_MAX_WAIT_MINUTES = 8;
 
 export type ReviewActionCommit = {
   sha: string;
@@ -925,7 +924,7 @@ export function buildStandaloneAiReviewSection(
     currentHeadSha: options.currentHeadSha,
     githubRepo: options.githubRepo,
     incompleteAgents: result.incompleteAgents,
-    maxWaitMinutes: DEFAULT_REVIEW_POLL_MAX_WAIT_MINUTES,
+    maxWaitMinutes: DEFAULT_REVIEW_POLLING_PROFILE.maxWaitMinutes,
   });
 
   return [
@@ -1062,7 +1061,7 @@ export function buildStandaloneReviewStartedEvent(
     kind: 'standalone_review_started',
     prNumber,
     prUrl,
-    reviewPollIntervalMinutes: DEFAULT_REVIEW_POLL_INTERVAL_MINUTES,
-    reviewPollMaxWaitMinutes: DEFAULT_REVIEW_POLL_MAX_WAIT_MINUTES,
+    reviewPollIntervalMinutes: DEFAULT_REVIEW_POLLING_PROFILE.intervalMinutes,
+    reviewPollMaxWaitMinutes: DEFAULT_REVIEW_POLLING_PROFILE.maxWaitMinutes,
   };
 }

--- a/tools/delivery/review-polling-profile.ts
+++ b/tools/delivery/review-polling-profile.ts
@@ -1,0 +1,30 @@
+export type ReviewPollingProfile = {
+  intervalMinutes: number;
+  maxWaitMinutes: number;
+  /** When true, allow one extra poll at max+interval if agents are still in flight at the max check. */
+  extendByOneInterval: boolean;
+};
+
+export const DEFAULT_REVIEW_POLLING_PROFILE: ReviewPollingProfile = {
+  intervalMinutes: 2,
+  maxWaitMinutes: 10,
+  extendByOneInterval: true,
+};
+
+export function computeExtendedReviewPollMaxWaitMinutes(
+  intervalMinutes: number,
+  maxWaitMinutes: number,
+): number {
+  return maxWaitMinutes + intervalMinutes;
+}
+
+export function resolveDeliveryReviewPollingProfile(state: {
+  reviewPollIntervalMinutes: number;
+  reviewPollMaxWaitMinutes: number;
+}): ReviewPollingProfile {
+  return {
+    intervalMinutes: state.reviewPollIntervalMinutes,
+    maxWaitMinutes: state.reviewPollMaxWaitMinutes,
+    extendByOneInterval: true,
+  };
+}

--- a/tools/delivery/review.test.ts
+++ b/tools/delivery/review.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { AiReviewFetcherResult } from './orchestrator';
+import { buildStandaloneReviewStartedEvent } from './pr-metadata';
+import {
+  DEFAULT_REVIEW_POLLING_PROFILE,
+  pollForAiReview,
+  runAiReviewLifecycleWithAdapters,
+  type ReviewPollingProfile,
+} from './review';
+import type { TicketReviewDependencies } from './review';
+
+function emptyUndetected(): AiReviewFetcherResult {
+  return {
+    agents: [],
+    artifactText: '',
+    comments: [],
+    detected: false,
+    vendors: [],
+  };
+}
+
+function inFlight(): AiReviewFetcherResult {
+  return {
+    agents: [
+      {
+        agent: 'external',
+        state: 'started',
+        findingsCount: undefined,
+        note: undefined,
+      },
+    ],
+    artifactText: '',
+    comments: [],
+    detected: true,
+    vendors: [],
+  };
+}
+
+function allTerminal(): AiReviewFetcherResult {
+  return {
+    agents: [
+      {
+        agent: 'external',
+        state: 'completed',
+        findingsCount: 0,
+        note: undefined,
+      },
+    ],
+    artifactText: '',
+    comments: [],
+    detected: true,
+    vendors: [],
+  };
+}
+
+function baseDeps(
+  overrides: Partial<TicketReviewDependencies> & {
+    fetcher: TicketReviewDependencies['fetcher'];
+  },
+): TicketReviewDependencies {
+  return {
+    relativeToRepo: (cwd, p) => p,
+    resolveReviewFetcher: () => 'fetcher',
+    resolveReviewThread: () => '{"resolved":true}',
+    resolveReviewTriager: () => 'triager',
+    runProcess: () => '',
+    ...overrides,
+  };
+}
+
+describe('pollForAiReview', () => {
+  it('extends the polling window to 12 minutes only when agents are still in flight at the 10-minute check', async () => {
+    let virtualNow = 0;
+    let pollCalls = 0;
+    const profile: ReviewPollingProfile = {
+      ...DEFAULT_REVIEW_POLLING_PROFILE,
+    };
+
+    const result = await pollForAiReview(
+      '/wt',
+      1,
+      profile,
+      0,
+      baseDeps({
+        fetcher: () => {
+          pollCalls += 1;
+          if (pollCalls < 5) {
+            return emptyUndetected();
+          }
+          if (pollCalls === 5) {
+            return inFlight();
+          }
+          return inFlight();
+        },
+        now: () => virtualNow,
+        sleep: async (ms: number) => {
+          virtualNow += ms;
+        },
+      }),
+    );
+
+    expect(result.status).toBe('clean_timeout');
+    if (result.status !== 'clean_timeout') {
+      throw new Error('expected clean_timeout');
+    }
+    expect(result.effectiveMaxWaitMinutes).toBe(12);
+    expect(result.incompleteAgents).toEqual(['external']);
+    expect(pollCalls).toBe(6);
+  });
+
+  it('does not extend when triage becomes ready by the 10-minute check', async () => {
+    let virtualNow = 0;
+    let pollCalls = 0;
+    const profile: ReviewPollingProfile = {
+      ...DEFAULT_REVIEW_POLLING_PROFILE,
+    };
+
+    const result = await pollForAiReview(
+      '/wt',
+      1,
+      profile,
+      0,
+      baseDeps({
+        fetcher: () => {
+          pollCalls += 1;
+          if (pollCalls < 5) {
+            return emptyUndetected();
+          }
+          return allTerminal();
+        },
+        now: () => virtualNow,
+        sleep: async (ms: number) => {
+          virtualNow += ms;
+        },
+      }),
+    );
+
+    expect(result.status).toBe('triage_ready');
+    if (result.status !== 'triage_ready') {
+      throw new Error('expected triage_ready');
+    }
+    expect(result.effectiveMaxWaitMinutes).toBe(10);
+    expect(pollCalls).toBe(5);
+  });
+
+  it('does not schedule a 12-minute check when extendByOneInterval is false', async () => {
+    let virtualNow = 0;
+    let pollCalls = 0;
+    const profile: ReviewPollingProfile = {
+      ...DEFAULT_REVIEW_POLLING_PROFILE,
+      extendByOneInterval: false,
+    };
+
+    const result = await pollForAiReview(
+      '/wt',
+      1,
+      profile,
+      0,
+      baseDeps({
+        fetcher: () => {
+          pollCalls += 1;
+          if (pollCalls < 5) {
+            return emptyUndetected();
+          }
+          return inFlight();
+        },
+        now: () => virtualNow,
+        sleep: async (ms: number) => {
+          virtualNow += ms;
+        },
+      }),
+    );
+
+    expect(result.status).toBe('clean_timeout');
+    expect(result.effectiveMaxWaitMinutes).toBe(10);
+    expect(pollCalls).toBe(5);
+  });
+});
+
+describe('review polling profile wiring', () => {
+  it('uses the default profile for standalone review started notifications', () => {
+    const event = buildStandaloneReviewStartedEvent(
+      42,
+      'https://example.test/pull/42',
+    );
+    expect(event.kind).toBe('standalone_review_started');
+    if (event.kind !== 'standalone_review_started') {
+      throw new Error('expected standalone_review_started');
+    }
+    expect(event.reviewPollIntervalMinutes).toBe(
+      DEFAULT_REVIEW_POLLING_PROFILE.intervalMinutes,
+    );
+    expect(event.reviewPollMaxWaitMinutes).toBe(
+      DEFAULT_REVIEW_POLLING_PROFILE.maxWaitMinutes,
+    );
+  });
+});
+
+describe('runAiReviewLifecycleWithAdapters', () => {
+  it('routes ticketed vs standalone handlers without mixing outcome semantics', async () => {
+    type RouteTag = { kind: 'ticketed' | 'standalone'; triaged: boolean };
+    let virtualNow = 0;
+    let pollCalls = 0;
+    const profile: ReviewPollingProfile = {
+      intervalMinutes: 2,
+      maxWaitMinutes: 10,
+      extendByOneInterval: false,
+    };
+
+    const ticketed = await runAiReviewLifecycleWithAdapters<RouteTag>({
+      profile,
+      worktreePath: '/wt',
+      prNumber: 1,
+      pollWindowStartedAt: 0,
+      dependencies: baseDeps({
+        fetcher: () => {
+          pollCalls += 1;
+          if (pollCalls < 5) {
+            return emptyUndetected();
+          }
+          return allTerminal();
+        },
+        now: () => virtualNow,
+        sleep: async (ms: number) => {
+          virtualNow += ms;
+        },
+      }),
+      onTriageOrPartial: async () => ({ kind: 'ticketed', triaged: true }),
+      onCleanTimeout: async () => ({ kind: 'ticketed', triaged: false }),
+    });
+
+    expect(ticketed).toEqual({ kind: 'ticketed', triaged: true });
+
+    virtualNow = 0;
+    pollCalls = 0;
+
+    const standalone = await runAiReviewLifecycleWithAdapters<RouteTag>({
+      profile,
+      worktreePath: '/wt',
+      prNumber: 1,
+      pollWindowStartedAt: 0,
+      dependencies: baseDeps({
+        fetcher: () => {
+          pollCalls += 1;
+          if (pollCalls < 5) {
+            return emptyUndetected();
+          }
+          return allTerminal();
+        },
+        now: () => virtualNow,
+        sleep: async (ms: number) => {
+          virtualNow += ms;
+        },
+      }),
+      onTriageOrPartial: async () => ({ kind: 'standalone', triaged: true }),
+      onCleanTimeout: async () => ({ kind: 'standalone', triaged: false }),
+    });
+
+    expect(standalone).toEqual({ kind: 'standalone', triaged: true });
+  });
+});

--- a/tools/delivery/review.ts
+++ b/tools/delivery/review.ts
@@ -17,8 +17,19 @@ import type {
   TicketState,
 } from './orchestrator';
 
-const STANDALONE_REVIEW_POLL_INTERVAL_MINUTES = 2;
-const STANDALONE_REVIEW_POLL_MAX_WAIT_MINUTES = 10;
+import {
+  type ReviewPollingProfile,
+  DEFAULT_REVIEW_POLLING_PROFILE,
+  computeExtendedReviewPollMaxWaitMinutes,
+  resolveDeliveryReviewPollingProfile,
+} from './review-polling-profile';
+
+export {
+  type ReviewPollingProfile,
+  DEFAULT_REVIEW_POLLING_PROFILE,
+  computeExtendedReviewPollMaxWaitMinutes,
+  resolveDeliveryReviewPollingProfile,
+} from './review-polling-profile';
 
 function formatError(error: unknown): string {
   if (error instanceof Error) {
@@ -374,7 +385,7 @@ export type StandaloneAiReviewDependencies = Pick<
     ) => Promise<void>;
   };
 
-type PollForAiReviewResult =
+export type PollForAiReviewResult =
   | {
       status: 'triage_ready';
       result: AiReviewFetcherResult;
@@ -487,13 +498,6 @@ function formatIncompleteAiReviewWithoutFindingsNote(
 
 function formatNoAiReviewFeedbackNote(maxWaitMinutes: number): string {
   return `No AI review feedback was detected within the ${maxWaitMinutes}-minute polling window.`;
-}
-
-function computeExtendedReviewPollMaxWaitMinutes(
-  intervalMinutes: number,
-  maxWaitMinutes: number,
-): number {
-  return maxWaitMinutes + intervalMinutes;
 }
 
 function mergeReviewOutcome(
@@ -715,11 +719,10 @@ export function resolveNativeReviewThreads(
   return resolutions;
 }
 
-async function pollForAiReview(
+export async function pollForAiReview(
   worktreePath: string,
   prNumber: number,
-  intervalMinutes: number,
-  maxWaitMinutes: number,
+  profile: ReviewPollingProfile,
   pollWindowStartedAt: number,
   dependencies: Pick<TicketReviewDependencies, 'fetcher' | 'now' | 'sleep'> &
     ReviewCoreDependencies,
@@ -730,6 +733,8 @@ async function pollForAiReview(
     dependencies.fetcher ??
     ((nextWorktreePath: string, nextPrNumber: number) =>
       runAiReviewFetcher(nextWorktreePath, nextPrNumber, dependencies));
+  const intervalMinutes = profile.intervalMinutes;
+  const maxWaitMinutes = profile.maxWaitMinutes;
   const checks = buildReviewPollCheckMinutes(intervalMinutes, maxWaitMinutes);
   const extendedMaxWaitMinutes = computeExtendedReviewPollMaxWaitMinutes(
     intervalMinutes,
@@ -763,6 +768,7 @@ async function pollForAiReview(
     }
 
     if (
+      profile.extendByOneInterval &&
       !extended &&
       checkMinute === maxWaitMinutes &&
       hasInFlightReviewAgents(result)
@@ -1045,6 +1051,44 @@ async function persistStandaloneAiReviewResult(
   return result;
 }
 
+export type AiReviewLifecycleHooks<T> = {
+  onTriageOrPartial: (
+    reviewPollResult: Extract<
+      PollForAiReviewResult,
+      { status: 'triage_ready' | 'partial_timeout' }
+    >,
+  ) => Promise<T>;
+  onCleanTimeout: (reviewPollResult: PollForAiReviewResult) => Promise<T>;
+};
+
+export async function runAiReviewLifecycleWithAdapters<T>(input: {
+  profile: ReviewPollingProfile;
+  worktreePath: string;
+  prNumber: number;
+  pollWindowStartedAt: number;
+  dependencies: Pick<TicketReviewDependencies, 'fetcher' | 'now' | 'sleep'> &
+    ReviewCoreDependencies;
+  onTriageOrPartial: AiReviewLifecycleHooks<T>['onTriageOrPartial'];
+  onCleanTimeout: AiReviewLifecycleHooks<T>['onCleanTimeout'];
+}): Promise<T> {
+  const reviewPollResult = await pollForAiReview(
+    input.worktreePath,
+    input.prNumber,
+    input.profile,
+    input.pollWindowStartedAt,
+    input.dependencies,
+  );
+
+  if (
+    reviewPollResult.status === 'triage_ready' ||
+    reviewPollResult.status === 'partial_timeout'
+  ) {
+    return input.onTriageOrPartial(reviewPollResult);
+  }
+
+  return input.onCleanTimeout(reviewPollResult);
+}
+
 export async function runTicketReviewLifecycle(
   state: DeliveryState,
   cwd: string,
@@ -1070,102 +1114,103 @@ export async function runTicketReviewLifecycle(
       resolveNativeReviewThreads(worktreePath, comments, dependencies));
   const { pollWindowStartedAt, pollWindowStartedAtIso } =
     resolveReviewPollWindowStart(target.prOpenedAt, now);
-  const reviewPollResult = await pollForAiReview(
-    target.worktreePath,
-    target.prNumber,
-    state.reviewPollIntervalMinutes,
-    state.reviewPollMaxWaitMinutes,
+  const profile = resolveDeliveryReviewPollingProfile(state);
+
+  return runAiReviewLifecycleWithAdapters({
+    profile,
+    worktreePath: target.worktreePath,
+    prNumber: target.prNumber,
     pollWindowStartedAt,
     dependencies,
-  );
-
-  if (
-    reviewPollResult.status === 'triage_ready' ||
-    reviewPollResult.status === 'partial_timeout'
-  ) {
-    const processedReview = await processDetectedAiReview({
-      artifactStemPath: resolve(
-        cwd,
-        state.reviewsDirPath,
-        `${target.id}-ai-review`,
-      ),
-      detectedReview: reviewPollResult.result,
-      effectiveMaxWaitMinutes: reviewPollResult.effectiveMaxWaitMinutes,
-      incompleteAgents:
-        reviewPollResult.status === 'partial_timeout'
-          ? reviewPollResult.incompleteAgents
-          : undefined,
-      mode: 'ticketed',
-      previousOutcome: target.reviewOutcome,
-      resolveThreads,
-      triager,
-      worktreePath: target.worktreePath,
-    });
-    const nextStatus =
-      processedReview.outcome === 'needs_patch' ? 'needs_patch' : 'reviewed';
-    return applyTicketReviewUpdate(
-      state,
-      target.id,
-      (ticket) => ({
-        ...ticket,
-        prOpenedAt: ticket.prOpenedAt ?? pollWindowStartedAtIso,
-        status: nextStatus,
-        reviewActionSummary: processedReview.actionSummary,
-        reviewComments: processedReview.comments,
-        reviewArtifactJsonPath: dependencies.relativeToRepo(
+    async onTriageOrPartial(reviewPollResult) {
+      const processedReview = await processDetectedAiReview({
+        artifactStemPath: resolve(
           cwd,
-          processedReview.artifactJsonPath,
+          state.reviewsDirPath,
+          `${target.id}-ai-review`,
         ),
-        reviewArtifactPath: dependencies.relativeToRepo(
-          cwd,
-          processedReview.artifactTextPath,
-        ),
-        reviewFetchedAt: new Date(now()).toISOString(),
-        reviewHeadSha: processedReview.reviewedHeadSha,
-        reviewNonActionSummary: processedReview.nonActionSummary,
-        reviewOutcome: accumulateTicketReviewOutcome(
-          ticket.reviewOutcome,
-          processedReview.outcome,
-        ),
-        reviewNote: processedReview.note,
-        reviewIncompleteAgents: processedReview.incompleteAgents,
-        reviewThreadResolutions: processedReview.threadResolutions,
-        reviewVendors: processedReview.vendors,
-      }),
-      dependencies,
-    );
-  }
-
-  const processedReview = processCleanAiReview({
-    effectiveMaxWaitMinutes: reviewPollResult.effectiveMaxWaitMinutes,
-    incompleteAgents: reviewPollResult.incompleteAgents,
-    maxWaitMinutes: state.reviewPollMaxWaitMinutes,
-    previousOutcome: target.reviewOutcome,
+        detectedReview: reviewPollResult.result,
+        effectiveMaxWaitMinutes: reviewPollResult.effectiveMaxWaitMinutes,
+        incompleteAgents:
+          reviewPollResult.status === 'partial_timeout'
+            ? reviewPollResult.incompleteAgents
+            : undefined,
+        mode: 'ticketed',
+        previousOutcome: target.reviewOutcome,
+        resolveThreads,
+        triager,
+        worktreePath: target.worktreePath,
+      });
+      const nextStatus =
+        processedReview.outcome === 'needs_patch' ? 'needs_patch' : 'reviewed';
+      return applyTicketReviewUpdate(
+        state,
+        target.id,
+        (ticket) => ({
+          ...ticket,
+          prOpenedAt: ticket.prOpenedAt ?? pollWindowStartedAtIso,
+          status: nextStatus,
+          reviewActionSummary: processedReview.actionSummary,
+          reviewComments: processedReview.comments,
+          reviewArtifactJsonPath: dependencies.relativeToRepo(
+            cwd,
+            processedReview.artifactJsonPath,
+          ),
+          reviewArtifactPath: dependencies.relativeToRepo(
+            cwd,
+            processedReview.artifactTextPath,
+          ),
+          reviewFetchedAt: new Date(now()).toISOString(),
+          reviewHeadSha: processedReview.reviewedHeadSha,
+          reviewNonActionSummary: processedReview.nonActionSummary,
+          reviewOutcome: accumulateTicketReviewOutcome(
+            ticket.reviewOutcome,
+            processedReview.outcome,
+          ),
+          reviewNote: processedReview.note,
+          reviewIncompleteAgents: processedReview.incompleteAgents,
+          reviewThreadResolutions: processedReview.threadResolutions,
+          reviewVendors: processedReview.vendors,
+        }),
+        dependencies,
+      );
+    },
+    async onCleanTimeout(reviewPollResult) {
+      const processedReview = processCleanAiReview({
+        effectiveMaxWaitMinutes: reviewPollResult.effectiveMaxWaitMinutes,
+        incompleteAgents:
+          reviewPollResult.status === 'clean_timeout'
+            ? reviewPollResult.incompleteAgents
+            : undefined,
+        maxWaitMinutes: profile.maxWaitMinutes,
+        previousOutcome: target.reviewOutcome,
+      });
+      return applyTicketReviewUpdate(
+        state,
+        target.id,
+        (ticket) => ({
+          ...ticket,
+          prOpenedAt: ticket.prOpenedAt ?? pollWindowStartedAtIso,
+          status: 'reviewed',
+          reviewActionSummary: undefined,
+          reviewComments: undefined,
+          reviewArtifactJsonPath: undefined,
+          reviewArtifactPath: undefined,
+          reviewHeadSha: undefined,
+          reviewNonActionSummary: undefined,
+          reviewOutcome: accumulateTicketReviewOutcome(
+            ticket.reviewOutcome,
+            processedReview.outcome,
+          ),
+          reviewNote: processedReview.note,
+          reviewIncompleteAgents: processedReview.incompleteAgents,
+          reviewThreadResolutions: undefined,
+          reviewVendors: [],
+        }),
+        dependencies,
+      );
+    },
   });
-  return applyTicketReviewUpdate(
-    state,
-    target.id,
-    (ticket) => ({
-      ...ticket,
-      prOpenedAt: ticket.prOpenedAt ?? pollWindowStartedAtIso,
-      status: 'reviewed',
-      reviewActionSummary: undefined,
-      reviewComments: undefined,
-      reviewArtifactJsonPath: undefined,
-      reviewArtifactPath: undefined,
-      reviewHeadSha: undefined,
-      reviewNonActionSummary: undefined,
-      reviewOutcome: accumulateTicketReviewOutcome(
-        ticket.reviewOutcome,
-        processedReview.outcome,
-      ),
-      reviewNote: processedReview.note,
-      reviewIncompleteAgents: processedReview.incompleteAgents,
-      reviewThreadResolutions: undefined,
-      reviewVendors: [],
-    }),
-    dependencies,
-  );
 }
 
 export async function runStandaloneAiReviewLifecycle(
@@ -1192,88 +1237,89 @@ export async function runStandaloneAiReviewLifecycle(
     pullRequest.createdAt,
     now,
   );
-  const reviewPollResult = await pollForAiReview(
-    cwd,
-    pullRequest.number,
-    STANDALONE_REVIEW_POLL_INTERVAL_MINUTES,
-    STANDALONE_REVIEW_POLL_MAX_WAIT_MINUTES,
+  const profile = DEFAULT_REVIEW_POLLING_PROFILE;
+
+  return runAiReviewLifecycleWithAdapters({
+    profile,
+    worktreePath: cwd,
+    prNumber: pullRequest.number,
     pollWindowStartedAt,
     dependencies,
-  );
-
-  if (
-    reviewPollResult.status === 'triage_ready' ||
-    reviewPollResult.status === 'partial_timeout'
-  ) {
-    const processedReview = await processDetectedAiReview({
-      artifactStemPath: resolve(
+    async onTriageOrPartial(reviewPollResult) {
+      const processedReview = await processDetectedAiReview({
+        artifactStemPath: resolve(
+          cwd,
+          '.agents/ai-review',
+          `pr-${pullRequest.number}`,
+          'review',
+        ),
+        detectedReview: reviewPollResult.result,
+        effectiveMaxWaitMinutes: reviewPollResult.effectiveMaxWaitMinutes,
+        incompleteAgents:
+          reviewPollResult.status === 'partial_timeout'
+            ? reviewPollResult.incompleteAgents
+            : undefined,
+        mapOutcome: mapStandaloneReviewOutcome,
+        mode: 'standalone',
+        previousOutcome,
+        resolveThreads,
+        triager,
+        worktreePath: cwd,
+      });
+      const standaloneResult: StandaloneAiReviewResult = {
+        actionSummary: processedReview.actionSummary,
+        artifactJsonPath: dependencies.relativeToRepo(
+          cwd,
+          processedReview.artifactJsonPath,
+        ),
+        artifactTextPath: dependencies.relativeToRepo(
+          cwd,
+          processedReview.artifactTextPath,
+        ),
+        incompleteAgents: processedReview.incompleteAgents,
+        note: processedReview.note,
+        comments: processedReview.comments,
+        nonActionSummary: processedReview.nonActionSummary,
+        outcome: processedReview.outcome,
+        prNumber: pullRequest.number,
+        prUrl: pullRequest.url,
+        reviewedHeadSha: processedReview.reviewedHeadSha,
+        threadResolutions: processedReview.threadResolutions,
+        vendors: processedReview.vendors,
+      };
+      return persistStandaloneAiReviewResult(
         cwd,
-        '.agents/ai-review',
-        `pr-${pullRequest.number}`,
-        'review',
-      ),
-      detectedReview: reviewPollResult.result,
-      effectiveMaxWaitMinutes: reviewPollResult.effectiveMaxWaitMinutes,
-      incompleteAgents:
-        reviewPollResult.status === 'partial_timeout'
-          ? reviewPollResult.incompleteAgents
-          : undefined,
-      mapOutcome: mapStandaloneReviewOutcome,
-      mode: 'standalone',
-      previousOutcome,
-      resolveThreads,
-      triager,
-      worktreePath: cwd,
-    });
-    const standaloneResult: StandaloneAiReviewResult = {
-      actionSummary: processedReview.actionSummary,
-      artifactJsonPath: dependencies.relativeToRepo(
+        pullRequest,
+        standaloneResult,
+        dependencies,
+      );
+    },
+    async onCleanTimeout(reviewPollResult) {
+      const processedReview = processCleanAiReview({
+        effectiveMaxWaitMinutes: reviewPollResult.effectiveMaxWaitMinutes,
+        incompleteAgents:
+          reviewPollResult.status === 'clean_timeout'
+            ? reviewPollResult.incompleteAgents
+            : undefined,
+        maxWaitMinutes: profile.maxWaitMinutes,
+        previousOutcome,
+      });
+      const standaloneResult: StandaloneAiReviewResult = {
+        incompleteAgents: processedReview.incompleteAgents,
+        note: processedReview.note,
+        outcome: processedReview.outcome,
+        prNumber: pullRequest.number,
+        prUrl: pullRequest.url,
+        vendors: [],
+      };
+      return persistStandaloneAiReviewResult(
         cwd,
-        processedReview.artifactJsonPath,
-      ),
-      artifactTextPath: dependencies.relativeToRepo(
-        cwd,
-        processedReview.artifactTextPath,
-      ),
-      incompleteAgents: processedReview.incompleteAgents,
-      note: processedReview.note,
-      comments: processedReview.comments,
-      nonActionSummary: processedReview.nonActionSummary,
-      outcome: processedReview.outcome,
-      prNumber: pullRequest.number,
-      prUrl: pullRequest.url,
-      reviewedHeadSha: processedReview.reviewedHeadSha,
-      threadResolutions: processedReview.threadResolutions,
-      vendors: processedReview.vendors,
-    };
-    return persistStandaloneAiReviewResult(
-      cwd,
-      pullRequest,
-      standaloneResult,
-      dependencies,
-    );
-  }
-
-  const processedReview = processCleanAiReview({
-    effectiveMaxWaitMinutes: reviewPollResult.effectiveMaxWaitMinutes,
-    incompleteAgents: reviewPollResult.incompleteAgents,
-    maxWaitMinutes: STANDALONE_REVIEW_POLL_MAX_WAIT_MINUTES,
-    previousOutcome,
+        pullRequest,
+        standaloneResult,
+        dependencies,
+      );
+    },
   });
-  const standaloneResult: StandaloneAiReviewResult = {
-    incompleteAgents: processedReview.incompleteAgents,
-    note: processedReview.note,
-    outcome: processedReview.outcome,
-    prNumber: pullRequest.number,
-    prUrl: pullRequest.url,
-    vendors: [],
-  };
-  return persistStandaloneAiReviewResult(
-    cwd,
-    pullRequest,
-    standaloneResult,
-    dependencies,
-  );
 }
 
 export async function writeStandaloneAiReviewNote(


### PR DESCRIPTION
## Summary
Unifies AI review polling configuration (2/10 + optional +2 extension), shared lifecycle runner, and metadata/notification copy so ticketed and standalone paths stay consistent.

## Internal review (before external ai-review)
- `bun run verify` and `bun test ./tools/delivery/` passed before push.
- No product/runtime `src/` changes; delivery tooling only.

## Risk / rollback
Low blast radius; revert single merge commit if needed.

## Note
Existing `state.json` files with `reviewPollMaxWaitMinutes: 8` are unchanged until recreated.

<!-- ai-review:start -->
## External AI Review

- outcome: `operator_input_needed`
- reviewed commit: [`b1fb74a1861e`](https://github.com/cesarnml/pirate_claw/commit/b1fb74a1861e4cab1fe87240cc84e0f3d4a254eb)
- current branch head: [`b1fb74a1861e`](https://github.com/cesarnml/pirate_claw/commit/b1fb74a1861e4cab1fe87240cc84e0f3d4a254eb)
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Unresolved Review Findings

- [greptile] `onCleanTimeout` type is wider than necessary `tools/delivery/review.ts:1062` [thread](https://github.com/cesarnml/pirate_claw/pull/93#discussion_r3052450914)
- [sonarqube] Refactor this function to reduce its Cognitive Complexity from 19 to the 15 allowed. `tools/delivery/review.ts:722` [thread](https://sonarcloud.io/project/issues?id=cesarnml_pirate_claw&issues=AZ1tupI_9depOQ5yBTOX&open=AZ1tupI_9depOQ5yBTOX&pullRequest=93)

- triage note: AI review reached the 12-minute limit while waiting on: coderabbit. Triage the captured findings and rerun manually if needed.
- triage summary: Flagged 1 finding comment(s) for follow-up.

### No-Action Rationale

- Left 1 unclear comment(s) for manual judgment.
- incomplete agents at timeout: `coderabbit`
<!-- ai-review:end -->
