### PR TITLE
feat(api): attach TMDB from cache on GET /api/candidates [P11.04]

### DIFF
--- a/docs/02-delivery/phase-11/ticket-04-candidates-vertical-slice.md
+++ b/docs/02-delivery/phase-11/ticket-04-candidates-vertical-slice.md
@@ -22,3 +22,9 @@ The operator’s primary queue view benefits from TMDB when configured; when TMD
 ## Rationale
 
 Candidates are last among the read paths so lazy enrichment reuses movie and TV caches; a dedicated ticket prevents duplicating TMDB calls across three surfaces.
+
+**Implementation notes (P11.04 delivered):**
+
+- `GET /api/candidates` uses `enrichCandidatesFromCache` (`src/tmdb/candidate-cache-enrich.ts`): reads only `TmdbCache` rows keyed with `movieMatchKey` / `tvMatchKey` — no TMDB HTTP. Reuses `movieCacheRowToPublic` and `tvCacheRowToShowMeta` from existing enrichment modules.
+- CLI passes `tmdbCache: tmdbMovies?.cache ?? tmdbShows?.cache` so the cache is wired whenever TMDB deps exist.
+- Dashboard candidates table: poster column, TMDB rating column, display title prefers cached TMDB name/title when present (list view; TV still links to show detail).

--- a/docs/02-delivery/phase-11/ticket-04-candidates-vertical-slice.md
+++ b/docs/02-delivery/phase-11/ticket-04-candidates-vertical-slice.md
@@ -28,3 +28,4 @@ Candidates are last among the read paths so lazy enrichment reuses movie and TV 
 - `GET /api/candidates` uses `enrichCandidatesFromCache` (`src/tmdb/candidate-cache-enrich.ts`): reads only `TmdbCache` rows keyed with `movieMatchKey` / `tvMatchKey` — no TMDB HTTP. Reuses `movieCacheRowToPublic` and `tvCacheRowToShowMeta` from existing enrichment modules.
 - CLI passes `tmdbCache: tmdbMovies?.cache ?? tmdbShows?.cache` so the cache is wired whenever TMDB deps exist.
 - Dashboard candidates table: poster column, TMDB rating column, display title prefers cached TMDB name/title when present (list view; TV still links to show detail).
+- `onCandidateTmdbCacheError` logs cache read failures without failing the request; tests cover movie + TV cache paths with `try/finally` DB cleanup.

--- a/src/api.ts
+++ b/src/api.ts
@@ -75,6 +75,11 @@ export type ApiFetchDeps = {
    * SQLite cache only — same rows as movies/shows enrichment, no extra HTTP.
    */
   tmdbCache?: TmdbCache;
+  /** Optional hook when a cache read throws during candidate enrichment (fail-open). */
+  onCandidateTmdbCacheError?: (
+    error: unknown,
+    candidate: CandidateStateRecord,
+  ) => void;
 };
 
 function json500(): Response {
@@ -105,6 +110,7 @@ export function createApiFetch(
     tmdbMovies,
     tmdbShows,
     tmdbCache,
+    onCandidateTmdbCacheError,
   } = deps;
 
   return async (request: Request) => {
@@ -128,7 +134,11 @@ export function createApiFetch(
       try {
         const list = repository.listCandidateStates();
         const candidates = tmdbCache
-          ? enrichCandidatesFromCache(list, tmdbCache)
+          ? enrichCandidatesFromCache(
+              list,
+              tmdbCache,
+              onCandidateTmdbCacheError,
+            )
           : list;
         return Response.json({ candidates });
       } catch {

--- a/src/api.ts
+++ b/src/api.ts
@@ -14,6 +14,8 @@ import { isDueFeed } from './poll-state';
 import type { PollState } from './poll-state';
 import type { CandidateStateRecord, Repository } from './repository';
 import type { CycleResult } from './runtime-artifacts';
+import type { TmdbCache } from './tmdb/cache';
+import { enrichCandidatesFromCache } from './tmdb/candidate-cache-enrich';
 import type { MovieEnrichDeps } from './tmdb/movie-enrichment';
 import { enrichMovieBreakdowns } from './tmdb/movie-enrichment';
 import type { TvEnrichDeps } from './tmdb/tv-enrichment';
@@ -68,6 +70,11 @@ export type ApiFetchDeps = {
   tmdbMovies?: MovieEnrichDeps;
   /** When set (TMDB configured), GET /api/shows lazily enriches from cache + TMDB. */
   tmdbShows?: TvEnrichDeps;
+  /**
+   * When set (TMDB configured), GET /api/candidates attaches TMDB fields from the
+   * SQLite cache only — same rows as movies/shows enrichment, no extra HTTP.
+   */
+  tmdbCache?: TmdbCache;
 };
 
 function json500(): Response {
@@ -97,6 +104,7 @@ export function createApiFetch(
     loadPollState,
     tmdbMovies,
     tmdbShows,
+    tmdbCache,
   } = deps;
 
   return async (request: Request) => {
@@ -117,9 +125,15 @@ export function createApiFetch(
     }
 
     if (path === '/api/candidates') {
-      return safeJson(() => ({
-        candidates: repository.listCandidateStates(),
-      }));
+      try {
+        const list = repository.listCandidateStates();
+        const candidates = tmdbCache
+          ? enrichCandidatesFromCache(list, tmdbCache)
+          : list;
+        return Response.json({ candidates });
+      } catch {
+        return json500();
+      }
     }
 
     if (path === '/api/shows') {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -251,6 +251,7 @@ export async function runCli(argv: string[]): Promise<number> {
                   loadPollState,
                   tmdbMovies,
                   tmdbShows,
+                  tmdbCache: tmdbMovies?.cache ?? tmdbShows?.cache,
                 })
               : undefined,
         });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -252,6 +252,12 @@ export async function runCli(argv: string[]): Promise<number> {
                   tmdbMovies,
                   tmdbShows,
                   tmdbCache: tmdbMovies?.cache ?? tmdbShows?.cache,
+                  onCandidateTmdbCacheError: (err, c) =>
+                    log(
+                      `[tmdb] candidate cache enrich failed ${c.identityKey}: ${
+                        err instanceof Error ? err.message : String(err)
+                      }`,
+                    ),
                 })
               : undefined,
         });

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,6 +1,8 @@
 import { Database } from 'bun:sqlite';
 
+import type { TmdbMoviePublic } from './movie-api-types';
 import { ensureTmdbSchema } from './tmdb/schema';
+import type { TmdbTvShowMeta } from './tv-api-types';
 import type { RawFeedItem } from './feed';
 import type { NormalizedFeedItem } from './normalize';
 
@@ -85,6 +87,8 @@ export type CandidateStateRecord = {
   lastSeenRunId: number;
   lastFeedItemId?: number;
   updatedAt: string;
+  /** Present on API responses when TMDB cache has a hit for this identity. */
+  tmdb?: TmdbMoviePublic | TmdbTvShowMeta;
 };
 
 export type RecordCandidateOutcomeInput = {

--- a/src/tmdb/candidate-cache-enrich.ts
+++ b/src/tmdb/candidate-cache-enrich.ts
@@ -12,6 +12,7 @@ import { tvCacheRowToShowMeta } from './tv-enrichment';
 export function enrichCandidatesFromCache(
   candidates: CandidateStateRecord[],
   cache: TmdbCache,
+  onError?: (error: unknown, candidate: CandidateStateRecord) => void,
 ): CandidateStateRecord[] {
   return candidates.map((c) => {
     try {
@@ -34,8 +35,8 @@ export function enrichCandidatesFromCache(
           }
         }
       }
-    } catch {
-      // Ignore cache read errors; return unenriched candidate.
+    } catch (error) {
+      onError?.(error, c);
     }
     return c;
   });

--- a/src/tmdb/candidate-cache-enrich.ts
+++ b/src/tmdb/candidate-cache-enrich.ts
@@ -1,0 +1,42 @@
+import type { CandidateStateRecord } from '../repository';
+import type { TmdbCache } from './cache';
+import { movieMatchKey, tvMatchKey } from './keys';
+import { movieCacheRowToPublic } from './movie-enrichment';
+import { isCacheExpired } from './settings';
+import { tvCacheRowToShowMeta } from './tv-enrichment';
+
+/**
+ * Attach TMDB poster/rating/etc. from existing SQLite cache rows only (no TMDB HTTP).
+ * Matches keys used by movie and TV lazy enrichment.
+ */
+export function enrichCandidatesFromCache(
+  candidates: CandidateStateRecord[],
+  cache: TmdbCache,
+): CandidateStateRecord[] {
+  return candidates.map((c) => {
+    try {
+      if (c.mediaType === 'movie') {
+        const key = movieMatchKey(c.normalizedTitle, c.year);
+        const row = cache.getMovie(key);
+        if (row && !isCacheExpired(row.expiresAt)) {
+          const tmdb = movieCacheRowToPublic(row);
+          if (tmdb) {
+            return { ...c, tmdb };
+          }
+        }
+      } else {
+        const key = tvMatchKey(c.normalizedTitle);
+        const row = cache.getTv(key);
+        if (row && !isCacheExpired(row.expiresAt)) {
+          const tmdb = tvCacheRowToShowMeta(row);
+          if (tmdb) {
+            return { ...c, tmdb };
+          }
+        }
+      }
+    } catch {
+      // Ignore cache read errors; return unenriched candidate.
+    }
+    return c;
+  });
+}

--- a/src/tmdb/movie-enrichment.ts
+++ b/src/tmdb/movie-enrichment.ts
@@ -1,7 +1,7 @@
 import type { MovieBreakdown, TmdbMoviePublic } from '../movie-api-types';
 import { backdropUrl, posterUrl } from './constants';
 import type { TmdbHttpClient } from './client';
-import type { TmdbCache } from './cache';
+import type { TmdbCache, TmdbMovieCacheRow } from './cache';
 import { movieMatchKey } from './keys';
 import { expiresAtIso, isCacheExpired } from './settings';
 
@@ -31,6 +31,16 @@ function cacheRowToPublic(row: {
     voteAverage: row.voteAverage ?? undefined,
     voteCount: row.voteCount ?? undefined,
   };
+}
+
+/** Map a cache row to API fields; returns undefined for negative (miss) rows. */
+export function movieCacheRowToPublic(
+  row: TmdbMovieCacheRow,
+): TmdbMoviePublic | undefined {
+  if (row.isNegative) {
+    return undefined;
+  }
+  return cacheRowToPublic(row);
 }
 
 async function resolveMatchKey(

--- a/src/tmdb/tv-enrichment.ts
+++ b/src/tmdb/tv-enrichment.ts
@@ -6,7 +6,7 @@ import type {
   TmdbTvShowMeta,
 } from '../tv-api-types';
 import type { TmdbHttpClient } from './client';
-import type { TmdbCache } from './cache';
+import type { TmdbCache, TmdbTvCacheRow } from './cache';
 import { backdropUrl, posterUrl, stillUrl } from './constants';
 import { tvMatchKey } from './keys';
 import { expiresAtIso, isCacheExpired } from './settings';
@@ -39,6 +39,16 @@ function tvRowToShowMeta(row: {
     voteCount: row.voteCount ?? undefined,
     numberOfSeasons: row.numberOfSeasons ?? undefined,
   };
+}
+
+/** Map a cache row to show meta; returns undefined for negative (miss) rows. */
+export function tvCacheRowToShowMeta(
+  row: TmdbTvCacheRow,
+): TmdbTvShowMeta | undefined {
+  if (row.isNegative) {
+    return undefined;
+  }
+  return tvRowToShowMeta(row);
 }
 
 async function resolveShow(

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,3 +1,4 @@
+import { Database } from 'bun:sqlite';
 import { describe, expect, it } from 'bun:test';
 
 import {
@@ -14,6 +15,9 @@ import type { AppConfig } from '../src/config';
 import type { PollState } from '../src/poll-state';
 import type { CandidateStateRecord, Repository } from '../src/repository';
 import type { CycleResult } from '../src/runtime-artifacts';
+import { TmdbCache } from '../src/tmdb/cache';
+import { movieMatchKey } from '../src/tmdb/keys';
+import { ensureTmdbSchema } from '../src/tmdb/schema';
 
 function stubRepository(overrides: Partial<Repository> = {}): Repository {
   return {
@@ -201,6 +205,42 @@ describe('GET /api/candidates', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.candidates).toEqual(candidates);
+  });
+
+  it('merges TMDB from SQLite cache when tmdbCache is set (no HTTP)', async () => {
+    const db = new Database(':memory:');
+    ensureTmdbSchema(db);
+    const cache = new TmdbCache(db);
+    const matchKey = movieMatchKey('test movie', 2024);
+    cache.upsertMovie({
+      matchKey,
+      tmdbId: 99,
+      isNegative: false,
+      expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+      title: 'Test Movie TMDB',
+      overview: null,
+      posterPath: '/p.jpg',
+      backdropPath: null,
+      voteAverage: 7.5,
+      voteCount: 10,
+      genreIdsJson: '[]',
+      releaseDate: null,
+    });
+    const candidates = [movieCandidate()];
+    const deps: ApiFetchDeps = {
+      ...createDeps({ listCandidateStates: () => candidates as never }),
+      tmdbCache: cache,
+    };
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/candidates'),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.candidates[0].tmdb?.title).toBe('Test Movie TMDB');
+    expect(body.candidates[0].tmdb?.voteAverage).toBe(7.5);
+    db.close();
   });
 });
 

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -16,7 +16,7 @@ import type { PollState } from '../src/poll-state';
 import type { CandidateStateRecord, Repository } from '../src/repository';
 import type { CycleResult } from '../src/runtime-artifacts';
 import { TmdbCache } from '../src/tmdb/cache';
-import { movieMatchKey } from '../src/tmdb/keys';
+import { movieMatchKey, tvMatchKey } from '../src/tmdb/keys';
 import { ensureTmdbSchema } from '../src/tmdb/schema';
 
 function stubRepository(overrides: Partial<Repository> = {}): Repository {
@@ -209,38 +209,82 @@ describe('GET /api/candidates', () => {
 
   it('merges TMDB from SQLite cache when tmdbCache is set (no HTTP)', async () => {
     const db = new Database(':memory:');
-    ensureTmdbSchema(db);
-    const cache = new TmdbCache(db);
-    const matchKey = movieMatchKey('test movie', 2024);
-    cache.upsertMovie({
-      matchKey,
-      tmdbId: 99,
-      isNegative: false,
-      expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
-      title: 'Test Movie TMDB',
-      overview: null,
-      posterPath: '/p.jpg',
-      backdropPath: null,
-      voteAverage: 7.5,
-      voteCount: 10,
-      genreIdsJson: '[]',
-      releaseDate: null,
-    });
-    const candidates = [movieCandidate()];
-    const deps: ApiFetchDeps = {
-      ...createDeps({ listCandidateStates: () => candidates as never }),
-      tmdbCache: cache,
-    };
-    const handler = createApiFetch(deps);
-    const response = await handler(
-      new Request('http://localhost/api/candidates'),
-    );
+    try {
+      ensureTmdbSchema(db);
+      const cache = new TmdbCache(db);
+      const matchKey = movieMatchKey('test movie', 2024);
+      cache.upsertMovie({
+        matchKey,
+        tmdbId: 99,
+        isNegative: false,
+        expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+        title: 'Test Movie TMDB',
+        overview: null,
+        posterPath: '/p.jpg',
+        backdropPath: null,
+        voteAverage: 7.5,
+        voteCount: 10,
+        genreIdsJson: '[]',
+        releaseDate: null,
+      });
+      const candidates = [movieCandidate()];
+      const deps: ApiFetchDeps = {
+        ...createDeps({ listCandidateStates: () => candidates as never }),
+        tmdbCache: cache,
+      };
+      const handler = createApiFetch(deps);
+      const response = await handler(
+        new Request('http://localhost/api/candidates'),
+      );
 
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.candidates[0].tmdb?.title).toBe('Test Movie TMDB');
-    expect(body.candidates[0].tmdb?.voteAverage).toBe(7.5);
-    db.close();
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.candidates[0].tmdb?.title).toBe('Test Movie TMDB');
+      expect(body.candidates[0].tmdb?.voteAverage).toBe(7.5);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('merges TV TMDB from SQLite cache when tmdbCache is set (no HTTP)', async () => {
+    const db = new Database(':memory:');
+    try {
+      ensureTmdbSchema(db);
+      const cache = new TmdbCache(db);
+      const matchKey = tvMatchKey('test show');
+      cache.upsertTv({
+        matchKey,
+        tmdbId: 42,
+        isNegative: false,
+        expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+        name: 'Test Show TMDB',
+        overview: null,
+        posterPath: '/t.jpg',
+        backdropPath: null,
+        voteAverage: 8,
+        voteCount: 5,
+        genreIdsJson: '[]',
+        firstAirDate: null,
+        numberOfSeasons: 1,
+        seasonsJson: null,
+      });
+      const candidates = [tvCandidate()];
+      const deps: ApiFetchDeps = {
+        ...createDeps({ listCandidateStates: () => candidates as never }),
+        tmdbCache: cache,
+      };
+      const handler = createApiFetch(deps);
+      const response = await handler(
+        new Request('http://localhost/api/candidates'),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.candidates[0].tmdb?.name).toBe('Test Show TMDB');
+      expect(body.candidates[0].tmdb?.voteAverage).toBe(8);
+    } finally {
+      db.close();
+    }
   });
 });
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -42,6 +42,8 @@ export type CandidateStateRecord = {
 	lastSeenRunId: number;
 	lastFeedItemId?: number;
 	updatedAt: string;
+	/** From GET /api/candidates when TMDB cache has metadata for this title. */
+	tmdb?: TmdbMoviePublic | TmdbTvShowMeta;
 };
 
 export type TmdbTvEpisodeMeta = {

--- a/web/src/routes/candidates/+page.svelte
+++ b/web/src/routes/candidates/+page.svelte
@@ -21,6 +21,21 @@
 		return encodeURIComponent(c.normalizedTitle);
 	}
 
+	function formatRating(v: number | undefined): string {
+		if (v === undefined) return '—';
+		return v.toFixed(1);
+	}
+
+	function displayTitle(c: CandidateStateRecord): string {
+		if (c.mediaType === 'movie' && c.tmdb && 'title' in c.tmdb && c.tmdb.title) {
+			return c.tmdb.title;
+		}
+		if (c.mediaType === 'tv' && c.tmdb && 'name' in c.tmdb && c.tmdb.name) {
+			return c.tmdb.name;
+		}
+		return c.normalizedTitle;
+	}
+
 	const statusColors: Record<string, string> = {
 		queued: 'bg-gray-700 text-gray-200',
 		skipped: 'bg-gray-600 text-gray-300',
@@ -58,6 +73,7 @@
 		<table class="w-full table-auto border-collapse text-sm">
 			<thead>
 				<tr class="border-b border-gray-700 text-left text-gray-400">
+					<th class="py-2 pr-2 w-14" aria-hidden="true"></th>
 					<th class="py-2 pr-4">Title</th>
 					<th
 						class="py-2 pr-4"
@@ -71,6 +87,7 @@
 					</th>
 					<th class="py-2 pr-4">Rule</th>
 					<th class="py-2 pr-4">Resolution</th>
+					<th class="py-2 pr-4">TMDB</th>
 					<th
 						class="py-2 pr-4"
 						aria-sort={sortKey === 'status' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
@@ -88,18 +105,46 @@
 			<tbody>
 				{#each sorted as candidate (candidate.identityKey)}
 					<tr class="border-b border-gray-800 hover:bg-gray-800/40">
+						<td class="py-2 pr-2 align-top">
+							{#if candidate.tmdb?.posterUrl}
+								<img
+									src={candidate.tmdb.posterUrl}
+									alt=""
+									class="h-12 w-8 rounded object-cover"
+									loading="lazy"
+								/>
+							{:else}
+								<div
+									class="flex h-12 w-8 items-center justify-center rounded bg-gray-800 text-[10px] text-gray-600"
+								>
+									—
+								</div>
+							{/if}
+						</td>
 						<td class="py-2 pr-4 font-medium">
 							{#if candidate.mediaType === 'tv'}
 								<a href="/shows/{showSlug(candidate)}" class="text-blue-400 hover:underline">
-									{candidate.normalizedTitle}
+									{displayTitle(candidate)}
 								</a>
 							{:else}
-								{candidate.normalizedTitle}
+								{displayTitle(candidate)}
 							{/if}
 						</td>
 						<td class="py-2 pr-4 text-gray-300">{candidate.mediaType}</td>
 						<td class="py-2 pr-4 text-gray-300">{candidate.ruleName}</td>
 						<td class="py-2 pr-4 text-gray-300">{candidate.resolution ?? '—'}</td>
+						<td class="py-2 pr-4 text-gray-300">
+							{#if candidate.tmdb?.voteAverage !== undefined}
+								<span
+									class="rounded bg-amber-900/60 px-1.5 py-0.5 text-xs text-amber-100"
+									title="TMDB vote average"
+								>
+									★ {formatRating(candidate.tmdb.voteAverage)}
+								</span>
+							{:else}
+								—
+							{/if}
+						</td>
 						<td class="py-2 pr-4">
 
 								<span

--- a/web/src/routes/candidates/candidates.test.ts
+++ b/web/src/routes/candidates/candidates.test.ts
@@ -26,6 +26,20 @@ const mockCandidate: CandidateStateRecord = {
 };
 
 describe('/candidates', () => {
+	it('renders TMDB rating when candidate includes tmdb metadata', () => {
+		const withTmdb: CandidateStateRecord = {
+			...mockCandidate,
+			tmdb: {
+				name: 'The Show TMDB',
+				posterUrl: 'https://example.com/poster.jpg',
+				voteAverage: 8.2,
+			},
+		};
+		render(Page, { data: { candidates: [withTmdb], error: null } });
+		expect(screen.getByText('The Show TMDB')).toBeInTheDocument();
+		expect(screen.getByTitle('TMDB vote average')).toHaveTextContent('★ 8.2');
+	});
+
 	it('renders table with candidate data', () => {
 		render(Page, { data: { candidates: [mockCandidate], error: null } });
 		expect(screen.getByText('The Show')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- delivery ticket: `P11.04 Candidates vertical slice: enrich GET /api/candidates, candidate list/detail UI`
- ticket file: [docs/02-delivery/phase-11/ticket-04-candidates-vertical-slice.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-11/ticket-04-candidates-vertical-slice.md)
- stacked base branch: `agents/p11-03-tv-shows-vertical-slice-show-season-episode-tmdb-enrich-get-api-shows-show-ui`
- post-verify self-audit: completed at 2026-04-08 17:49 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`cc31b39ad26e`](https://github.com/cesarnml/pirate_claw/commit/cc31b39ad26e229d6c28c861467204243f30dc98)
- current branch head: [`057ff2e5d6f4`](https://github.com/cesarnml/pirate_claw/commit/057ff2e5d6f49d837e3062607b813b8c32b5aa0e)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `cc31b39ad26e` address all findings from that review.
- vendors: `coderabbit`, `greptile`

### Resolved Review Findings

- [coderabbit] Close test resources via `finally` to avoid leaked DB handles. (native GitHub thread resolved) `test/api.test.ts:244` [thread](https://github.com/cesarnml/pirate_claw/pull/97#discussion_r3053197575)
- [greptile] Missing TV-candidate cache enrichment test (native GitHub thread resolved) `test/api.test.ts:244` [thread](https://github.com/cesarnml/pirate_claw/pull/97#discussion_r3053189374)
