### PR TITLE
docs(phase-11): align overview, roadmap, and README for TMDB exit [P11.06]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pirate Claw is a local CLI for pulling media candidates from RSS feeds, matching them against your rules, and queueing approved downloads in Transmission.
 
-Phases 01-09 of the current product roadmap are implemented on `main`. The currently documented engineering epics through Epic 03 are also implemented on `main`. Further product-surface or delivery-tooling expansion now requires a new planning pass and new approved phase/epic docs.
+Phases 01–10 of the current product roadmap are implemented on `main`. The currently documented engineering epics through Epic 03 are also implemented on `main`. Phase 11 (TMDB metadata enrichment) is implemented in the phase-11 delivery stack; after review, merge the stacked PRs with `bun run closeout-stack --plan docs/02-delivery/phase-11/implementation-plan.md` rather than ad hoc cherry-picks. Further product-surface or delivery-tooling expansion beyond that still requires a new planning pass and new approved phase/epic docs when the work is not a small bounded change.
 
 It currently supports:
 
@@ -17,6 +17,8 @@ It currently supports:
 - effective config inspection through `pirate-claw config show`
 - env-backed Transmission credentials via process env or `.env`
 - read-only daemon HTTP API for external consumers when `runtime.apiPort` is configured
+- optional TMDB-backed posters, ratings, and metadata on API and dashboard when a `tmdb` API key is configured (see `pirate-claw.config.example.json`)
+- read-only browser dashboard in `web/` that talks to the daemon API (Phase 10)
 
 ## Commands
 
@@ -78,7 +80,8 @@ High-level config shape:
 - `tv`: either the legacy per-show rule array or a compact `defaults + shows` object
 - `movies`: global movie intake policy
 - `transmission`: local Transmission RPC settings (optional `downloadDirs` for per-media-type download directories)
-- `runtime`: daemon scheduling and artifact settings (optional, all fields have defaults; `apiPort` enables the HTTP API)
+- `runtime`: daemon scheduling and artifact settings (optional, all fields have defaults; `apiPort` enables the HTTP API; `tmdbRefreshIntervalMinutes` controls background TMDB cache refresh, default 360 minutes, `0` disables)
+- `tmdb`: optional TMDB API key (`apiKey` or env `PIRATE_CLAW_TMDB_API_KEY`) and optional cache TTL overrides
 
 Example:
 
@@ -246,6 +249,12 @@ curl http://localhost:3000/api/health
 ```
 
 All endpoints are read-only. No endpoint mutates daemon state. There is no authentication in this version — it is designed for private NAS networks.
+
+Candidate, show, and movie payloads include TMDB fields when a match exists in the local cache; otherwise they fall back to Phase-10-style local data.
+
+## Read-only dashboard (`web/`)
+
+With the daemon listening (`runtime.apiPort`), run the SvelteKit app from `web/` (`bun install --cwd web` then `bun run --cwd web dev`, configured to reach your daemon base URL) to browse candidates, shows, and movies in the browser. TMDB posters and ratings appear when configured.
 
 ## Current Scope
 

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -273,7 +273,7 @@ Goal:
 
 Current status:
 
-- planned, not yet implemented
+- implemented on `main`
 
 Committed scope:
 
@@ -285,9 +285,10 @@ Committed scope:
 Explicitly deferred:
 
 - config editing through the UI
-- TMDB metadata, posters, or ratings
 - visually rich styling or theming
 - Docker Compose orchestration
+
+TMDB metadata, posters, and ratings are covered by Phase 11, not Phase 10.
 
 Working notes:
 
@@ -301,7 +302,7 @@ Goal:
 
 Current status:
 
-- product doc approved; delivery ticket decomposition in `docs/02-delivery/phase-11/implementation-plan.md` — implementation not started
+- implemented per approved tickets `P11.01`–`P11.06` in `docs/02-delivery/phase-11/implementation-plan.md` (stacked PR delivery; merge onto `main` with `bun run closeout-stack --plan docs/02-delivery/phase-11/implementation-plan.md` after developer review)
 
 Committed scope:
 
@@ -309,6 +310,7 @@ Committed scope:
 - candidate-to-TMDB matching for movies and TV
 - SQLite-cached metadata with configurable TTL
 - enriched API responses and dashboard views with posters and ratings
+- background TMDB refresh on a daemon timer (`runtime.tmdbRefreshIntervalMinutes`, independent of RSS polling)
 - display-only — ratings do not gate the intake pipeline
 
 Explicitly deferred:
@@ -335,9 +337,8 @@ These items emerged during ideation and are explicitly deferred beyond Phase 11:
 
 ## Current Planning Posture
 
-- product phases `01`-`09` and engineering epics `01`-`03` are complete on `main`
-- product phase `10` is planned with an approved product doc and a delivery implementation plan
-- product phase `11` is planned with an approved product doc and an approved ticket decomposition (`docs/02-delivery/phase-11/`), but implementation has not started
+- product phases `01`–`10` and engineering epics `01`–`03` are complete on `main`
+- product phase `11` is implemented in the phase-11 stacked PR queue; durable docs and exit verification are ticket `P11.06`
 - each new phase requires an explicit planning pass, approved ticket decomposition, and developer sign-off before implementation starts
 - smaller bounded changes can still proceed as standalone PR work without inventing a new phase
 
@@ -353,4 +354,4 @@ Working notes:
 - promote durable technical choices into ADRs
 - numbered phases are planning buckets, not a promise of strict implementation sequence when dependencies allow independent work
 
-Last verified against `README.md` and active delivery plans: 2026-04-09.
+Last verified against `README.md` and active delivery plans: 2026-04-08.

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -10,7 +10,7 @@ Its job is to answer three questions quickly:
 
 ## Current Repo State
 
-Pirate Claw is implemented through Phase 09.
+Pirate Claw is implemented through Phase 10 on `main`, with Phase 11 (TMDB enrichment) delivered in the phase-11 stacked PR path (`docs/02-delivery/phase-11/`).
 
 Current delivered surface:
 
@@ -28,10 +28,12 @@ Current delivered surface:
 - movie codec policy mode via `movies.codecPolicy` (`prefer` by default, `require` for strict matching)
 - queue-time Transmission `movie` / `tv` labels with warning+retry fallback when labels are unsupported
 - per-media-type Transmission download directories via `transmission.downloadDirs`
+- read-only SvelteKit dashboard in `web/` that consumes the daemon HTTP API (run the daemon with `runtime.apiPort`, then `bun run --cwd web dev` or the production build)
+- optional TMDB enrichment: `tmdb` config block and/or `PIRATE_CLAW_TMDB_API_KEY`, SQLite-backed cache, lazy enrichment on API reads, and an optional daemon background refresh cadence via `runtime.tmdbRefreshIntervalMinutes` (default 6 hours; set `0` to disable)
 
 Current product boundary:
 
-- local CLI only
+- local CLI plus optional read-only browser dashboard
 - Transmission is the downloader adapter
 - SQLite is the local persistence boundary
 - real-world feed compatibility for EZTV and Atlas is implemented
@@ -41,10 +43,11 @@ Current product boundary:
 - shared runtime lock prevents overlapping cycles
 - machine-readable and human-readable cycle artifacts with bounded retention
 - read-only daemon HTTP API (`/api/health`, `/api/status`, `/api/candidates`, `/api/shows`, `/api/movies`, `/api/feeds`, `/api/config`) when `runtime.apiPort` is configured
+- TMDB metadata is display-only and does not gate RSS intake
 
 Still deferred:
 
-- web UI
+- config editing through the web UI
 - remote feed capture
 - hosted persistence
 - download renaming or organization rules
@@ -55,7 +58,7 @@ Last verified against `README.md` and CLI commands: 2026-04-08.
 
 Current planning focus:
 
-- see [`roadmap.md`](./roadmap.md) for numbered phases: Phase 10 (read-only dashboard) and Phase 11 (TMDB enrichment) have approved product docs; Phase 11 also has an approved ticket decomposition under `docs/02-delivery/phase-11/`
+- see [`roadmap.md`](./roadmap.md) for numbered phases and what is on `main` versus the phase-11 stack
 - use the roadmap to confirm whether the request is a bounded standalone change or needs a new approved phase/epic planning pass
 - treat the current Phase 07 config surface and the current extracted delivery-orchestrator module boundaries as the baseline for future work
 

--- a/docs/02-delivery/phase-11/ticket-06-docs-exit-verification.md
+++ b/docs/02-delivery/phase-11/ticket-06-docs-exit-verification.md
@@ -24,3 +24,21 @@ Documentation reflects Phase 11 delivery plan location; roadmap/start-here/READM
 ## Rationale
 
 Keeps durable docs aligned with AGENTS ticket-completion expectations and avoids shipping code without discoverable plan links.
+
+**P11.06 delivered:**
+
+- `docs/README.md` already indexed `phase-11/implementation-plan.md`; left consistent.
+- `docs/00-overview/roadmap.md`: Phase 10 marked implemented on `main`; Phase 11 marked implemented via stacked delivery with `closeout-stack` merge note; planning posture updated; Phase 10 deferral text adjusted so TMDB is attributed to Phase 11.
+- `docs/00-overview/start-here.md`: current state through Phase 10 on `main` and Phase 11 in the stack; dashboard + TMDB surfaces; deferred list no longer claims “web UI” is missing.
+- `README.md`: Phase 11 / closeout pointer, TMDB and `tmdbRefreshIntervalMinutes` in config shape, dashboard subsection.
+
+**Exit condition checklist** (vs `docs/01-product/phase-11-tmdb-metadata-enrichment.md`):
+
+| Product exit criterion                                                   | Status                                                         |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| Dashboard shows TMDB posters and ratings when TMDB is configured         | Met (candidates/show/movie views; stack implements enrichment) |
+| Show detail shows TMDB season/episode metadata with local download state | Met                                                            |
+| Movie candidates show TMDB overview, rating, poster                      | Met                                                            |
+| Graceful degrade when TMDB missing or unreachable                        | Met (lazy enrichment + logging; UI tolerates absent fields)    |
+
+**Explicit deferrals** in the product doc remain unchanged (rating gates, search-to-add, calendar, UI config editor, speculative unmatched candidates, local image CDN, etc.).


### PR DESCRIPTION
## Summary

- delivery ticket: `P11.06 Docs, index updates, exit verification`
- ticket file: [docs/02-delivery/phase-11/ticket-06-docs-exit-verification.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-11/ticket-06-docs-exit-verification.md)
- stacked base branch: `agents/p11-05-background-tmdb-enrichment-scheduler`
- post-verify self-audit: completed at 2026-04-08 18:14 UTC

## External AI Review

- outcome: `clean`
- current branch head: [`81a45aab0a52`](https://github.com/cesarnml/pirate_claw/commit/81a45aab0a5263d58eda237142d738b9fa6fc47e)
- no prudent follow-up changes were required.
