### PR TITLE
feat(api): expose config revision etag header [P13.02]

### DIFF
--- a/docs/02-delivery/phase-13/ticket-02-config-read-revision-metadata.md
+++ b/docs/02-delivery/phase-13/ticket-02-config-read-revision-metadata.md
@@ -22,4 +22,6 @@ Config read responses expose revision metadata suitable for optimistic concurren
 
 ## Rationale
 
-To be completed during implementation with behavior/tradeoff notes.
+- Added an `ETag` response header on `GET /api/config` so later write operations can perform optimistic concurrency checks without changing the JSON payload contract.
+- The revision value is computed from the redacted config payload, keeping secret values out of the hash input while still producing stable revisions for unchanged readable config state.
+- Tests now assert header presence and unchanged-read stability to lock the contract before write-path tickets consume it.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import type { AppConfig, FeedConfig, RuntimeConfig } from './config';
 import type { MovieBreakdown } from './movie-api-types';
 export type { MovieBreakdown, TmdbMoviePublic } from './movie-api-types';
@@ -182,7 +183,16 @@ export function createApiFetch(
     }
 
     if (path === '/api/config') {
-      return safeJson(() => redactConfig(config));
+      try {
+        const redacted = redactConfig(config);
+        return Response.json(redacted, {
+          headers: {
+            ETag: buildConfigEtag(redacted),
+          },
+        });
+      } catch {
+        return json500();
+      }
     }
 
     return Response.json({ error: 'not found' }, { status: 404 });
@@ -312,4 +322,10 @@ export function redactConfig(config: AppConfig): AppConfig {
   }
 
   return next;
+}
+
+function buildConfigEtag(config: AppConfig): string {
+  const serialized = JSON.stringify(config);
+  const digest = createHash('sha256').update(serialized).digest('hex');
+  return `"${digest}"`;
 }

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -561,6 +561,7 @@ describe('GET /api/config', () => {
       'http://localhost:9091/transmission/rpc',
     );
     expect(body.runtime.apiWriteToken).toBe('[redacted]');
+    expect(response.headers.get('etag')).toMatch(/^"[0-9a-f]{64}"$/);
   });
 
   it('does not mutate the original config object', async () => {
@@ -570,6 +571,20 @@ describe('GET /api/config', () => {
 
     expect(deps.config.transmission.username).toBe('user');
     expect(deps.config.transmission.password).toBe('pass');
+  });
+
+  it('returns a stable ETag across unchanged reads', async () => {
+    const deps = createDeps();
+    const handler = createApiFetch(deps);
+
+    const first = await handler(new Request('http://localhost/api/config'));
+    const second = await handler(new Request('http://localhost/api/config'));
+
+    const firstEtag = first.headers.get('etag');
+    const secondEtag = second.headers.get('etag');
+
+    expect(firstEtag).toBeTruthy();
+    expect(firstEtag).toBe(secondEtag);
   });
 });
 


### PR DESCRIPTION
## Summary

- delivery ticket: `P13.02 Config Resource Read Metadata`
- ticket file: [docs/02-delivery/phase-13/ticket-02-config-read-revision-metadata.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-13/ticket-02-config-read-revision-metadata.md)
- stacked base branch: `agents/p13-01-config-model-and-token-wiring`
- post-verify self-audit: completed at 2026-04-09 08:39 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`5e8b7b95f7e0`](https://github.com/cesarnml/pirate_claw/commit/5e8b7b95f7e01ba691922223f3d02879d3258a71)
- current branch head: [`5e8b7b95f7e0`](https://github.com/cesarnml/pirate_claw/commit/5e8b7b95f7e01ba691922223f3d02879d3258a71)
- vendors: `coderabbit`, `greptile`
