### PR TITLE
feat(web): migrate movies view to design system cards [P12.06]

### DIFF
--- a/docs/02-delivery/phase-12/ticket-06-movies-view.md
+++ b/docs/02-delivery/phase-12/ticket-06-movies-view.md
@@ -20,4 +20,6 @@ Movies page is visually consistent with Phase 12; primary render and error paths
 
 ## Rationale
 
-_To be filled during implementation._
+Migrated the movies route to **shadcn** `Card` rows (poster + metadata), `Badge` with **`aria-label`** for TMDB rating, and the shared **destructive `Alert`** pattern for API errors. Metadata uses token-aligned `text-foreground` / `text-muted-foreground` instead of raw grays.
+
+Tests: **`web/src/routes/movies/movies.test.ts`** (happy path, empty, error).

--- a/web/src/routes/movies/+page.svelte
+++ b/web/src/routes/movies/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Card, CardContent } from '$lib/components/ui/card';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
@@ -9,74 +12,83 @@
 	}
 </script>
 
-<h1 class="text-2xl font-semibold">Movies</h1>
-<p class="mt-2 text-gray-400">
+<h1 class="text-3xl font-bold tracking-tight">Movies</h1>
+<p class="mt-1 text-sm text-muted-foreground">
 	TMDB poster and rating appear when the daemon has a TMDB API key and metadata is available.
 </p>
 
 {#if data.error}
-	<p class="mt-4 text-red-400" role="alert">{data.error}</p>
+	<Alert variant="destructive" class="mt-6">
+		<AlertTitle>API unavailable</AlertTitle>
+		<AlertDescription>{data.error}</AlertDescription>
+	</Alert>
 {:else if data.movies.length === 0}
-	<p class="mt-4 text-gray-400">No movie candidates yet.</p>
+	<Card class="mt-6">
+		<CardContent class="pt-6">
+			<p class="text-sm text-muted-foreground">No movie candidates yet.</p>
+		</CardContent>
+	</Card>
 {:else}
-	<ul class="mt-6 space-y-6">
+	<ul class="mt-8 list-none space-y-4">
 		{#each data.movies as movie (movie.identityKey)}
-			<li
-				class="flex flex-col gap-3 rounded-lg border border-gray-700 bg-gray-800/50 p-4 sm:flex-row sm:items-start"
-			>
-				{#if movie.tmdb?.posterUrl}
-					<img
-						src={movie.tmdb.posterUrl}
-						alt={`Poster for ${movie.tmdb?.title ?? movie.normalizedTitle}${movie.year ? ` (${movie.year})` : ''}`}
-						class="mx-auto h-48 w-32 shrink-0 rounded object-cover sm:mx-0"
-						loading="lazy"
-					/>
-				{:else}
-					<div
-						class="mx-auto flex h-48 w-32 shrink-0 items-center justify-center rounded bg-gray-700 text-xs text-gray-500 sm:mx-0"
-					>
-						No poster
-					</div>
-				{/if}
-				<div class="min-w-0 flex-1">
-					<div class="flex flex-wrap items-baseline gap-2">
-						<h2 class="text-lg font-medium text-gray-100">
-							{movie.tmdb?.title ?? movie.normalizedTitle}
-						</h2>
-						{#if movie.year}
-							<span class="text-gray-400">({movie.year})</span>
-						{/if}
-						{#if movie.tmdb?.voteAverage !== undefined}
-							<span
-								class="rounded bg-amber-900/60 px-2 py-0.5 text-sm text-amber-100"
-								title="TMDB vote average"
+			<li>
+				<Card>
+					<CardContent class="flex flex-col gap-4 p-4 sm:flex-row sm:items-start">
+						{#if movie.tmdb?.posterUrl}
+							<img
+								src={movie.tmdb.posterUrl}
+								alt={`Poster for ${movie.tmdb?.title ?? movie.normalizedTitle}${movie.year ? ` (${movie.year})` : ''}`}
+								class="mx-auto h-48 w-32 shrink-0 rounded-md object-cover sm:mx-0"
+								loading="lazy"
+							/>
+						{:else}
+							<div
+								class="mx-auto flex h-48 w-32 shrink-0 items-center justify-center rounded-md bg-muted text-xs text-muted-foreground sm:mx-0"
 							>
-								★ {formatRating(movie.tmdb.voteAverage)}
-							</span>
+								No poster
+							</div>
 						{/if}
-					</div>
-					{#if movie.tmdb?.overview}
-						<p class="mt-2 text-sm leading-relaxed text-gray-300">{movie.tmdb.overview}</p>
-					{/if}
-					<dl class="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-400">
-						<div>
-							<dt class="inline">Status:</dt>
-							<dd class="inline text-gray-300">{movie.status}</dd>
+						<div class="min-w-0 flex-1">
+							<div class="flex flex-wrap items-baseline gap-2">
+								<h2 class="text-lg font-semibold tracking-tight">
+									{movie.tmdb?.title ?? movie.normalizedTitle}
+								</h2>
+								{#if movie.year}
+									<span class="text-muted-foreground">({movie.year})</span>
+								{/if}
+								{#if movie.tmdb?.voteAverage !== undefined}
+									<Badge
+										variant="secondary"
+										aria-label="TMDB vote average: {formatRating(movie.tmdb.voteAverage)}"
+									>
+										★ {formatRating(movie.tmdb.voteAverage)}
+									</Badge>
+								{/if}
+							</div>
+							{#if movie.tmdb?.overview}
+								<p class="mt-2 text-sm leading-relaxed text-muted-foreground">{movie.tmdb.overview}</p>
+							{/if}
+							<dl class="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+								<div>
+									<dt class="inline">Status:</dt>
+									<dd class="inline text-foreground">{movie.status}</dd>
+								</div>
+								{#if movie.resolution}
+									<div>
+										<dt class="inline">Resolution:</dt>
+										<dd class="inline text-foreground">{movie.resolution}</dd>
+									</div>
+								{/if}
+								{#if movie.codec}
+									<div>
+										<dt class="inline">Codec:</dt>
+										<dd class="inline text-foreground">{movie.codec}</dd>
+									</div>
+								{/if}
+							</dl>
 						</div>
-						{#if movie.resolution}
-							<div>
-								<dt class="inline">Resolution:</dt>
-								<dd class="inline text-gray-300">{movie.resolution}</dd>
-							</div>
-						{/if}
-						{#if movie.codec}
-							<div>
-								<dt class="inline">Codec:</dt>
-								<dd class="inline text-gray-300">{movie.codec}</dd>
-							</div>
-						{/if}
-					</dl>
-				</div>
+					</CardContent>
+				</Card>
 			</li>
 		{/each}
 	</ul>

--- a/web/src/routes/movies/movies.test.ts
+++ b/web/src/routes/movies/movies.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Page from './+page.svelte';
+import type { MovieBreakdown } from '$lib/types';
+
+const mockMovie: MovieBreakdown = {
+	identityKey: 'movie-1',
+	normalizedTitle: 'Example Film',
+	status: 'queued',
+	year: 2020,
+	resolution: '1080p',
+	codec: 'h264',
+	tmdb: {
+		title: 'Example Film',
+		posterUrl: 'https://example.com/poster.jpg',
+		overview: 'A test overview.',
+		voteAverage: 7.2,
+	},
+};
+
+describe('/movies', () => {
+	it('renders movie cards with TMDB metadata', () => {
+		render(Page, { data: { movies: [mockMovie], error: null } });
+		expect(screen.getByRole('heading', { name: 'Movies' })).toBeInTheDocument();
+		expect(screen.getByText('Example Film')).toBeInTheDocument();
+		expect(screen.getByText('A test overview.')).toBeInTheDocument();
+		expect(screen.getByLabelText(/TMDB vote average/)).toHaveTextContent('★ 7.2');
+		expect(screen.getByText('1080p')).toBeInTheDocument();
+	});
+
+	it('renders empty state', () => {
+		render(Page, { data: { movies: [], error: null } });
+		expect(screen.getByText('No movie candidates yet.')).toBeInTheDocument();
+	});
+
+	it('renders error state', () => {
+		render(Page, { data: { movies: [], error: 'Could not reach the API.' } });
+		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
+	});
+});


### PR DESCRIPTION
## Summary

- delivery ticket: `P12.06 Movies View`
- ticket file: [docs/02-delivery/phase-12/ticket-06-movies-view.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-12/ticket-06-movies-view.md)
- stacked base branch: `agents/p12-05-show-detail`
- post-verify self-audit: completed at 2026-04-09 01:17 UTC
