### PR TITLE
feat(tmdb): foundation config, client, SQLite cache, graceful degrade [P11.01]

### DIFF
--- a/docs/02-delivery/phase-11/ticket-01-foundation-tmdb-client-cache.md
+++ b/docs/02-delivery/phase-11/ticket-01-foundation-tmdb-client-cache.md
@@ -25,3 +25,9 @@ With TMDB configured, the daemon starts and migrations apply; with TMDB omitted 
 ## Rationale
 
 This ticket isolates persistence and external API risk so later vertical slices can focus on matching and read-path enrichment without mixing schema migrations with UI work.
+
+**Implementation notes (P11.01):**
+
+- Optional `tmdb` config supports `cacheTtlDays` and `negativeCacheTtlDays` (defaults in code); `GET /api/config` redacts `tmdb.apiKey` like Transmission credentials.
+- `ensureSchema` applies `tmdb_movie_cache`, `tmdb_tv_cache`, and `tmdb_tv_season_cache` via `ensureTmdbSchema`.
+- Tests cover match-key helpers, config validation, TMDB table presence after migration, config redaction, and isolated `.env` loading for Transmission so parent env does not mask sibling `.env` values.

--- a/docs/02-delivery/phase-11/ticket-01-foundation-tmdb-client-cache.md
+++ b/docs/02-delivery/phase-11/ticket-01-foundation-tmdb-client-cache.md
@@ -31,3 +31,4 @@ This ticket isolates persistence and external API risk so later vertical slices 
 - Optional `tmdb` config supports `cacheTtlDays` and `negativeCacheTtlDays` (defaults in code); `GET /api/config` redacts `tmdb.apiKey` like Transmission credentials.
 - `ensureSchema` applies `tmdb_movie_cache`, `tmdb_tv_cache`, and `tmdb_tv_season_cache` via `ensureTmdbSchema`.
 - Tests cover match-key helpers, config validation, TMDB table presence after migration, config redaction, and isolated `.env` loading for Transmission so parent env does not mask sibling `.env` values.
+- Follow-up from AI review: TMDB client uses slot reservation in `throttle()` for concurrent safety; HTTP 429 without `Retry-After` falls back to exponential backoff; `ensureTmdbSchema` uses one statement per `database.run` inside a transaction; invalid cache expiry timestamps are treated as expired.

--- a/pirate-claw.config.example.json
+++ b/pirate-claw.config.example.json
@@ -44,5 +44,10 @@
     "artifactDir": ".pirate-claw/runtime",
     "artifactRetentionDays": 7,
     "apiPort": 3000
+  },
+  "tmdb": {
+    "apiKey": "your-tmdb-api-key",
+    "cacheTtlDays": 7,
+    "negativeCacheTtlDays": 1
   }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -286,7 +286,7 @@ export function buildFeedStatuses(
 // --- Config redaction ---
 
 export function redactConfig(config: AppConfig): AppConfig {
-  return {
+  const next: AppConfig = {
     ...config,
     transmission: {
       ...config.transmission,
@@ -294,4 +294,10 @@ export function redactConfig(config: AppConfig): AppConfig {
       password: '[redacted]',
     },
   };
+
+  if (next.tmdb?.apiKey) {
+    next.tmdb = { ...next.tmdb, apiKey: '[redacted]' };
+  }
+
+  return next;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,15 @@ export type RuntimeConfig = {
   apiPort?: number;
 };
 
+/** Optional TMDB enrichment (Phase 11). API key may be supplied via env instead. */
+export type TmdbConfig = {
+  apiKey?: string;
+  /** Successful fetch TTL; default 7 days. */
+  cacheTtlDays?: number;
+  /** Miss / error TTL; default 1 day. */
+  negativeCacheTtlDays?: number;
+};
+
 export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   runIntervalMinutes: 30,
   reconcileIntervalMinutes: 1,
@@ -63,6 +72,7 @@ export type AppConfig = {
   movies: MoviePolicy;
   transmission: TransmissionConfig;
   runtime: RuntimeConfig;
+  tmdb?: TmdbConfig;
 };
 
 const DEFAULT_CONFIG_PATH = 'pirate-claw.config.json';
@@ -119,6 +129,7 @@ export function validateConfig(
     movies: validateMoviePolicy(movies, path),
     transmission: validateTransmission(transmission, path, env),
     runtime: validateRuntime(input.runtime, path),
+    tmdb: validateOptionalTmdb(input.tmdb, path),
   };
 }
 
@@ -575,6 +586,65 @@ const supportedCodecs = new Set(['x264', 'x265']);
 function expectString(input: unknown, path: string): string {
   if (typeof input !== 'string' || input.length === 0) {
     throw new ConfigError(`Config file "${path}" must be a non-empty string.`);
+  }
+
+  return input;
+}
+
+function validateOptionalTmdb(
+  input: unknown,
+  path: string,
+): TmdbConfig | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  const tmdb = expectRecord(input, `${path} tmdb`);
+
+  const apiKey =
+    tmdb.apiKey === undefined
+      ? undefined
+      : typeof tmdb.apiKey === 'string'
+        ? tmdb.apiKey
+        : (() => {
+            throw new ConfigError(
+              `Config file "${path} tmdb apiKey" must be a string.`,
+            );
+          })();
+
+  const cacheTtlDays = validateOptionalTmdbDayCount(
+    tmdb.cacheTtlDays,
+    `${path} tmdb cacheTtlDays`,
+  );
+  const negativeCacheTtlDays = validateOptionalTmdbDayCount(
+    tmdb.negativeCacheTtlDays,
+    `${path} tmdb negativeCacheTtlDays`,
+  );
+
+  return {
+    apiKey,
+    cacheTtlDays,
+    negativeCacheTtlDays,
+  };
+}
+
+function validateOptionalTmdbDayCount(
+  input: unknown,
+  label: string,
+): number | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  if (
+    typeof input !== 'number' ||
+    !Number.isFinite(input) ||
+    input <= 0 ||
+    input > 3650
+  ) {
+    throw new ConfigError(
+      `Config file "${label}" must be a finite positive number of days (max 3650).`,
+    );
   }
 
   return input;

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,5 +1,6 @@
 import { Database } from 'bun:sqlite';
 
+import { ensureTmdbSchema } from './tmdb/schema';
 import type { RawFeedItem } from './feed';
 import type { NormalizedFeedItem } from './normalize';
 
@@ -240,6 +241,8 @@ export function ensureSchema(database: Database): void {
   ensureCandidateStateColumn(database, 'transmission_percent_done', 'REAL');
   ensureCandidateStateColumn(database, 'transmission_done_date', 'TEXT');
   ensureCandidateStateColumn(database, 'transmission_download_dir', 'TEXT');
+
+  ensureTmdbSchema(database);
 }
 
 export function hasStatusSchema(database: Database): boolean {

--- a/src/tmdb/cache.ts
+++ b/src/tmdb/cache.ts
@@ -1,0 +1,248 @@
+import type { Database } from 'bun:sqlite';
+
+export type TmdbMovieCacheRow = {
+  matchKey: string;
+  tmdbId: number | null;
+  isNegative: boolean;
+  expiresAt: string;
+  title: string | null;
+  overview: string | null;
+  posterPath: string | null;
+  backdropPath: string | null;
+  voteAverage: number | null;
+  voteCount: number | null;
+  genreIdsJson: string | null;
+  releaseDate: string | null;
+};
+
+export type TmdbTvCacheRow = {
+  matchKey: string;
+  tmdbId: number | null;
+  isNegative: boolean;
+  expiresAt: string;
+  name: string | null;
+  overview: string | null;
+  posterPath: string | null;
+  backdropPath: string | null;
+  voteAverage: number | null;
+  voteCount: number | null;
+  genreIdsJson: string | null;
+  firstAirDate: string | null;
+  numberOfSeasons: number | null;
+  seasonsJson: string | null;
+};
+
+export type TmdbTvSeasonCacheRow = {
+  showMatchKey: string;
+  seasonNumber: number;
+  expiresAt: string;
+  episodesJson: string;
+};
+
+export class TmdbCache {
+  constructor(private readonly db: Database) {}
+
+  getMovie(matchKey: string): TmdbMovieCacheRow | undefined {
+    const row = this.db
+      .query(
+        `SELECT
+          match_key AS matchKey,
+          tmdb_id AS tmdbId,
+          is_negative AS isNegative,
+          expires_at AS expiresAt,
+          title,
+          overview,
+          poster_path AS posterPath,
+          backdrop_path AS backdropPath,
+          vote_average AS voteAverage,
+          vote_count AS voteCount,
+          genre_ids_json AS genreIdsJson,
+          release_date AS releaseDate
+        FROM tmdb_movie_cache
+        WHERE match_key = ?1`,
+      )
+      .get(matchKey) as
+      | (Omit<TmdbMovieCacheRow, 'isNegative'> & { isNegative: number })
+      | null
+      | undefined;
+
+    if (!row) {
+      return undefined;
+    }
+    return { ...row, isNegative: row.isNegative === 1 };
+  }
+
+  upsertMovie(row: TmdbMovieCacheRow): void {
+    this.db.run(
+      `INSERT INTO tmdb_movie_cache (
+        match_key, tmdb_id, is_negative, expires_at,
+        title, overview, poster_path, backdrop_path,
+        vote_average, vote_count, genre_ids_json, release_date
+      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+      ON CONFLICT(match_key) DO UPDATE SET
+        tmdb_id = excluded.tmdb_id,
+        is_negative = excluded.is_negative,
+        expires_at = excluded.expires_at,
+        title = excluded.title,
+        overview = excluded.overview,
+        poster_path = excluded.poster_path,
+        backdrop_path = excluded.backdrop_path,
+        vote_average = excluded.vote_average,
+        vote_count = excluded.vote_count,
+        genre_ids_json = excluded.genre_ids_json,
+        release_date = excluded.release_date`,
+      [
+        row.matchKey,
+        row.tmdbId,
+        row.isNegative ? 1 : 0,
+        row.expiresAt,
+        row.title,
+        row.overview,
+        row.posterPath,
+        row.backdropPath,
+        row.voteAverage,
+        row.voteCount,
+        row.genreIdsJson,
+        row.releaseDate,
+      ],
+    );
+  }
+
+  getTv(matchKey: string): TmdbTvCacheRow | undefined {
+    const row = this.db
+      .query(
+        `SELECT
+          match_key AS matchKey,
+          tmdb_id AS tmdbId,
+          is_negative AS isNegative,
+          expires_at AS expiresAt,
+          name,
+          overview,
+          poster_path AS posterPath,
+          backdrop_path AS backdropPath,
+          vote_average AS voteAverage,
+          vote_count AS voteCount,
+          genre_ids_json AS genreIdsJson,
+          first_air_date AS firstAirDate,
+          number_of_seasons AS numberOfSeasons,
+          seasons_json AS seasonsJson
+        FROM tmdb_tv_cache
+        WHERE match_key = ?1`,
+      )
+      .get(matchKey) as
+      | (Omit<TmdbTvCacheRow, 'isNegative'> & { isNegative: number })
+      | null
+      | undefined;
+
+    if (!row) {
+      return undefined;
+    }
+    return { ...row, isNegative: row.isNegative === 1 };
+  }
+
+  upsertTv(row: TmdbTvCacheRow): void {
+    this.db.run(
+      `INSERT INTO tmdb_tv_cache (
+        match_key, tmdb_id, is_negative, expires_at,
+        name, overview, poster_path, backdrop_path,
+        vote_average, vote_count, genre_ids_json,
+        first_air_date, number_of_seasons, seasons_json
+      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+      ON CONFLICT(match_key) DO UPDATE SET
+        tmdb_id = excluded.tmdb_id,
+        is_negative = excluded.is_negative,
+        expires_at = excluded.expires_at,
+        name = excluded.name,
+        overview = excluded.overview,
+        poster_path = excluded.poster_path,
+        backdrop_path = excluded.backdrop_path,
+        vote_average = excluded.vote_average,
+        vote_count = excluded.vote_count,
+        genre_ids_json = excluded.genre_ids_json,
+        first_air_date = excluded.first_air_date,
+        number_of_seasons = excluded.number_of_seasons,
+        seasons_json = excluded.seasons_json`,
+      [
+        row.matchKey,
+        row.tmdbId,
+        row.isNegative ? 1 : 0,
+        row.expiresAt,
+        row.name,
+        row.overview,
+        row.posterPath,
+        row.backdropPath,
+        row.voteAverage,
+        row.voteCount,
+        row.genreIdsJson,
+        row.firstAirDate,
+        row.numberOfSeasons,
+        row.seasonsJson,
+      ],
+    );
+  }
+
+  getTvSeason(
+    showMatchKey: string,
+    seasonNumber: number,
+  ): TmdbTvSeasonCacheRow | undefined {
+    const row = this.db
+      .query(
+        `SELECT
+          show_match_key AS showMatchKey,
+          season_number AS seasonNumber,
+          expires_at AS expiresAt,
+          episodes_json AS episodesJson
+        FROM tmdb_tv_season_cache
+        WHERE show_match_key = ?1 AND season_number = ?2`,
+      )
+      .get(showMatchKey, seasonNumber) as
+      | TmdbTvSeasonCacheRow
+      | null
+      | undefined;
+
+    return row ?? undefined;
+  }
+
+  upsertTvSeason(row: TmdbTvSeasonCacheRow): void {
+    this.db.run(
+      `INSERT INTO tmdb_tv_season_cache (
+        show_match_key, season_number, expires_at, episodes_json
+      ) VALUES (?1, ?2, ?3, ?4)
+      ON CONFLICT(show_match_key, season_number) DO UPDATE SET
+        expires_at = excluded.expires_at,
+        episodes_json = excluded.episodes_json`,
+      [row.showMatchKey, row.seasonNumber, row.expiresAt, row.episodesJson],
+    );
+  }
+
+  listExpiredMovieKeys(nowIso: string): string[] {
+    const rows = this.db
+      .query(
+        `SELECT match_key AS k FROM tmdb_movie_cache WHERE expires_at < ?1`,
+      )
+      .all(nowIso) as { k: string }[];
+
+    return rows.map((r) => r.k);
+  }
+
+  listExpiredTvKeys(nowIso: string): string[] {
+    const rows = this.db
+      .query(`SELECT match_key AS k FROM tmdb_tv_cache WHERE expires_at < ?1`)
+      .all(nowIso) as { k: string }[];
+
+    return rows.map((r) => r.k);
+  }
+
+  listExpiredTvSeasonKeys(
+    nowIso: string,
+  ): { showKey: string; season: number }[] {
+    const rows = this.db
+      .query(
+        `SELECT show_match_key AS showKey, season_number AS season
+         FROM tmdb_tv_season_cache WHERE expires_at < ?1`,
+      )
+      .all(nowIso) as { showKey: string; season: number }[];
+
+    return rows;
+  }
+}

--- a/src/tmdb/client.ts
+++ b/src/tmdb/client.ts
@@ -1,0 +1,150 @@
+import { TMDB_API_BASE } from './constants';
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MIN_REQUEST_INTERVAL_MS = 55;
+
+export type TmdbSearchMovieResult = {
+  id: number;
+  title: string;
+  release_date?: string;
+};
+
+export type TmdbMovieDetails = {
+  id: number;
+  title: string;
+  overview?: string;
+  poster_path?: string | null;
+  backdrop_path?: string | null;
+  vote_average?: number;
+  vote_count?: number;
+  genres?: { id: number }[];
+  release_date?: string;
+};
+
+export type TmdbSearchTvResult = {
+  id: number;
+  name: string;
+  first_air_date?: string;
+};
+
+export type TmdbTvDetails = {
+  id: number;
+  name: string;
+  overview?: string;
+  poster_path?: string | null;
+  backdrop_path?: string | null;
+  vote_average?: number;
+  vote_count?: number;
+  genres?: { id: number }[];
+  first_air_date?: string;
+  number_of_seasons?: number;
+  seasons?: { season_number: number; episode_count: number }[];
+};
+
+export type TmdbTvSeasonDetails = {
+  season_number: number;
+  episodes?: {
+    episode_number: number;
+    name?: string;
+    still_path?: string | null;
+    air_date?: string;
+    overview?: string;
+  }[];
+};
+
+export class TmdbHttpClient {
+  private lastRequestAt = 0;
+
+  constructor(
+    private readonly apiKey: string,
+    private readonly log: (message: string) => void,
+    private readonly timeoutMs = DEFAULT_TIMEOUT_MS,
+  ) {}
+
+  private async throttle(): Promise<void> {
+    const elapsed = Date.now() - this.lastRequestAt;
+    if (elapsed < MIN_REQUEST_INTERVAL_MS) {
+      await new Promise((r) =>
+        setTimeout(r, MIN_REQUEST_INTERVAL_MS - elapsed),
+      );
+    }
+  }
+
+  private async getJson<T>(path: string, retry429 = 0): Promise<T | null> {
+    await this.throttle();
+    const url = `${TMDB_API_BASE}${path}${path.includes('?') ? '&' : '?'}api_key=${encodeURIComponent(this.apiKey)}`;
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        signal: AbortSignal.timeout(this.timeoutMs),
+        headers: { Accept: 'application/json' },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.log(`tmdb request failed: ${path} (${message})`);
+      return null;
+    } finally {
+      this.lastRequestAt = Date.now();
+    }
+
+    if (response.status === 429) {
+      const retryAfter = Number(response.headers.get('retry-after'));
+      const waitSec = Number.isFinite(retryAfter)
+        ? retryAfter
+        : Math.min(2 ** retry429, 32);
+      this.log(`tmdb rate limited (429) on ${path}; waiting ${waitSec}s`);
+      if (retry429 < 4) {
+        await new Promise((r) => setTimeout(r, waitSec * 1000));
+        return this.getJson<T>(path, retry429 + 1);
+      }
+      return null;
+    }
+
+    if (!response.ok) {
+      this.log(`tmdb HTTP ${response.status} for ${path}`);
+      return null;
+    }
+
+    return (await response.json()) as T;
+  }
+
+  async searchMovie(
+    query: string,
+    year?: number,
+  ): Promise<TmdbSearchMovieResult | null> {
+    const q = encodeURIComponent(query);
+    const y = year != null ? `&year=${year}` : '';
+    const data = await this.getJson<{ results?: TmdbSearchMovieResult[] }>(
+      `/search/movie?query=${q}${y}`,
+    );
+    const first = data?.results?.[0];
+    return first ?? null;
+  }
+
+  async getMovie(movieId: number): Promise<TmdbMovieDetails | null> {
+    return this.getJson<TmdbMovieDetails>(`/movie/${movieId}`);
+  }
+
+  async searchTv(query: string): Promise<TmdbSearchTvResult | null> {
+    const q = encodeURIComponent(query);
+    const data = await this.getJson<{ results?: TmdbSearchTvResult[] }>(
+      `/search/tv?query=${q}`,
+    );
+    const first = data?.results?.[0];
+    return first ?? null;
+  }
+
+  async getTv(tvId: number): Promise<TmdbTvDetails | null> {
+    return this.getJson<TmdbTvDetails>(`/tv/${tvId}`);
+  }
+
+  async getTvSeason(
+    tvId: number,
+    seasonNumber: number,
+  ): Promise<TmdbTvSeasonDetails | null> {
+    return this.getJson<TmdbTvSeasonDetails>(
+      `/tv/${tvId}/season/${seasonNumber}`,
+    );
+  }
+}

--- a/src/tmdb/client.ts
+++ b/src/tmdb/client.ts
@@ -61,12 +61,17 @@ export class TmdbHttpClient {
     private readonly timeoutMs = DEFAULT_TIMEOUT_MS,
   ) {}
 
+  /** Reserves the next allowed request time so concurrent callers serialize. */
   private async throttle(): Promise<void> {
-    const elapsed = Date.now() - this.lastRequestAt;
-    if (elapsed < MIN_REQUEST_INTERVAL_MS) {
-      await new Promise((r) =>
-        setTimeout(r, MIN_REQUEST_INTERVAL_MS - elapsed),
-      );
+    const now = Date.now();
+    const scheduled = Math.max(
+      this.lastRequestAt + MIN_REQUEST_INTERVAL_MS,
+      now,
+    );
+    this.lastRequestAt = scheduled;
+    const waitMs = scheduled - now;
+    if (waitMs > 0) {
+      await new Promise((r) => setTimeout(r, waitMs));
     }
   }
 
@@ -84,15 +89,16 @@ export class TmdbHttpClient {
       const message = error instanceof Error ? error.message : String(error);
       this.log(`tmdb request failed: ${path} (${message})`);
       return null;
-    } finally {
-      this.lastRequestAt = Date.now();
     }
 
     if (response.status === 429) {
-      const retryAfter = Number(response.headers.get('retry-after'));
-      const waitSec = Number.isFinite(retryAfter)
-        ? retryAfter
-        : Math.min(2 ** retry429, 32);
+      const retryAfterRaw = response.headers.get('retry-after');
+      const retryAfter =
+        retryAfterRaw !== null ? Number(retryAfterRaw) : Number.NaN;
+      const waitSec =
+        Number.isFinite(retryAfter) && retryAfter > 0
+          ? retryAfter
+          : Math.min(2 ** retry429, 32);
       this.log(`tmdb rate limited (429) on ${path}; waiting ${waitSec}s`);
       if (retry429 < 4) {
         await new Promise((r) => setTimeout(r, waitSec * 1000));

--- a/src/tmdb/constants.ts
+++ b/src/tmdb/constants.ts
@@ -3,6 +3,8 @@ export const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p';
 
 export const TMDB_POSTER_SIZE = 'w500';
 
+export const TMDB_BACKDROP_SIZE = 'w1280';
+
 export const TMDB_API_BASE = 'https://api.themoviedb.org/3';
 
 export function posterUrl(
@@ -20,5 +22,5 @@ export function backdropUrl(
   if (!backdropPath) {
     return undefined;
   }
-  return `${TMDB_IMAGE_BASE}/w1280${backdropPath}`;
+  return `${TMDB_IMAGE_BASE}/${TMDB_BACKDROP_SIZE}${backdropPath}`;
 }

--- a/src/tmdb/constants.ts
+++ b/src/tmdb/constants.ts
@@ -1,0 +1,24 @@
+/** TMDB image CDN base; append size path + file path from API. */
+export const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p';
+
+export const TMDB_POSTER_SIZE = 'w500';
+
+export const TMDB_API_BASE = 'https://api.themoviedb.org/3';
+
+export function posterUrl(
+  posterPath: string | null | undefined,
+): string | undefined {
+  if (!posterPath) {
+    return undefined;
+  }
+  return `${TMDB_IMAGE_BASE}/${TMDB_POSTER_SIZE}${posterPath}`;
+}
+
+export function backdropUrl(
+  backdropPath: string | null | undefined,
+): string | undefined {
+  if (!backdropPath) {
+    return undefined;
+  }
+  return `${TMDB_IMAGE_BASE}/w1280${backdropPath}`;
+}

--- a/src/tmdb/keys.ts
+++ b/src/tmdb/keys.ts
@@ -1,0 +1,9 @@
+/** Stable lookup key for movie cache (normalized title + year). */
+export function movieMatchKey(normalizedTitle: string, year?: number): string {
+  return `${normalizedTitle.toLowerCase().trim()}|${year ?? '_'}`;
+}
+
+/** Stable lookup key for TV show cache. */
+export function tvMatchKey(normalizedTitle: string): string {
+  return normalizedTitle.toLowerCase().trim();
+}

--- a/src/tmdb/schema.ts
+++ b/src/tmdb/schema.ts
@@ -1,0 +1,49 @@
+import type { Database } from 'bun:sqlite';
+
+/**
+ * TMDB cache tables (Phase 11). Idempotent DDL: split movie vs TV, optional
+ * season rows for later vertical slices.
+ */
+export function ensureTmdbSchema(database: Database): void {
+  database.run(`
+    CREATE TABLE IF NOT EXISTS tmdb_movie_cache (
+      match_key TEXT PRIMARY KEY NOT NULL,
+      tmdb_id INTEGER,
+      is_negative INTEGER NOT NULL DEFAULT 0,
+      expires_at TEXT NOT NULL,
+      title TEXT,
+      overview TEXT,
+      poster_path TEXT,
+      backdrop_path TEXT,
+      vote_average REAL,
+      vote_count INTEGER,
+      genre_ids_json TEXT,
+      release_date TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS tmdb_tv_cache (
+      match_key TEXT PRIMARY KEY NOT NULL,
+      tmdb_id INTEGER,
+      is_negative INTEGER NOT NULL DEFAULT 0,
+      expires_at TEXT NOT NULL,
+      name TEXT,
+      overview TEXT,
+      poster_path TEXT,
+      backdrop_path TEXT,
+      vote_average REAL,
+      vote_count INTEGER,
+      genre_ids_json TEXT,
+      first_air_date TEXT,
+      number_of_seasons INTEGER,
+      seasons_json TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS tmdb_tv_season_cache (
+      show_match_key TEXT NOT NULL,
+      season_number INTEGER NOT NULL,
+      expires_at TEXT NOT NULL,
+      episodes_json TEXT NOT NULL,
+      PRIMARY KEY (show_match_key, season_number)
+    );
+  `);
+}

--- a/src/tmdb/schema.ts
+++ b/src/tmdb/schema.ts
@@ -5,45 +5,49 @@ import type { Database } from 'bun:sqlite';
  * season rows for later vertical slices.
  */
 export function ensureTmdbSchema(database: Database): void {
-  database.run(`
-    CREATE TABLE IF NOT EXISTS tmdb_movie_cache (
-      match_key TEXT PRIMARY KEY NOT NULL,
-      tmdb_id INTEGER,
-      is_negative INTEGER NOT NULL DEFAULT 0,
-      expires_at TEXT NOT NULL,
-      title TEXT,
-      overview TEXT,
-      poster_path TEXT,
-      backdrop_path TEXT,
-      vote_average REAL,
-      vote_count INTEGER,
-      genre_ids_json TEXT,
-      release_date TEXT
-    );
-
-    CREATE TABLE IF NOT EXISTS tmdb_tv_cache (
-      match_key TEXT PRIMARY KEY NOT NULL,
-      tmdb_id INTEGER,
-      is_negative INTEGER NOT NULL DEFAULT 0,
-      expires_at TEXT NOT NULL,
-      name TEXT,
-      overview TEXT,
-      poster_path TEXT,
-      backdrop_path TEXT,
-      vote_average REAL,
-      vote_count INTEGER,
-      genre_ids_json TEXT,
-      first_air_date TEXT,
-      number_of_seasons INTEGER,
-      seasons_json TEXT
-    );
-
-    CREATE TABLE IF NOT EXISTS tmdb_tv_season_cache (
-      show_match_key TEXT NOT NULL,
-      season_number INTEGER NOT NULL,
-      expires_at TEXT NOT NULL,
-      episodes_json TEXT NOT NULL,
-      PRIMARY KEY (show_match_key, season_number)
-    );
-  `);
+  database.transaction(() => {
+    database.run(`
+      CREATE TABLE IF NOT EXISTS tmdb_movie_cache (
+        match_key TEXT PRIMARY KEY NOT NULL,
+        tmdb_id INTEGER,
+        is_negative INTEGER NOT NULL DEFAULT 0,
+        expires_at TEXT NOT NULL,
+        title TEXT,
+        overview TEXT,
+        poster_path TEXT,
+        backdrop_path TEXT,
+        vote_average REAL,
+        vote_count INTEGER,
+        genre_ids_json TEXT,
+        release_date TEXT
+      );
+    `);
+    database.run(`
+      CREATE TABLE IF NOT EXISTS tmdb_tv_cache (
+        match_key TEXT PRIMARY KEY NOT NULL,
+        tmdb_id INTEGER,
+        is_negative INTEGER NOT NULL DEFAULT 0,
+        expires_at TEXT NOT NULL,
+        name TEXT,
+        overview TEXT,
+        poster_path TEXT,
+        backdrop_path TEXT,
+        vote_average REAL,
+        vote_count INTEGER,
+        genre_ids_json TEXT,
+        first_air_date TEXT,
+        number_of_seasons INTEGER,
+        seasons_json TEXT
+      );
+    `);
+    database.run(`
+      CREATE TABLE IF NOT EXISTS tmdb_tv_season_cache (
+        show_match_key TEXT NOT NULL,
+        season_number INTEGER NOT NULL,
+        expires_at TEXT NOT NULL,
+        episodes_json TEXT NOT NULL,
+        PRIMARY KEY (show_match_key, season_number)
+      );
+    `);
+  })();
 }

--- a/src/tmdb/settings.ts
+++ b/src/tmdb/settings.ts
@@ -12,7 +12,7 @@ export function resolveTmdbSettings(
 ): ResolvedTmdbSettings | null {
   const fromEnv = env.PIRATE_CLAW_TMDB_API_KEY?.trim();
   const fromFile = config.tmdb?.apiKey?.trim();
-  const apiKey = (fromEnv ?? fromFile ?? '').trim();
+  const apiKey = fromEnv ?? fromFile ?? '';
   if (!apiKey) {
     return null;
   }
@@ -32,5 +32,6 @@ export function expiresAtIso(ttlMs: number): string {
 }
 
 export function isCacheExpired(expiresAt: string): boolean {
-  return Date.parse(expiresAt) <= Date.now();
+  const parsed = Date.parse(expiresAt);
+  return Number.isNaN(parsed) || parsed <= Date.now();
 }

--- a/src/tmdb/settings.ts
+++ b/src/tmdb/settings.ts
@@ -1,0 +1,36 @@
+import type { AppConfig } from '../config';
+
+export type ResolvedTmdbSettings = {
+  apiKey: string;
+  cacheTtlMs: number;
+  negativeCacheTtlMs: number;
+};
+
+export function resolveTmdbSettings(
+  config: AppConfig,
+  env: Record<string, string | undefined> = process.env,
+): ResolvedTmdbSettings | null {
+  const fromEnv = env.PIRATE_CLAW_TMDB_API_KEY?.trim();
+  const fromFile = config.tmdb?.apiKey?.trim();
+  const apiKey = (fromEnv ?? fromFile ?? '').trim();
+  if (!apiKey) {
+    return null;
+  }
+
+  const cacheTtlDays = config.tmdb?.cacheTtlDays ?? 7;
+  const negativeDays = config.tmdb?.negativeCacheTtlDays ?? 1;
+
+  return {
+    apiKey,
+    cacheTtlMs: cacheTtlDays * 86_400_000,
+    negativeCacheTtlMs: negativeDays * 86_400_000,
+  };
+}
+
+export function expiresAtIso(ttlMs: number): string {
+  return new Date(Date.now() + ttlMs).toISOString();
+}
+
+export function isCacheExpired(expiresAt: string): boolean {
+  return Date.parse(expiresAt) <= Date.now();
+}

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -607,4 +607,19 @@ describe('redactConfig', () => {
     expect(redacted.transmission.password).toBe('[redacted]');
     expect(config.transmission.username).toBe('user');
   });
+
+  it('redacts tmdb apiKey when present', () => {
+    const config: AppConfig = {
+      ...stubConfig(),
+      tmdb: {
+        apiKey: 'secret-tmdb',
+        cacheTtlDays: 14,
+        negativeCacheTtlDays: 2,
+      },
+    };
+    const redacted = redactConfig(config);
+
+    expect(redacted.tmdb?.apiKey).toBe('[redacted]');
+    expect(config.tmdb?.apiKey).toBe('secret-tmdb');
+  });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -556,6 +556,11 @@ describe('validateConfig', () => {
   });
 
   it('loads transmission credentials from a sibling .env file', async () => {
+    const prevUser = process.env.PIRATE_CLAW_TRANSMISSION_USERNAME;
+    const prevPass = process.env.PIRATE_CLAW_TRANSMISSION_PASSWORD;
+    delete process.env.PIRATE_CLAW_TRANSMISSION_USERNAME;
+    delete process.env.PIRATE_CLAW_TRANSMISSION_PASSWORD;
+
     const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-config-'));
     try {
       const configPath = join(directory, 'pirate-claw.config.json');
@@ -590,6 +595,16 @@ describe('validateConfig', () => {
       });
     } finally {
       await Bun.$`rm -rf ${directory}`;
+      if (prevUser !== undefined) {
+        process.env.PIRATE_CLAW_TRANSMISSION_USERNAME = prevUser;
+      } else {
+        delete process.env.PIRATE_CLAW_TRANSMISSION_USERNAME;
+      }
+      if (prevPass !== undefined) {
+        process.env.PIRATE_CLAW_TRANSMISSION_PASSWORD = prevPass;
+      } else {
+        delete process.env.PIRATE_CLAW_TRANSMISSION_PASSWORD;
+      }
     }
   });
 
@@ -718,6 +733,32 @@ describe('validateConfig', () => {
         'Config file "config transmission downloadDirs tv" must be a non-empty string.',
       ),
     );
+  });
+
+  it('accepts optional tmdb block', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      tmdb: {
+        apiKey: 'test-key',
+        cacheTtlDays: 14,
+        negativeCacheTtlDays: 2,
+      },
+    });
+
+    expect(config.tmdb).toEqual({
+      apiKey: 'test-key',
+      cacheTtlDays: 14,
+      negativeCacheTtlDays: 2,
+    });
+  });
+
+  it('fails when tmdb cacheTtlDays is out of range', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        tmdb: { cacheTtlDays: 0 },
+      }),
+    ).toThrow(ConfigError);
   });
 });
 

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -546,6 +546,28 @@ describe('SQLite repository', () => {
       },
     ]);
   });
+
+  it('creates TMDB cache tables in ensureSchema', async () => {
+    const path = await createDatabasePath();
+    const database = openDatabase(path);
+
+    openDatabases.push(database);
+    ensureSchema(database);
+
+    const rows = database
+      .query(
+        `SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'tmdb_%' ORDER BY name`,
+      )
+      .all() as Array<{ name: string }>;
+
+    const names = rows.map((row) => row.name);
+
+    expect(names).toEqual([
+      'tmdb_movie_cache',
+      'tmdb_tv_cache',
+      'tmdb_tv_season_cache',
+    ]);
+  });
 });
 
 function createTestRepository(path: string) {

--- a/test/tmdb-keys.test.ts
+++ b/test/tmdb-keys.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 
 import { movieMatchKey, tvMatchKey } from '../src/tmdb/keys';
+import { isCacheExpired } from '../src/tmdb/settings';
 
 describe('tmdb match keys', () => {
   it('builds stable movie keys with year', () => {
@@ -13,5 +14,11 @@ describe('tmdb match keys', () => {
 
   it('normalizes tv keys', () => {
     expect(tvMatchKey('  My Show  ')).toBe('my show');
+  });
+});
+
+describe('isCacheExpired', () => {
+  it('treats invalid expiresAt as expired', () => {
+    expect(isCacheExpired('not-a-date')).toBe(true);
   });
 });

--- a/test/tmdb-keys.test.ts
+++ b/test/tmdb-keys.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'bun:test';
+
+import { movieMatchKey, tvMatchKey } from '../src/tmdb/keys';
+
+describe('tmdb match keys', () => {
+  it('builds stable movie keys with year', () => {
+    expect(movieMatchKey('Some Film', 2024)).toBe('some film|2024');
+  });
+
+  it('builds movie keys without year', () => {
+    expect(movieMatchKey('Unknown', undefined)).toBe('unknown|_');
+  });
+
+  it('normalizes tv keys', () => {
+    expect(tvMatchKey('  My Show  ')).toBe('my show');
+  });
+});


### PR DESCRIPTION
## Summary

- delivery ticket: `P11.01 Foundation: TMDB config, client, SQLite cache, graceful degrade`
- ticket file: [docs/02-delivery/phase-11/ticket-01-foundation-tmdb-client-cache.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-11/ticket-01-foundation-tmdb-client-cache.md)
- stacked base branch: `main`
- internal review: completed at 2026-04-08 16:45 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`27e3bca59f86`](https://github.com/cesarnml/pirate_claw/commit/27e3bca59f868511dd91fd8899f6ecd70370f2e9)
- current branch head: [`6178ffdfd0bb`](https://github.com/cesarnml/pirate_claw/commit/6178ffdfd0bba81bb7c6907a064db3ae6f753f41)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `27e3bca59f86` address all findings from that review.
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Potential race condition in throttle mechanism with concurrent requests. (native GitHub thread resolved) `src/tmdb/client.ts:71` [thread](https://github.com/cesarnml/pirate_claw/pull/94#discussion_r3052882227)
- [greptile] Zero-wait retry when `Retry-After` header is absent (native GitHub thread resolved) `src/tmdb/client.ts:95` [thread](https://github.com/cesarnml/pirate_claw/pull/94#discussion_r3052863212)
