### PR TITLE
feat(api): add auth-gated runtime config writes [P13.03]

### DIFF
--- a/docs/02-delivery/phase-13/ticket-03-auth-gated-config-write-endpoint.md
+++ b/docs/02-delivery/phase-13/ticket-03-auth-gated-config-write-endpoint.md
@@ -25,4 +25,6 @@ Write endpoint(s) exist with token gating and disabled-by-default behavior, writ
 
 ## Rationale
 
-To be completed during implementation with behavior/tradeoff notes.
+- Added `PUT /api/config` with explicit disabled/unauthorized/forbidden responses so mutating behavior is opt-in and token-gated by default.
+- Limited write payloads to `runtime` updates only to avoid expanding config mutation surface before dedicated ticket scope.
+- Reused `validateConfig` for merged-on-disk config validation and persisted changes via atomic temp-file rename to reduce corruption risk on partial writes.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { renameSync, writeFileSync } from 'node:fs';
 import type { AppConfig, FeedConfig, RuntimeConfig } from './config';
 import { ConfigError, validateConfig } from './config';
@@ -224,8 +224,14 @@ export function createApiFetch(
         return Response.json({ error: 'forbidden' }, { status: 403 });
       }
 
+      let body: unknown;
       try {
-        const body = await request.json();
+        body = await request.json();
+      } catch {
+        return Response.json({ error: 'invalid json body' }, { status: 400 });
+      }
+
+      try {
         const patch = expectRecord(body, 'request body');
         const runtimePatch = requireRecord(patch, 'runtime', 'request body');
 
@@ -259,7 +265,7 @@ export function createApiFetch(
         if (error instanceof ConfigError) {
           return Response.json({ error: error.message }, { status: 400 });
         }
-        return Response.json({ error: 'invalid json body' }, { status: 400 });
+        return json500();
       }
     }
 
@@ -402,7 +408,7 @@ function parseBearerToken(header: string | null): string | null {
   if (!header) {
     return null;
   }
-  const match = /^Bearer\s+(.+)$/.exec(header.trim());
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
   return match?.[1]?.trim() || null;
 }
 
@@ -418,8 +424,11 @@ function writeConfigAtomically(
   path: string,
   config: Record<string, unknown>,
 ): void {
-  const tempPath = `${path}.${process.pid}.tmp`;
-  writeFileSync(tempPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+  const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(config, null, 2)}\n`, {
+    encoding: 'utf8',
+    flag: 'wx',
+  });
   renameSync(tempPath, path);
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,7 @@
 import { createHash } from 'node:crypto';
+import { renameSync, writeFileSync } from 'node:fs';
 import type { AppConfig, FeedConfig, RuntimeConfig } from './config';
+import { ConfigError, validateConfig } from './config';
 import type { MovieBreakdown } from './movie-api-types';
 export type { MovieBreakdown, TmdbMoviePublic } from './movie-api-types';
 import type { ShowBreakdown, ShowEpisode, ShowSeason } from './tv-api-types';
@@ -65,6 +67,7 @@ export type ApiFetchDeps = {
   repository: Repository;
   health: HealthState;
   config: AppConfig;
+  configPath: string;
   pollStatePath: string;
   loadPollState: (path: string) => PollState;
   /** When set (TMDB configured), GET /api/movies lazily enriches from cache + TMDB. */
@@ -106,6 +109,7 @@ export function createApiFetch(
     repository,
     health,
     config,
+    configPath,
     pollStatePath,
     loadPollState,
     tmdbMovies,
@@ -113,6 +117,7 @@ export function createApiFetch(
     tmdbCache,
     onCandidateTmdbCacheError,
   } = deps;
+  let activeConfig = config;
 
   return async (request: Request) => {
     const path = new URL(request.url).pathname;
@@ -173,18 +178,22 @@ export function createApiFetch(
       }
     }
 
-    if (path === '/api/feeds') {
+    if (path === '/api/feeds' && request.method === 'GET') {
       return safeJson(() => {
         const pollState = loadPollState(pollStatePath);
         return {
-          feeds: buildFeedStatuses(config.feeds, pollState, config.runtime),
+          feeds: buildFeedStatuses(
+            activeConfig.feeds,
+            pollState,
+            activeConfig.runtime,
+          ),
         };
       });
     }
 
-    if (path === '/api/config') {
+    if (path === '/api/config' && request.method === 'GET') {
       try {
-        const redacted = redactConfig(config);
+        const redacted = redactConfig(activeConfig);
         return Response.json(redacted, {
           headers: {
             ETag: buildConfigEtag(redacted),
@@ -192,6 +201,65 @@ export function createApiFetch(
         });
       } catch {
         return json500();
+      }
+    }
+
+    if (path === '/api/config' && request.method === 'PUT') {
+      const writeToken = activeConfig.runtime.apiWriteToken;
+      if (!writeToken) {
+        return Response.json(
+          { error: 'config writes are disabled' },
+          { status: 403 },
+        );
+      }
+
+      const bearer = parseBearerToken(request.headers.get('authorization'));
+      if (!bearer) {
+        return Response.json(
+          { error: 'missing bearer token' },
+          { status: 401 },
+        );
+      }
+      if (bearer !== writeToken) {
+        return Response.json({ error: 'forbidden' }, { status: 403 });
+      }
+
+      try {
+        const body = await request.json();
+        const patch = expectRecord(body, 'request body');
+        const runtimePatch = requireRecord(patch, 'runtime', 'request body');
+
+        // Runtime-only updates for now; non-runtime updates are out-of-scope in this phase.
+        for (const key of Object.keys(patch)) {
+          if (key !== 'runtime') {
+            throw new ConfigError(
+              `Config file "request body ${key}" is not writable; only "runtime" is supported.`,
+            );
+          }
+        }
+
+        const baseOnDisk = await readConfigFileRecord(configPath);
+        const merged = {
+          ...baseOnDisk,
+          runtime: {
+            ...(isRecord(baseOnDisk.runtime) ? baseOnDisk.runtime : {}),
+            ...runtimePatch,
+          },
+        };
+
+        const validated = validateConfig(merged, 'config');
+        writeConfigAtomically(configPath, merged);
+        activeConfig = validated;
+
+        const redacted = redactConfig(activeConfig);
+        return Response.json(redacted, {
+          headers: { ETag: buildConfigEtag(redacted) },
+        });
+      } catch (error) {
+        if (error instanceof ConfigError) {
+          return Response.json({ error: error.message }, { status: 400 });
+        }
+        return Response.json({ error: 'invalid json body' }, { status: 400 });
       }
     }
 
@@ -328,4 +396,48 @@ function buildConfigEtag(config: AppConfig): string {
   const serialized = JSON.stringify(config);
   const digest = createHash('sha256').update(serialized).digest('hex');
   return `"${digest}"`;
+}
+
+function parseBearerToken(header: string | null): string | null {
+  if (!header) {
+    return null;
+  }
+  const match = /^Bearer\s+(.+)$/.exec(header.trim());
+  return match?.[1]?.trim() || null;
+}
+
+async function readConfigFileRecord(
+  path: string,
+): Promise<Record<string, unknown>> {
+  const file = Bun.file(path);
+  const parsed = await file.json();
+  return expectRecord(parsed, 'config');
+}
+
+function writeConfigAtomically(
+  path: string,
+  config: Record<string, unknown>,
+): void {
+  const tempPath = `${path}.${process.pid}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+  renameSync(tempPath, path);
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === 'object' && input !== null && !Array.isArray(input);
+}
+
+function expectRecord(input: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(input)) {
+    throw new ConfigError(`Config file "${label}" must be an object.`);
+  }
+  return input;
+}
+
+function requireRecord(
+  input: Record<string, unknown>,
+  key: string,
+  label: string,
+): Record<string, unknown> {
+  return expectRecord(input[key], `${label} ${key}`);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -262,6 +262,7 @@ export async function runCli(argv: string[]): Promise<number> {
                   repository,
                   health,
                   config,
+                  configPath: resolvedConfigPath,
                   pollStatePath,
                   loadPollState,
                   tmdbMovies,

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,5 +1,8 @@
 import { Database } from 'bun:sqlite';
 import { describe, expect, it } from 'bun:test';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import {
   type ApiFetchDeps,
@@ -75,6 +78,7 @@ function createDeps(overrides: Partial<Repository> = {}): ApiFetchDeps {
     repository: stubRepository(overrides),
     health: createHealthState(),
     config: stubConfig(),
+    configPath: '/nonexistent/pirate-claw.config.json',
     pollStatePath: '/nonexistent/poll-state.json',
     loadPollState: () => emptyPollState,
   };
@@ -585,6 +589,138 @@ describe('GET /api/config', () => {
 
     expect(firstEtag).toBeTruthy();
     expect(firstEtag).toBe(secondEtag);
+  });
+});
+
+describe('PUT /api/config', () => {
+  it('returns 403 when config writes are disabled', async () => {
+    const deps = createDeps();
+    deps.config.runtime.apiWriteToken = undefined;
+    const handler = createApiFetch(deps);
+
+    const response = await handler(
+      new Request('http://localhost/api/config', {
+        method: 'PUT',
+        headers: { Authorization: 'Bearer any-token' },
+        body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: 'config writes are disabled',
+    });
+  });
+
+  it('returns 401 when bearer token is missing', async () => {
+    const deps = createDeps();
+    deps.config.runtime.apiWriteToken = 'write-token';
+    const handler = createApiFetch(deps);
+
+    const response = await handler(
+      new Request('http://localhost/api/config', {
+        method: 'PUT',
+        body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'missing bearer token' });
+  });
+
+  it('returns 403 when bearer token is invalid', async () => {
+    const deps = createDeps();
+    deps.config.runtime.apiWriteToken = 'write-token';
+    const handler = createApiFetch(deps);
+
+    const response = await handler(
+      new Request('http://localhost/api/config', {
+        method: 'PUT',
+        headers: { Authorization: 'Bearer wrong-token' },
+        body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: 'forbidden' });
+  });
+
+  it('returns 400 when payload validation fails', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-api-config-'));
+    const configPath = join(directory, 'pirate-claw.config.json');
+    await Bun.write(configPath, JSON.stringify(stubConfig(), null, 2));
+
+    const deps = createDeps();
+    deps.configPath = configPath;
+    deps.config.runtime.apiWriteToken = 'write-token';
+    const handler = createApiFetch(deps);
+
+    const response = await handler(
+      new Request('http://localhost/api/config', {
+        method: 'PUT',
+        headers: { Authorization: 'Bearer write-token' },
+        body: JSON.stringify({ feeds: [] }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'Config file "request body runtime" must be an object.',
+    });
+  });
+
+  it('returns 400 when runtime validation fails', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-api-config-'));
+    const configPath = join(directory, 'pirate-claw.config.json');
+    await Bun.write(configPath, JSON.stringify(stubConfig(), null, 2));
+
+    const deps = createDeps();
+    deps.configPath = configPath;
+    deps.config.runtime.apiWriteToken = 'write-token';
+    const handler = createApiFetch(deps);
+
+    const response = await handler(
+      new Request('http://localhost/api/config', {
+        method: 'PUT',
+        headers: { Authorization: 'Bearer write-token' },
+        body: JSON.stringify({
+          runtime: { runIntervalMinutes: 0 },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toMatch(/runIntervalMinutes/);
+  });
+
+  it('writes runtime updates and returns redacted config with ETag', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-api-config-'));
+    const configPath = join(directory, 'pirate-claw.config.json');
+    await Bun.write(configPath, JSON.stringify(stubConfig(), null, 2));
+
+    const deps = createDeps();
+    deps.configPath = configPath;
+    deps.config.runtime.apiWriteToken = 'write-token';
+    const handler = createApiFetch(deps);
+
+    const response = await handler(
+      new Request('http://localhost/api/config', {
+        method: 'PUT',
+        headers: { Authorization: 'Bearer write-token' },
+        body: JSON.stringify({
+          runtime: { runIntervalMinutes: 15 },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.runtime.runIntervalMinutes).toBe(15);
+    expect(body.runtime.apiWriteToken).toBeUndefined();
+    expect(response.headers.get('etag')).toMatch(/^"[0-9a-f]{64}"$/);
+
+    const persisted = await Bun.file(configPath).json();
+    expect(persisted.runtime.runIntervalMinutes).toBe(15);
   });
 });
 

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -645,6 +645,29 @@ describe('PUT /api/config', () => {
     expect(await response.json()).toEqual({ error: 'forbidden' });
   });
 
+  it('accepts lowercase bearer auth scheme', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-api-config-'));
+    const configPath = join(directory, 'pirate-claw.config.json');
+    const config = stubConfig();
+    config.runtime.apiWriteToken = 'write-token';
+    await Bun.write(configPath, JSON.stringify(config, null, 2));
+
+    const deps = createDeps();
+    deps.config = structuredClone(config);
+    deps.configPath = configPath;
+    const handler = createApiFetch(deps);
+
+    const response = await handler(
+      new Request('http://localhost/api/config', {
+        method: 'PUT',
+        headers: { Authorization: 'bearer write-token' },
+        body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
   it('returns 400 when payload validation fails', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-api-config-'));
     const configPath = join(directory, 'pirate-claw.config.json');
@@ -696,11 +719,13 @@ describe('PUT /api/config', () => {
   it('writes runtime updates and returns redacted config with ETag', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-api-config-'));
     const configPath = join(directory, 'pirate-claw.config.json');
-    await Bun.write(configPath, JSON.stringify(stubConfig(), null, 2));
+    const config = stubConfig();
+    config.runtime.apiWriteToken = 'write-token';
+    await Bun.write(configPath, JSON.stringify(config, null, 2));
 
     const deps = createDeps();
+    deps.config = structuredClone(config);
     deps.configPath = configPath;
-    deps.config.runtime.apiWriteToken = 'write-token';
     const handler = createApiFetch(deps);
 
     const response = await handler(
@@ -716,11 +741,29 @@ describe('PUT /api/config', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.runtime.runIntervalMinutes).toBe(15);
-    expect(body.runtime.apiWriteToken).toBeUndefined();
+    expect(body.runtime.apiWriteToken).toBe('[redacted]');
     expect(response.headers.get('etag')).toMatch(/^"[0-9a-f]{64}"$/);
 
     const persisted = await Bun.file(configPath).json();
     expect(persisted.runtime.runIntervalMinutes).toBe(15);
+  });
+
+  it('returns 500 when config persistence fails', async () => {
+    const deps = createDeps();
+    deps.config.runtime.apiWriteToken = 'write-token';
+    deps.configPath = '/definitely/missing/pirate-claw.config.json';
+    const handler = createApiFetch(deps);
+
+    const response = await handler(
+      new Request('http://localhost/api/config', {
+        method: 'PUT',
+        headers: { Authorization: 'Bearer write-token' },
+        body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: 'internal server error' });
   });
 });
 


### PR DESCRIPTION
## Summary

- delivery ticket: `P13.03 Auth-Gated Config Write Endpoint`
- ticket file: [docs/02-delivery/phase-13/ticket-03-auth-gated-config-write-endpoint.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-13/ticket-03-auth-gated-config-write-endpoint.md)
- stacked base branch: `agents/p13-02-config-resource-read-metadata`
- post-verify self-audit: completed at 2026-04-09 08:49 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`2fafef059fba`](https://github.com/cesarnml/pirate_claw/commit/2fafef059fbab3b8303209c3845ac9bbee49de29)
- current branch head: [`cdd9d3b61092`](https://github.com/cesarnml/pirate_claw/commit/cdd9d3b6109232dcfe1dc90ff065778064d48cc0)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `2fafef059fba` address all findings from that review.
- vendors: `coderabbit`, `greptile`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Return `500` for config-file read/write failures. (native GitHub thread resolved) `src/api.ts:262` [thread](https://github.com/cesarnml/pirate_claw/pull/111#discussion_r3056623600)
- [coderabbit] Accept lowercase `bearer` in `Authorization`. (native GitHub thread resolved) `src/api.ts:406` [thread](https://github.com/cesarnml/pirate_claw/pull/111#discussion_r3056623612)
- [coderabbit] Use a unique temp file per write. (native GitHub thread resolved) `src/api.ts:423` [thread](https://github.com/cesarnml/pirate_claw/pull/111#discussion_r3056623624)
- [coderabbit] Keep `deps.config` and `configPath` seeded from the same config. (native GitHub thread resolved) `test/api.test.ts:704` [thread](https://github.com/cesarnml/pirate_claw/pull/111#discussion_r3056623632)
- [greptile] `cesarnml` has reached the 50-review limit for trial accounts. To continue receiving code reviews, [upgrade your plan](https://app.grepti... (patched)

### No-Action Rationale

- Left 1 unclear comment(s) for manual judgment.
