### PR TITLE
feat(web): migrate show detail to design system tables and cards [P12.05]

### DIFF
--- a/docs/02-delivery/phase-12/ticket-05-show-detail.md
+++ b/docs/02-delivery/phase-12/ticket-05-show-detail.md
@@ -22,3 +22,5 @@ Show detail page matches Phase 12; tests pass; no loss of displayed fields vs pr
 ## Rationale
 
 Rebuilt show detail with **shadcn** `Alert` (API error), `Card` (not-found + per-season blocks), `Table` for episode rows, and `Badge` for TMDB vote average. The back control is a ghost **`Button` → `/shows`** (aligned with the new list route). Hero backdrop uses **`hsl(var(--background) / 0.92)`** over the TMDB backdrop so the overlay tracks theme tokens. Episode stills use non-empty **`alt`** when a title exists. `shows.test.ts` assertions are unchanged (headings, E01, error/not-found).
+
+Follow-up (AI review): backdrop **`url()`** only uses **parsed `https:`** URLs; hero poster **`loading="eager"`** + **`fetchpriority="high"`**; vote **`Badge`** uses **`aria-label`**; first table column header has **`sr-only` “Still image”**.

--- a/docs/02-delivery/phase-12/ticket-05-show-detail.md
+++ b/docs/02-delivery/phase-12/ticket-05-show-detail.md
@@ -21,4 +21,4 @@ Show detail page matches Phase 12; tests pass; no loss of displayed fields vs pr
 
 ## Rationale
 
-_To be filled during implementation._
+Rebuilt show detail with **shadcn** `Alert` (API error), `Card` (not-found + per-season blocks), `Table` for episode rows, and `Badge` for TMDB vote average. The back control is a ghost **`Button` → `/shows`** (aligned with the new list route). Hero backdrop uses **`hsl(var(--background) / 0.92)`** over the TMDB backdrop so the overlay tracks theme tokens. Episode stills use non-empty **`alt`** when a title exists. `shows.test.ts` assertions are unchanged (headings, E01, error/not-found).

--- a/web/src/routes/shows/[slug]/+page.svelte
+++ b/web/src/routes/shows/[slug]/+page.svelte
@@ -23,6 +23,18 @@
 	function displayTitle(show: NonNullable<PageData['show']>): string {
 		return show.tmdb?.name ?? show.normalizedTitle;
 	}
+
+	/** Only allow https URLs in inline `background: url(...)` to avoid CSS injection from malformed strings. */
+	function safeHttpsBackgroundUrl(raw: string | undefined): string | undefined {
+		if (!raw) return undefined;
+		try {
+			const u = new URL(raw);
+			if (u.protocol !== 'https:') return undefined;
+			return u.href;
+		} catch {
+			return undefined;
+		}
+	}
 </script>
 
 <div class="mb-4">
@@ -41,11 +53,12 @@
 		</CardContent>
 	</Card>
 {:else}
+	{@const backdropUrl = safeHttpsBackgroundUrl(data.show.tmdb?.backdropUrl)}
 	<div
 		class="mb-8 flex flex-col gap-4 rounded-xl border border-border sm:flex-row sm:items-start"
-		class:overflow-hidden={!!data.show.tmdb?.backdropUrl}
-		style={data.show.tmdb?.backdropUrl
-			? `background: linear-gradient(hsl(var(--background) / 0.92), hsl(var(--background) / 0.92)), url(${data.show.tmdb.backdropUrl}) center/cover no-repeat`
+		class:overflow-hidden={!!backdropUrl}
+		style={backdropUrl
+			? `background: linear-gradient(hsl(var(--background) / 0.92), hsl(var(--background) / 0.92)), url(${backdropUrl}) center/cover no-repeat`
 			: undefined}
 	>
 		{#if data.show.tmdb?.posterUrl}
@@ -53,7 +66,8 @@
 				src={data.show.tmdb.posterUrl}
 				alt={`Poster for ${displayTitle(data.show)}`}
 				class="mx-auto h-56 w-40 shrink-0 rounded-md object-cover sm:mx-0"
-				loading="lazy"
+				loading="eager"
+				fetchpriority="high"
 			/>
 		{:else}
 			<div
@@ -68,7 +82,10 @@
 					{displayTitle(data.show)}
 				</h1>
 				{#if data.show.tmdb?.voteAverage !== undefined}
-					<Badge variant="secondary" title="TMDB vote average">
+					<Badge
+						variant="secondary"
+						aria-label="TMDB vote average: {formatRating(data.show.tmdb.voteAverage)}"
+					>
 						★ {formatRating(data.show.tmdb.voteAverage)}
 					</Badge>
 				{/if}
@@ -97,7 +114,9 @@
 						<Table>
 							<TableHeader>
 								<TableRow>
-									<TableHead class="w-28"></TableHead>
+									<TableHead class="w-28">
+										<span class="sr-only">Still image</span>
+									</TableHead>
 									<TableHead>Episode</TableHead>
 									<TableHead>Title</TableHead>
 									<TableHead>Status</TableHead>

--- a/web/src/routes/shows/[slug]/+page.svelte
+++ b/web/src/routes/shows/[slug]/+page.svelte
@@ -1,4 +1,16 @@
 <script lang="ts">
+	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Button } from '$lib/components/ui/button';
+	import { Card, CardContent, CardHeader } from '$lib/components/ui/card';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow
+	} from '$lib/components/ui/table';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
@@ -7,56 +19,61 @@
 		if (v === undefined) return '—';
 		return v.toFixed(1);
 	}
+
+	function displayTitle(show: NonNullable<PageData['show']>): string {
+		return show.tmdb?.name ?? show.normalizedTitle;
+	}
 </script>
 
 <div class="mb-4">
-	<a href="/candidates" class="text-sm text-gray-400 hover:text-white">← Candidates</a>
+	<Button variant="ghost" size="sm" href="/shows" class="-ml-2 h-auto px-2 py-1">← Shows</Button>
 </div>
 
 {#if data.error}
-	<p class="text-red-400" role="alert">{data.error}</p>
+	<Alert variant="destructive">
+		<AlertTitle>API unavailable</AlertTitle>
+		<AlertDescription>{data.error}</AlertDescription>
+	</Alert>
 {:else if !data.show}
-	<p class="text-gray-400">Show not found.</p>
+	<Card class="mt-4">
+		<CardContent class="pt-6">
+			<p class="text-sm text-muted-foreground">Show not found.</p>
+		</CardContent>
+	</Card>
 {:else}
 	<div
-		class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start"
-		class:rounded-lg={!!data.show.tmdb?.backdropUrl}
-		class:border={!!data.show.tmdb?.backdropUrl}
-		class:border-gray-700={!!data.show.tmdb?.backdropUrl}
+		class="mb-8 flex flex-col gap-4 rounded-xl border border-border sm:flex-row sm:items-start"
 		class:overflow-hidden={!!data.show.tmdb?.backdropUrl}
 		style={data.show.tmdb?.backdropUrl
-			? `background: linear-gradient(rgba(17,24,39,0.92), rgba(17,24,39,0.92)), url(${data.show.tmdb.backdropUrl}) center/cover no-repeat`
+			? `background: linear-gradient(hsl(var(--background) / 0.92), hsl(var(--background) / 0.92)), url(${data.show.tmdb.backdropUrl}) center/cover no-repeat`
 			: undefined}
 	>
 		{#if data.show.tmdb?.posterUrl}
 			<img
 				src={data.show.tmdb.posterUrl}
-				alt={`Poster for ${data.show.tmdb?.name ?? data.show.normalizedTitle}`}
-				class="mx-auto h-56 w-40 shrink-0 rounded object-cover sm:mx-0"
+				alt={`Poster for ${displayTitle(data.show)}`}
+				class="mx-auto h-56 w-40 shrink-0 rounded-md object-cover sm:mx-0"
 				loading="lazy"
 			/>
 		{:else}
 			<div
-				class="mx-auto flex h-56 w-40 shrink-0 items-center justify-center rounded bg-gray-700 text-xs text-gray-500 sm:mx-0"
+				class="mx-auto flex h-56 w-40 shrink-0 items-center justify-center rounded-md bg-muted text-xs text-muted-foreground sm:mx-0"
 			>
 				No poster
 			</div>
 		{/if}
-		<div class="min-w-0 flex-1">
+		<div class="min-w-0 flex-1 p-4 sm:py-4 sm:pr-4 sm:pl-0">
 			<div class="flex flex-wrap items-baseline gap-2">
-				<h1 class="text-2xl font-semibold text-gray-100">
-					{data.show.tmdb?.name ?? data.show.normalizedTitle}
+				<h1 class="text-2xl font-semibold tracking-tight">
+					{displayTitle(data.show)}
 				</h1>
 				{#if data.show.tmdb?.voteAverage !== undefined}
-					<span
-						class="rounded bg-amber-900/60 px-2 py-0.5 text-sm text-amber-100"
-						title="TMDB vote average"
-					>
+					<Badge variant="secondary" title="TMDB vote average">
 						★ {formatRating(data.show.tmdb.voteAverage)}
-					</span>
+					</Badge>
 				{/if}
-				{#if data.show.tmdb?.numberOfSeasons != null}
-					<span class="text-sm text-gray-400">
+				{#if data.show.tmdb?.numberOfSeasons !== undefined}
+					<span class="text-sm text-muted-foreground">
 						{data.show.tmdb.numberOfSeasons} season{data.show.tmdb.numberOfSeasons === 1
 							? ''
 							: 's'} (TMDB)
@@ -64,63 +81,71 @@
 				{/if}
 			</div>
 			{#if data.show.tmdb?.overview}
-				<p class="mt-3 text-sm leading-relaxed text-gray-300">{data.show.tmdb.overview}</p>
+				<p class="mt-3 text-sm leading-relaxed text-muted-foreground">{data.show.tmdb.overview}</p>
 			{/if}
 		</div>
 	</div>
 
 	{#each data.show.seasons as season (season.season)}
 		<section class="mb-8">
-			<h2 class="mb-3 text-lg font-medium text-gray-300">Season {season.season}</h2>
-			<table class="w-full table-auto border-collapse text-sm">
-				<thead>
-					<tr class="border-b border-gray-700 text-left text-gray-400">
-						<th class="py-2 pr-2 w-16"></th>
-						<th class="py-2 pr-4">Episode</th>
-						<th class="py-2 pr-4">Title</th>
-						<th class="py-2 pr-4">Status</th>
-						<th class="py-2">Queued At</th>
-					</tr>
-				</thead>
-				<tbody>
-					{#each season.episodes as ep (ep.identityKey)}
-						<tr class="border-b border-gray-800 hover:bg-gray-800/40">
-							<td class="py-2 pr-2 align-top">
-								{#if ep.tmdb?.stillUrl}
-									<img
-										src={ep.tmdb.stillUrl}
-										alt=""
-										class="h-14 w-24 rounded object-cover"
-										loading="lazy"
-									/>
-								{:else}
-									<div class="h-14 w-24 rounded bg-gray-700/80"></div>
-								{/if}
-							</td>
-							<td class="py-2 pr-4 align-top font-medium whitespace-nowrap">
-								E{String(ep.episode).padStart(2, '0')}
-							</td>
-							<td class="py-2 pr-4 align-top text-gray-200">
-								{#if ep.tmdb?.name}
-									<span>{ep.tmdb.name}</span>
-									{#if ep.tmdb.airDate}
-										<span class="ml-1 text-xs text-gray-500">({ep.tmdb.airDate})</span>
-									{/if}
-								{:else}
-									<span class="text-gray-500">—</span>
-								{/if}
-							</td>
-							<td class="py-2 pr-4 align-top text-gray-300">
-								{ep.status}
-								{#if ep.lifecycleStatus}
-									<span class="ml-1 text-xs text-gray-500">({ep.lifecycleStatus})</span>
-								{/if}
-							</td>
-							<td class="py-2 align-top text-gray-400">{ep.queuedAt ?? '—'}</td>
-						</tr>
-					{/each}
-				</tbody>
-			</table>
+			<Card>
+				<CardHeader class="pb-3">
+					<h2 class="text-lg font-semibold tracking-tight">Season {season.season}</h2>
+				</CardHeader>
+				<CardContent class="pt-0">
+					<div class="rounded-md border border-border">
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead class="w-28"></TableHead>
+									<TableHead>Episode</TableHead>
+									<TableHead>Title</TableHead>
+									<TableHead>Status</TableHead>
+									<TableHead>Queued At</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{#each season.episodes as ep (ep.identityKey)}
+									<TableRow>
+										<TableCell class="align-top">
+											{#if ep.tmdb?.stillUrl}
+												<img
+													src={ep.tmdb.stillUrl}
+													alt={ep.tmdb?.name ? `Still for ${ep.tmdb.name}` : 'Episode still'}
+													class="h-14 w-24 rounded-md object-cover"
+													loading="lazy"
+												/>
+											{:else}
+												<div class="h-14 w-24 rounded-md bg-muted"></div>
+											{/if}
+										</TableCell>
+										<TableCell class="align-top font-medium whitespace-nowrap">
+											E{String(ep.episode).padStart(2, '0')}
+										</TableCell>
+										<TableCell class="align-top">
+											{#if ep.tmdb?.name}
+												<span>{ep.tmdb.name}</span>
+												{#if ep.tmdb.airDate}
+													<span class="ml-1 text-xs text-muted-foreground">({ep.tmdb.airDate})</span>
+												{/if}
+											{:else}
+												<span class="text-muted-foreground">—</span>
+											{/if}
+										</TableCell>
+										<TableCell class="align-top">
+											{ep.status}
+											{#if ep.lifecycleStatus}
+												<span class="ml-1 text-xs text-muted-foreground">({ep.lifecycleStatus})</span>
+											{/if}
+										</TableCell>
+										<TableCell class="align-top text-muted-foreground">{ep.queuedAt ?? '—'}</TableCell>
+									</TableRow>
+								{/each}
+							</TableBody>
+						</Table>
+					</div>
+				</CardContent>
+			</Card>
 		</section>
 	{/each}
 {/if}


### PR DESCRIPTION
## Summary

- delivery ticket: `P12.05 Show Detail`
- ticket file: [docs/02-delivery/phase-12/ticket-05-show-detail.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-12/ticket-05-show-detail.md)
- stacked base branch: `agents/p12-04-shows-list`
- post-verify self-audit: completed at 2026-04-09 01:09 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`0d786eff08c1`](https://github.com/cesarnml/pirate_claw/commit/0d786eff08c1d8d08a3bed16bfbf00aea3f0607c)
- current branch head: [`cdd507ff4d8b`](https://github.com/cesarnml/pirate_claw/commit/cdd507ff4d8bf37c4023882c8fea86294b319c5e)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `0d786eff08c1` address all findings from that review.
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Avoid an unlabeled table column header. (native GitHub thread resolved) `web/src/routes/shows/[slug]/+page.svelte:101` [thread](https://github.com/cesarnml/pirate_claw/pull/105#discussion_r3054986696)
- [greptile] Unsanitised URL interpolated into inline CSS (native GitHub thread resolved) `web/src/routes/shows/[slug]/+page.svelte:49` [thread](https://github.com/cesarnml/pirate_claw/pull/105#discussion_r3054984013)
- [greptile] Lazy-loading hero poster hurts LCP (native GitHub thread resolved) `web/src/routes/shows/[slug]/+page.svelte:56` [thread](https://github.com/cesarnml/pirate_claw/pull/105#discussion_r3054983938)
- [greptile] `title` attribute is unreliable for screen readers (native GitHub thread resolved) `web/src/routes/shows/[slug]/+page.svelte:73` [thread](https://github.com/cesarnml/pirate_claw/pull/105#discussion_r3054983981)
