### PR TITLE
feat(web): migrate dashboard home to design system cards and alert [P12.03]

### DIFF
--- a/docs/02-delivery/phase-12/ticket-03-dashboard-home.md
+++ b/docs/02-delivery/phase-12/ticket-03-dashboard-home.md
@@ -21,3 +21,5 @@ Home page renders correctly with API data and error paths; dashboard tests pass.
 ## Rationale
 
 Migrated the home dashboard to **shadcn-svelte** `Card` sections for daemon metadata and recent runs, `Table` for the run list (matching the candidates page pattern), and `Alert` + `AlertDescription` for the API error path. Quick links use `Button` with `href` (outline) for consistent focus and hit targets. Section titles remain semantic `h2` elements so existing Vitest queries for `heading` roles stay valid. Added an assertion for the **Movies** quick link to match the ticket’s “including to Movies” requirement.
+
+Follow-up (AI review): `Alert` root now maps `role` to **`alert`** for the destructive variant and **`status`** for the default variant, with an optional `role` override. The error state includes **`AlertTitle`** (“API unavailable”) plus description. The “Loading…” branch documents that it is defensive relative to current `load` behavior.

--- a/docs/02-delivery/phase-12/ticket-03-dashboard-home.md
+++ b/docs/02-delivery/phase-12/ticket-03-dashboard-home.md
@@ -20,4 +20,4 @@ Home page renders correctly with API data and error paths; dashboard tests pass.
 
 ## Rationale
 
-_To be filled during implementation._
+Migrated the home dashboard to **shadcn-svelte** `Card` sections for daemon metadata and recent runs, `Table` for the run list (matching the candidates page pattern), and `Alert` + `AlertDescription` for the API error path. Quick links use `Button` with `href` (outline) for consistent focus and hit targets. Section titles remain semantic `h2` elements so existing Vitest queries for `heading` roles stay valid. Added an assertion for the **Movies** quick link to match the ticket’s “including to Movies” requirement.

--- a/web/src/lib/components/ui/alert/alert-action.svelte
+++ b/web/src/lib/components/ui/alert/alert-action.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-action"
+	class={cn("absolute top-2 right-2", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/alert/alert-description.svelte
+++ b/web/src/lib/components/ui/alert/alert-description.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-description"
+	class={cn(
+		"text-muted-foreground text-sm text-balance md:text-pretty [&_p:not(:last-child)]:mb-4 [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/alert/alert-title.svelte
+++ b/web/src/lib/components/ui/alert/alert-title.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-title"
+	class={cn(
+		"font-medium group-has-[>svg]/alert:col-start-2 [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/alert/alert.svelte
+++ b/web/src/lib/components/ui/alert/alert.svelte
@@ -1,0 +1,43 @@
+<script lang="ts" module>
+	import { type VariantProps, tv } from "tailwind-variants";
+
+	export const alertVariants = tv({
+		base: "grid gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4 group/alert relative w-full",
+		variants: {
+			variant: {
+				default: "bg-card text-card-foreground",
+				destructive: "text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	});
+
+	export type AlertVariant = VariantProps<typeof alertVariants>["variant"];
+</script>
+
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		variant = "default",
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		variant?: AlertVariant;
+	} = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert"
+	role="alert"
+	class={cn(alertVariants({ variant }), className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/alert/alert.svelte
+++ b/web/src/lib/components/ui/alert/alert.svelte
@@ -25,17 +25,22 @@
 		ref = $bindable(null),
 		class: className,
 		variant = "default",
+		role: roleProp,
 		children,
 		...restProps
 	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
 		variant?: AlertVariant;
 	} = $props();
+
+	const effectiveRole = $derived(
+		roleProp ?? (variant === "destructive" ? "alert" : "status"),
+	);
 </script>
 
 <div
 	bind:this={ref}
 	data-slot="alert"
-	role="alert"
+	role={effectiveRole}
 	class={cn(alertVariants({ variant }), className)}
 	{...restProps}
 >

--- a/web/src/lib/components/ui/alert/index.ts
+++ b/web/src/lib/components/ui/alert/index.ts
@@ -1,0 +1,17 @@
+import Root from "./alert.svelte";
+import Description from "./alert-description.svelte";
+import Title from "./alert-title.svelte";
+import Action from "./alert-action.svelte";
+export { alertVariants, type AlertVariant } from "./alert.svelte";
+
+export {
+	Root,
+	Description,
+	Title,
+	Action,
+	//
+	Root as Alert,
+	Description as AlertDescription,
+	Title as AlertTitle,
+	Action as AlertAction,
+};

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Alert, AlertDescription } from '$lib/components/ui/alert';
+	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent, CardHeader } from '$lib/components/ui/card';
 	import {
@@ -37,6 +37,7 @@
 
 {#if data.error}
 	<Alert variant="destructive" class="mt-6">
+		<AlertTitle>API unavailable</AlertTitle>
 		<AlertDescription>{data.error}</AlertDescription>
 	</Alert>
 {:else if data.health}
@@ -122,5 +123,6 @@
 		<Button variant="outline" size="sm" href="/config">View Config</Button>
 	</nav>
 {:else}
+	<!-- Defensive: load currently returns either health or error, not both null -->
 	<p class="mt-6 text-sm text-muted-foreground">Loading…</p>
 {/if}

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,4 +1,15 @@
 <script lang="ts">
+	import { Alert, AlertDescription } from '$lib/components/ui/alert';
+	import { Button } from '$lib/components/ui/button';
+	import { Card, CardContent, CardHeader } from '$lib/components/ui/card';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow
+	} from '$lib/components/ui/table';
 	import type { PageData } from './$types';
 
 	const { data }: { data: PageData } = $props();
@@ -22,81 +33,94 @@
 	}
 </script>
 
-<h1 class="text-2xl font-semibold">Dashboard</h1>
+<h1 class="text-3xl font-bold tracking-tight">Dashboard</h1>
 
 {#if data.error}
-	<p class="mt-4 text-red-400" role="alert">{data.error}</p>
+	<Alert variant="destructive" class="mt-6">
+		<AlertDescription>{data.error}</AlertDescription>
+	</Alert>
 {:else if data.health}
 	{@const health = data.health}
 	{@const runs = data.runs}
 
-	<section class="mt-6">
-		<h2 class="text-lg font-semibold text-gray-200">Daemon</h2>
-		<dl class="mt-2 rounded bg-gray-800 p-3 text-sm">
-			<div class="flex gap-2">
-				<dt class="text-gray-400">Uptime:</dt>
-				<dd class="text-gray-200">{formatUptime(health.uptime)}</dd>
-			</div>
-			<div class="flex gap-2">
-				<dt class="text-gray-400">Started at:</dt>
-				<dd class="text-gray-200">{formatDate(health.startedAt)}</dd>
-			</div>
-			{#if health.lastRunCycle}
-				<div class="flex gap-2">
-					<dt class="text-gray-400">Last run cycle:</dt>
-					<dd class="text-gray-200">{formatDate(health.lastRunCycle.startedAt)}</dd>
-				</div>
-			{/if}
-			{#if health.lastReconcileCycle}
-				<div class="flex gap-2">
-					<dt class="text-gray-400">Last reconcile:</dt>
-					<dd class="text-gray-200">{formatDate(health.lastReconcileCycle.startedAt)}</dd>
-				</div>
-			{/if}
-		</dl>
+	<section class="mt-8 space-y-6">
+		<Card>
+			<CardHeader class="pb-3">
+				<h2 class="text-lg font-semibold tracking-tight">Daemon</h2>
+			</CardHeader>
+			<CardContent>
+				<dl class="grid gap-3 text-sm">
+					<div class="flex flex-wrap gap-2">
+						<dt class="text-muted-foreground">Uptime</dt>
+						<dd class="font-medium">{formatUptime(health.uptime)}</dd>
+					</div>
+					<div class="flex flex-wrap gap-2">
+						<dt class="text-muted-foreground">Started at</dt>
+						<dd class="font-medium">{formatDate(health.startedAt)}</dd>
+					</div>
+					{#if health.lastRunCycle}
+						<div class="flex flex-wrap gap-2">
+							<dt class="text-muted-foreground">Last run cycle</dt>
+							<dd class="font-medium">{formatDate(health.lastRunCycle.startedAt)}</dd>
+						</div>
+					{/if}
+					{#if health.lastReconcileCycle}
+						<div class="flex flex-wrap gap-2">
+							<dt class="text-muted-foreground">Last reconcile</dt>
+							<dd class="font-medium">{formatDate(health.lastReconcileCycle.startedAt)}</dd>
+						</div>
+					{/if}
+				</dl>
+			</CardContent>
+		</Card>
+
+		<Card>
+			<CardHeader class="pb-3">
+				<h2 class="text-lg font-semibold tracking-tight">Recent Runs</h2>
+			</CardHeader>
+			<CardContent>
+				{#if runs.length === 0}
+					<p class="text-sm text-muted-foreground">No runs recorded yet.</p>
+				{:else}
+					<div class="rounded-md border border-border">
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>ID</TableHead>
+									<TableHead>Started</TableHead>
+									<TableHead>Status</TableHead>
+									<TableHead class="text-right">Queued</TableHead>
+									<TableHead class="text-right">Failed</TableHead>
+									<TableHead class="text-right">Skipped</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{#each runs as run}
+									<TableRow>
+										<TableCell class="font-mono text-xs">{run.id}</TableCell>
+										<TableCell>{formatDate(run.startedAt)}</TableCell>
+										<TableCell>{run.status}</TableCell>
+										<TableCell class="text-right">{run.counts.queued ?? 0}</TableCell>
+										<TableCell class="text-right">{run.counts.failed ?? 0}</TableCell>
+										<TableCell class="text-right"
+											>{(run.counts.skipped_duplicate ?? 0) +
+												(run.counts.skipped_no_match ?? 0)}</TableCell
+										>
+									</TableRow>
+								{/each}
+							</TableBody>
+						</Table>
+					</div>
+				{/if}
+			</CardContent>
+		</Card>
 	</section>
 
-	<section class="mt-6">
-		<h2 class="text-lg font-semibold text-gray-200">Recent Runs</h2>
-		{#if runs.length === 0}
-			<p class="mt-2 text-gray-400">No runs recorded yet.</p>
-		{:else}
-			<table class="mt-2 w-full text-left text-sm">
-				<thead>
-					<tr class="border-b border-gray-700 text-gray-400">
-						<th class="py-2 pr-4">ID</th>
-						<th class="py-2 pr-4">Started</th>
-						<th class="py-2 pr-4">Status</th>
-						<th class="py-2 pr-4">Queued</th>
-						<th class="py-2 pr-4">Failed</th>
-						<th class="py-2 pr-4">Skipped</th>
-					</tr>
-				</thead>
-				<tbody>
-					{#each runs as run}
-						<tr class="border-b border-gray-800 text-gray-300">
-							<td class="py-2 pr-4 font-mono">{run.id}</td>
-							<td class="py-2 pr-4">{formatDate(run.startedAt)}</td>
-							<td class="py-2 pr-4">{run.status}</td>
-							<td class="py-2 pr-4">{run.counts.queued ?? 0}</td>
-							<td class="py-2 pr-4">{run.counts.failed ?? 0}</td>
-							<td class="py-2 pr-4"
-								>{(run.counts.skipped_duplicate ?? 0) +
-									(run.counts.skipped_no_match ?? 0)}</td
-							>
-						</tr>
-					{/each}
-				</tbody>
-			</table>
-		{/if}
-	</section>
-
-	<nav class="mt-8 flex gap-4 text-sm">
-		<a href="/candidates" class="text-blue-400 hover:underline">View Candidates</a>
-		<a href="/movies" class="text-blue-400 hover:underline">Movies</a>
-		<a href="/config" class="text-blue-400 hover:underline">View Config</a>
+	<nav class="mt-8 flex flex-wrap gap-2" aria-label="Quick links">
+		<Button variant="outline" size="sm" href="/candidates">View Candidates</Button>
+		<Button variant="outline" size="sm" href="/movies">Movies</Button>
+		<Button variant="outline" size="sm" href="/config">View Config</Button>
 	</nav>
 {:else}
-	<p class="mt-4 text-gray-400">Loading…</p>
+	<p class="mt-6 text-sm text-muted-foreground">Loading…</p>
 {/if}
-

--- a/web/src/routes/dashboard.test.ts
+++ b/web/src/routes/dashboard.test.ts
@@ -38,6 +38,7 @@ describe('/', () => {
 			'/candidates',
 		);
 		expect(screen.getByRole('link', { name: 'View Config' })).toHaveAttribute('href', '/config');
+		expect(screen.getByRole('link', { name: 'Movies' })).toHaveAttribute('href', '/movies');
 	});
 
 	it('renders error state when API is unreachable', () => {


### PR DESCRIPTION
## Summary

- delivery ticket: `P12.03 Dashboard Home`
- ticket file: [docs/02-delivery/phase-12/ticket-03-dashboard-home.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-12/ticket-03-dashboard-home.md)
- stacked base branch: `agents/p12-02-candidates-view`
- post-verify self-audit: completed at 2026-04-09 00:50 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`4baf7fedd64d`](https://github.com/cesarnml/pirate_claw/commit/4baf7fedd64d22031a74e976592049f54bdfef8a)
- current branch head: [`81d9bb406b95`](https://github.com/cesarnml/pirate_claw/commit/81d9bb406b9552d6be9c3e2037f18df48a3ae33b)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `4baf7fedd64d` address all findings from that review.
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Resolved Review Findings

- [greptile] `role="alert"` applied unconditionally to all variants (native GitHub thread resolved) `web/src/lib/components/ui/alert/alert.svelte:37` [thread](https://github.com/cesarnml/pirate_claw/pull/103#discussion_r3054939933)
- [greptile] Error alert missing a visible title (native GitHub thread resolved) `web/src/routes/+page.svelte:41` [thread](https://github.com/cesarnml/pirate_claw/pull/103#discussion_r3054939968)
- [greptile] Unreachable "Loading…" branch (native GitHub thread resolved) `web/src/routes/+page.svelte:126` [thread](https://github.com/cesarnml/pirate_claw/pull/103#discussion_r3054940033)
