### PR TITLE
feat(tmdb): movies lazy API enrich and dashboard movies page [P11.02]

### DIFF
--- a/docs/02-delivery/phase-11/ticket-02-movies-vertical-slice.md
+++ b/docs/02-delivery/phase-11/ticket-02-movies-vertical-slice.md
@@ -24,3 +24,10 @@ With TMDB configured, an operator can browse movie-related dashboard views and s
 ## Rationale
 
 Movies are the first vertical slice after foundation so the simpler TMDB entity (single title+year match) validates client, cache, and UI patterns before TV season/episode complexity.
+
+**Implementation notes (P11.02):**
+
+- `GET /api/movies` uses `buildMovieBreakdowns` then `enrichMovieBreakdowns` when the daemon has resolved TMDB settings (`tmdbMovies` on `ApiFetchDeps`): SQLite cache read, TTL via `isCacheExpired`, TMDB search + movie details on miss, positive/negative cache rows.
+- JSON adds optional `tmdb` on each movie row (`posterUrl`, `backdropUrl`, `overview`, `voteAverage`, `voteCount`, `tmdbId`, `title`).
+- Dashboard: new `/movies` route listing movie candidates with poster placeholder, rating badge, and overview when present.
+- `createApiFetch` returns an async `fetch` handler; callers `await` the handler result.

--- a/docs/02-delivery/phase-11/ticket-02-movies-vertical-slice.md
+++ b/docs/02-delivery/phase-11/ticket-02-movies-vertical-slice.md
@@ -31,3 +31,4 @@ Movies are the first vertical slice after foundation so the simpler TMDB entity 
 - JSON adds optional `tmdb` on each movie row (`posterUrl`, `backdropUrl`, `overview`, `voteAverage`, `voteCount`, `tmdbId`, `title`).
 - Dashboard: new `/movies` route listing movie candidates with poster placeholder, rating badge, and overview when present.
 - `createApiFetch` returns an async `fetch` handler; callers `await` the handler result.
+- Review follow-up: SQLite negative rows only after a definitive TMDB search miss; `getMovie` null and network errors log without negative caching; cache read inside the same `try` as API calls; `safeJson`/`json500` reduce handler complexity; `tmdbMovieEnrichDeps()` in `cli.ts`; movies page poster `alt` text and rating badge gated on TMDB vote data.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,8 +1,12 @@
 import type { AppConfig, FeedConfig, RuntimeConfig } from './config';
+import type { MovieBreakdown } from './movie-api-types';
+export type { MovieBreakdown, TmdbMoviePublic } from './movie-api-types';
 import { isDueFeed } from './poll-state';
 import type { PollState } from './poll-state';
 import type { CandidateStateRecord, Repository } from './repository';
 import type { CycleResult } from './runtime-artifacts';
+import type { MovieEnrichDeps } from './tmdb/movie-enrichment';
+import { enrichMovieBreakdowns } from './tmdb/movie-enrichment';
 
 export type CycleSnapshot = {
   status: CycleResult['status'];
@@ -49,18 +53,27 @@ export type ApiFetchDeps = {
   config: AppConfig;
   pollStatePath: string;
   loadPollState: (path: string) => PollState;
+  /** When set (TMDB configured), GET /api/movies lazily enriches from cache + TMDB. */
+  tmdbMovies?: MovieEnrichDeps;
 };
 
 export function createApiFetch(
   deps?: ApiFetchDeps,
-): (request: Request) => Response {
+): (request: Request) => Response | Promise<Response> {
   if (!deps) {
     return () => Response.json({ error: 'not found' }, { status: 404 });
   }
 
-  const { repository, health, config, pollStatePath, loadPollState } = deps;
+  const {
+    repository,
+    health,
+    config,
+    pollStatePath,
+    loadPollState,
+    tmdbMovies,
+  } = deps;
 
-  return (request: Request) => {
+  return async (request: Request) => {
     const url = new URL(request.url);
 
     if (url.pathname === '/api/health') {
@@ -114,7 +127,11 @@ export function createApiFetch(
     if (url.pathname === '/api/movies') {
       try {
         const candidates = repository.listCandidateStates();
-        return Response.json({ movies: buildMovieBreakdowns(candidates) });
+        const base = buildMovieBreakdowns(candidates);
+        const movies = tmdbMovies
+          ? await enrichMovieBreakdowns(base, tmdbMovies)
+          : base;
+        return Response.json({ movies });
       } catch {
         return Response.json(
           { error: 'internal server error' },
@@ -219,17 +236,6 @@ export function buildShowBreakdowns(
 }
 
 // --- Movie breakdowns ---
-
-export type MovieBreakdown = {
-  normalizedTitle: string;
-  year?: number;
-  resolution?: string;
-  codec?: string;
-  identityKey: string;
-  status: string;
-  lifecycleStatus?: string;
-  queuedAt?: string;
-};
 
 export function buildMovieBreakdowns(
   candidates: CandidateStateRecord[],

--- a/src/api.ts
+++ b/src/api.ts
@@ -57,6 +57,18 @@ export type ApiFetchDeps = {
   tmdbMovies?: MovieEnrichDeps;
 };
 
+function json500(): Response {
+  return Response.json({ error: 'internal server error' }, { status: 500 });
+}
+
+function safeJson<T>(body: () => T): Response {
+  try {
+    return Response.json(body());
+  } catch {
+    return json500();
+  }
+}
+
 export function createApiFetch(
   deps?: ApiFetchDeps,
 ): (request: Request) => Response | Promise<Response> {
@@ -74,9 +86,9 @@ export function createApiFetch(
   } = deps;
 
   return async (request: Request) => {
-    const url = new URL(request.url);
+    const path = new URL(request.url).pathname;
 
-    if (url.pathname === '/api/health') {
+    if (path === '/api/health') {
       const uptimeMs = Date.now() - new Date(health.startedAt).getTime();
       return Response.json({
         uptime: uptimeMs,
@@ -86,45 +98,24 @@ export function createApiFetch(
       });
     }
 
-    if (url.pathname === '/api/status') {
-      try {
-        return Response.json({
-          runs: repository.listRecentRunSummaries(),
-        });
-      } catch {
-        return Response.json(
-          { error: 'internal server error' },
-          { status: 500 },
-        );
-      }
+    if (path === '/api/status') {
+      return safeJson(() => ({ runs: repository.listRecentRunSummaries() }));
     }
 
-    if (url.pathname === '/api/candidates') {
-      try {
-        return Response.json({
-          candidates: repository.listCandidateStates(),
-        });
-      } catch {
-        return Response.json(
-          { error: 'internal server error' },
-          { status: 500 },
-        );
-      }
+    if (path === '/api/candidates') {
+      return safeJson(() => ({
+        candidates: repository.listCandidateStates(),
+      }));
     }
 
-    if (url.pathname === '/api/shows') {
-      try {
+    if (path === '/api/shows') {
+      return safeJson(() => {
         const candidates = repository.listCandidateStates();
-        return Response.json({ shows: buildShowBreakdowns(candidates) });
-      } catch {
-        return Response.json(
-          { error: 'internal server error' },
-          { status: 500 },
-        );
-      }
+        return { shows: buildShowBreakdowns(candidates) };
+      });
     }
 
-    if (url.pathname === '/api/movies') {
+    if (path === '/api/movies') {
       try {
         const candidates = repository.listCandidateStates();
         const base = buildMovieBreakdowns(candidates);
@@ -133,36 +124,21 @@ export function createApiFetch(
           : base;
         return Response.json({ movies });
       } catch {
-        return Response.json(
-          { error: 'internal server error' },
-          { status: 500 },
-        );
+        return json500();
       }
     }
 
-    if (url.pathname === '/api/feeds') {
-      try {
+    if (path === '/api/feeds') {
+      return safeJson(() => {
         const pollState = loadPollState(pollStatePath);
-        return Response.json({
+        return {
           feeds: buildFeedStatuses(config.feeds, pollState, config.runtime),
-        });
-      } catch {
-        return Response.json(
-          { error: 'internal server error' },
-          { status: 500 },
-        );
-      }
+        };
+      });
     }
 
-    if (url.pathname === '/api/config') {
-      try {
-        return Response.json(redactConfig(config));
-      } catch {
-        return Response.json(
-          { error: 'internal server error' },
-          { status: 500 },
-        );
-      }
+    if (path === '/api/config') {
+      return safeJson(() => redactConfig(config));
     }
 
     return Response.json({ error: 'not found' }, { status: 404 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,9 @@ import {
   type CandidateStateRecord,
   type RunSummaryRecord,
 } from './repository';
+import { TmdbCache } from './tmdb/cache';
+import { TmdbHttpClient } from './tmdb/client';
+import { resolveTmdbSettings } from './tmdb/settings';
 import { createTransmissionDownloader } from './transmission';
 
 export async function runCli(argv: string[]): Promise<number> {
@@ -141,6 +144,20 @@ export async function runCli(argv: string[]): Promise<number> {
 
         const health = createHealthState();
 
+        const tmdbResolved = resolveTmdbSettings(config);
+        const tmdbMovies =
+          tmdbResolved && config.runtime.apiPort != null
+            ? {
+                cache: new TmdbCache(database),
+                client: new TmdbHttpClient(tmdbResolved.apiKey, (m: string) =>
+                  log(`[tmdb] ${m}`),
+                ),
+                cacheTtlMs: tmdbResolved.cacheTtlMs,
+                negativeCacheTtlMs: tmdbResolved.negativeCacheTtlMs,
+                log: (m: string) => log(`[tmdb] ${m}`),
+              }
+            : undefined;
+
         await runDaemonLoop({
           runCycle: async () => {
             let pollState = loadPollState(pollStatePath);
@@ -194,6 +211,7 @@ export async function runCli(argv: string[]): Promise<number> {
                   config,
                   pollStatePath,
                   loadPollState,
+                  tmdbMovies,
                 })
               : undefined,
         });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,8 +2,15 @@ import { existsSync } from 'node:fs';
 
 import { join } from 'node:path';
 
+import type { Database } from 'bun:sqlite';
+
 import { createApiFetch, createHealthState, recordCycleInHealth } from './api';
-import { ConfigError, loadConfig, resolveConfigPath } from './config';
+import {
+  type AppConfig,
+  ConfigError,
+  loadConfig,
+  resolveConfigPath,
+} from './config';
 import { daemonOptionsFromConfig, runDaemonLoop } from './daemon';
 import {
   reconcileCandidates,
@@ -30,8 +37,29 @@ import {
 } from './repository';
 import { TmdbCache } from './tmdb/cache';
 import { TmdbHttpClient } from './tmdb/client';
+import type { MovieEnrichDeps } from './tmdb/movie-enrichment';
 import { resolveTmdbSettings } from './tmdb/settings';
 import { createTransmissionDownloader } from './transmission';
+
+function tmdbMovieEnrichDeps(
+  database: Database,
+  config: AppConfig,
+  log: (message: string) => void,
+): MovieEnrichDeps | undefined {
+  const tmdbResolved = resolveTmdbSettings(config);
+  if (!tmdbResolved || config.runtime.apiPort == null) {
+    return undefined;
+  }
+  return {
+    cache: new TmdbCache(database),
+    client: new TmdbHttpClient(tmdbResolved.apiKey, (m: string) =>
+      log(`[tmdb] ${m}`),
+    ),
+    cacheTtlMs: tmdbResolved.cacheTtlMs,
+    negativeCacheTtlMs: tmdbResolved.negativeCacheTtlMs,
+    log: (m: string) => log(`[tmdb] ${m}`),
+  };
+}
 
 export async function runCli(argv: string[]): Promise<number> {
   const [command, ...rest] = argv;
@@ -144,19 +172,7 @@ export async function runCli(argv: string[]): Promise<number> {
 
         const health = createHealthState();
 
-        const tmdbResolved = resolveTmdbSettings(config);
-        const tmdbMovies =
-          tmdbResolved && config.runtime.apiPort != null
-            ? {
-                cache: new TmdbCache(database),
-                client: new TmdbHttpClient(tmdbResolved.apiKey, (m: string) =>
-                  log(`[tmdb] ${m}`),
-                ),
-                cacheTtlMs: tmdbResolved.cacheTtlMs,
-                negativeCacheTtlMs: tmdbResolved.negativeCacheTtlMs,
-                log: (m: string) => log(`[tmdb] ${m}`),
-              }
-            : undefined;
+        const tmdbMovies = tmdbMovieEnrichDeps(database, config, log);
 
         await runDaemonLoop({
           runCycle: async () => {

--- a/src/movie-api-types.ts
+++ b/src/movie-api-types.ts
@@ -1,0 +1,22 @@
+/** TMDB fields exposed on movie API responses (dashboard + JSON). */
+export type TmdbMoviePublic = {
+  tmdbId?: number;
+  title?: string;
+  posterUrl?: string;
+  backdropUrl?: string;
+  overview?: string;
+  voteAverage?: number;
+  voteCount?: number;
+};
+
+export type MovieBreakdown = {
+  normalizedTitle: string;
+  year?: number;
+  resolution?: string;
+  codec?: string;
+  identityKey: string;
+  status: string;
+  lifecycleStatus?: string;
+  queuedAt?: string;
+  tmdb?: TmdbMoviePublic;
+};

--- a/src/tmdb/movie-enrichment.ts
+++ b/src/tmdb/movie-enrichment.ts
@@ -1,0 +1,167 @@
+import type { MovieBreakdown, TmdbMoviePublic } from '../movie-api-types';
+import { backdropUrl, posterUrl } from './constants';
+import type { TmdbHttpClient } from './client';
+import type { TmdbCache } from './cache';
+import { movieMatchKey } from './keys';
+import { expiresAtIso, isCacheExpired } from './settings';
+
+export type MovieEnrichDeps = {
+  cache: TmdbCache;
+  client: TmdbHttpClient;
+  cacheTtlMs: number;
+  negativeCacheTtlMs: number;
+  log: (message: string) => void;
+};
+
+function cacheRowToPublic(row: {
+  tmdbId: number | null;
+  title: string | null;
+  overview: string | null;
+  posterPath: string | null;
+  backdropPath: string | null;
+  voteAverage: number | null;
+  voteCount: number | null;
+}): TmdbMoviePublic {
+  return {
+    tmdbId: row.tmdbId ?? undefined,
+    title: row.title ?? undefined,
+    posterUrl: posterUrl(row.posterPath),
+    backdropUrl: backdropUrl(row.backdropPath),
+    overview: row.overview ?? undefined,
+    voteAverage: row.voteAverage ?? undefined,
+    voteCount: row.voteCount ?? undefined,
+  };
+}
+
+async function resolveMatchKey(
+  key: string,
+  sample: MovieBreakdown,
+  deps: MovieEnrichDeps,
+): Promise<TmdbMoviePublic | undefined> {
+  const cached = deps.cache.getMovie(key);
+  if (cached && !isCacheExpired(cached.expiresAt)) {
+    if (cached.isNegative) {
+      return undefined;
+    }
+    return cacheRowToPublic(cached);
+  }
+
+  const title = sample.normalizedTitle;
+  const year = sample.year;
+
+  try {
+    const search = await deps.client.searchMovie(title, year);
+    if (!search) {
+      deps.cache.upsertMovie({
+        matchKey: key,
+        tmdbId: null,
+        isNegative: true,
+        expiresAt: expiresAtIso(deps.negativeCacheTtlMs),
+        title: null,
+        overview: null,
+        posterPath: null,
+        backdropPath: null,
+        voteAverage: null,
+        voteCount: null,
+        genreIdsJson: null,
+        releaseDate: null,
+      });
+      deps.log(`tmdb movie search miss: ${key}`);
+      return undefined;
+    }
+
+    const details = await deps.client.getMovie(search.id);
+    if (!details) {
+      deps.cache.upsertMovie({
+        matchKey: key,
+        tmdbId: null,
+        isNegative: true,
+        expiresAt: expiresAtIso(deps.negativeCacheTtlMs),
+        title: null,
+        overview: null,
+        posterPath: null,
+        backdropPath: null,
+        voteAverage: null,
+        voteCount: null,
+        genreIdsJson: null,
+        releaseDate: null,
+      });
+      return undefined;
+    }
+
+    const genreIdsJson = JSON.stringify(details.genres?.map((g) => g.id) ?? []);
+
+    deps.cache.upsertMovie({
+      matchKey: key,
+      tmdbId: details.id,
+      isNegative: false,
+      expiresAt: expiresAtIso(deps.cacheTtlMs),
+      title: details.title,
+      overview: details.overview ?? null,
+      posterPath: details.poster_path ?? null,
+      backdropPath: details.backdrop_path ?? null,
+      voteAverage: details.vote_average ?? null,
+      voteCount: details.vote_count ?? null,
+      genreIdsJson,
+      releaseDate: details.release_date ?? null,
+    });
+
+    return cacheRowToPublic({
+      tmdbId: details.id,
+      title: details.title,
+      overview: details.overview ?? null,
+      posterPath: details.poster_path ?? null,
+      backdropPath: details.backdrop_path ?? null,
+      voteAverage: details.vote_average ?? null,
+      voteCount: details.vote_count ?? null,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    deps.log(`tmdb movie enrich failed for ${key}: ${message}`);
+    deps.cache.upsertMovie({
+      matchKey: key,
+      tmdbId: null,
+      isNegative: true,
+      expiresAt: expiresAtIso(deps.negativeCacheTtlMs),
+      title: null,
+      overview: null,
+      posterPath: null,
+      backdropPath: null,
+      voteAverage: null,
+      voteCount: null,
+      genreIdsJson: null,
+      releaseDate: null,
+    });
+    return undefined;
+  }
+}
+
+/**
+ * Enrich movie breakdown rows with TMDB metadata (lazy cache + API on miss).
+ */
+export async function enrichMovieBreakdowns(
+  movies: MovieBreakdown[],
+  deps: MovieEnrichDeps,
+): Promise<MovieBreakdown[]> {
+  const uniqueKeys = [
+    ...new Set(movies.map((m) => movieMatchKey(m.normalizedTitle, m.year))),
+  ];
+
+  const resolved = new Map<string, TmdbMoviePublic | undefined>();
+
+  for (const key of uniqueKeys) {
+    const sample = movies.find(
+      (m) => movieMatchKey(m.normalizedTitle, m.year) === key,
+    );
+    if (!sample) {
+      continue;
+    }
+    resolved.set(key, await resolveMatchKey(key, sample, deps));
+  }
+
+  return movies.map((m) => {
+    const key = movieMatchKey(m.normalizedTitle, m.year);
+    const tmdb = resolved.get(key);
+    return tmdb ? { ...m, tmdb } : { ...m };
+  });
+}

--- a/src/tmdb/movie-enrichment.ts
+++ b/src/tmdb/movie-enrichment.ts
@@ -38,18 +38,15 @@ async function resolveMatchKey(
   sample: MovieBreakdown,
   deps: MovieEnrichDeps,
 ): Promise<TmdbMoviePublic | undefined> {
-  const cached = deps.cache.getMovie(key);
-  if (cached && !isCacheExpired(cached.expiresAt)) {
-    if (cached.isNegative) {
-      return undefined;
-    }
-    return cacheRowToPublic(cached);
-  }
-
   const title = sample.normalizedTitle;
   const year = sample.year;
 
   try {
+    const cached = deps.cache.getMovie(key);
+    if (cached && !isCacheExpired(cached.expiresAt)) {
+      return cached.isNegative ? undefined : cacheRowToPublic(cached);
+    }
+
     const search = await deps.client.searchMovie(title, year);
     if (!search) {
       deps.cache.upsertMovie({
@@ -72,20 +69,9 @@ async function resolveMatchKey(
 
     const details = await deps.client.getMovie(search.id);
     if (!details) {
-      deps.cache.upsertMovie({
-        matchKey: key,
-        tmdbId: null,
-        isNegative: true,
-        expiresAt: expiresAtIso(deps.negativeCacheTtlMs),
-        title: null,
-        overview: null,
-        posterPath: null,
-        backdropPath: null,
-        voteAverage: null,
-        voteCount: null,
-        genreIdsJson: null,
-        releaseDate: null,
-      });
+      deps.log(
+        `tmdb movie details unavailable: ${key} (id=${String(search.id)})`,
+      );
       return undefined;
     }
 
@@ -118,20 +104,6 @@ async function resolveMatchKey(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     deps.log(`tmdb movie enrich failed for ${key}: ${message}`);
-    deps.cache.upsertMovie({
-      matchKey: key,
-      tmdbId: null,
-      isNegative: true,
-      expiresAt: expiresAtIso(deps.negativeCacheTtlMs),
-      title: null,
-      overview: null,
-      posterPath: null,
-      backdropPath: null,
-      voteAverage: null,
-      voteCount: null,
-      genreIdsJson: null,
-      releaseDate: null,
-    });
     return undefined;
   }
 }

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -77,16 +77,16 @@ function createDeps(overrides: Partial<Repository> = {}): ApiFetchDeps {
 }
 
 describe('createApiFetch', () => {
-  it('returns 404 for any request when no deps provided', () => {
+  it('returns 404 for any request when no deps provided', async () => {
     const handler = createApiFetch();
-    const response = handler(new Request('http://localhost/anything'));
+    const response = await handler(new Request('http://localhost/anything'));
 
     expect(response.status).toBe(404);
   });
 
   it('returns JSON error body when no deps provided', async () => {
     const handler = createApiFetch();
-    const response = handler(new Request('http://localhost/anything'));
+    const response = await handler(new Request('http://localhost/anything'));
     const body = await response.json();
 
     expect(body).toEqual({ error: 'not found' });
@@ -95,7 +95,7 @@ describe('createApiFetch', () => {
   it('returns 404 for unknown routes', async () => {
     const deps = createDeps();
     const handler = createApiFetch(deps);
-    const response = handler(new Request('http://localhost/unknown'));
+    const response = await handler(new Request('http://localhost/unknown'));
 
     expect(response.status).toBe(404);
     expect(await response.json()).toEqual({ error: 'not found' });
@@ -106,7 +106,7 @@ describe('GET /api/health', () => {
   it('returns uptime and startedAt', async () => {
     const deps = createDeps();
     const handler = createApiFetch(deps);
-    const response = handler(new Request('http://localhost/api/health'));
+    const response = await handler(new Request('http://localhost/api/health'));
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -130,7 +130,7 @@ describe('GET /api/health', () => {
     };
     recordCycleInHealth(deps.health, runResult);
 
-    const response = handler(new Request('http://localhost/api/health'));
+    const response = await handler(new Request('http://localhost/api/health'));
     const body = await response.json();
 
     expect(body.lastRunCycle).toEqual({
@@ -161,7 +161,7 @@ describe('GET /api/status', () => {
     ];
     const deps = createDeps({ listRecentRunSummaries: () => runs });
     const handler = createApiFetch(deps);
-    const response = handler(new Request('http://localhost/api/status'));
+    const response = await handler(new Request('http://localhost/api/status'));
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -194,7 +194,9 @@ describe('GET /api/candidates', () => {
     ];
     const deps = createDeps({ listCandidateStates: () => candidates as never });
     const handler = createApiFetch(deps);
-    const response = handler(new Request('http://localhost/api/candidates'));
+    const response = await handler(
+      new Request('http://localhost/api/candidates'),
+    );
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -210,7 +212,7 @@ describe('GET /api/status — error handling', () => {
       },
     });
     const handler = createApiFetch(deps);
-    const response = handler(new Request('http://localhost/api/status'));
+    const response = await handler(new Request('http://localhost/api/status'));
 
     expect(response.status).toBe(500);
     expect(await response.json()).toEqual({ error: 'internal server error' });
@@ -225,7 +227,9 @@ describe('GET /api/candidates — error handling', () => {
       },
     });
     const handler = createApiFetch(deps);
-    const response = handler(new Request('http://localhost/api/candidates'));
+    const response = await handler(
+      new Request('http://localhost/api/candidates'),
+    );
 
     expect(response.status).toBe(500);
     expect(await response.json()).toEqual({ error: 'internal server error' });
@@ -367,7 +371,7 @@ describe('GET /api/shows', () => {
       listCandidateStates: () => candidates as never,
     });
     const handler = createApiFetch(deps);
-    const response = handler(new Request('http://localhost/api/shows'));
+    const response = await handler(new Request('http://localhost/api/shows'));
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -388,7 +392,7 @@ describe('GET /api/shows', () => {
       listCandidateStates: () => candidates as never,
     });
     const handler = createApiFetch(deps);
-    const response = handler(new Request('http://localhost/api/shows'));
+    const response = await handler(new Request('http://localhost/api/shows'));
     const body = await response.json();
 
     expect(body.shows).toHaveLength(1);
@@ -402,7 +406,7 @@ describe('GET /api/movies', () => {
       listCandidateStates: () => candidates as never,
     });
     const handler = createApiFetch(deps);
-    const response = handler(new Request('http://localhost/api/movies'));
+    const response = await handler(new Request('http://localhost/api/movies'));
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -420,7 +424,7 @@ describe('GET /api/movies', () => {
       listCandidateStates: () => candidates as never,
     });
     const handler = createApiFetch(deps);
-    const response = handler(new Request('http://localhost/api/movies'));
+    const response = await handler(new Request('http://localhost/api/movies'));
     const body = await response.json();
 
     expect(body.movies).toHaveLength(1);
@@ -435,7 +439,7 @@ describe('GET /api/feeds', () => {
     const deps = createDeps();
     deps.loadPollState = () => pollState;
     const handler = createApiFetch(deps);
-    const response = handler(new Request('http://localhost/api/feeds'));
+    const response = await handler(new Request('http://localhost/api/feeds'));
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -450,7 +454,7 @@ describe('GET /api/feeds', () => {
     const deps = createDeps();
     deps.loadPollState = () => ({ feeds: {} });
     const handler = createApiFetch(deps);
-    const response = handler(new Request('http://localhost/api/feeds'));
+    const response = await handler(new Request('http://localhost/api/feeds'));
     const body = await response.json();
 
     expect(body.feeds[0].isDue).toBe(true);
@@ -462,7 +466,7 @@ describe('GET /api/config', () => {
   it('returns config with redacted credentials', async () => {
     const deps = createDeps();
     const handler = createApiFetch(deps);
-    const response = handler(new Request('http://localhost/api/config'));
+    const response = await handler(new Request('http://localhost/api/config'));
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -476,7 +480,7 @@ describe('GET /api/config', () => {
   it('does not mutate the original config object', async () => {
     const deps = createDeps();
     const handler = createApiFetch(deps);
-    handler(new Request('http://localhost/api/config'));
+    await handler(new Request('http://localhost/api/config'));
 
     expect(deps.config.transmission.username).toBe('user');
     expect(deps.config.transmission.password).toBe('pass');

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -62,6 +62,28 @@ export type ShowBreakdown = {
 	seasons: ShowSeason[];
 };
 
+export type TmdbMoviePublic = {
+	tmdbId?: number;
+	title?: string;
+	posterUrl?: string;
+	backdropUrl?: string;
+	overview?: string;
+	voteAverage?: number;
+	voteCount?: number;
+};
+
+export type MovieBreakdown = {
+	normalizedTitle: string;
+	year?: number;
+	resolution?: string;
+	codec?: string;
+	identityKey: string;
+	status: CandidateStatus;
+	lifecycleStatus?: string;
+	queuedAt?: string;
+	tmdb?: TmdbMoviePublic;
+};
+
 export type FeedConfig = {
 	name: string;
 	url: string;

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -93,6 +93,7 @@
 
 	<nav class="mt-8 flex gap-4 text-sm">
 		<a href="/candidates" class="text-blue-400 hover:underline">View Candidates</a>
+		<a href="/movies" class="text-blue-400 hover:underline">Movies</a>
 		<a href="/config" class="text-blue-400 hover:underline">View Config</a>
 	</nav>
 {:else}

--- a/web/src/routes/movies/+page.server.ts
+++ b/web/src/routes/movies/+page.server.ts
@@ -1,0 +1,12 @@
+import { apiFetch } from '$lib/server/api';
+import type { MovieBreakdown } from '$lib/types';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+	try {
+		const data = await apiFetch<{ movies: MovieBreakdown[] }>('/api/movies');
+		return { movies: data.movies, error: null };
+	} catch {
+		return { movies: [] as MovieBreakdown[], error: 'Could not reach the API.' };
+	}
+};

--- a/web/src/routes/movies/+page.svelte
+++ b/web/src/routes/movies/+page.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	function formatRating(v: number | undefined): string {
+		if (v === undefined) return '—';
+		return v.toFixed(1);
+	}
+</script>
+
+<h1 class="text-2xl font-semibold">Movies</h1>
+<p class="mt-2 text-gray-400">
+	TMDB poster and rating appear when the daemon has a TMDB API key and metadata is available.
+</p>
+
+{#if data.error}
+	<p class="mt-4 text-red-400" role="alert">{data.error}</p>
+{:else if data.movies.length === 0}
+	<p class="mt-4 text-gray-400">No movie candidates yet.</p>
+{:else}
+	<ul class="mt-6 space-y-6">
+		{#each data.movies as movie (movie.identityKey)}
+			<li
+				class="flex flex-col gap-3 rounded-lg border border-gray-700 bg-gray-800/50 p-4 sm:flex-row sm:items-start"
+			>
+				{#if movie.tmdb?.posterUrl}
+					<img
+						src={movie.tmdb.posterUrl}
+						alt=""
+						class="mx-auto h-48 w-32 shrink-0 rounded object-cover sm:mx-0"
+						loading="lazy"
+					/>
+				{:else}
+					<div
+						class="mx-auto flex h-48 w-32 shrink-0 items-center justify-center rounded bg-gray-700 text-xs text-gray-500 sm:mx-0"
+					>
+						No poster
+					</div>
+				{/if}
+				<div class="min-w-0 flex-1">
+					<div class="flex flex-wrap items-baseline gap-2">
+						<h2 class="text-lg font-medium text-gray-100">
+							{movie.tmdb?.title ?? movie.normalizedTitle}
+						</h2>
+						{#if movie.year}
+							<span class="text-gray-400">({movie.year})</span>
+						{/if}
+						<span
+							class="rounded bg-amber-900/60 px-2 py-0.5 text-sm text-amber-100"
+							title="TMDB vote average"
+						>
+							★ {formatRating(movie.tmdb?.voteAverage)}
+						</span>
+					</div>
+					{#if movie.tmdb?.overview}
+						<p class="mt-2 text-sm leading-relaxed text-gray-300">{movie.tmdb.overview}</p>
+					{/if}
+					<dl class="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-400">
+						<div>
+							<dt class="inline">Status:</dt>
+							<dd class="inline text-gray-300">{movie.status}</dd>
+						</div>
+						{#if movie.resolution}
+							<div>
+								<dt class="inline">Resolution:</dt>
+								<dd class="inline text-gray-300">{movie.resolution}</dd>
+							</div>
+						{/if}
+						{#if movie.codec}
+							<div>
+								<dt class="inline">Codec:</dt>
+								<dd class="inline text-gray-300">{movie.codec}</dd>
+							</div>
+						{/if}
+					</dl>
+				</div>
+			</li>
+		{/each}
+	</ul>
+{/if}

--- a/web/src/routes/movies/+page.svelte
+++ b/web/src/routes/movies/+page.svelte
@@ -27,7 +27,7 @@
 				{#if movie.tmdb?.posterUrl}
 					<img
 						src={movie.tmdb.posterUrl}
-						alt=""
+						alt={`Poster for ${movie.tmdb?.title ?? movie.normalizedTitle}${movie.year ? ` (${movie.year})` : ''}`}
 						class="mx-auto h-48 w-32 shrink-0 rounded object-cover sm:mx-0"
 						loading="lazy"
 					/>
@@ -46,12 +46,14 @@
 						{#if movie.year}
 							<span class="text-gray-400">({movie.year})</span>
 						{/if}
-						<span
-							class="rounded bg-amber-900/60 px-2 py-0.5 text-sm text-amber-100"
-							title="TMDB vote average"
-						>
-							★ {formatRating(movie.tmdb?.voteAverage)}
-						</span>
+						{#if movie.tmdb?.voteAverage !== undefined}
+							<span
+								class="rounded bg-amber-900/60 px-2 py-0.5 text-sm text-amber-100"
+								title="TMDB vote average"
+							>
+								★ {formatRating(movie.tmdb.voteAverage)}
+							</span>
+						{/if}
 					</div>
 					{#if movie.tmdb?.overview}
 						<p class="mt-2 text-sm leading-relaxed text-gray-300">{movie.tmdb.overview}</p>


### PR DESCRIPTION
## Summary

- delivery ticket: `P11.02 Movies vertical slice: TMDB match, lazy API enrich, minimal movie UI`
- ticket file: [docs/02-delivery/phase-11/ticket-02-movies-vertical-slice.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-11/ticket-02-movies-vertical-slice.md)
- stacked base branch: `agents/p11-01-foundation-tmdb-config-client-sqlite-cache-graceful-degrade`
- internal review: completed at 2026-04-08 16:58 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`40a666065437`](https://github.com/cesarnml/pirate_claw/commit/40a66606543770afba129fceebe70ced74879257)
- current branch head: [`8f8b81fead47`](https://github.com/cesarnml/pirate_claw/commit/8f8b81fead47a55c9a5630430b91569a35501742)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `40a666065437` address all findings from that review.
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Don't turn transient TMDB/cache failures into hard negative matches. (native GitHub thread resolved) `src/tmdb/movie-enrichment.ts:47` [thread](https://github.com/cesarnml/pirate_claw/pull/95#discussion_r3052955047)
- [coderabbit] Add meaningful alt text for poster images. (native GitHub thread resolved) `web/src/routes/movies/+page.svelte:33` [thread](https://github.com/cesarnml/pirate_claw/pull/95#discussion_r3052955057)
- [greptile] Missing log message when `getMovie` returns null (native GitHub thread resolved) `src/tmdb/movie-enrichment.ts:90` [thread](https://github.com/cesarnml/pirate_claw/pull/95#discussion_r3052933056)
- [greptile] Empty `alt` text on a content image (native GitHub thread resolved) `web/src/routes/movies/+page.svelte:33` [thread](https://github.com/cesarnml/pirate_claw/pull/95#discussion_r3052933142)
- [greptile] Rating badge renders unconditionally (native GitHub thread resolved) `web/src/routes/movies/+page.svelte:55` [thread](https://github.com/cesarnml/pirate_claw/pull/95#discussion_r3052932978)
- [sonarqube] Refactor this function to reduce its Cognitive Complexity from 21 to the 15 allowed. (patched) `src/api.ts:76` [thread](https://sonarcloud.io/project/issues?id=cesarnml_pirate_claw&issues=AZ1uD7d_Bm8DzMOuQyPF&open=AZ1uD7d_Bm8DzMOuQyPF&pullRequest=95)
- [sonarqube] Refactor this function to reduce its Cognitive Complexity from 16 to the 15 allowed. (patched) `src/cli.ts:36` [thread](https://sonarcloud.io/project/issues?id=cesarnml_pirate_claw&issues=AZ1uD7gJBm8DzMOuQyPG&open=AZ1uD7gJBm8DzMOuQyPG&pullRequest=95)

### No-Action Rationale

- Left 2 unclear comment(s) for manual judgment.
