### PR TITLE
feat(api): enforce if-match revision checks on config writes [P13.04]

### DIFF
--- a/docs/02-delivery/phase-13/ticket-04-if-match-conflict-contract.md
+++ b/docs/02-delivery/phase-13/ticket-04-if-match-conflict-contract.md
@@ -23,4 +23,6 @@ Write requests enforce revision preconditions and return `409` on stale revision
 
 ## Rationale
 
-To be completed during implementation with behavior/tradeoff notes.
+- Required `If-Match` for config writes and surfaced `428` when missing so clients must participate in optimistic concurrency.
+- Added deterministic `409` conflict responses when provided revisions are stale, with current `ETag` echoed for immediate retry workflows.
+- Conflict checks happen before persistence; stale writes never touch disk, preserving safe/no-partial-write behavior.

--- a/src/api.ts
+++ b/src/api.ts
@@ -224,6 +224,21 @@ export function createApiFetch(
         return Response.json({ error: 'forbidden' }, { status: 403 });
       }
 
+      const currentEtag = buildConfigEtag(redactConfig(activeConfig));
+      const ifMatch = request.headers.get('if-match');
+      if (!ifMatch) {
+        return Response.json(
+          { error: 'if-match header is required' },
+          { status: 428, headers: { ETag: currentEtag } },
+        );
+      }
+      if (!ifMatchMatches(ifMatch, currentEtag)) {
+        return Response.json(
+          { error: 'config revision conflict' },
+          { status: 409, headers: { ETag: currentEtag } },
+        );
+      }
+
       let body: unknown;
       try {
         body = await request.json();
@@ -410,6 +425,14 @@ function parseBearerToken(header: string | null): string | null {
   }
   const match = /^Bearer\s+(.+)$/i.exec(header.trim());
   return match?.[1]?.trim() || null;
+}
+
+function ifMatchMatches(ifMatch: string, currentEtag: string): boolean {
+  const parts = ifMatch
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  return parts.includes('*') || parts.includes(currentEtag);
 }
 
 async function readConfigFileRecord(

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -660,7 +660,10 @@ describe('PUT /api/config', () => {
     const response = await handler(
       new Request('http://localhost/api/config', {
         method: 'PUT',
-        headers: { Authorization: 'bearer write-token' },
+        headers: {
+          Authorization: 'bearer write-token',
+          'If-Match': '*',
+        },
         body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
       }),
     );
@@ -681,7 +684,7 @@ describe('PUT /api/config', () => {
     const response = await handler(
       new Request('http://localhost/api/config', {
         method: 'PUT',
-        headers: { Authorization: 'Bearer write-token' },
+        headers: { Authorization: 'Bearer write-token', 'If-Match': '*' },
         body: JSON.stringify({ feeds: [] }),
       }),
     );
@@ -705,7 +708,7 @@ describe('PUT /api/config', () => {
     const response = await handler(
       new Request('http://localhost/api/config', {
         method: 'PUT',
-        headers: { Authorization: 'Bearer write-token' },
+        headers: { Authorization: 'Bearer write-token', 'If-Match': '*' },
         body: JSON.stringify({
           runtime: { runIntervalMinutes: 0 },
         }),
@@ -728,10 +731,16 @@ describe('PUT /api/config', () => {
     deps.configPath = configPath;
     const handler = createApiFetch(deps);
 
+    const current = await handler(new Request('http://localhost/api/config'));
+    const currentEtag = current.headers.get('etag')!;
+
     const response = await handler(
       new Request('http://localhost/api/config', {
         method: 'PUT',
-        headers: { Authorization: 'Bearer write-token' },
+        headers: {
+          Authorization: 'Bearer write-token',
+          'If-Match': currentEtag,
+        },
         body: JSON.stringify({
           runtime: { runIntervalMinutes: 15 },
         }),
@@ -757,13 +766,56 @@ describe('PUT /api/config', () => {
     const response = await handler(
       new Request('http://localhost/api/config', {
         method: 'PUT',
-        headers: { Authorization: 'Bearer write-token' },
+        headers: { Authorization: 'Bearer write-token', 'If-Match': '*' },
         body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
       }),
     );
 
     expect(response.status).toBe(500);
     expect(await response.json()).toEqual({ error: 'internal server error' });
+  });
+
+  it('returns 428 when If-Match header is missing', async () => {
+    const deps = createDeps();
+    deps.config.runtime.apiWriteToken = 'write-token';
+    const handler = createApiFetch(deps);
+
+    const response = await handler(
+      new Request('http://localhost/api/config', {
+        method: 'PUT',
+        headers: { Authorization: 'Bearer write-token' },
+        body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
+      }),
+    );
+
+    expect(response.status).toBe(428);
+    expect(await response.json()).toEqual({
+      error: 'if-match header is required',
+    });
+    expect(response.headers.get('etag')).toMatch(/^"[0-9a-f]{64}"$/);
+  });
+
+  it('returns 409 when If-Match revision is stale', async () => {
+    const deps = createDeps();
+    deps.config.runtime.apiWriteToken = 'write-token';
+    const handler = createApiFetch(deps);
+
+    const response = await handler(
+      new Request('http://localhost/api/config', {
+        method: 'PUT',
+        headers: {
+          Authorization: 'Bearer write-token',
+          'If-Match': '"deadbeef"',
+        },
+        body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: 'config revision conflict',
+    });
+    expect(response.headers.get('etag')).toMatch(/^"[0-9a-f]{64}"$/);
   });
 });
 


### PR DESCRIPTION
## Summary

- delivery ticket: `P13.04 If-Match Conflict Contract`
- ticket file: [docs/02-delivery/phase-13/ticket-04-if-match-conflict-contract.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-13/ticket-04-if-match-conflict-contract.md)
- stacked base branch: `agents/p13-03-auth-gated-config-write-endpoint`
- post-verify self-audit: completed at 2026-04-09 09:01 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`7e2d39434a26`](https://github.com/cesarnml/pirate_claw/commit/7e2d39434a26854df8825e5a8085716db13d9dfb)
- current branch head: [`7e2d39434a26`](https://github.com/cesarnml/pirate_claw/commit/7e2d39434a26854df8825e5a8085716db13d9dfb)
- vendors: `coderabbit`, `sonarqube`
