### PR TITLE
feat(web): add restart messaging and strict settings guards [P13.06]

### DIFF
--- a/docs/02-delivery/phase-13/ticket-06-restart-ux-and-bounded-guards.md
+++ b/docs/02-delivery/phase-13/ticket-06-restart-ux-and-bounded-guards.md
@@ -25,4 +25,6 @@ Settings UX communicates restart requirement clearly, runtime-only guardrails ar
 
 ## Rationale
 
-To be completed during implementation with behavior/tradeoff notes.
+- Save success messaging now explicitly states that daemon restart is required before runtime changes apply, reducing operator ambiguity.
+- Added strict form-field allowlisting in the server action so out-of-scope fields are rejected before proxying to the daemon API.
+- Expanded route tests to cover success/restart messaging and server-side out-of-scope field rejection behavior.

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -36,6 +36,34 @@ function parseOptionalInt(input: unknown): number | undefined {
 	return value;
 }
 
+function validateRuntimeBounds(
+	field: string,
+	value: number | undefined
+): { ok: true } | { ok: false; message: string } {
+	if (value === undefined) return { ok: true };
+	if (!Number.isInteger(value)) {
+		return { ok: false, message: `Field "${field}" has invalid value.` };
+	}
+
+	if (field === 'runIntervalMinutes' || field === 'reconcileIntervalMinutes') {
+		return value > 0 ? { ok: true } : { ok: false, message: `Field "${field}" has invalid value.` };
+	}
+
+	if (field === 'tmdbRefreshIntervalMinutes') {
+		return value >= 0
+			? { ok: true }
+			: { ok: false, message: `Field "${field}" has invalid value.` };
+	}
+
+	if (field === 'apiPort') {
+		return value >= 1 && value <= 65535
+			? { ok: true }
+			: { ok: false, message: `Field "${field}" has invalid value.` };
+	}
+
+	return { ok: true };
+}
+
 export const actions: Actions = {
 	saveRuntime: async ({ request }) => {
 		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
@@ -75,6 +103,18 @@ export const actions: Actions = {
 		].some((value) => Number.isNaN(value));
 		if (invalidRuntimeField) {
 			return fail(400, { message: 'Runtime fields must be whole numbers.' });
+		}
+
+		for (const [field, value] of [
+			['runIntervalMinutes', runIntervalMinutes],
+			['reconcileIntervalMinutes', reconcileIntervalMinutes],
+			['tmdbRefreshIntervalMinutes', tmdbRefreshIntervalMinutes],
+			['apiPort', apiPort]
+		] as const) {
+			const result = validateRuntimeBounds(field, value);
+			if (!result.ok) {
+				return fail(400, { message: result.message });
+			}
 		}
 
 		const payload = {

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -44,6 +44,19 @@ export const actions: Actions = {
 		}
 
 		const formData = await request.formData();
+		const allowedFields = new Set([
+			'ifMatch',
+			'runIntervalMinutes',
+			'reconcileIntervalMinutes',
+			'tmdbRefreshIntervalMinutes',
+			'apiPort'
+		]);
+		for (const key of formData.keys()) {
+			if (!allowedFields.has(key)) {
+				return fail(400, { message: `Field "${key}" is not allowed.` });
+			}
+		}
+
 		const ifMatch = String(formData.get('ifMatch') ?? '').trim();
 		if (!ifMatch) {
 			return fail(400, { message: 'Missing config revision. Reload and try again.' });
@@ -100,7 +113,7 @@ export const actions: Actions = {
 
 			return {
 				success: true,
-				message: 'Settings saved.',
+				message: 'Settings saved. Restart the daemon for changes to take effect.',
 				etag: response.headers.get('etag')
 			};
 		} catch (error) {

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -224,6 +224,10 @@
 					<div class="text-muted-foreground text-xs">
 						Revision: <code>{currentEtag ?? 'missing'}</code>
 					</div>
+					<p class="text-muted-foreground text-xs">
+						Saving writes config only. Restart the daemon process to apply new runtime intervals and
+						port changes.
+					</p>
 					<div>
 						<button
 							type="submit"

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -80,4 +80,23 @@ describe('/config', () => {
 		});
 		expect(screen.getByRole('alert')).toHaveTextContent('config revision conflict');
 	});
+
+	it('renders restart-required success messaging', () => {
+		render(Page, {
+			data: { config: mockConfig, error: null, etag: '"rev-1"' },
+			form: {
+				success: true,
+				message: 'Settings saved. Restart the daemon for changes to take effect.',
+				etag: '"rev-2"'
+			}
+		});
+		expect(screen.getByRole('status')).toHaveTextContent(
+			'Restart the daemon for changes to take effect'
+		);
+		expect(
+			screen.getByText(
+				/Restart the daemon process to apply new runtime intervals and port changes/i
+			)
+		).toBeInTheDocument();
+	});
 });

--- a/web/src/routes/config/page.server.test.ts
+++ b/web/src/routes/config/page.server.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('$env/dynamic/private', () => ({
+	env: {
+		PIRATE_CLAW_API_WRITE_TOKEN: 'write-token'
+	}
+}));
+
+const apiRequestMock = vi.fn();
+vi.mock('$lib/server/api', () => ({
+	apiRequest: apiRequestMock
+}));
+
+describe('config page server actions', () => {
+	it('rejects out-of-scope fields before API call', async () => {
+		const { actions } = await import('./+page.server');
+		apiRequestMock.mockReset();
+
+		const body = new URLSearchParams();
+		body.set('ifMatch', '"rev-1"');
+		body.set('runIntervalMinutes', '15');
+		body.set('feeds', '[]');
+
+		const result = await actions.saveRuntime({
+			request: new Request('http://localhost/config', {
+				method: 'POST',
+				headers: { 'content-type': 'application/x-www-form-urlencoded' },
+				body
+			})
+		} as never);
+
+		expect((result as { status?: number }).status).toBe(400);
+		expect((result as { data?: { message?: string } }).data?.message).toContain('not allowed');
+		expect(apiRequestMock).not.toHaveBeenCalled();
+	});
+});

--- a/web/src/routes/config/page.server.test.ts
+++ b/web/src/routes/config/page.server.test.ts
@@ -33,4 +33,27 @@ describe('config page server actions', () => {
 		expect((result as { data?: { message?: string } }).data?.message).toContain('not allowed');
 		expect(apiRequestMock).not.toHaveBeenCalled();
 	});
+
+	it('rejects out-of-range runtime values', async () => {
+		const { actions } = await import('./+page.server');
+		apiRequestMock.mockReset();
+
+		const body = new URLSearchParams();
+		body.set('ifMatch', '"rev-1"');
+		body.set('runIntervalMinutes', '0');
+
+		const result = await actions.saveRuntime({
+			request: new Request('http://localhost/config', {
+				method: 'POST',
+				headers: { 'content-type': 'application/x-www-form-urlencoded' },
+				body
+			})
+		} as never);
+
+		expect((result as { status?: number }).status).toBe(400);
+		expect((result as { data?: { message?: string } }).data?.message).toContain(
+			'runIntervalMinutes'
+		);
+		expect(apiRequestMock).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
## Summary

- delivery ticket: `P13.06 Restart UX and Bounded Field Guards`
- ticket file: [docs/02-delivery/phase-13/ticket-06-restart-ux-and-bounded-guards.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-13/ticket-06-restart-ux-and-bounded-guards.md)
- stacked base branch: `agents/p13-05-web-settings-server-side-save-flow`
- post-verify self-audit: completed at 2026-04-09 09:28 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`07197a217a35`](https://github.com/cesarnml/pirate_claw/commit/07197a217a35d4b8294d28a385663a4b4402f11b)
- current branch head: [`a8775a3ca537`](https://github.com/cesarnml/pirate_claw/commit/a8775a3ca5374b7405185d6ff54ec6d86ae59d05)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `07197a217a35` address all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Enforce server-side numeric bounds, not just field allowlisting. (native GitHub thread resolved) `web/src/routes/config/+page.server.ts:58` [thread](https://github.com/cesarnml/pirate_claw/pull/114#discussion_r3056836533)
