### PR TITLE
feat(web): migrate shows list to design system grid and API load [P12.04]

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -27,6 +27,7 @@
     "retryability",
     "retarget",
     "SARIF",
+    "shadcn",
     "sonarcloud",
     "sonarqube",
     "sonarqubecloud",

--- a/docs/02-delivery/phase-12/ticket-04-shows-list.md
+++ b/docs/02-delivery/phase-12/ticket-04-shows-list.md
@@ -23,3 +23,5 @@ Shows list page is visually aligned with Phase 12; navigation to `/shows/[slug]`
 Added **`+page.server.ts`** loading `/api/shows` (same contract as show detail) so the list is data-backed. The page uses **shadcn** `Card` tiles in a responsive grid, `Badge` for TMDB rating, and the same **destructive `Alert` + title/description** pattern as the dashboard for API errors. Empty state matches other Phase 12 read-only views. Links use `encodeURIComponent(normalizedTitle.toLowerCase())` to stay consistent with `[slug]` resolution.
 
 Tests live at **`web/src/routes/shows/shows.test.ts`** (render with mock show, empty, and error).
+
+Follow-up (AI review): poster **`alt`** uses the display title; TMDB optional fields use strict `!== undefined` checks; `formatRating` only accepts `number`; **`shadcn`** added to root `cspell.json` for rationale copy.

--- a/docs/02-delivery/phase-12/ticket-04-shows-list.md
+++ b/docs/02-delivery/phase-12/ticket-04-shows-list.md
@@ -20,4 +20,6 @@ Shows list page is visually aligned with Phase 12; navigation to `/shows/[slug]`
 
 ## Rationale
 
-_To be filled during implementation — note any new test file path._
+Added **`+page.server.ts`** loading `/api/shows` (same contract as show detail) so the list is data-backed. The page uses **shadcn** `Card` tiles in a responsive grid, `Badge` for TMDB rating, and the same **destructive `Alert` + title/description** pattern as the dashboard for API errors. Empty state matches other Phase 12 read-only views. Links use `encodeURIComponent(normalizedTitle.toLowerCase())` to stay consistent with `[slug]` resolution.
+
+Tests live at **`web/src/routes/shows/shows.test.ts`** (render with mock show, empty, and error).

--- a/web/src/routes/shows/+page.server.ts
+++ b/web/src/routes/shows/+page.server.ts
@@ -1,0 +1,16 @@
+import { apiFetch } from '$lib/server/api';
+import type { ShowBreakdown } from '$lib/types';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+	try {
+		const data = await apiFetch<{ shows: ShowBreakdown[] }>('/api/shows');
+		return { shows: data.shows, error: null };
+	} catch (err) {
+		console.error('[shows list] failed to load /api/shows:', err);
+		return {
+			shows: [] as ShowBreakdown[],
+			error: 'Could not reach the API.',
+		};
+	}
+};

--- a/web/src/routes/shows/+page.svelte
+++ b/web/src/routes/shows/+page.svelte
@@ -1,2 +1,88 @@
-<h1 class="text-2xl font-semibold">Shows</h1>
-<p class="mt-2 text-gray-400">Navigate to a show from the candidates list.</p>
+<script lang="ts">
+	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Card, CardContent } from '$lib/components/ui/card';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	function showHref(show: (typeof data.shows)[number]): string {
+		return `/shows/${encodeURIComponent(show.normalizedTitle.toLowerCase())}`;
+	}
+
+	function formatRating(v: number | undefined): string {
+		if (v === undefined) return '—';
+		return v.toFixed(1);
+	}
+
+	function displayTitle(show: (typeof data.shows)[number]): string {
+		return show.tmdb?.name ?? show.normalizedTitle;
+	}
+</script>
+
+<h1 class="text-3xl font-bold tracking-tight">Shows</h1>
+<p class="mt-1 text-sm text-muted-foreground">Tracked TV series from the daemon. Open a show for seasons and episodes.</p>
+
+{#if data.error}
+	<Alert variant="destructive" class="mt-6">
+		<AlertTitle>API unavailable</AlertTitle>
+		<AlertDescription>{data.error}</AlertDescription>
+	</Alert>
+{:else if data.shows.length === 0}
+	<Card class="mt-6">
+		<CardContent class="pt-6">
+			<p class="text-sm text-muted-foreground">No shows recorded yet.</p>
+		</CardContent>
+	</Card>
+{:else}
+	<ul class="mt-8 grid list-none gap-4 sm:grid-cols-2 lg:grid-cols-3">
+		{#each data.shows as show (show.normalizedTitle)}
+			<li>
+				<a
+					href={showHref(show)}
+					class="group block h-full rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				>
+					<Card
+						class="h-full overflow-hidden transition-colors group-hover:border-primary/40 group-hover:bg-accent/30"
+					>
+						<CardContent class="flex gap-4 p-4">
+							{#if show.tmdb?.posterUrl}
+								<img
+									src={show.tmdb.posterUrl}
+									alt=""
+									class="h-28 w-[4.5rem] shrink-0 rounded-md object-cover"
+									loading="lazy"
+								/>
+							{:else}
+								<div
+									class="flex h-28 w-[4.5rem] shrink-0 items-center justify-center rounded-md bg-muted text-xs text-muted-foreground"
+								>
+									No poster
+								</div>
+							{/if}
+							<div class="min-w-0 flex-1">
+								<p class="font-medium leading-snug group-hover:text-primary">
+									{displayTitle(show)}
+								</p>
+								<div class="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+									{#if show.tmdb?.voteAverage !== undefined}
+										<Badge variant="secondary" title="TMDB vote average">
+											★ {formatRating(show.tmdb.voteAverage)}
+										</Badge>
+									{/if}
+									{#if show.tmdb?.numberOfSeasons != null}
+										<span>
+											{show.tmdb.numberOfSeasons} season{show.tmdb.numberOfSeasons === 1
+												? ''
+												: 's'}
+										</span>
+									{/if}
+								</div>
+							</div>
+						</CardContent>
+					</Card>
+				</a>
+			</li>
+		{/each}
+	</ul>
+{/if}

--- a/web/src/routes/shows/+page.svelte
+++ b/web/src/routes/shows/+page.svelte
@@ -10,8 +10,7 @@
 		return `/shows/${encodeURIComponent(show.normalizedTitle.toLowerCase())}`;
 	}
 
-	function formatRating(v: number | undefined): string {
-		if (v === undefined) return '—';
+	function formatRating(v: number): string {
 		return v.toFixed(1);
 	}
 
@@ -49,7 +48,7 @@
 							{#if show.tmdb?.posterUrl}
 								<img
 									src={show.tmdb.posterUrl}
-									alt=""
+									alt={`Poster for ${displayTitle(show)}`}
 									class="h-28 w-[4.5rem] shrink-0 rounded-md object-cover"
 									loading="lazy"
 								/>
@@ -70,7 +69,7 @@
 											★ {formatRating(show.tmdb.voteAverage)}
 										</Badge>
 									{/if}
-									{#if show.tmdb?.numberOfSeasons != null}
+									{#if show.tmdb?.numberOfSeasons !== undefined}
 										<span>
 											{show.tmdb.numberOfSeasons} season{show.tmdb.numberOfSeasons === 1
 												? ''

--- a/web/src/routes/shows/shows.test.ts
+++ b/web/src/routes/shows/shows.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Page from './+page.svelte';
+import type { ShowBreakdown } from '$lib/types';
+
+const mockShow: ShowBreakdown = {
+	normalizedTitle: 'The Example Show',
+	seasons: [
+		{
+			season: 1,
+			episodes: [],
+		},
+	],
+	tmdb: {
+		name: 'The Example Show',
+		posterUrl: 'https://example.com/poster.jpg',
+		voteAverage: 8.1,
+		numberOfSeasons: 3,
+	},
+};
+
+describe('/shows', () => {
+	it('renders show cards with TMDB metadata and link to detail', () => {
+		render(Page, { data: { shows: [mockShow], error: null } });
+		expect(screen.getByRole('heading', { name: 'Shows' })).toBeInTheDocument();
+		expect(screen.getByText('The Example Show')).toBeInTheDocument();
+		expect(screen.getByTitle('TMDB vote average')).toHaveTextContent('★ 8.1');
+		expect(screen.getByRole('link', { name: /The Example Show/i })).toHaveAttribute(
+			'href',
+			'/shows/the%20example%20show',
+		);
+	});
+
+	it('renders empty state when there are no shows', () => {
+		render(Page, { data: { shows: [], error: null } });
+		expect(screen.getByText('No shows recorded yet.')).toBeInTheDocument();
+	});
+
+	it('renders error state when API is unreachable', () => {
+		render(Page, { data: { shows: [], error: 'Could not reach the API.' } });
+		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
+	});
+});


### PR DESCRIPTION
## Summary

- delivery ticket: `P12.04 Shows List`
- ticket file: [docs/02-delivery/phase-12/ticket-04-shows-list.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-12/ticket-04-shows-list.md)
- stacked base branch: `agents/p12-03-dashboard-home`
- post-verify self-audit: completed at 2026-04-09 01:00 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`32cf69078d94`](https://github.com/cesarnml/pirate_claw/commit/32cf69078d9406f9c87e054398176448b917d877)
- current branch head: [`a96626369db0`](https://github.com/cesarnml/pirate_claw/commit/a96626369db0095c9d41d694d9d564d00a018b9b)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `32cf69078d94` address all findings from that review.
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Add "shadcn" to `cspell.json` before merge. (native GitHub thread resolved) `docs/02-delivery/phase-12/ticket-04-shows-list.md:25` [thread](https://github.com/cesarnml/pirate_claw/pull/104#discussion_r3054966608)
- [greptile] Poster image uses empty alt (native GitHub thread resolved) `web/src/routes/shows/+page.svelte:55` [thread](https://github.com/cesarnml/pirate_claw/pull/104#discussion_r3054962452)
- [greptile] Inconsistent nullish checks for optional fields (native GitHub thread resolved) `web/src/routes/shows/+page.svelte:79` [thread](https://github.com/cesarnml/pirate_claw/pull/104#discussion_r3054962498)
