### PR TITLE
docs: close phase 13 operator documentation loop [P13.07]

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ It currently supports:
 - status inspection and retry of failed submissions
 - effective config inspection through `pirate-claw config show`
 - env-backed Transmission credentials via process env or `.env`
-- read-only daemon HTTP API for external consumers when `runtime.apiPort` is configured
+- daemon HTTP API with read endpoints and bounded opt-in runtime config writes when `runtime.apiPort` is configured
 - optional TMDB-backed posters, ratings, and metadata on API and dashboard when a `tmdb` API key is configured (see `pirate-claw.config.example.json`)
-- read-only browser dashboard (SvelteKit app in `web/`) that talks to the daemon HTTP API (Phase 10)
+- browser dashboard (SvelteKit app in `web/`) with read views plus bounded runtime Settings save flow (Phase 13)
 
 ## Commands
 
@@ -80,7 +80,7 @@ High-level config shape:
 - `tv`: either the legacy per-show rule array or a compact `defaults + shows` object
 - `movies`: global movie intake policy
 - `transmission`: local Transmission RPC settings (optional `downloadDirs` for per-media-type download directories)
-- `runtime`: daemon scheduling and artifact settings (optional, all fields have defaults; `apiPort` enables the HTTP API; `tmdbRefreshIntervalMinutes` controls background TMDB cache refresh, default 360 minutes, `0` disables)
+- `runtime`: daemon scheduling and artifact settings (optional, all fields have defaults; `apiPort` enables the HTTP API; `tmdbRefreshIntervalMinutes` controls background TMDB cache refresh, default 360 minutes, `0` disables; `apiWriteToken` opt-in enables bounded config writes)
 - `tmdb`: optional TMDB API key (`apiKey` or env `PIRATE_CLAW_TMDB_API_KEY`) and optional cache TTL overrides
 
 Example:
@@ -227,6 +227,7 @@ When `runtime.apiPort` is omitted, no HTTP listener starts.
 | `GET /api/movies`     | Movie candidates sorted by title                           |
 | `GET /api/feeds`      | Feed config with poll state and `isDue` status             |
 | `GET /api/config`     | Effective config with Transmission credentials redacted    |
+| `PUT /api/config`     | Bounded runtime config write (token + `If-Match` required) |
 
 ### Example
 
@@ -248,7 +249,15 @@ curl http://localhost:3000/api/health
 }
 ```
 
-All endpoints are read-only. No endpoint mutates daemon state. There is no authentication in this version — it is designed for private NAS networks.
+Write behavior is intentionally bounded:
+
+- writes are disabled unless `runtime.apiWriteToken` (or env `PIRATE_CLAW_API_WRITE_TOKEN`) is configured
+- `PUT /api/config` requires `Authorization: Bearer <token>`
+- `PUT /api/config` requires `If-Match` with the latest `ETag` from `GET /api/config` (`409` on stale revisions)
+- only approved runtime fields are writable through this path in v1
+- writes are atomic file updates
+
+Dashboard Settings uses a server-side SvelteKit action for writes, so the token stays server-only. After a successful save, restart the daemon process for runtime changes to take effect.
 
 Candidate, show, and movie payloads include TMDB fields when a match exists in the local cache; otherwise they fall back to Phase-10-style local data.
 

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -370,7 +370,7 @@ Goal:
 
 Current status:
 
-- product definition only — see [`docs/01-product/phase-13-daemon-config-write-api-and-settings.md`](../01-product/phase-13-daemon-config-write-api-and-settings.md)
+- implemented on `main` via `P13.01`-`P13.07` stacked delivery
 
 Committed scope:
 

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -10,7 +10,7 @@ Its job is to answer three questions quickly:
 
 ## Current Repo State
 
-Pirate Claw is implemented through **Phase 11** on `main` (product phases 01–11; see [`roadmap.md`](./roadmap.md)). Delivery artifacts and tickets for Phase 11 live under [`docs/02-delivery/phase-11/`](../02-delivery/phase-11/). **Phase 12** (dashboard design system and read-only UI) is delivered as a stacked PR phase; see [`docs/02-delivery/phase-12/implementation-plan.md`](../02-delivery/phase-12/implementation-plan.md). Product definitions for **Phase 13** (bounded config write API and Settings) and **Phase 14** (feeds/rules UI placeholder) live under [`docs/01-product/`](../01-product/). Phases **13–14** are **not yet implemented** in code.
+Pirate Claw is implemented through **Phase 13** on `main` (product phases 01–13; see [`roadmap.md`](./roadmap.md)). Delivery artifacts for Phases 12 and 13 live under [`docs/02-delivery/`](../02-delivery/). Product definition for **Phase 14** (feeds/rules UI placeholder) lives under [`docs/01-product/`](../01-product/). Phase **14** is **not yet implemented** in code.
 
 Current delivered surface:
 
@@ -28,7 +28,7 @@ Current delivered surface:
 - movie codec policy mode via `movies.codecPolicy` (`prefer` by default, `require` for strict matching)
 - queue-time Transmission `movie` / `tv` labels with warning+retry fallback when labels are unsupported
 - per-media-type Transmission download directories via `transmission.downloadDirs`
-- read-only SvelteKit dashboard in `web/` that consumes the daemon HTTP API (run the daemon with `runtime.apiPort`, then `bun run --cwd web dev` or the production build)
+- SvelteKit dashboard in `web/` that consumes the daemon HTTP API, including bounded runtime Settings writes through server-side actions
 - optional TMDB enrichment: `tmdb` config block and/or `PIRATE_CLAW_TMDB_API_KEY`, SQLite-backed cache, lazy enrichment on API reads, and an optional daemon background refresh cadence via `runtime.tmdbRefreshIntervalMinutes` (default 6 hours; set `0` to disable)
 
 Current product boundary:
@@ -47,7 +47,7 @@ Current product boundary:
 
 Still deferred:
 
-- full feeds and rules authoring through the web UI (see Phase 14 placeholder; bounded runtime Settings planned for Phase 13)
+- full feeds and rules authoring through the web UI (see Phase 14 placeholder)
 - remote feed capture
 - hosted persistence
 - download renaming or organization rules

--- a/docs/02-delivery/phase-13/ticket-07-docs-env-example-and-phase-exit.md
+++ b/docs/02-delivery/phase-13/ticket-07-docs-env-example-and-phase-exit.md
@@ -27,4 +27,6 @@ Operator-facing and phase-status docs accurately reflect shipped Phase 13 behavi
 
 ## Rationale
 
-To be completed during implementation with behavior/tradeoff notes.
+- `.env.example` already contains `PIRATE_CLAW_API_WRITE_TOKEN`, so ticket closeout focused on clarifying operator behavior and phase status docs rather than duplicating env-surface edits.
+- Updated README and overview docs to reflect shipped Phase 13 semantics: token-gated bounded writes, `If-Match` conflict safety, and restart-required runtime apply behavior.
+- Marked Phase 13 as implemented in roadmap/index docs so new threads do not treat Settings write flow as future work.

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ Phase-level product definitions.
 - `phase-10-read-only-dashboard.md`: SvelteKit browser-based read-only dashboard
 - `phase-11-tmdb-metadata-enrichment.md`: TMDB ratings, posters, and metadata enrichment
 - `phase-12-dashboard-design-system-and-read-ui.md`: shadcn-svelte dashboard redesign (read-only; delivered via stacked PRs)
-- `phase-13-daemon-config-write-api-and-settings.md`: bounded config write API and Settings (not yet implemented)
+- `phase-13-daemon-config-write-api-and-settings.md`: bounded config write API and Settings (implemented)
 - `phase-14-feeds-rules-ui-placeholder.md`: future feeds/rules UI scope (placeholder only)
 
 ### `02-delivery`


### PR DESCRIPTION
## Summary

- delivery ticket: `P13.07 Docs, Env Example, and Phase Exit`
- ticket file: [docs/02-delivery/phase-13/ticket-07-docs-env-example-and-phase-exit.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-13/ticket-07-docs-env-example-and-phase-exit.md)
- stacked base branch: `agents/p13-06-restart-ux-and-bounded-field-guards`
- post-verify self-audit: completed at 2026-04-09 09:41 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`bab03646f3b6`](https://github.com/cesarnml/pirate_claw/commit/bab03646f3b62b01abf89b6f0f4cbb82edf8e78f)
- current branch head: [`bab03646f3b6`](https://github.com/cesarnml/pirate_claw/commit/bab03646f3b62b01abf89b6f0f4cbb82edf8e78f)
- vendors: `coderabbit`, `sonarqube`
