### PR TITLE
feat(web): add server-side runtime settings save flow [P13.05]

### DIFF
--- a/docs/02-delivery/phase-13/ticket-05-web-settings-server-save-flow.md
+++ b/docs/02-delivery/phase-13/ticket-05-web-settings-server-save-flow.md
@@ -24,4 +24,6 @@ Operators can submit runtime-only settings changes via server-side proxy flow, w
 
 ## Rationale
 
-To be completed during implementation with behavior/tradeoff notes.
+- Added a server-only `saveRuntime` action in `+page.server.ts` so browser clients never receive or submit the write token directly.
+- Save flow now forwards `If-Match` with the loaded config `ETag`, preserving optimistic concurrency semantics from the API layer.
+- Config route now includes runtime edit controls and explicit success/error alerts, giving operators clear save feedback without widening editable scope beyond runtime fields.

--- a/web/src/lib/server/api.ts
+++ b/web/src/lib/server/api.ts
@@ -1,11 +1,22 @@
 import { env } from '$env/dynamic/private';
 
-export async function apiFetch<T>(path: string): Promise<T> {
+export function buildApiUrl(path: string): string {
 	const baseUrl = (env.PIRATE_CLAW_API_URL ?? '').replace(/\/$/, '');
 	if (!baseUrl) {
 		throw new Error('PIRATE_CLAW_API_URL is required but not set');
 	}
-	const url = `${baseUrl}${path}`;
+	return `${baseUrl}${path}`;
+}
+
+export async function apiRequest(
+	path: string,
+	init?: Parameters<typeof fetch>[1]
+): Promise<Response> {
+	return fetch(buildApiUrl(path), init);
+}
+
+export async function apiFetch<T>(path: string): Promise<T> {
+	const url = buildApiUrl(path);
 	const res = await fetch(url);
 	if (!res.ok) {
 		throw new Error(`API request failed: ${res.status} ${res.statusText} — ${url}`);

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -142,6 +142,7 @@ export type RuntimeConfig = {
 	artifactDir: string;
 	artifactRetentionDays: number;
 	apiPort?: number;
+	tmdbRefreshIntervalMinutes?: number;
 };
 
 export type AppConfig = {

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -1,13 +1,111 @@
-import { apiFetch } from '$lib/server/api';
+import { env } from '$env/dynamic/private';
+import { fail } from '@sveltejs/kit';
+import { apiRequest } from '$lib/server/api';
 import type { AppConfig } from '$lib/types';
-import type { PageServerLoad } from './$types';
+import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
 	try {
-		const config = await apiFetch<AppConfig>('/api/config');
-		return { config, error: null };
+		const response = await apiRequest('/api/config');
+		if (!response.ok) {
+			throw new Error(`config load failed: ${response.status}`);
+		}
+
+		const config = (await response.json()) as AppConfig;
+		return {
+			config,
+			etag: response.headers.get('etag'),
+			error: null
+		};
 	} catch (err) {
 		console.error('[config] failed to load config:', err);
-		return { config: null as AppConfig | null, error: 'Could not reach the API.' };
+		return {
+			config: null as AppConfig | null,
+			etag: null as string | null,
+			error: 'Could not reach the API.'
+		};
+	}
+};
+
+function parseOptionalInt(input: unknown): number | undefined {
+	if (input === null || input === undefined) return undefined;
+	const raw = String(input).trim();
+	if (!raw) return undefined;
+	const value = Number(raw);
+	if (!Number.isFinite(value) || !Number.isInteger(value)) return Number.NaN;
+	return value;
+}
+
+export const actions: Actions = {
+	saveRuntime: async ({ request }) => {
+		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+		if (!writeToken) {
+			return fail(500, { message: 'Server write token is not configured.' });
+		}
+
+		const formData = await request.formData();
+		const ifMatch = String(formData.get('ifMatch') ?? '').trim();
+		if (!ifMatch) {
+			return fail(400, { message: 'Missing config revision. Reload and try again.' });
+		}
+
+		const runIntervalMinutes = parseOptionalInt(formData.get('runIntervalMinutes'));
+		const reconcileIntervalMinutes = parseOptionalInt(formData.get('reconcileIntervalMinutes'));
+		const tmdbRefreshIntervalMinutes = parseOptionalInt(formData.get('tmdbRefreshIntervalMinutes'));
+		const apiPort = parseOptionalInt(formData.get('apiPort'));
+
+		const invalidRuntimeField = [
+			runIntervalMinutes,
+			reconcileIntervalMinutes,
+			tmdbRefreshIntervalMinutes,
+			apiPort
+		].some((value) => Number.isNaN(value));
+		if (invalidRuntimeField) {
+			return fail(400, { message: 'Runtime fields must be whole numbers.' });
+		}
+
+		const payload = {
+			runtime: {
+				runIntervalMinutes,
+				reconcileIntervalMinutes,
+				tmdbRefreshIntervalMinutes: tmdbRefreshIntervalMinutes ?? 0,
+				...(apiPort === undefined ? {} : { apiPort })
+			}
+		};
+
+		try {
+			const response = await apiRequest('/api/config', {
+				method: 'PUT',
+				headers: {
+					'content-type': 'application/json',
+					authorization: `Bearer ${writeToken}`,
+					'if-match': ifMatch
+				},
+				body: JSON.stringify(payload)
+			});
+
+			if (!response.ok) {
+				let message = `Save failed (${response.status}).`;
+				try {
+					const body = (await response.json()) as { error?: string };
+					if (body.error) message = body.error;
+				} catch {
+					// keep fallback message
+				}
+				return fail(response.status, {
+					message,
+					etag: response.headers.get('etag')
+				});
+			}
+
+			return {
+				success: true,
+				message: 'Settings saved.',
+				etag: response.headers.get('etag')
+			};
+		} catch (error) {
+			console.error('[config] save failed:', error);
+			return fail(500, { message: 'Could not save settings.' });
+		}
 	}
 };

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
+	import { enhance } from '$app/forms';
 	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
 	import { Card, CardContent, CardHeader } from '$lib/components/ui/card';
-	import type { PageData } from './$types';
+	import type { ActionData, PageData } from './$types';
 
-	const { data }: { data: PageData } = $props();
+	const { data, form }: { data: PageData; form?: ActionData } = $props();
+	const currentEtag = $derived(form?.etag ?? data.etag ?? null);
 </script>
 
 <h1 class="text-3xl font-bold tracking-tight">Config</h1>
 <p class="text-muted-foreground mt-1 text-sm">
-	Read-only effective configuration from the API (secrets redacted).
+	Effective configuration from the API (secrets redacted). Runtime fields can be edited and saved.
 </p>
 
 {#if data.error}
@@ -20,6 +22,13 @@
 	{@const config = data.config}
 
 	<div class="mt-8 space-y-6 pr-1">
+		{#if form?.message}
+			<Alert variant={form?.success ? 'default' : 'destructive'}>
+				<AlertTitle>{form?.success ? 'Save complete' : 'Save failed'}</AlertTitle>
+				<AlertDescription>{form.message}</AlertDescription>
+			</Alert>
+		{/if}
+
 		<Card>
 			<CardHeader class="pb-3">
 				<h2 class="text-lg font-semibold tracking-tight">Feeds</h2>
@@ -149,30 +158,82 @@
 				<h2 class="text-lg font-semibold tracking-tight">Runtime</h2>
 			</CardHeader>
 			<CardContent class="pt-0">
-				<dl class="grid gap-2 text-sm">
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">Run interval:</dt>
-						<dd class="text-foreground">{config.runtime.runIntervalMinutes}m</dd>
+				<form method="POST" action="?/saveRuntime" use:enhance class="grid gap-4 text-sm">
+					<input type="hidden" name="ifMatch" value={currentEtag ?? ''} />
+
+					<div class="grid gap-1">
+						<label class="text-muted-foreground" for="runIntervalMinutes"
+							>Run interval (minutes)</label
+						>
+						<input
+							id="runIntervalMinutes"
+							name="runIntervalMinutes"
+							type="number"
+							min="1"
+							step="1"
+							value={config.runtime.runIntervalMinutes}
+							class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+						/>
 					</div>
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">Reconcile interval:</dt>
-						<dd class="text-foreground">{config.runtime.reconcileIntervalMinutes}m</dd>
+
+					<div class="grid gap-1">
+						<label class="text-muted-foreground" for="reconcileIntervalMinutes">
+							Reconcile interval (minutes)
+						</label>
+						<input
+							id="reconcileIntervalMinutes"
+							name="reconcileIntervalMinutes"
+							type="number"
+							min="1"
+							step="1"
+							value={config.runtime.reconcileIntervalMinutes}
+							class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+						/>
 					</div>
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">Artifact dir:</dt>
-						<dd class="text-foreground">{config.runtime.artifactDir}</dd>
+
+					<div class="grid gap-1">
+						<label class="text-muted-foreground" for="tmdbRefreshIntervalMinutes">
+							TMDB refresh interval (minutes, 0 disables)
+						</label>
+						<input
+							id="tmdbRefreshIntervalMinutes"
+							name="tmdbRefreshIntervalMinutes"
+							type="number"
+							min="0"
+							step="1"
+							value={config.runtime.tmdbRefreshIntervalMinutes ?? 0}
+							class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+						/>
 					</div>
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">Artifact retention:</dt>
-						<dd class="text-foreground">{config.runtime.artifactRetentionDays} days</dd>
+
+					<div class="grid gap-1">
+						<label class="text-muted-foreground" for="apiPort">API port (optional)</label>
+						<input
+							id="apiPort"
+							name="apiPort"
+							type="number"
+							min="1"
+							max="65535"
+							step="1"
+							value={config.runtime.apiPort ?? ''}
+							placeholder="unset"
+							class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+						/>
 					</div>
-					{#if config.runtime.apiPort !== undefined}
-						<div class="flex flex-wrap gap-2">
-							<dt class="text-muted-foreground">API port:</dt>
-							<dd class="text-foreground">{config.runtime.apiPort}</dd>
-						</div>
-					{/if}
-				</dl>
+
+					<div class="text-muted-foreground text-xs">
+						Revision: <code>{currentEtag ?? 'missing'}</code>
+					</div>
+					<div>
+						<button
+							type="submit"
+							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium"
+							disabled={!currentEtag}
+						>
+							Save runtime settings
+						</button>
+					</div>
+				</form>
 			</CardContent>
 		</Card>
 	</div>

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -41,7 +41,7 @@ const mockConfig: AppConfig = {
 
 describe('/config', () => {
 	it('renders config sections with mock data', () => {
-		render(Page, { data: { config: mockConfig, error: null } });
+		render(Page, { data: { config: mockConfig, error: null, etag: '"rev-1"' }, form: undefined });
 		expect(screen.getByRole('heading', { name: 'Feeds' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'TV Rules' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Movies' })).toBeInTheDocument();
@@ -49,10 +49,14 @@ describe('/config', () => {
 		expect(screen.getByRole('heading', { name: 'Runtime' })).toBeInTheDocument();
 		expect(screen.getByText('TestFeed')).toBeInTheDocument();
 		expect(screen.getByText('hd-tv')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Save runtime settings' })).toBeInTheDocument();
 	});
 
 	it('renders error state when API is unreachable', () => {
-		render(Page, { data: { config: null, error: 'Could not reach the API.' } });
+		render(Page, {
+			data: { config: null, error: 'Could not reach the API.', etag: null },
+			form: undefined
+		});
 		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
 	});
 
@@ -60,10 +64,20 @@ describe('/config', () => {
 		render(Page, {
 			data: {
 				config: { ...mockConfig, feeds: [], tv: [] },
-				error: null
-			}
+				error: null,
+				etag: '"rev-1"'
+			},
+			form: undefined
 		});
 		expect(screen.getByText('No feeds configured.')).toBeInTheDocument();
 		expect(screen.getByText('No TV rules configured.')).toBeInTheDocument();
+	});
+
+	it('renders save error message from action data', () => {
+		render(Page, {
+			data: { config: mockConfig, error: null, etag: '"rev-1"' },
+			form: { message: 'config revision conflict' }
+		});
+		expect(screen.getByRole('alert')).toHaveTextContent('config revision conflict');
 	});
 });


### PR DESCRIPTION
## Summary

- delivery ticket: `P13.05 Web Settings Server-Side Save Flow`
- ticket file: [docs/02-delivery/phase-13/ticket-05-web-settings-server-save-flow.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-13/ticket-05-web-settings-server-save-flow.md)
- stacked base branch: `agents/p13-04-if-match-conflict-contract`
- post-verify self-audit: completed at 2026-04-09 09:20 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`05c6513d3fae`](https://github.com/cesarnml/pirate_claw/commit/05c6513d3faef73bf91f13768ac5818a717b7b91)
- current branch head: [`05c6513d3fae`](https://github.com/cesarnml/pirate_claw/commit/05c6513d3faef73bf91f13768ac5818a717b7b91)
- vendors: `sonarqube`
