### PR TITLE
feat(config): wire runtime api write token precedence [P13.01]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 TELEGRAM_CHAT_ID=your-telegram-chat-id
+PIRATE_CLAW_API_WRITE_TOKEN=your-config-write-token
 PIRATE_CLAW_TRANSMISSION_USERNAME=your-transmission-username
 PIRATE_CLAW_TRANSMISSION_PASSWORD=your-transmission-password
-PIRATE_CLAW_API_WRITE_TOKEN=your-config-write-token

--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 TELEGRAM_CHAT_ID=your-telegram-chat-id
 PIRATE_CLAW_TRANSMISSION_USERNAME=your-transmission-username
 PIRATE_CLAW_TRANSMISSION_PASSWORD=your-transmission-password
+PIRATE_CLAW_API_WRITE_TOKEN=your-config-write-token

--- a/docs/02-delivery/phase-13/ticket-01-config-model-and-token-wiring.md
+++ b/docs/02-delivery/phase-13/ticket-01-config-model-and-token-wiring.md
@@ -27,4 +27,7 @@ Config parsing and validation support token wiring with env precedence, tests pa
 
 ## Rationale
 
-To be completed during implementation with behavior/tradeoff notes.
+- Added `runtime.apiWriteToken` as an optional runtime field so existing configs remain valid when the token is omitted.
+- Enforced precedence `PIRATE_CLAW_API_WRITE_TOKEN` > config file token to support operational secret management without file edits.
+- Treating empty token values as disabled avoids accidental write enablement while still allowing explicit opt-out in file-backed config.
+- Extended API config redaction to include `runtime.apiWriteToken` so read endpoints continue to avoid leaking secrets.

--- a/src/api.ts
+++ b/src/api.ts
@@ -296,6 +296,10 @@ export function buildFeedStatuses(
 export function redactConfig(config: AppConfig): AppConfig {
   const next: AppConfig = {
     ...config,
+    runtime: {
+      ...config.runtime,
+      ...(config.runtime.apiWriteToken ? { apiWriteToken: '[redacted]' } : {}),
+    },
     transmission: {
       ...config.transmission,
       username: '[redacted]',

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,6 +48,7 @@ export type RuntimeConfig = {
   artifactDir: string;
   artifactRetentionDays: number;
   apiPort?: number;
+  apiWriteToken?: string;
   /**
    * How often to run TMDB cache refresh in the daemon (independent of RSS polling).
    * Zero disables the background pass; omitted uses the default (see `DEFAULT_RUNTIME_CONFIG` and `validateRuntime`).
@@ -85,6 +86,7 @@ export type AppConfig = {
 const DEFAULT_CONFIG_PATH = 'pirate-claw.config.json';
 const TRANSMISSION_USERNAME_ENV = 'PIRATE_CLAW_TRANSMISSION_USERNAME';
 const TRANSMISSION_PASSWORD_ENV = 'PIRATE_CLAW_TRANSMISSION_PASSWORD';
+const API_WRITE_TOKEN_ENV = 'PIRATE_CLAW_API_WRITE_TOKEN';
 
 export class ConfigError extends Error {
   constructor(message: string) {
@@ -135,7 +137,7 @@ export function validateConfig(
     tv: validateTvConfig(input.tv, path),
     movies: validateMoviePolicy(movies, path),
     transmission: validateTransmission(transmission, path, env),
-    runtime: validateRuntime(input.runtime, path),
+    runtime: validateRuntime(input.runtime, path, env),
     tmdb: validateOptionalTmdb(input.tmdb, path),
   };
 }
@@ -657,7 +659,11 @@ function validateOptionalTmdbDayCount(
   return input;
 }
 
-function validateRuntime(input: unknown, path: string): RuntimeConfig {
+function validateRuntime(
+  input: unknown,
+  path: string,
+  env: Record<string, string | undefined>,
+): RuntimeConfig {
   if (input === undefined) {
     return { ...DEFAULT_RUNTIME_CONFIG };
   }
@@ -687,12 +693,38 @@ function validateRuntime(input: unknown, path: string): RuntimeConfig {
       runtime.apiPort,
       `${path} runtime apiPort`,
     ),
+    apiWriteToken: resolveApiWriteToken(
+      runtime.apiWriteToken,
+      env[API_WRITE_TOKEN_ENV],
+      `${path} runtime apiWriteToken`,
+    ),
     tmdbRefreshIntervalMinutes:
       validateOptionalTmdbRefreshInterval(
         runtime.tmdbRefreshIntervalMinutes,
         `${path} runtime tmdbRefreshIntervalMinutes`,
       ) ?? DEFAULT_RUNTIME_CONFIG.tmdbRefreshIntervalMinutes,
   };
+}
+
+function resolveApiWriteToken(
+  inlineValue: unknown,
+  envValue: string | undefined,
+  path: string,
+): string | undefined {
+  if (typeof envValue === 'string' && envValue.length > 0) {
+    return envValue;
+  }
+
+  if (inlineValue === undefined) {
+    return undefined;
+  }
+
+  if (typeof inlineValue !== 'string') {
+    throw new ConfigError(`Config file "${path}" must be a string.`);
+  }
+
+  // Empty string in config intentionally disables write auth.
+  return inlineValue.length > 0 ? inlineValue : undefined;
 }
 
 const MAX_INTERVAL_MINUTES = 44_640;

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -549,6 +549,7 @@ describe('GET /api/feeds', () => {
 describe('GET /api/config', () => {
   it('returns config with redacted credentials', async () => {
     const deps = createDeps();
+    deps.config.runtime.apiWriteToken = 'write-token';
     const handler = createApiFetch(deps);
     const response = await handler(new Request('http://localhost/api/config'));
 
@@ -559,6 +560,7 @@ describe('GET /api/config', () => {
     expect(body.transmission.url).toBe(
       'http://localhost:9091/transmission/rpc',
     );
+    expect(body.runtime.apiWriteToken).toBe('[redacted]');
   });
 
   it('does not mutate the original config object', async () => {
@@ -689,11 +691,14 @@ describe('buildFeedStatuses', () => {
 describe('redactConfig', () => {
   it('redacts transmission username and password', () => {
     const config = stubConfig();
+    config.runtime.apiWriteToken = 'write-token';
     const redacted = redactConfig(config);
 
     expect(redacted.transmission.username).toBe('[redacted]');
     expect(redacted.transmission.password).toBe('[redacted]');
+    expect(redacted.runtime.apiWriteToken).toBe('[redacted]');
     expect(config.transmission.username).toBe('user');
+    expect(config.runtime.apiWriteToken).toBe('write-token');
   });
 
   it('redacts tmdb apiKey when present', () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -381,6 +381,54 @@ describe('validateConfig', () => {
     expect(config.runtime.apiPort).toBeUndefined();
   });
 
+  it('leaves runtime.apiWriteToken undefined when omitted', () => {
+    const config = validateConfig(createMinimalConfig());
+
+    expect(config.runtime.apiWriteToken).toBeUndefined();
+  });
+
+  it('accepts runtime.apiWriteToken from config', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      runtime: { apiWriteToken: 'config-token' },
+    });
+
+    expect(config.runtime.apiWriteToken).toBe('config-token');
+  });
+
+  it('treats empty runtime.apiWriteToken as disabled', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      runtime: { apiWriteToken: '' },
+    });
+
+    expect(config.runtime.apiWriteToken).toBeUndefined();
+  });
+
+  it('prefers PIRATE_CLAW_API_WRITE_TOKEN env override over config token', () => {
+    const config = validateConfig(
+      {
+        ...createMinimalConfig(),
+        runtime: { apiWriteToken: 'config-token' },
+      },
+      'config',
+      {
+        PIRATE_CLAW_API_WRITE_TOKEN: 'env-token',
+      },
+    );
+
+    expect(config.runtime.apiWriteToken).toBe('env-token');
+  });
+
+  it('fails when runtime.apiWriteToken is not a string', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        runtime: { apiWriteToken: 12345 },
+      }),
+    ).toThrow(/runtime apiWriteToken.*must be a string/);
+  });
+
   it('fails when runtime.apiPort is zero', () => {
     expect(() =>
       validateConfig({
@@ -589,6 +637,7 @@ describe('validateConfig', () => {
         [
           'PIRATE_CLAW_TRANSMISSION_USERNAME=dotenv-user',
           'PIRATE_CLAW_TRANSMISSION_PASSWORD="dotenv-pass"',
+          'PIRATE_CLAW_API_WRITE_TOKEN=dotenv-write-token',
         ].join('\n'),
       );
       await Bun.write(
@@ -598,6 +647,9 @@ describe('validateConfig', () => {
             ...createMinimalConfig(),
             transmission: {
               url: 'http://localhost:9091/transmission/rpc',
+            },
+            runtime: {
+              apiWriteToken: 'config-write-token',
             },
           },
           null,
@@ -612,6 +664,7 @@ describe('validateConfig', () => {
         username: 'dotenv-user',
         password: 'dotenv-pass',
       });
+      expect(config.runtime.apiWriteToken).toBe('dotenv-write-token');
     } finally {
       await Bun.$`rm -rf ${directory}`;
       if (prevUser !== undefined) {


### PR DESCRIPTION
## Summary

- delivery ticket: `P13.01 Config Model and Token Wiring`
- ticket file: [docs/02-delivery/phase-13/ticket-01-config-model-and-token-wiring.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-13/ticket-01-config-model-and-token-wiring.md)
- stacked base branch: `main`
- post-verify self-audit: completed at 2026-04-09 08:29 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`8f4636625de4`](https://github.com/cesarnml/pirate_claw/commit/8f4636625de47b287c316e31c089c7a51bd94c25)
- current branch head: [`74dbcd0f2ce8`](https://github.com/cesarnml/pirate_claw/commit/74dbcd0f2ce8e8cb0d12d7f7774c391d98066f2e)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `8f4636625de4` address all findings from that review.
- vendors: `coderabbit`, `greptile`

### Resolved Review Findings

- [greptile] `cesarnml` has reached the 50-review limit for trial accounts. To continue receiving code reviews, [upgrade your plan](https://app.grepti... (patched)
