### PR TITLE
feat(daemon): background TMDB refresh on schedule [P11.05]

### DIFF
--- a/docs/02-delivery/phase-11/ticket-05-background-tmdb-scheduler.md
+++ b/docs/02-delivery/phase-11/ticket-05-background-tmdb-scheduler.md
@@ -28,3 +28,9 @@ Lazy API reads ship value first; this ticket adds operational completeness after
 - `runtime.tmdbRefreshIntervalMinutes` (default 360; set `0` to disable) drives a `setInterval` in `runDaemonLoop` that is **not** gated by the RSS `busy` lock.
 - `runTmdbBackgroundRefresh` (`src/tmdb/background-refresh.ts`) reuses `buildMovieBreakdowns` / `buildShowBreakdowns` plus `enrichMovieBreakdowns` / `enrichShowBreakdowns` — same cache/TTL behavior as API reads, no duplicate TMDB client logic.
 - TMDB refresh is only scheduled when `tmdbMovieEnrichDeps` / `tmdbShowsEnrichDeps` resolve (TMDB API key configured).
+
+**Review follow-up (PR #98):**
+
+- `RuntimeConfig` JSDoc for `tmdbRefreshIntervalMinutes` now matches `validateRuntime`: omitted → default interval, `0` disables; lazy reads still work without background refresh.
+- TMDB enrich deps no longer require `runtime.apiPort` (HTTP API is optional); background refresh runs in daemon-only mode when TMDB is configured. `createApiFetch` remains gated on `apiPort` for API-specific paths.
+- Daemon scheduling reads `tmdbRefreshIntervalMinutes` with a non-null assertion after `loadConfig` because `validateRuntime` always sets the field while `RuntimeConfig` still types it optional.

--- a/docs/02-delivery/phase-11/ticket-05-background-tmdb-scheduler.md
+++ b/docs/02-delivery/phase-11/ticket-05-background-tmdb-scheduler.md
@@ -22,3 +22,9 @@ With TMDB configured, metadata stays fresh within TTL without requiring every en
 ## Rationale
 
 Lazy API reads ship value first; this ticket adds operational completeness after all read paths exist, matching the grill-me ordering (scheduler after candidates slice).
+
+**Implementation notes (P11.05 delivered):**
+
+- `runtime.tmdbRefreshIntervalMinutes` (default 360; set `0` to disable) drives a `setInterval` in `runDaemonLoop` that is **not** gated by the RSS `busy` lock.
+- `runTmdbBackgroundRefresh` (`src/tmdb/background-refresh.ts`) reuses `buildMovieBreakdowns` / `buildShowBreakdowns` plus `enrichMovieBreakdowns` / `enrichShowBreakdowns` — same cache/TTL behavior as API reads, no duplicate TMDB client logic.
+- TMDB refresh is only scheduled when `tmdbMovieEnrichDeps` / `tmdbShowsEnrichDeps` resolve (TMDB API key configured).

--- a/pirate-claw.config.example.json
+++ b/pirate-claw.config.example.json
@@ -43,7 +43,8 @@
     "reconcileIntervalMinutes": 1,
     "artifactDir": ".pirate-claw/runtime",
     "artifactRetentionDays": 7,
-    "apiPort": 3000
+    "apiPort": 3000,
+    "tmdbRefreshIntervalMinutes": 360
   },
   "tmdb": {
     "apiKey": "your-tmdb-api-key",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,7 @@ import {
   type CandidateStateRecord,
   type RunSummaryRecord,
 } from './repository';
+import { runTmdbBackgroundRefresh } from './tmdb/background-refresh';
 import { TmdbCache } from './tmdb/cache';
 import { TmdbHttpClient } from './tmdb/client';
 import type { MovieEnrichDeps } from './tmdb/movie-enrichment';
@@ -195,6 +196,10 @@ export async function runCli(argv: string[]): Promise<number> {
 
         const tmdbMovies = tmdbMovieEnrichDeps(database, config, log);
         const tmdbShows = tmdbShowsEnrichDeps(database, config, log);
+        const tmdbRefreshIntervalMinutes =
+          config.runtime.tmdbRefreshIntervalMinutes ?? 360;
+        const scheduleTmdbRefresh =
+          (tmdbMovies || tmdbShows) && tmdbRefreshIntervalMinutes > 0;
 
         await runDaemonLoop({
           runCycle: async () => {
@@ -233,6 +238,16 @@ export async function runCli(argv: string[]): Promise<number> {
             });
             console.log(formatReconcileSummary(result));
           },
+          tmdbRefreshCycle: scheduleTmdbRefresh
+            ? async () => {
+                await runTmdbBackgroundRefresh({
+                  repository,
+                  tmdbMovies,
+                  tmdbShows,
+                  log,
+                });
+              }
+            : undefined,
           options: daemonOptionsFromConfig(config.runtime),
           signal: controller.signal,
           log,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,7 +49,7 @@ function tmdbMovieEnrichDeps(
   log: (message: string) => void,
 ): MovieEnrichDeps | undefined {
   const tmdbResolved = resolveTmdbSettings(config);
-  if (!tmdbResolved || config.runtime.apiPort == null) {
+  if (!tmdbResolved) {
     return undefined;
   }
   return {
@@ -69,7 +69,7 @@ function tmdbShowsEnrichDeps(
   log: (message: string) => void,
 ): TvEnrichDeps | undefined {
   const tmdbResolved = resolveTmdbSettings(config);
-  if (!tmdbResolved || config.runtime.apiPort == null) {
+  if (!tmdbResolved) {
     return undefined;
   }
   return {
@@ -197,7 +197,7 @@ export async function runCli(argv: string[]): Promise<number> {
         const tmdbMovies = tmdbMovieEnrichDeps(database, config, log);
         const tmdbShows = tmdbShowsEnrichDeps(database, config, log);
         const tmdbRefreshIntervalMinutes =
-          config.runtime.tmdbRefreshIntervalMinutes ?? 360;
+          config.runtime.tmdbRefreshIntervalMinutes!;
         const scheduleTmdbRefresh =
           (tmdbMovies || tmdbShows) && tmdbRefreshIntervalMinutes > 0;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,6 +48,11 @@ export type RuntimeConfig = {
   artifactDir: string;
   artifactRetentionDays: number;
   apiPort?: number;
+  /**
+   * How often to run TMDB cache refresh in the daemon (independent of RSS polling).
+   * Omitted or zero disables the background pass (lazy API reads still work).
+   */
+  tmdbRefreshIntervalMinutes?: number;
 };
 
 /** Optional TMDB enrichment (Phase 11). API key may be supplied via env instead. */
@@ -64,6 +69,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   reconcileIntervalMinutes: 1,
   artifactDir: '.pirate-claw/runtime',
   artifactRetentionDays: 7,
+  tmdbRefreshIntervalMinutes: 360,
 };
 
 export type AppConfig = {
@@ -680,10 +686,41 @@ function validateRuntime(input: unknown, path: string): RuntimeConfig {
       runtime.apiPort,
       `${path} runtime apiPort`,
     ),
+    tmdbRefreshIntervalMinutes:
+      validateOptionalTmdbRefreshInterval(
+        runtime.tmdbRefreshIntervalMinutes,
+        `${path} runtime tmdbRefreshIntervalMinutes`,
+      ) ?? DEFAULT_RUNTIME_CONFIG.tmdbRefreshIntervalMinutes,
   };
 }
 
 const MAX_INTERVAL_MINUTES = 44_640;
+
+function validateOptionalTmdbRefreshInterval(
+  input: unknown,
+  label: string,
+): number | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  if (
+    typeof input !== 'number' ||
+    !Number.isFinite(input) ||
+    input < 0 ||
+    input > MAX_INTERVAL_MINUTES
+  ) {
+    throw new ConfigError(
+      `Config file "${label}" must be a finite non-negative number of minutes (max ${MAX_INTERVAL_MINUTES}), or omit to use the default.`,
+    );
+  }
+
+  if (input === 0) {
+    return 0;
+  }
+
+  return input;
+}
 
 function optionalPositiveNumber(
   input: unknown,

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,7 +50,8 @@ export type RuntimeConfig = {
   apiPort?: number;
   /**
    * How often to run TMDB cache refresh in the daemon (independent of RSS polling).
-   * Omitted or zero disables the background pass (lazy API reads still work).
+   * Zero disables the background pass; omitted uses the default (see `DEFAULT_RUNTIME_CONFIG` and `validateRuntime`).
+   * Lazy API reads still work when background refresh is disabled.
    */
   tmdbRefreshIntervalMinutes?: number;
 };

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -5,19 +5,26 @@ export type DaemonOptions = {
   runIntervalMs: number;
   reconcileIntervalMs: number;
   apiPort?: number;
+  /** When set (TMDB configured + interval > 0), daemon schedules background refreshes. */
+  tmdbRefreshIntervalMs?: number;
 };
 
 export function daemonOptionsFromConfig(runtime: RuntimeConfig): DaemonOptions {
+  const tmdbMin = runtime.tmdbRefreshIntervalMinutes;
   return {
     runIntervalMs: runtime.runIntervalMinutes * 60 * 1000,
     reconcileIntervalMs: runtime.reconcileIntervalMinutes * 60 * 1000,
     apiPort: runtime.apiPort,
+    tmdbRefreshIntervalMs:
+      tmdbMin != null && tmdbMin > 0 ? tmdbMin * 60 * 1000 : undefined,
   };
 }
 
 export async function runDaemonLoop(input: {
   runCycle: () => Promise<void>;
   reconcileCycle: () => Promise<void>;
+  /** Optional TMDB cache refresh; does not share the RSS `busy` lock. */
+  tmdbRefreshCycle?: () => Promise<void>;
   options: DaemonOptions;
   signal: AbortSignal;
   log?: (message: string) => void;
@@ -56,6 +63,8 @@ export async function runDaemonLoop(input: {
     }
   };
   let inFlight: Promise<void> | undefined;
+  let tmdbInFlight: Promise<void> | undefined;
+  let tmdbBusy = false;
 
   async function guardedCycle(
     type: string,
@@ -87,6 +96,38 @@ export async function runDaemonLoop(input: {
     }
   }
 
+  async function runTmdbRefresh(): Promise<void> {
+    if (!input.tmdbRefreshCycle) {
+      return;
+    }
+    if (tmdbBusy) {
+      log('tmdb_refresh cycle skipped: already_running');
+      emitCycleResult({
+        type: 'tmdb_refresh',
+        status: 'skipped',
+        startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+        durationMs: 0,
+        skipReason: 'already_running',
+      });
+      return;
+    }
+    tmdbBusy = true;
+    const promise = executeCycle(
+      'tmdb_refresh',
+      input.tmdbRefreshCycle,
+      log,
+      emitCycleResult,
+    );
+    tmdbInFlight = promise;
+    try {
+      await promise;
+    } finally {
+      tmdbBusy = false;
+      tmdbInFlight = undefined;
+    }
+  }
+
   log('daemon started');
 
   await guardedCycle('run', runCycle);
@@ -108,6 +149,17 @@ export async function runDaemonLoop(input: {
     guardedCycle('reconcile', reconcileCycle);
   }, options.reconcileIntervalMs);
 
+  let tmdbTimer: ReturnType<typeof setInterval> | undefined;
+  if (
+    options.tmdbRefreshIntervalMs != null &&
+    options.tmdbRefreshIntervalMs > 0 &&
+    input.tmdbRefreshCycle
+  ) {
+    tmdbTimer = setInterval(() => {
+      void runTmdbRefresh();
+    }, options.tmdbRefreshIntervalMs);
+  }
+
   await new Promise<void>((resolve) => {
     if (signal.aborted) {
       resolve();
@@ -119,6 +171,9 @@ export async function runDaemonLoop(input: {
 
   clearInterval(runTimer);
   clearInterval(reconcileTimer);
+  if (tmdbTimer) {
+    clearInterval(tmdbTimer);
+  }
 
   if (server) {
     server.stop();
@@ -127,6 +182,10 @@ export async function runDaemonLoop(input: {
 
   if (inFlight) {
     await inFlight;
+  }
+
+  if (tmdbInFlight) {
+    await tmdbInFlight;
   }
 
   log('daemon stopped');

--- a/src/tmdb/background-refresh.ts
+++ b/src/tmdb/background-refresh.ts
@@ -1,0 +1,36 @@
+import { buildMovieBreakdowns, buildShowBreakdowns } from '../api';
+import type { Repository } from '../repository';
+import type { MovieEnrichDeps } from './movie-enrichment';
+import { enrichMovieBreakdowns } from './movie-enrichment';
+import type { TvEnrichDeps } from './tv-enrichment';
+import { enrichShowBreakdowns } from './tv-enrichment';
+
+/**
+ * Warm or refresh TMDB cache for current candidates using the same lazy enrichment
+ * as API reads (respects TTL / negative-cache rules). Does not block RSS intake.
+ */
+export async function runTmdbBackgroundRefresh(input: {
+  repository: Repository;
+  tmdbMovies?: MovieEnrichDeps;
+  tmdbShows?: TvEnrichDeps;
+  log: (message: string) => void;
+}): Promise<void> {
+  const { repository, tmdbMovies, tmdbShows, log } = input;
+  if (!tmdbMovies && !tmdbShows) {
+    return;
+  }
+
+  const candidates = repository.listCandidateStates();
+
+  if (tmdbMovies) {
+    const movies = buildMovieBreakdowns(candidates);
+    await enrichMovieBreakdowns(movies, tmdbMovies);
+  }
+
+  if (tmdbShows) {
+    const shows = buildShowBreakdowns(candidates);
+    await enrichShowBreakdowns(shows, tmdbShows);
+  }
+
+  log('[tmdb] background refresh completed');
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -612,6 +612,7 @@ describe('pirate-claw config show', () => {
         reconcileIntervalMinutes: 1,
         artifactDir: '.pirate-claw/runtime',
         artifactRetentionDays: 7,
+        tmdbRefreshIntervalMinutes: 360,
       },
     });
   });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -283,6 +283,7 @@ describe('validateConfig', () => {
     expect(config.runtime.reconcileIntervalMinutes).toBe(1);
     expect(config.runtime.artifactDir).toBe('.pirate-claw/runtime');
     expect(config.runtime.artifactRetentionDays).toBe(7);
+    expect(config.runtime.tmdbRefreshIntervalMinutes).toBe(360);
   });
 
   it('applies all runtime overrides when fully specified', () => {
@@ -301,6 +302,7 @@ describe('validateConfig', () => {
       reconcileIntervalMinutes: 5,
       artifactDir: '/custom/path',
       artifactRetentionDays: 14,
+      tmdbRefreshIntervalMinutes: 360,
     });
   });
 
@@ -354,6 +356,23 @@ describe('validateConfig', () => {
     });
 
     expect(config.runtime.apiPort).toBe(3000);
+  });
+
+  it('accepts runtime.tmdbRefreshIntervalMinutes zero to disable background refresh', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      runtime: { tmdbRefreshIntervalMinutes: 0 },
+    });
+    expect(config.runtime.tmdbRefreshIntervalMinutes).toBe(0);
+  });
+
+  it('fails when runtime.tmdbRefreshIntervalMinutes is negative', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        runtime: { tmdbRefreshIntervalMinutes: -1 },
+      }),
+    ).toThrow(/tmdbRefreshIntervalMinutes/);
   });
 
   it('leaves runtime.apiPort undefined when omitted', () => {

--- a/test/daemon.test.ts
+++ b/test/daemon.test.ts
@@ -422,4 +422,30 @@ describe('daemon', () => {
       // Expected: connection refused
     }
   });
+
+  it('schedules tmdb_refresh independently of run/reconcile', async () => {
+    const log: string[] = [];
+    const controller = new AbortController();
+    let tmdbCount = 0;
+    setTimeout(() => controller.abort(), 80);
+    await runDaemonLoop({
+      runCycle: async () => {},
+      reconcileCycle: async () => {},
+      tmdbRefreshCycle: async () => {
+        tmdbCount += 1;
+      },
+      options: {
+        runIntervalMs: 600_000,
+        reconcileIntervalMs: 600_000,
+        tmdbRefreshIntervalMs: 10,
+      },
+      signal: controller.signal,
+      log: (msg) => log.push(msg),
+    });
+
+    expect(tmdbCount).toBeGreaterThanOrEqual(1);
+    expect(log.some((m) => m.includes('tmdb_refresh cycle completed'))).toBe(
+      true,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- delivery ticket: `P11.05 Background TMDB enrichment scheduler`
- ticket file: [docs/02-delivery/phase-11/ticket-05-background-tmdb-scheduler.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-11/ticket-05-background-tmdb-scheduler.md)
- stacked base branch: `agents/p11-04-candidates-vertical-slice-enrich-get-api-candidates-candidate-list-detail-ui`
- post-verify self-audit: completed at 2026-04-08 18:01 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`4c3e91957c4a`](https://github.com/cesarnml/pirate_claw/commit/4c3e91957c4ab71cb517e2f89cb04a33cfee9406)
- current branch head: [`66a54b32a631`](https://github.com/cesarnml/pirate_claw/commit/66a54b32a631e3c2dddc7cc45771218c1e629740)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `4c3e91957c4a` address all findings from that review.
- vendors: `coderabbit`, `greptile`

### Resolved Review Findings

- [coderabbit] Inline runtime docs contradict actual default behavior. (native GitHub thread resolved) `src/config.ts:54` [thread](https://github.com/cesarnml/pirate_claw/pull/98#discussion_r3053256877)
- [greptile] Dead code fallback `?? 360` (native GitHub thread resolved) `src/cli.ts:200` [thread](https://github.com/cesarnml/pirate_claw/pull/98#discussion_r3053246346)
