### PR TITLE
feat(tmdb): TV lazy enrich for /api/shows and show detail UI [P11.03]

### DIFF
--- a/docs/02-delivery/phase-11/ticket-03-tv-shows-vertical-slice.md
+++ b/docs/02-delivery/phase-11/ticket-03-tv-shows-vertical-slice.md
@@ -23,3 +23,11 @@ Show detail pages show TMDB-backed season/episode context when configured; grace
 ## Rationale
 
 TV is the heavier TMDB shape; it lands after movies so shared UI and cache patterns are already proven while keeping tickets reviewable.
+
+**Implementation notes (P11.03 delivered):**
+
+- Added `src/tmdb/tv-enrichment.ts` with lazy TV show + per-season TMDB fetch, mirroring movie enrichment: negative cache **only** on `searchTv` miss; no negative rows on transient `getTv` / `getTvSeason` failures or cache read errors (cache reads stay inside `try`).
+- `GET /api/shows` is async and enriches when TMDB deps are wired (same shared `TmdbCache` + `TmdbHttpClient` as movies via `tmdbShows` in `ApiFetchDeps`).
+- Show breakdown types live in `src/tv-api-types.ts` (show + episode TMDB fields) to avoid circular imports with enrichment.
+- `src/tmdb/constants.ts`: `stillUrl()` for episode stills (`w300`).
+- Dashboard show detail (`web/src/routes/shows/[slug]/+page.svelte`): poster, backdrop tint, rating when vote average exists, season count, overview, table columns for TMDB still + episode title + air date alongside local status.

--- a/docs/02-delivery/phase-11/ticket-03-tv-shows-vertical-slice.md
+++ b/docs/02-delivery/phase-11/ticket-03-tv-shows-vertical-slice.md
@@ -26,7 +26,7 @@ TV is the heavier TMDB shape; it lands after movies so shared UI and cache patte
 
 **Implementation notes (P11.03 delivered):**
 
-- Added `src/tmdb/tv-enrichment.ts` with lazy TV show + per-season TMDB fetch, mirroring movie enrichment: negative cache **only** on `searchTv` miss; no negative rows on transient `getTv` / `getTvSeason` failures or cache read errors (cache reads stay inside `try`).
+- Added `src/tmdb/tv-enrichment.ts` with lazy TV show + per-season TMDB fetch: negative cache on `searchTv` miss; **season** detail miss (`getTvSeason` empty) upserts `episodesJson: '[]'` with negative TTL so we do not hammer TMDB; cached `[]` is treated as “no episodes” on read. **Show** detail miss after a successful search (`getTv` null) is **not** negative-cached (same policy as movie detail fetches—may be transient). CLI wires `TvEnrichDeps` explicitly (no cast from movie deps). `enrichShowBreakdowns` runs shows and seasons in parallel (`Promise.all`); HTTP remains serialized by the TMDB client throttle.
 - `GET /api/shows` is async and enriches when TMDB deps are wired (same shared `TmdbCache` + `TmdbHttpClient` as movies via `tmdbShows` in `ApiFetchDeps`).
 - Show breakdown types live in `src/tv-api-types.ts` (show + episode TMDB fields) to avoid circular imports with enrichment.
 - `src/tmdb/constants.ts`: `stillUrl()` for episode stills (`w300`).

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,12 +1,23 @@
 import type { AppConfig, FeedConfig, RuntimeConfig } from './config';
 import type { MovieBreakdown } from './movie-api-types';
 export type { MovieBreakdown, TmdbMoviePublic } from './movie-api-types';
+import type { ShowBreakdown, ShowEpisode, ShowSeason } from './tv-api-types';
+
+export type {
+  ShowBreakdown,
+  ShowEpisode,
+  ShowSeason,
+  TmdbTvEpisodeMeta,
+  TmdbTvShowMeta,
+} from './tv-api-types';
 import { isDueFeed } from './poll-state';
 import type { PollState } from './poll-state';
 import type { CandidateStateRecord, Repository } from './repository';
 import type { CycleResult } from './runtime-artifacts';
 import type { MovieEnrichDeps } from './tmdb/movie-enrichment';
 import { enrichMovieBreakdowns } from './tmdb/movie-enrichment';
+import type { TvEnrichDeps } from './tmdb/tv-enrichment';
+import { enrichShowBreakdowns } from './tmdb/tv-enrichment';
 
 export type CycleSnapshot = {
   status: CycleResult['status'];
@@ -55,6 +66,8 @@ export type ApiFetchDeps = {
   loadPollState: (path: string) => PollState;
   /** When set (TMDB configured), GET /api/movies lazily enriches from cache + TMDB. */
   tmdbMovies?: MovieEnrichDeps;
+  /** When set (TMDB configured), GET /api/shows lazily enriches from cache + TMDB. */
+  tmdbShows?: TvEnrichDeps;
 };
 
 function json500(): Response {
@@ -83,6 +96,7 @@ export function createApiFetch(
     pollStatePath,
     loadPollState,
     tmdbMovies,
+    tmdbShows,
   } = deps;
 
   return async (request: Request) => {
@@ -109,10 +123,16 @@ export function createApiFetch(
     }
 
     if (path === '/api/shows') {
-      return safeJson(() => {
+      try {
         const candidates = repository.listCandidateStates();
-        return { shows: buildShowBreakdowns(candidates) };
-      });
+        const base = buildShowBreakdowns(candidates);
+        const shows = tmdbShows
+          ? await enrichShowBreakdowns(base, tmdbShows)
+          : base;
+        return Response.json({ shows });
+      } catch {
+        return json500();
+      }
     }
 
     if (path === '/api/movies') {
@@ -146,24 +166,6 @@ export function createApiFetch(
 }
 
 // --- Show breakdowns ---
-
-export type ShowEpisode = {
-  episode: number;
-  identityKey: string;
-  status: string;
-  lifecycleStatus?: string;
-  queuedAt?: string;
-};
-
-export type ShowSeason = {
-  season: number;
-  episodes: ShowEpisode[];
-};
-
-export type ShowBreakdown = {
-  normalizedTitle: string;
-  seasons: ShowSeason[];
-};
 
 export function buildShowBreakdowns(
   candidates: CandidateStateRecord[],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,7 @@ import {
 import { TmdbCache } from './tmdb/cache';
 import { TmdbHttpClient } from './tmdb/client';
 import type { MovieEnrichDeps } from './tmdb/movie-enrichment';
+import type { TvEnrichDeps } from './tmdb/tv-enrichment';
 import { resolveTmdbSettings } from './tmdb/settings';
 import { createTransmissionDownloader } from './transmission';
 
@@ -59,6 +60,14 @@ function tmdbMovieEnrichDeps(
     negativeCacheTtlMs: tmdbResolved.negativeCacheTtlMs,
     log: (m: string) => log(`[tmdb] ${m}`),
   };
+}
+
+function tmdbShowsEnrichDeps(
+  database: Database,
+  config: AppConfig,
+  log: (message: string) => void,
+): TvEnrichDeps | undefined {
+  return tmdbMovieEnrichDeps(database, config, log) as TvEnrichDeps | undefined;
 }
 
 export async function runCli(argv: string[]): Promise<number> {
@@ -173,6 +182,7 @@ export async function runCli(argv: string[]): Promise<number> {
         const health = createHealthState();
 
         const tmdbMovies = tmdbMovieEnrichDeps(database, config, log);
+        const tmdbShows = tmdbShowsEnrichDeps(database, config, log);
 
         await runDaemonLoop({
           runCycle: async () => {
@@ -228,6 +238,7 @@ export async function runCli(argv: string[]): Promise<number> {
                   pollStatePath,
                   loadPollState,
                   tmdbMovies,
+                  tmdbShows,
                 })
               : undefined,
         });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,7 +67,19 @@ function tmdbShowsEnrichDeps(
   config: AppConfig,
   log: (message: string) => void,
 ): TvEnrichDeps | undefined {
-  return tmdbMovieEnrichDeps(database, config, log) as TvEnrichDeps | undefined;
+  const tmdbResolved = resolveTmdbSettings(config);
+  if (!tmdbResolved || config.runtime.apiPort == null) {
+    return undefined;
+  }
+  return {
+    cache: new TmdbCache(database),
+    client: new TmdbHttpClient(tmdbResolved.apiKey, (m: string) =>
+      log(`[tmdb] ${m}`),
+    ),
+    cacheTtlMs: tmdbResolved.cacheTtlMs,
+    negativeCacheTtlMs: tmdbResolved.negativeCacheTtlMs,
+    log: (m: string) => log(`[tmdb] ${m}`),
+  };
 }
 
 export async function runCli(argv: string[]): Promise<number> {

--- a/src/tmdb/constants.ts
+++ b/src/tmdb/constants.ts
@@ -5,6 +5,9 @@ export const TMDB_POSTER_SIZE = 'w500';
 
 export const TMDB_BACKDROP_SIZE = 'w1280';
 
+/** Episode still images (smaller than posters). */
+export const TMDB_STILL_SIZE = 'w300';
+
 export const TMDB_API_BASE = 'https://api.themoviedb.org/3';
 
 export function posterUrl(
@@ -23,4 +26,13 @@ export function backdropUrl(
     return undefined;
   }
   return `${TMDB_IMAGE_BASE}/${TMDB_BACKDROP_SIZE}${backdropPath}`;
+}
+
+export function stillUrl(
+  stillPath: string | null | undefined,
+): string | undefined {
+  if (!stillPath) {
+    return undefined;
+  }
+  return `${TMDB_IMAGE_BASE}/${TMDB_STILL_SIZE}${stillPath}`;
 }

--- a/src/tmdb/tv-enrichment.ts
+++ b/src/tmdb/tv-enrichment.ts
@@ -1,0 +1,252 @@
+import type {
+  ShowBreakdown,
+  ShowEpisode,
+  ShowSeason,
+  TmdbTvEpisodeMeta,
+  TmdbTvShowMeta,
+} from '../tv-api-types';
+import type { TmdbHttpClient } from './client';
+import type { TmdbCache } from './cache';
+import { backdropUrl, posterUrl, stillUrl } from './constants';
+import { tvMatchKey } from './keys';
+import { expiresAtIso, isCacheExpired } from './settings';
+
+export type TvEnrichDeps = {
+  cache: TmdbCache;
+  client: TmdbHttpClient;
+  cacheTtlMs: number;
+  negativeCacheTtlMs: number;
+  log: (message: string) => void;
+};
+
+function tvRowToShowMeta(row: {
+  tmdbId: number | null;
+  name: string | null;
+  posterPath: string | null;
+  backdropPath: string | null;
+  overview: string | null;
+  voteAverage: number | null;
+  voteCount: number | null;
+  numberOfSeasons: number | null;
+}): TmdbTvShowMeta {
+  return {
+    tmdbId: row.tmdbId ?? undefined,
+    name: row.name ?? undefined,
+    posterUrl: posterUrl(row.posterPath),
+    backdropUrl: backdropUrl(row.backdropPath),
+    overview: row.overview ?? undefined,
+    voteAverage: row.voteAverage ?? undefined,
+    voteCount: row.voteCount ?? undefined,
+    numberOfSeasons: row.numberOfSeasons ?? undefined,
+  };
+}
+
+async function resolveShow(
+  matchKey: string,
+  normalizedTitle: string,
+  deps: TvEnrichDeps,
+): Promise<TmdbTvShowMeta | undefined> {
+  try {
+    const cached = deps.cache.getTv(matchKey);
+    if (cached && !isCacheExpired(cached.expiresAt)) {
+      return cached.isNegative ? undefined : tvRowToShowMeta(cached);
+    }
+
+    const search = await deps.client.searchTv(normalizedTitle);
+    if (!search) {
+      deps.cache.upsertTv({
+        matchKey,
+        tmdbId: null,
+        isNegative: true,
+        expiresAt: expiresAtIso(deps.negativeCacheTtlMs),
+        name: null,
+        overview: null,
+        posterPath: null,
+        backdropPath: null,
+        voteAverage: null,
+        voteCount: null,
+        genreIdsJson: null,
+        firstAirDate: null,
+        numberOfSeasons: null,
+        seasonsJson: null,
+      });
+      deps.log(`tmdb tv search miss: ${matchKey}`);
+      return undefined;
+    }
+
+    const details = await deps.client.getTv(search.id);
+    if (!details) {
+      deps.log(
+        `tmdb tv details unavailable: ${matchKey} (id=${String(search.id)})`,
+      );
+      return undefined;
+    }
+
+    const genreIdsJson = JSON.stringify(details.genres?.map((g) => g.id) ?? []);
+    const seasonsJson = details.seasons
+      ? JSON.stringify(details.seasons)
+      : null;
+
+    deps.cache.upsertTv({
+      matchKey,
+      tmdbId: details.id,
+      isNegative: false,
+      expiresAt: expiresAtIso(deps.cacheTtlMs),
+      name: details.name,
+      overview: details.overview ?? null,
+      posterPath: details.poster_path ?? null,
+      backdropPath: details.backdrop_path ?? null,
+      voteAverage: details.vote_average ?? null,
+      voteCount: details.vote_count ?? null,
+      genreIdsJson,
+      firstAirDate: details.first_air_date ?? null,
+      numberOfSeasons: details.number_of_seasons ?? null,
+      seasonsJson,
+    });
+
+    return tvRowToShowMeta({
+      tmdbId: details.id,
+      name: details.name,
+      posterPath: details.poster_path ?? null,
+      backdropPath: details.backdrop_path ?? null,
+      overview: details.overview ?? null,
+      voteAverage: details.vote_average ?? null,
+      voteCount: details.vote_count ?? null,
+      numberOfSeasons: details.number_of_seasons ?? null,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    deps.log(`tmdb tv enrich failed for ${matchKey}: ${message}`);
+    return undefined;
+  }
+}
+
+async function loadSeasonEpisodes(
+  showMatchKey: string,
+  tvId: number,
+  seasonNumber: number,
+  deps: TvEnrichDeps,
+): Promise<
+  | {
+      episode_number: number;
+      name?: string;
+      still_path?: string | null;
+      air_date?: string;
+      overview?: string;
+    }[]
+  | undefined
+> {
+  try {
+    const cached = deps.cache.getTvSeason(showMatchKey, seasonNumber);
+    if (cached && !isCacheExpired(cached.expiresAt)) {
+      const parsed = JSON.parse(cached.episodesJson) as {
+        episode_number: number;
+        name?: string;
+        still_path?: string | null;
+        air_date?: string;
+        overview?: string;
+      }[];
+      return parsed;
+    }
+
+    const detail = await deps.client.getTvSeason(tvId, seasonNumber);
+    if (!detail?.episodes) {
+      deps.log(
+        `tmdb tv season unavailable: ${showMatchKey} s${String(seasonNumber)}`,
+      );
+      return undefined;
+    }
+
+    const episodesJson = JSON.stringify(detail.episodes);
+    deps.cache.upsertTvSeason({
+      showMatchKey,
+      seasonNumber,
+      expiresAt: expiresAtIso(deps.cacheTtlMs),
+      episodesJson,
+    });
+
+    return detail.episodes;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    deps.log(
+      `tmdb tv season load failed ${showMatchKey} s${String(seasonNumber)}: ${message}`,
+    );
+    return undefined;
+  }
+}
+
+function episodeMetaFromTmdb(ep: {
+  episode_number: number;
+  name?: string;
+  still_path?: string | null;
+  air_date?: string;
+  overview?: string;
+}): TmdbTvEpisodeMeta {
+  return {
+    name: ep.name,
+    stillUrl: stillUrl(ep.still_path),
+    airDate: ep.air_date,
+    overview: ep.overview,
+  };
+}
+
+async function enrichSeason(
+  showMatchKey: string,
+  tvId: number,
+  season: ShowSeason,
+  deps: TvEnrichDeps,
+): Promise<ShowSeason> {
+  const tmdbEps = await loadSeasonEpisodes(
+    showMatchKey,
+    tvId,
+    season.season,
+    deps,
+  );
+  if (!tmdbEps) {
+    return season;
+  }
+
+  const episodes: ShowEpisode[] = season.episodes.map((local) => {
+    const hit = tmdbEps.find((e) => e.episode_number === local.episode);
+    if (!hit) {
+      return local;
+    }
+    return { ...local, tmdb: episodeMetaFromTmdb(hit) };
+  });
+
+  return { season: season.season, episodes };
+}
+
+/**
+ * Enrich TV show breakdowns with TMDB metadata (lazy cache + API on miss).
+ */
+export async function enrichShowBreakdowns(
+  shows: ShowBreakdown[],
+  deps: TvEnrichDeps,
+): Promise<ShowBreakdown[]> {
+  const out: ShowBreakdown[] = [];
+
+  for (const show of shows) {
+    const key = tvMatchKey(show.normalizedTitle);
+    const showMeta = await resolveShow(key, show.normalizedTitle, deps);
+
+    if (!showMeta?.tmdbId) {
+      out.push(showMeta ? { ...show, tmdb: showMeta } : show);
+      continue;
+    }
+
+    const tvId = showMeta.tmdbId;
+    const seasons: ShowSeason[] = [];
+    for (const season of show.seasons) {
+      seasons.push(await enrichSeason(key, tvId, season, deps));
+    }
+
+    out.push({
+      normalizedTitle: show.normalizedTitle,
+      seasons,
+      tmdb: showMeta,
+    });
+  }
+
+  return out;
+}

--- a/src/tmdb/tv-enrichment.ts
+++ b/src/tmdb/tv-enrichment.ts
@@ -76,6 +76,8 @@ async function resolveShow(
 
     const details = await deps.client.getTv(search.id);
     if (!details) {
+      // Same policy as movie enrichment: do not negative-cache detail fetch
+      // failures (may be transient HTTP/network); only search miss is negative.
       deps.log(
         `tmdb tv details unavailable: ${matchKey} (id=${String(search.id)})`,
       );
@@ -146,6 +148,9 @@ async function loadSeasonEpisodes(
         air_date?: string;
         overview?: string;
       }[];
+      if (parsed.length === 0) {
+        return undefined;
+      }
       return parsed;
     }
 
@@ -154,6 +159,12 @@ async function loadSeasonEpisodes(
       deps.log(
         `tmdb tv season unavailable: ${showMatchKey} s${String(seasonNumber)}`,
       );
+      deps.cache.upsertTvSeason({
+        showMatchKey,
+        seasonNumber,
+        expiresAt: expiresAtIso(deps.negativeCacheTtlMs),
+        episodesJson: '[]',
+      });
       return undefined;
     }
 
@@ -224,29 +235,25 @@ export async function enrichShowBreakdowns(
   shows: ShowBreakdown[],
   deps: TvEnrichDeps,
 ): Promise<ShowBreakdown[]> {
-  const out: ShowBreakdown[] = [];
+  return Promise.all(
+    shows.map(async (show) => {
+      const key = tvMatchKey(show.normalizedTitle);
+      const showMeta = await resolveShow(key, show.normalizedTitle, deps);
 
-  for (const show of shows) {
-    const key = tvMatchKey(show.normalizedTitle);
-    const showMeta = await resolveShow(key, show.normalizedTitle, deps);
+      if (!showMeta?.tmdbId) {
+        return showMeta ? { ...show, tmdb: showMeta } : show;
+      }
 
-    if (!showMeta?.tmdbId) {
-      out.push(showMeta ? { ...show, tmdb: showMeta } : show);
-      continue;
-    }
+      const tvId = showMeta.tmdbId;
+      const seasons = await Promise.all(
+        show.seasons.map((season) => enrichSeason(key, tvId, season, deps)),
+      );
 
-    const tvId = showMeta.tmdbId;
-    const seasons: ShowSeason[] = [];
-    for (const season of show.seasons) {
-      seasons.push(await enrichSeason(key, tvId, season, deps));
-    }
-
-    out.push({
-      normalizedTitle: show.normalizedTitle,
-      seasons,
-      tmdb: showMeta,
-    });
-  }
-
-  return out;
+      return {
+        normalizedTitle: show.normalizedTitle,
+        seasons,
+        tmdb: showMeta,
+      };
+    }),
+  );
 }

--- a/src/tv-api-types.ts
+++ b/src/tv-api-types.ts
@@ -1,0 +1,39 @@
+/** TMDB metadata attached to a TV show breakdown (API + dashboard). */
+export type TmdbTvShowMeta = {
+  tmdbId?: number;
+  name?: string;
+  posterUrl?: string;
+  backdropUrl?: string;
+  overview?: string;
+  voteAverage?: number;
+  voteCount?: number;
+  numberOfSeasons?: number;
+};
+
+/** Per-episode TMDB fields merged next to local candidate state. */
+export type TmdbTvEpisodeMeta = {
+  name?: string;
+  stillUrl?: string;
+  airDate?: string;
+  overview?: string;
+};
+
+export type ShowEpisode = {
+  episode: number;
+  identityKey: string;
+  status: string;
+  lifecycleStatus?: string;
+  queuedAt?: string;
+  tmdb?: TmdbTvEpisodeMeta;
+};
+
+export type ShowSeason = {
+  season: number;
+  episodes: ShowEpisode[];
+};
+
+export type ShowBreakdown = {
+  normalizedTitle: string;
+  seasons: ShowSeason[];
+  tmdb?: TmdbTvShowMeta;
+};

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -44,12 +44,31 @@ export type CandidateStateRecord = {
 	updatedAt: string;
 };
 
+export type TmdbTvEpisodeMeta = {
+	name?: string;
+	stillUrl?: string;
+	airDate?: string;
+	overview?: string;
+};
+
+export type TmdbTvShowMeta = {
+	tmdbId?: number;
+	name?: string;
+	posterUrl?: string;
+	backdropUrl?: string;
+	overview?: string;
+	voteAverage?: number;
+	voteCount?: number;
+	numberOfSeasons?: number;
+};
+
 export type ShowEpisode = {
 	episode: number;
 	identityKey: string;
 	status: CandidateStatus;
 	lifecycleStatus?: string;
 	queuedAt?: string;
+	tmdb?: TmdbTvEpisodeMeta;
 };
 
 export type ShowSeason = {
@@ -60,6 +79,7 @@ export type ShowSeason = {
 export type ShowBreakdown = {
 	normalizedTitle: string;
 	seasons: ShowSeason[];
+	tmdb?: TmdbTvShowMeta;
 };
 
 export type TmdbMoviePublic = {

--- a/web/src/routes/shows/[slug]/+page.svelte
+++ b/web/src/routes/shows/[slug]/+page.svelte
@@ -2,6 +2,11 @@
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
+
+	function formatRating(v: number | undefined): string {
+		if (v === undefined) return '—';
+		return v.toFixed(1);
+	}
 </script>
 
 <div class="mb-4">
@@ -13,7 +18,56 @@
 {:else if !data.show}
 	<p class="text-gray-400">Show not found.</p>
 {:else}
-	<h1 class="mb-6 text-2xl font-semibold">{data.show.normalizedTitle}</h1>
+	<div
+		class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start"
+		class:rounded-lg={!!data.show.tmdb?.backdropUrl}
+		class:border={!!data.show.tmdb?.backdropUrl}
+		class:border-gray-700={!!data.show.tmdb?.backdropUrl}
+		class:overflow-hidden={!!data.show.tmdb?.backdropUrl}
+		style={data.show.tmdb?.backdropUrl
+			? `background: linear-gradient(rgba(17,24,39,0.92), rgba(17,24,39,0.92)), url(${data.show.tmdb.backdropUrl}) center/cover no-repeat`
+			: undefined}
+	>
+		{#if data.show.tmdb?.posterUrl}
+			<img
+				src={data.show.tmdb.posterUrl}
+				alt={`Poster for ${data.show.tmdb?.name ?? data.show.normalizedTitle}`}
+				class="mx-auto h-56 w-40 shrink-0 rounded object-cover sm:mx-0"
+				loading="lazy"
+			/>
+		{:else}
+			<div
+				class="mx-auto flex h-56 w-40 shrink-0 items-center justify-center rounded bg-gray-700 text-xs text-gray-500 sm:mx-0"
+			>
+				No poster
+			</div>
+		{/if}
+		<div class="min-w-0 flex-1">
+			<div class="flex flex-wrap items-baseline gap-2">
+				<h1 class="text-2xl font-semibold text-gray-100">
+					{data.show.tmdb?.name ?? data.show.normalizedTitle}
+				</h1>
+				{#if data.show.tmdb?.voteAverage !== undefined}
+					<span
+						class="rounded bg-amber-900/60 px-2 py-0.5 text-sm text-amber-100"
+						title="TMDB vote average"
+					>
+						★ {formatRating(data.show.tmdb.voteAverage)}
+					</span>
+				{/if}
+				{#if data.show.tmdb?.numberOfSeasons != null}
+					<span class="text-sm text-gray-400">
+						{data.show.tmdb.numberOfSeasons} season{data.show.tmdb.numberOfSeasons === 1
+							? ''
+							: 's'} (TMDB)
+					</span>
+				{/if}
+			</div>
+			{#if data.show.tmdb?.overview}
+				<p class="mt-3 text-sm leading-relaxed text-gray-300">{data.show.tmdb.overview}</p>
+			{/if}
+		</div>
+	</div>
 
 	{#each data.show.seasons as season (season.season)}
 		<section class="mb-8">
@@ -21,7 +75,9 @@
 			<table class="w-full table-auto border-collapse text-sm">
 				<thead>
 					<tr class="border-b border-gray-700 text-left text-gray-400">
+						<th class="py-2 pr-2 w-16"></th>
 						<th class="py-2 pr-4">Episode</th>
+						<th class="py-2 pr-4">Title</th>
 						<th class="py-2 pr-4">Status</th>
 						<th class="py-2">Queued At</th>
 					</tr>
@@ -29,14 +85,38 @@
 				<tbody>
 					{#each season.episodes as ep (ep.identityKey)}
 						<tr class="border-b border-gray-800 hover:bg-gray-800/40">
-							<td class="py-2 pr-4 font-medium">E{String(ep.episode).padStart(2, '0')}</td>
-							<td class="py-2 pr-4 text-gray-300">
+							<td class="py-2 pr-2 align-top">
+								{#if ep.tmdb?.stillUrl}
+									<img
+										src={ep.tmdb.stillUrl}
+										alt=""
+										class="h-14 w-24 rounded object-cover"
+										loading="lazy"
+									/>
+								{:else}
+									<div class="h-14 w-24 rounded bg-gray-700/80"></div>
+								{/if}
+							</td>
+							<td class="py-2 pr-4 align-top font-medium whitespace-nowrap">
+								E{String(ep.episode).padStart(2, '0')}
+							</td>
+							<td class="py-2 pr-4 align-top text-gray-200">
+								{#if ep.tmdb?.name}
+									<span>{ep.tmdb.name}</span>
+									{#if ep.tmdb.airDate}
+										<span class="ml-1 text-xs text-gray-500">({ep.tmdb.airDate})</span>
+									{/if}
+								{:else}
+									<span class="text-gray-500">—</span>
+								{/if}
+							</td>
+							<td class="py-2 pr-4 align-top text-gray-300">
 								{ep.status}
 								{#if ep.lifecycleStatus}
 									<span class="ml-1 text-xs text-gray-500">({ep.lifecycleStatus})</span>
 								{/if}
 							</td>
-							<td class="py-2 text-gray-400">{ep.queuedAt ?? '—'}</td>
+							<td class="py-2 align-top text-gray-400">{ep.queuedAt ?? '—'}</td>
 						</tr>
 					{/each}
 				</tbody>


### PR DESCRIPTION
## Summary

- delivery ticket: `P11.03 TV shows vertical slice: show/season/episode TMDB, enrich GET /api/shows, show UI`
- ticket file: [docs/02-delivery/phase-11/ticket-03-tv-shows-vertical-slice.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-11/ticket-03-tv-shows-vertical-slice.md)
- stacked base branch: `agents/p11-02-movies-vertical-slice-tmdb-match-lazy-api-enrich-minimal-movie-ui`
- post-verify self-audit: completed at 2026-04-08 17:38 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`ca3c8994e0db`](https://github.com/cesarnml/pirate_claw/commit/ca3c8994e0db8f9e392ae21ed48c661f12d1d416)
- current branch head: [`3ae124a7da00`](https://github.com/cesarnml/pirate_claw/commit/3ae124a7da00d244a33aa0d482198de77dd1da45)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `ca3c8994e0db` address all findings from that review.
- vendors: `coderabbit`, `greptile`

### Resolved Review Findings

- [greptile] Fragile `as` cast between structurally identical dep types (native GitHub thread resolved) `src/cli.ts:71` [thread](https://github.com/cesarnml/pirate_claw/pull/96#discussion_r3053133956)
- [greptile] Show details miss is not negatively cached (native GitHub thread resolved) `src/tmdb/tv-enrichment.ts:84` [thread](https://github.com/cesarnml/pirate_claw/pull/96#discussion_r3053133781)
- [greptile] Missing negative cache on season API miss (native GitHub thread resolved) `src/tmdb/tv-enrichment.ts:157` [thread](https://github.com/cesarnml/pirate_claw/pull/96#discussion_r3053133629)
