### PR TITLE
feat(web): migrate candidates view to shadcn Card and Table [P12.02]

### DIFF
--- a/docs/02-delivery/phase-12/ticket-02-candidates-view.md
+++ b/docs/02-delivery/phase-12/ticket-02-candidates-view.md
@@ -22,4 +22,4 @@ Candidates page matches Phase 12 visually and passes existing test intent; no re
 
 ## Rationale
 
-_To be filled during implementation — note reusable primitives introduced for later tickets._
+Migrated the candidates table into **shadcn-svelte** `Card`, `Table` (`TableHeader` / `TableBody` / `TableRow` / `TableCell` / `TableHead`), `Badge`, and `Button` (ghost sort controls). Status colors use `Badge variant="outline"` with token-aligned `cn()` classes instead of raw `gray-*` utilities. Error, empty, and sort behavior are unchanged; tests were not rewritten because visible text and roles stayed the same.

--- a/docs/02-delivery/phase-12/ticket-02-candidates-view.md
+++ b/docs/02-delivery/phase-12/ticket-02-candidates-view.md
@@ -22,4 +22,4 @@ Candidates page matches Phase 12 visually and passes existing test intent; no re
 
 ## Rationale
 
-Migrated the candidates table into **shadcn-svelte** `Card`, `Table` (`TableHeader` / `TableBody` / `TableRow` / `TableCell` / `TableHead`), `Badge`, and `Button` (ghost sort controls). Status colors use `Badge variant="outline"` with token-aligned `cn()` classes instead of raw `gray-*` utilities. Error, empty, and sort behavior are unchanged; tests were not rewritten because visible text and roles stayed the same.
+Migrated the candidates table into **shadcn-svelte** `Card`, `Table` (`TableHeader` / `TableBody` / `TableRow` / `TableCell` / `TableHead`), `Badge`, and `Button` (ghost sort controls). Status colors use `Badge variant="outline"` with token-aligned `cn()` classes instead of raw `gray-*` utilities. Error, empty, and sort behavior are unchanged. Vitest assertions are unchanged because visible labels and roles stayed the same (no selector rewrites were required).

--- a/web/src/lib/components/ui/badge/badge.svelte
+++ b/web/src/lib/components/ui/badge/badge.svelte
@@ -1,0 +1,49 @@
+<script lang="ts" module>
+	import { type VariantProps, tv } from "tailwind-variants";
+
+	export const badgeVariants = tv({
+		base: "h-5 gap-1 rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive group/badge inline-flex w-fit shrink-0 items-center justify-center overflow-hidden whitespace-nowrap transition-colors focus-visible:ring-[3px] [&>svg]:pointer-events-none",
+		variants: {
+			variant: {
+				default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+				secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+				destructive: "bg-destructive/10 [a]:hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 text-destructive dark:bg-destructive/20",
+				outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+				ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+				link: "text-primary underline-offset-4 hover:underline",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	});
+
+	export type BadgeVariant = VariantProps<typeof badgeVariants>["variant"];
+</script>
+
+<script lang="ts">
+	import type { HTMLAnchorAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		href,
+		class: className,
+		variant = "default",
+		children,
+		...restProps
+	}: WithElementRef<HTMLAnchorAttributes> & {
+		variant?: BadgeVariant;
+	} = $props();
+</script>
+
+<svelte:element
+	this={href ? "a" : "span"}
+	bind:this={ref}
+	data-slot="badge"
+	{href}
+	class={cn(badgeVariants({ variant }), className)}
+	{...restProps}
+>
+	{@render children?.()}
+</svelte:element>

--- a/web/src/lib/components/ui/badge/badge.svelte
+++ b/web/src/lib/components/ui/badge/badge.svelte
@@ -5,10 +5,11 @@
 		base: "h-5 gap-1 rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive group/badge inline-flex w-fit shrink-0 items-center justify-center overflow-hidden whitespace-nowrap transition-colors focus-visible:ring-[3px] [&>svg]:pointer-events-none",
 		variants: {
 			variant: {
-				default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
-				secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
-				destructive: "bg-destructive/10 [a]:hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 text-destructive dark:bg-destructive/20",
-				outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+				default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/80",
+				secondary: "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/80",
+				destructive:
+					"bg-destructive/10 [a&]:hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 text-destructive dark:bg-destructive/20",
+				outline: "border-border text-foreground [a&]:hover:bg-muted [a&]:hover:text-muted-foreground",
 				ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
 				link: "text-primary underline-offset-4 hover:underline",
 			},

--- a/web/src/lib/components/ui/badge/index.ts
+++ b/web/src/lib/components/ui/badge/index.ts
@@ -1,0 +1,2 @@
+export { default as Badge } from "./badge.svelte";
+export { badgeVariants, type BadgeVariant } from "./badge.svelte";

--- a/web/src/lib/components/ui/button/button.svelte
+++ b/web/src/lib/components/ui/button/button.svelte
@@ -8,7 +8,7 @@
 		variants: {
 			variant: {
 				default:
-					"bg-primary text-primary-foreground hover:bg-primary/80 [a]:hover:bg-primary/80",
+					"bg-primary text-primary-foreground hover:bg-primary/80 [a&]:hover:bg-primary/80",
 				outline: "border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground",
 				secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
 				ghost: "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",

--- a/web/src/lib/components/ui/card/card-action.svelte
+++ b/web/src/lib/components/ui/card/card-action.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="card-action"
+	class={cn(
+		"cn-card-action col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/card/card-action.svelte
+++ b/web/src/lib/components/ui/card/card-action.svelte
@@ -14,7 +14,7 @@
 	bind:this={ref}
 	data-slot="card-action"
 	class={cn(
-		"cn-card-action col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+		"col-start-2 row-span-2 row-start-1 self-start justify-self-end",
 		className
 	)}
 	{...restProps}

--- a/web/src/lib/components/ui/card/card-content.svelte
+++ b/web/src/lib/components/ui/card/card-content.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="card-content"
+	class={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/card/card-description.svelte
+++ b/web/src/lib/components/ui/card/card-description.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLParagraphElement>> = $props();
+</script>
+
+<p
+	bind:this={ref}
+	data-slot="card-description"
+	class={cn("text-muted-foreground text-sm", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</p>

--- a/web/src/lib/components/ui/card/card-footer.svelte
+++ b/web/src/lib/components/ui/card/card-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="card-footer"
+	class={cn("bg-muted/50 rounded-b-xl border-t p-4 group-data-[size=sm]/card:p-3 flex items-center", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/card/card-header.svelte
+++ b/web/src/lib/components/ui/card/card-header.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="card-header"
+	class={cn(
+		"gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3 group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/card/card-title.svelte
+++ b/web/src/lib/components/ui/card/card-title.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="card-title"
+	class={cn("text-base leading-snug font-medium group-data-[size=sm]/card:text-sm", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/card/card.svelte
+++ b/web/src/lib/components/ui/card/card.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		size = "default",
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & { size?: "default" | "sm" } = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="card"
+	data-size={size}
+	class={cn("ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-xl py-4 text-sm ring-1 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl group/card flex flex-col", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/card/card.svelte
+++ b/web/src/lib/components/ui/card/card.svelte
@@ -15,7 +15,7 @@
 	bind:this={ref}
 	data-slot="card"
 	data-size={size}
-	class={cn("ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-xl py-4 text-sm ring-1 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl group/card flex flex-col", className)}
+	class={cn("ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-xl py-4 text-sm ring-1 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 [&>img:first-child]:rounded-t-xl [&>img:last-child]:rounded-b-xl group/card flex flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/web/src/lib/components/ui/card/index.ts
+++ b/web/src/lib/components/ui/card/index.ts
@@ -1,0 +1,25 @@
+import Root from "./card.svelte";
+import Content from "./card-content.svelte";
+import Description from "./card-description.svelte";
+import Footer from "./card-footer.svelte";
+import Header from "./card-header.svelte";
+import Title from "./card-title.svelte";
+import Action from "./card-action.svelte";
+
+export {
+	Root,
+	Content,
+	Description,
+	Footer,
+	Header,
+	Title,
+	Action,
+	//
+	Root as Card,
+	Content as CardContent,
+	Description as CardDescription,
+	Footer as CardFooter,
+	Header as CardHeader,
+	Title as CardTitle,
+	Action as CardAction,
+};

--- a/web/src/lib/components/ui/table/index.ts
+++ b/web/src/lib/components/ui/table/index.ts
@@ -1,0 +1,28 @@
+import Root from "./table.svelte";
+import Body from "./table-body.svelte";
+import Caption from "./table-caption.svelte";
+import Cell from "./table-cell.svelte";
+import Footer from "./table-footer.svelte";
+import Head from "./table-head.svelte";
+import Header from "./table-header.svelte";
+import Row from "./table-row.svelte";
+
+export {
+	Root,
+	Body,
+	Caption,
+	Cell,
+	Footer,
+	Head,
+	Header,
+	Row,
+	//
+	Root as Table,
+	Body as TableBody,
+	Caption as TableCaption,
+	Cell as TableCell,
+	Footer as TableFooter,
+	Head as TableHead,
+	Header as TableHeader,
+	Row as TableRow,
+};

--- a/web/src/lib/components/ui/table/table-body.svelte
+++ b/web/src/lib/components/ui/table/table-body.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
+</script>
+
+<tbody bind:this={ref} data-slot="table-body" class={cn("[&_tr:last-child]:border-0", className)} {...restProps}>
+	{@render children?.()}
+</tbody>

--- a/web/src/lib/components/ui/table/table-caption.svelte
+++ b/web/src/lib/components/ui/table/table-caption.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<caption
+	bind:this={ref}
+	data-slot="table-caption"
+	class={cn("text-muted-foreground mt-4 text-sm", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</caption>

--- a/web/src/lib/components/ui/table/table-cell.svelte
+++ b/web/src/lib/components/ui/table/table-cell.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLTdAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLTdAttributes> = $props();
+</script>
+
+<td bind:this={ref} data-slot="table-cell" class={cn("p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0", className)} {...restProps}>
+	{@render children?.()}
+</td>

--- a/web/src/lib/components/ui/table/table-footer.svelte
+++ b/web/src/lib/components/ui/table/table-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
+</script>
+
+<tfoot
+	bind:this={ref}
+	data-slot="table-footer"
+	class={cn("bg-muted/50 border-t font-medium [&>tr]:last:border-b-0", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</tfoot>

--- a/web/src/lib/components/ui/table/table-head.svelte
+++ b/web/src/lib/components/ui/table/table-head.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLThAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLThAttributes> = $props();
+</script>
+
+<th bind:this={ref} data-slot="table-head" class={cn("text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0", className)} {...restProps}>
+	{@render children?.()}
+</th>

--- a/web/src/lib/components/ui/table/table-header.svelte
+++ b/web/src/lib/components/ui/table/table-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
+</script>
+
+<thead
+	bind:this={ref}
+	data-slot="table-header"
+	class={cn("[&_tr]:border-b", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</thead>

--- a/web/src/lib/components/ui/table/table-row.svelte
+++ b/web/src/lib/components/ui/table/table-row.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLTableRowElement>> = $props();
+</script>
+
+<tr bind:this={ref} data-slot="table-row" class={cn("hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors", className)} {...restProps}>
+	{@render children?.()}
+</tr>

--- a/web/src/lib/components/ui/table/table.svelte
+++ b/web/src/lib/components/ui/table/table.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type { HTMLTableAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLTableAttributes> = $props();
+</script>
+
+<div data-slot="table-container" class="relative w-full overflow-x-auto">
+	<table bind:this={ref} data-slot="table" class={cn("w-full caption-bottom text-sm", className)} {...restProps}>
+		{@render children?.()}
+	</table>
+</div>

--- a/web/src/routes/candidates/+page.svelte
+++ b/web/src/routes/candidates/+page.svelte
@@ -1,4 +1,21 @@
 <script lang="ts">
+	import { Badge } from '$lib/components/ui/badge';
+	import { Button } from '$lib/components/ui/button';
+	import {
+		Card,
+		CardContent,
+		CardHeader,
+		CardTitle
+	} from '$lib/components/ui/card';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow
+	} from '$lib/components/ui/table';
+	import { cn } from '$lib/utils';
 	import type { PageData } from './$types';
 	import type { CandidateStateRecord } from '$lib/types';
 
@@ -36,15 +53,15 @@
 		return c.normalizedTitle;
 	}
 
-	const statusColors: Record<string, string> = {
-		queued: 'bg-gray-700 text-gray-200',
-		skipped: 'bg-gray-600 text-gray-300',
-		rejected: 'bg-red-900 text-red-300',
-		duplicate: 'bg-yellow-900 text-yellow-300',
-		reconciled: 'bg-green-900 text-green-300',
-		downloading: 'bg-blue-900 text-blue-300',
-		completed: 'bg-green-800 text-green-200',
-		failed: 'bg-red-800 text-red-200',
+	const statusBadgeClass: Record<string, string> = {
+		queued: 'border-transparent bg-muted text-foreground',
+		skipped: 'border-transparent bg-muted/80 text-muted-foreground',
+		rejected: 'border-transparent bg-destructive/20 text-destructive',
+		duplicate: 'border-amber-500/50 bg-amber-950/40 text-amber-200',
+		reconciled: 'border-transparent bg-emerald-950/50 text-emerald-200',
+		downloading: 'border-transparent bg-blue-950/50 text-blue-200',
+		completed: 'border-transparent bg-emerald-900/60 text-emerald-100',
+		failed: 'border-transparent bg-destructive/30 text-destructive'
 	};
 
 	const sorted = $derived(
@@ -53,7 +70,7 @@
 			const bv = b[sortKey] ?? '';
 			const cmp = String(av).localeCompare(String(bv));
 			return sortAsc ? cmp : -cmp;
-		}),
+		})
 	);
 
 	function arrow(key: SortKey) {
@@ -62,103 +79,120 @@
 	}
 </script>
 
-<h1 class="mb-4 text-2xl font-semibold">Candidates</h1>
-
-{#if data.error}
-	<p class="text-red-400" role="alert">{data.error}</p>
-{:else if data.candidates.length === 0}
-	<p class="text-gray-400">No candidates found.</p>
-{:else}
-	<div class="overflow-x-auto">
-		<table class="w-full table-auto border-collapse text-sm">
-			<thead>
-				<tr class="border-b border-gray-700 text-left text-gray-400">
-					<th class="py-2 pr-2 w-14" aria-hidden="true"></th>
-					<th class="py-2 pr-4">Title</th>
-					<th
-						class="py-2 pr-4"
-						aria-sort={sortKey === 'mediaType' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
-					>
-						<button
-							type="button"
-							class="cursor-pointer text-left text-gray-400 hover:text-white"
-							onclick={() => toggleSort('mediaType')}
-						>Type{arrow('mediaType')}</button>
-					</th>
-					<th class="py-2 pr-4">Rule</th>
-					<th class="py-2 pr-4">Resolution</th>
-					<th class="py-2 pr-4">TMDB</th>
-					<th
-						class="py-2 pr-4"
-						aria-sort={sortKey === 'status' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
-					>
-						<button
-							type="button"
-							class="cursor-pointer text-left text-gray-400 hover:text-white"
-							onclick={() => toggleSort('status')}
-						>Status{arrow('status')}</button>
-					</th>
-					<th class="py-2 pr-4">Queued At</th>
-					<th class="py-2">Updated At</th>
-				</tr>
-			</thead>
-			<tbody>
-				{#each sorted as candidate (candidate.identityKey)}
-					<tr class="border-b border-gray-800 hover:bg-gray-800/40">
-						<td class="py-2 pr-2 align-top">
-							{#if candidate.tmdb?.posterUrl}
-								<img
-									src={candidate.tmdb.posterUrl}
-									alt=""
-									class="h-12 w-8 rounded object-cover"
-									loading="lazy"
-								/>
-							{:else}
-								<div
-									class="flex h-12 w-8 items-center justify-center rounded bg-gray-800 text-[10px] text-gray-600"
+<Card>
+	<CardHeader class="pb-4">
+		<CardTitle class="text-2xl">Candidates</CardTitle>
+	</CardHeader>
+	<CardContent class="pt-0">
+		{#if data.error}
+			<p class="text-destructive" role="alert">{data.error}</p>
+		{:else if data.candidates.length === 0}
+			<p class="text-muted-foreground">No candidates found.</p>
+		{:else}
+			<div class="overflow-x-auto rounded-md border border-border">
+				<Table>
+					<TableHeader>
+						<TableRow class="border-border hover:bg-transparent">
+							<TableHead class="w-14" aria-hidden="true"></TableHead>
+							<TableHead>Title</TableHead>
+							<TableHead
+								aria-sort={sortKey === 'mediaType' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+							>
+								<Button
+									variant="ghost"
+									size="sm"
+									class="-ml-2 h-8 text-muted-foreground hover:text-foreground"
+									onclick={() => toggleSort('mediaType')}
 								>
-									—
-								</div>
-							{/if}
-						</td>
-						<td class="py-2 pr-4 font-medium">
-							{#if candidate.mediaType === 'tv'}
-								<a href="/shows/{showSlug(candidate)}" class="text-blue-400 hover:underline">
-									{displayTitle(candidate)}
-								</a>
-							{:else}
-								{displayTitle(candidate)}
-							{/if}
-						</td>
-						<td class="py-2 pr-4 text-gray-300">{candidate.mediaType}</td>
-						<td class="py-2 pr-4 text-gray-300">{candidate.ruleName}</td>
-						<td class="py-2 pr-4 text-gray-300">{candidate.resolution ?? '—'}</td>
-						<td class="py-2 pr-4 text-gray-300">
-							{#if candidate.tmdb?.voteAverage !== undefined}
-								<span
-									class="rounded bg-amber-900/60 px-1.5 py-0.5 text-xs text-amber-100"
-									title="TMDB vote average"
+									Type{arrow('mediaType')}
+								</Button>
+							</TableHead>
+							<TableHead>Rule</TableHead>
+							<TableHead>Resolution</TableHead>
+							<TableHead>TMDB</TableHead>
+							<TableHead
+								aria-sort={sortKey === 'status' ? (sortAsc ? 'ascending' : 'descending') : 'none'}
+							>
+								<Button
+									variant="ghost"
+									size="sm"
+									class="-ml-2 h-8 text-muted-foreground hover:text-foreground"
+									onclick={() => toggleSort('status')}
 								>
-									★ {formatRating(candidate.tmdb.voteAverage)}
-								</span>
-							{:else}
-								—
-							{/if}
-						</td>
-						<td class="py-2 pr-4">
-
-								<span
-									class="rounded px-1.5 py-0.5 text-xs font-semibold {statusColors[candidate.status] ?? 'bg-gray-700 text-gray-200'}"
-								>{candidate.status}</span>
-							{#if candidate.lifecycleStatus}
-								<span class="ml-1 text-xs text-gray-500">({candidate.lifecycleStatus})</span>
-							{/if}
-						</td>
-						<td class="py-2 pr-4 text-gray-400">{candidate.queuedAt ?? '—'}</td>
-						<td class="py-2 text-gray-400">{candidate.updatedAt}</td>
-					</tr>
-				{/each}
-			</tbody>
-		</table>
-	</div>
-{/if}
+									Status{arrow('status')}
+								</Button>
+							</TableHead>
+							<TableHead>Queued At</TableHead>
+							<TableHead>Updated At</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{#each sorted as candidate (candidate.identityKey)}
+							<TableRow class="border-border">
+								<TableCell class="align-top">
+									{#if candidate.tmdb?.posterUrl}
+										<img
+											src={candidate.tmdb.posterUrl}
+											alt=""
+											class="h-12 w-8 rounded-md object-cover"
+											loading="lazy"
+										/>
+									{:else}
+										<div
+											class="flex h-12 w-8 items-center justify-center rounded-md border border-border bg-muted text-[10px] text-muted-foreground"
+										>
+											—
+										</div>
+									{/if}
+								</TableCell>
+								<TableCell class="font-medium">
+									{#if candidate.mediaType === 'tv'}
+										<a
+											href="/shows/{showSlug(candidate)}"
+											class="text-primary underline-offset-4 hover:underline"
+										>
+											{displayTitle(candidate)}
+										</a>
+									{:else}
+										{displayTitle(candidate)}
+									{/if}
+								</TableCell>
+								<TableCell class="text-muted-foreground">{candidate.mediaType}</TableCell>
+								<TableCell class="text-muted-foreground">{candidate.ruleName}</TableCell>
+								<TableCell class="text-muted-foreground">{candidate.resolution ?? '—'}</TableCell>
+								<TableCell class="text-muted-foreground">
+									{#if candidate.tmdb?.voteAverage !== undefined}
+										<Badge
+											variant="secondary"
+											class="bg-amber-950/50 font-normal text-amber-100"
+											title="TMDB vote average"
+										>
+											★ {formatRating(candidate.tmdb.voteAverage)}
+										</Badge>
+									{:else}
+										—
+									{/if}
+								</TableCell>
+								<TableCell>
+									<Badge
+										variant="outline"
+										class={cn('font-semibold', statusBadgeClass[candidate.status] ?? '')}
+									>
+										{candidate.status}
+									</Badge>
+									{#if candidate.lifecycleStatus}
+										<span class="ml-1 text-xs text-muted-foreground">
+											({candidate.lifecycleStatus})
+										</span>
+									{/if}
+								</TableCell>
+								<TableCell class="text-muted-foreground">{candidate.queuedAt ?? '—'}</TableCell>
+								<TableCell class="text-muted-foreground">{candidate.updatedAt}</TableCell>
+							</TableRow>
+						{/each}
+					</TableBody>
+				</Table>
+			</div>
+		{/if}
+	</CardContent>
+</Card>

--- a/web/src/routes/candidates/+page.svelte
+++ b/web/src/routes/candidates/+page.svelte
@@ -89,7 +89,7 @@
 		{:else if data.candidates.length === 0}
 			<p class="text-muted-foreground">No candidates found.</p>
 		{:else}
-			<div class="overflow-x-auto rounded-md border border-border">
+			<div class="rounded-md border border-border">
 				<Table>
 					<TableHeader>
 						<TableRow class="border-border hover:bg-transparent">


### PR DESCRIPTION
## Summary

- delivery ticket: `P12.02 Candidates View`
- ticket file: [docs/02-delivery/phase-12/ticket-02-candidates-view.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-12/ticket-02-candidates-view.md)
- stacked base branch: `agents/p12-01-design-system-foundations`

## External AI Review

- outcome: `patched`
- current branch head: [`5f20d037011b`](https://github.com/cesarnml/pirate_claw/commit/5f20d037011b1b848e9f568658ffcb65edfa02ea)
