### PR TITLE
feat(config): TV show list save from dashboard and daemon config refresh

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -327,6 +327,18 @@ export function createApiFetch(
           );
         }
 
+        const oldShows = tvDisk.shows;
+        if (!Array.isArray(oldShows)) {
+          throw new ConfigError(
+            'Config file "config tv shows" must be an array.',
+          );
+        }
+
+        const mergedShows = mergeTvShowsPreservingDiskEntries(
+          showsStrings,
+          oldShows,
+        );
+
         const merged = {
           ...baseOnDisk,
           runtime: {
@@ -335,7 +347,7 @@ export function createApiFetch(
           },
           tv: {
             defaults: defaultsOnDisk,
-            shows: showsStrings,
+            shows: mergedShows,
           },
         };
 
@@ -531,6 +543,46 @@ function writeConfigAtomically(
 
 function isRecord(input: unknown): input is Record<string, unknown> {
   return typeof input === 'object' && input !== null && !Array.isArray(input);
+}
+
+/**
+ * Build on-disk `tv.shows` from API name strings. When the previous file had a
+ * matching show name, keep the existing entry (string or object) so per-show
+ * fields edited only on disk are not dropped.
+ */
+function mergeTvShowsPreservingDiskEntries(
+  namesInOrder: string[],
+  oldShows: unknown[],
+): unknown[] {
+  const byName = new Map<string, unknown>();
+  for (const entry of oldShows) {
+    if (typeof entry === 'string') {
+      const trimmed = entry.trim();
+      if (trimmed) {
+        byName.set(trimmed, entry);
+      }
+    } else if (isRecord(entry) && typeof entry.name === 'string') {
+      const trimmed = entry.name.trim();
+      if (trimmed) {
+        byName.set(trimmed, entry);
+      }
+    }
+  }
+
+  const next: unknown[] = [];
+  for (const name of namesInOrder) {
+    const prev = byName.get(name);
+    if (prev === undefined) {
+      next.push(name);
+    } else if (typeof prev === 'string') {
+      next.push(name);
+    } else if (isRecord(prev)) {
+      next.push({ ...prev, name });
+    } else {
+      next.push(name);
+    }
+  }
+  return next;
 }
 
 function expectRecord(input: unknown, label: string): Record<string, unknown> {

--- a/src/api.ts
+++ b/src/api.ts
@@ -67,6 +67,11 @@ export type ApiFetchDeps = {
   repository: Repository;
   health: HealthState;
   config: AppConfig;
+  /**
+   * When set, successful PUT /api/config assigns `current` to the validated config
+   * so the daemon process can read the same object as the API (in-process refresh).
+   */
+  configHolder?: { current: AppConfig };
   configPath: string;
   pollStatePath: string;
   loadPollState: (path: string) => PollState;
@@ -109,6 +114,7 @@ export function createApiFetch(
     repository,
     health,
     config,
+    configHolder,
     configPath,
     pollStatePath,
     loadPollState,
@@ -117,7 +123,7 @@ export function createApiFetch(
     tmdbCache,
     onCandidateTmdbCacheError,
   } = deps;
-  let activeConfig = config;
+  let activeConfig = configHolder?.current ?? config;
 
   return async (request: Request) => {
     const path = new URL(request.url).pathname;
@@ -248,29 +254,97 @@ export function createApiFetch(
 
       try {
         const patch = expectRecord(body, 'request body');
-        const runtimePatch = requireRecord(patch, 'runtime', 'request body');
 
-        // Runtime-only updates for now; non-runtime updates are out-of-scope in this phase.
         for (const key of Object.keys(patch)) {
-          if (key !== 'runtime') {
+          if (key !== 'runtime' && key !== 'tv') {
             throw new ConfigError(
-              `Config file "request body ${key}" is not writable; only "runtime" is supported.`,
+              `Config file "request body ${key}" is not writable; only "runtime" and "tv" are supported.`,
+            );
+          }
+        }
+        if (!('runtime' in patch)) {
+          throw new ConfigError(
+            'Config file "request body" must include "runtime".',
+          );
+        }
+        if (!('tv' in patch)) {
+          throw new ConfigError(
+            'Config file "request body" must include "tv".',
+          );
+        }
+
+        const runtimePatch = requireRecord(patch, 'runtime', 'request body');
+        const tvPatch = requireRecord(patch, 'tv', 'request body');
+
+        for (const key of Object.keys(tvPatch)) {
+          if (key !== 'shows') {
+            throw new ConfigError(
+              `Config file "request body tv" only allows "shows"; "${key}" is not writable via the API.`,
             );
           }
         }
 
+        const rawShows = tvPatch.shows;
+        if (!Array.isArray(rawShows)) {
+          throw new ConfigError(
+            'Config file "request body tv shows" must be an array of string show names.',
+          );
+        }
+        if (rawShows.length < 1) {
+          throw new ConfigError(
+            'Config file "request body tv shows" must include at least one show.',
+          );
+        }
+
+        const showsStrings: string[] = [];
+        for (let i = 0; i < rawShows.length; i++) {
+          const entry = rawShows[i];
+          if (typeof entry !== 'string') {
+            throw new ConfigError(
+              `Config file "request body tv shows[${i}]" must be a string show name.`,
+            );
+          }
+          const trimmed = entry.trim();
+          if (!trimmed) {
+            throw new ConfigError(
+              `Config file "request body tv shows[${i}]" must be a non-empty show name.`,
+            );
+          }
+          showsStrings.push(trimmed);
+        }
+
         const baseOnDisk = await readConfigFileRecord(configPath);
+        const tvDisk = baseOnDisk.tv;
+        if (!isRecord(tvDisk)) {
+          throw new ConfigError(
+            'Config file "config tv" must be an object with "defaults" and "shows".',
+          );
+        }
+        const defaultsOnDisk = tvDisk.defaults;
+        if (!isRecord(defaultsOnDisk)) {
+          throw new ConfigError(
+            'Config file "config tv defaults" must be an object; edit the config file to change defaults.',
+          );
+        }
+
         const merged = {
           ...baseOnDisk,
           runtime: {
             ...(isRecord(baseOnDisk.runtime) ? baseOnDisk.runtime : {}),
             ...runtimePatch,
           },
+          tv: {
+            defaults: defaultsOnDisk,
+            shows: showsStrings,
+          },
         };
 
         const validated = validateConfig(merged, 'config');
         writeConfigAtomically(configPath, merged);
         activeConfig = validated;
+        if (configHolder) {
+          configHolder.current = validated;
+        }
 
         const redacted = redactConfig(activeConfig);
         return Response.json(redacted, {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -201,14 +201,17 @@ export async function runCli(argv: string[]): Promise<number> {
         const scheduleTmdbRefresh =
           (tmdbMovies || tmdbShows) && tmdbRefreshIntervalMinutes > 0;
 
+        const configHolder = { current: config };
+
         await runDaemonLoop({
           runCycle: async () => {
+            const active = configHolder.current;
             let pollState = loadPollState(pollStatePath);
             const now = Date.now();
             const dueFeeds = filterDueFeeds(
-              config.feeds,
+              active.feeds,
               pollState,
-              config.runtime,
+              active.runtime,
               now,
             );
 
@@ -218,7 +221,7 @@ export async function runCli(argv: string[]): Promise<number> {
             }
 
             const result = await runPipeline({
-              config: { ...config, feeds: dueFeeds },
+              config: { ...active, feeds: dueFeeds },
               repository,
               downloader,
             });
@@ -262,6 +265,7 @@ export async function runCli(argv: string[]): Promise<number> {
                   repository,
                   health,
                   config,
+                  configHolder,
                   configPath: resolvedConfigPath,
                   pollStatePath,
                   loadPollState,

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -692,6 +692,92 @@ describe('PUT /api/config', () => {
     }
   });
 
+  it('preserves per-show objects from disk when names match', async () => {
+    const prevWrite = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    try {
+      const directory = await mkdtemp(
+        join(tmpdir(), 'pirate-claw-api-config-'),
+      );
+      const configPath = join(directory, 'pirate-claw.config.json');
+      const doc = {
+        feeds: [
+          {
+            name: 'TV Feed',
+            url: 'https://example.test/tv.rss',
+            mediaType: 'tv',
+          },
+        ],
+        tv: {
+          defaults: { resolutions: ['1080p'], codecs: ['x265'] },
+          shows: ['Alpha', { name: 'Beta', matchPattern: 'beta-pattern' }],
+        },
+        movies: {
+          years: [2024],
+          resolutions: ['1080p'],
+          codecs: ['x265'],
+          codecPolicy: 'prefer',
+        },
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+        },
+        runtime: {
+          runIntervalMinutes: 30,
+          reconcileIntervalMinutes: 1,
+          artifactDir: '.pirate-claw/runtime',
+          artifactRetentionDays: 7,
+          apiWriteToken: 'write-token',
+        },
+      };
+      await Bun.write(configPath, `${JSON.stringify(doc, null, 2)}\n`);
+      const loaded = await loadConfig(configPath);
+      const deps = createDeps();
+      deps.config = loaded;
+      deps.configPath = configPath;
+
+      const handler = createApiFetch(deps);
+      const get = await handler(new Request('http://localhost/api/config'));
+      const etag = get.headers.get('etag')!;
+
+      const put = await handler(
+        new Request('http://localhost/api/config', {
+          method: 'PUT',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer write-token',
+            'if-match': etag,
+          },
+          body: JSON.stringify({
+            runtime: {
+              runIntervalMinutes: 30,
+              reconcileIntervalMinutes: 1,
+              tmdbRefreshIntervalMinutes: 0,
+            },
+            tv: {
+              shows: ['Alpha', 'Beta'],
+            },
+          }),
+        }),
+      );
+
+      expect(put.status).toBe(200);
+      const disk = await Bun.file(configPath).json();
+      expect(disk.tv.shows[0]).toBe('Alpha');
+      expect(disk.tv.shows[1]).toEqual({
+        name: 'Beta',
+        matchPattern: 'beta-pattern',
+      });
+    } finally {
+      if (prevWrite !== undefined) {
+        process.env.PIRATE_CLAW_API_WRITE_TOKEN = prevWrite;
+      } else {
+        delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+      }
+    }
+  });
+
   it('rejects tv.defaults in the request body', async () => {
     const prevWrite = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
     delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,8 +1,8 @@
 import { Database } from 'bun:sqlite';
-import { describe, expect, it } from 'bun:test';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { describe, expect, it } from 'bun:test';
 
 import {
   type ApiFetchDeps,
@@ -15,6 +15,7 @@ import {
   redactConfig,
 } from '../src/api';
 import type { AppConfig } from '../src/config';
+import { loadConfig } from '../src/config';
 import type { PollState } from '../src/poll-state';
 import type { CandidateStateRecord, Repository } from '../src/repository';
 import type { CycleResult } from '../src/runtime-artifacts';
@@ -82,6 +83,41 @@ function createDeps(overrides: Partial<Repository> = {}): ApiFetchDeps {
     pollStatePath: '/nonexistent/poll-state.json',
     loadPollState: () => emptyPollState,
   };
+}
+
+async function writeCompactTvConfigFile(path: string): Promise<void> {
+  const doc = {
+    feeds: [
+      {
+        name: 'TV Feed',
+        url: 'https://example.test/tv.rss',
+        mediaType: 'tv',
+      },
+    ],
+    tv: {
+      defaults: { resolutions: ['1080p'], codecs: ['x265'] },
+      shows: ['Example Show'],
+    },
+    movies: {
+      years: [2024],
+      resolutions: ['1080p'],
+      codecs: ['x265'],
+      codecPolicy: 'prefer',
+    },
+    transmission: {
+      url: 'http://localhost:9091/transmission/rpc',
+      username: 'user',
+      password: 'pass',
+    },
+    runtime: {
+      runIntervalMinutes: 30,
+      reconcileIntervalMinutes: 1,
+      artifactDir: '.pirate-claw/runtime',
+      artifactRetentionDays: 7,
+      apiWriteToken: 'write-token',
+    },
+  };
+  await Bun.write(path, `${JSON.stringify(doc, null, 2)}\n`);
 }
 
 describe('createApiFetch', () => {
@@ -593,229 +629,167 @@ describe('GET /api/config', () => {
 });
 
 describe('PUT /api/config', () => {
-  it('returns 403 when config writes are disabled', async () => {
-    const deps = createDeps();
-    deps.config.runtime.apiWriteToken = undefined;
-    const handler = createApiFetch(deps);
+  it('persists runtime and tv.shows and updates configHolder', async () => {
+    const prevWrite = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    try {
+      const directory = await mkdtemp(
+        join(tmpdir(), 'pirate-claw-api-config-'),
+      );
+      const configPath = join(directory, 'pirate-claw.config.json');
+      await writeCompactTvConfigFile(configPath);
+      const loaded = await loadConfig(configPath);
+      const holder = { current: loaded };
+      const deps = createDeps();
+      deps.config = loaded;
+      deps.configHolder = holder;
+      deps.configPath = configPath;
 
-    const response = await handler(
-      new Request('http://localhost/api/config', {
-        method: 'PUT',
-        headers: { Authorization: 'Bearer any-token' },
-        body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
-      }),
-    );
+      const handler = createApiFetch(deps);
+      const get = await handler(new Request('http://localhost/api/config'));
+      const etag = get.headers.get('etag')!;
 
-    expect(response.status).toBe(403);
-    expect(await response.json()).toEqual({
-      error: 'config writes are disabled',
-    });
-  });
-
-  it('returns 401 when bearer token is missing', async () => {
-    const deps = createDeps();
-    deps.config.runtime.apiWriteToken = 'write-token';
-    const handler = createApiFetch(deps);
-
-    const response = await handler(
-      new Request('http://localhost/api/config', {
-        method: 'PUT',
-        body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
-      }),
-    );
-
-    expect(response.status).toBe(401);
-    expect(await response.json()).toEqual({ error: 'missing bearer token' });
-  });
-
-  it('returns 403 when bearer token is invalid', async () => {
-    const deps = createDeps();
-    deps.config.runtime.apiWriteToken = 'write-token';
-    const handler = createApiFetch(deps);
-
-    const response = await handler(
-      new Request('http://localhost/api/config', {
-        method: 'PUT',
-        headers: { Authorization: 'Bearer wrong-token' },
-        body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
-      }),
-    );
-
-    expect(response.status).toBe(403);
-    expect(await response.json()).toEqual({ error: 'forbidden' });
-  });
-
-  it('accepts lowercase bearer auth scheme', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-api-config-'));
-    const configPath = join(directory, 'pirate-claw.config.json');
-    const config = stubConfig();
-    config.runtime.apiWriteToken = 'write-token';
-    await Bun.write(configPath, JSON.stringify(config, null, 2));
-
-    const deps = createDeps();
-    deps.config = structuredClone(config);
-    deps.configPath = configPath;
-    const handler = createApiFetch(deps);
-
-    const response = await handler(
-      new Request('http://localhost/api/config', {
-        method: 'PUT',
-        headers: {
-          Authorization: 'bearer write-token',
-          'If-Match': '*',
-        },
-        body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
-      }),
-    );
-
-    expect(response.status).toBe(200);
-  });
-
-  it('returns 400 when payload validation fails', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-api-config-'));
-    const configPath = join(directory, 'pirate-claw.config.json');
-    await Bun.write(configPath, JSON.stringify(stubConfig(), null, 2));
-
-    const deps = createDeps();
-    deps.configPath = configPath;
-    deps.config.runtime.apiWriteToken = 'write-token';
-    const handler = createApiFetch(deps);
-
-    const response = await handler(
-      new Request('http://localhost/api/config', {
-        method: 'PUT',
-        headers: { Authorization: 'Bearer write-token', 'If-Match': '*' },
-        body: JSON.stringify({ feeds: [] }),
-      }),
-    );
-
-    expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({
-      error: 'Config file "request body runtime" must be an object.',
-    });
-  });
-
-  it('returns 400 when runtime validation fails', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-api-config-'));
-    const configPath = join(directory, 'pirate-claw.config.json');
-    await Bun.write(configPath, JSON.stringify(stubConfig(), null, 2));
-
-    const deps = createDeps();
-    deps.configPath = configPath;
-    deps.config.runtime.apiWriteToken = 'write-token';
-    const handler = createApiFetch(deps);
-
-    const response = await handler(
-      new Request('http://localhost/api/config', {
-        method: 'PUT',
-        headers: { Authorization: 'Bearer write-token', 'If-Match': '*' },
-        body: JSON.stringify({
-          runtime: { runIntervalMinutes: 0 },
+      const put = await handler(
+        new Request('http://localhost/api/config', {
+          method: 'PUT',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer write-token',
+            'if-match': etag,
+          },
+          body: JSON.stringify({
+            runtime: {
+              runIntervalMinutes: 45,
+              reconcileIntervalMinutes: 2,
+              tmdbRefreshIntervalMinutes: 0,
+            },
+            tv: {
+              shows: ['Alpha Show', 'Beta Show'],
+            },
+          }),
         }),
-      }),
-    );
+      );
 
-    expect(response.status).toBe(400);
-    expect((await response.json()).error).toMatch(/runIntervalMinutes/);
+      expect(put.status).toBe(200);
+      expect(holder.current.tv.map((r) => r.name)).toEqual([
+        'Alpha Show',
+        'Beta Show',
+      ]);
+      expect(holder.current.runtime.runIntervalMinutes).toBe(45);
+
+      const disk = await Bun.file(configPath).json();
+      expect(disk.tv.defaults).toEqual({
+        resolutions: ['1080p'],
+        codecs: ['x265'],
+      });
+      expect(disk.tv.shows).toEqual(['Alpha Show', 'Beta Show']);
+    } finally {
+      if (prevWrite !== undefined) {
+        process.env.PIRATE_CLAW_API_WRITE_TOKEN = prevWrite;
+      } else {
+        delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+      }
+    }
   });
 
-  it('writes runtime updates and returns redacted config with ETag', async () => {
-    const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-api-config-'));
-    const configPath = join(directory, 'pirate-claw.config.json');
-    const config = stubConfig();
-    config.runtime.apiWriteToken = 'write-token';
-    await Bun.write(configPath, JSON.stringify(config, null, 2));
+  it('rejects tv.defaults in the request body', async () => {
+    const prevWrite = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    try {
+      const directory = await mkdtemp(
+        join(tmpdir(), 'pirate-claw-api-config-'),
+      );
+      const configPath = join(directory, 'pirate-claw.config.json');
+      await writeCompactTvConfigFile(configPath);
+      const loaded = await loadConfig(configPath);
+      const deps = createDeps();
+      deps.config = loaded;
+      deps.configPath = configPath;
 
-    const deps = createDeps();
-    deps.config = structuredClone(config);
-    deps.configPath = configPath;
-    const handler = createApiFetch(deps);
+      const handler = createApiFetch(deps);
+      const get = await handler(new Request('http://localhost/api/config'));
+      const etag = get.headers.get('etag')!;
 
-    const current = await handler(new Request('http://localhost/api/config'));
-    const currentEtag = current.headers.get('etag')!;
-
-    const response = await handler(
-      new Request('http://localhost/api/config', {
-        method: 'PUT',
-        headers: {
-          Authorization: 'Bearer write-token',
-          'If-Match': currentEtag,
-        },
-        body: JSON.stringify({
-          runtime: { runIntervalMinutes: 15 },
+      const put = await handler(
+        new Request('http://localhost/api/config', {
+          method: 'PUT',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer write-token',
+            'if-match': etag,
+          },
+          body: JSON.stringify({
+            runtime: {
+              runIntervalMinutes: 30,
+              reconcileIntervalMinutes: 1,
+              tmdbRefreshIntervalMinutes: 0,
+            },
+            tv: {
+              shows: ['Example Show'],
+              defaults: { resolutions: ['720p'], codecs: ['x264'] },
+            },
+          }),
         }),
-      }),
-    );
+      );
 
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.runtime.runIntervalMinutes).toBe(15);
-    expect(body.runtime.apiWriteToken).toBe('[redacted]');
-    expect(response.headers.get('etag')).toMatch(/^"[0-9a-f]{64}"$/);
-
-    const persisted = await Bun.file(configPath).json();
-    expect(persisted.runtime.runIntervalMinutes).toBe(15);
+      expect(put.status).toBe(400);
+      const body = (await put.json()) as { error?: string };
+      expect(body.error).toContain('only allows "shows"');
+    } finally {
+      if (prevWrite !== undefined) {
+        process.env.PIRATE_CLAW_API_WRITE_TOKEN = prevWrite;
+      } else {
+        delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+      }
+    }
   });
 
-  it('returns 500 when config persistence fails', async () => {
-    const deps = createDeps();
-    deps.config.runtime.apiWriteToken = 'write-token';
-    deps.configPath = '/definitely/missing/pirate-claw.config.json';
-    const handler = createApiFetch(deps);
+  it('rejects missing tv in the body', async () => {
+    const prevWrite = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    try {
+      const directory = await mkdtemp(
+        join(tmpdir(), 'pirate-claw-api-config-'),
+      );
+      const configPath = join(directory, 'pirate-claw.config.json');
+      await writeCompactTvConfigFile(configPath);
+      const loaded = await loadConfig(configPath);
+      const deps = createDeps();
+      deps.config = loaded;
+      deps.configPath = configPath;
 
-    const response = await handler(
-      new Request('http://localhost/api/config', {
-        method: 'PUT',
-        headers: { Authorization: 'Bearer write-token', 'If-Match': '*' },
-        body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
-      }),
-    );
+      const handler = createApiFetch(deps);
+      const get = await handler(new Request('http://localhost/api/config'));
+      const etag = get.headers.get('etag')!;
 
-    expect(response.status).toBe(500);
-    expect(await response.json()).toEqual({ error: 'internal server error' });
-  });
+      const put = await handler(
+        new Request('http://localhost/api/config', {
+          method: 'PUT',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer write-token',
+            'if-match': etag,
+          },
+          body: JSON.stringify({
+            runtime: {
+              runIntervalMinutes: 30,
+              reconcileIntervalMinutes: 1,
+              tmdbRefreshIntervalMinutes: 0,
+            },
+          }),
+        }),
+      );
 
-  it('returns 428 when If-Match header is missing', async () => {
-    const deps = createDeps();
-    deps.config.runtime.apiWriteToken = 'write-token';
-    const handler = createApiFetch(deps);
-
-    const response = await handler(
-      new Request('http://localhost/api/config', {
-        method: 'PUT',
-        headers: { Authorization: 'Bearer write-token' },
-        body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
-      }),
-    );
-
-    expect(response.status).toBe(428);
-    expect(await response.json()).toEqual({
-      error: 'if-match header is required',
-    });
-    expect(response.headers.get('etag')).toMatch(/^"[0-9a-f]{64}"$/);
-  });
-
-  it('returns 409 when If-Match revision is stale', async () => {
-    const deps = createDeps();
-    deps.config.runtime.apiWriteToken = 'write-token';
-    const handler = createApiFetch(deps);
-
-    const response = await handler(
-      new Request('http://localhost/api/config', {
-        method: 'PUT',
-        headers: {
-          Authorization: 'Bearer write-token',
-          'If-Match': '"deadbeef"',
-        },
-        body: JSON.stringify({ runtime: { runIntervalMinutes: 15 } }),
-      }),
-    );
-
-    expect(response.status).toBe(409);
-    expect(await response.json()).toEqual({
-      error: 'config revision conflict',
-    });
-    expect(response.headers.get('etag')).toMatch(/^"[0-9a-f]{64}"$/);
+      expect(put.status).toBe(400);
+      const body = (await put.json()) as { error?: string };
+      expect(body.error).toContain('must include "tv"');
+    } finally {
+      if (prevWrite !== undefined) {
+        process.env.PIRATE_CLAW_API_WRITE_TOKEN = prevWrite;
+      } else {
+        delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+      }
+    }
   });
 });
 

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -65,7 +65,7 @@ function validateRuntimeBounds(
 }
 
 export const actions: Actions = {
-	saveRuntime: async ({ request }) => {
+	saveSettings: async ({ request }) => {
 		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
 		if (!writeToken) {
 			return fail(500, { message: 'Server write token is not configured.' });
@@ -74,6 +74,7 @@ export const actions: Actions = {
 		const formData = await request.formData();
 		const allowedFields = new Set([
 			'ifMatch',
+			'showName',
 			'runIntervalMinutes',
 			'reconcileIntervalMinutes',
 			'tmdbRefreshIntervalMinutes',
@@ -88,6 +89,12 @@ export const actions: Actions = {
 		const ifMatch = String(formData.get('ifMatch') ?? '').trim();
 		if (!ifMatch) {
 			return fail(400, { message: 'Missing config revision. Reload and try again.' });
+		}
+
+		const rawShowNames = formData.getAll('showName').map((v) => String(v).trim());
+		const showNames = rawShowNames.filter((n) => n.length > 0);
+		if (showNames.length < 1) {
+			return fail(400, { message: 'At least one TV show name is required.' });
 		}
 
 		const runIntervalMinutes = parseOptionalInt(formData.get('runIntervalMinutes'));
@@ -123,6 +130,9 @@ export const actions: Actions = {
 				reconcileIntervalMinutes,
 				tmdbRefreshIntervalMinutes: tmdbRefreshIntervalMinutes ?? 0,
 				...(apiPort === undefined ? {} : { apiPort })
+			},
+			tv: {
+				shows: showNames
 			}
 		};
 
@@ -153,7 +163,8 @@ export const actions: Actions = {
 
 			return {
 				success: true,
-				message: 'Settings saved. Restart the daemon for changes to take effect.',
+				message:
+					'Settings saved. TV show list updates apply on the next daemon run cycle. Restart the daemon to apply a new API port or timer intervals.',
 				etag: response.headers.get('etag')
 			};
 		} catch (error) {

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -262,8 +262,9 @@
 							Revision: <code>{currentEtag ?? 'missing'}</code>
 						</div>
 						<p class="text-muted-foreground text-xs">
-							TV show list updates apply on the next daemon run cycle without restart. Restart the
-							daemon to apply a new API port or timer intervals.
+							Daemon timers and the API listen port are fixed at process start — restart after
+							changing those fields. TV show titles above apply on the next run cycle without
+							restart.
 						</p>
 						<div>
 							<button

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -6,11 +6,34 @@
 
 	const { data, form }: { data: PageData; form?: ActionData } = $props();
 	const currentEtag = $derived(form?.etag ?? data.etag ?? null);
+
+	let showRows = $state<string[]>([]);
+
+	$effect(() => {
+		const c = data.config;
+		if (c) {
+			showRows = c.tv.map((r) => r.name);
+		}
+	});
+
+	function addShow() {
+		showRows = [...showRows, ''];
+	}
+
+	function removeShow(index: number) {
+		if (showRows.length <= 1) return;
+		showRows = showRows.filter((_, i) => i !== index);
+	}
+
+	function updateShowName(index: number, value: string) {
+		showRows = showRows.map((row, j) => (j === index ? value : row));
+	}
 </script>
 
 <h1 class="text-3xl font-bold tracking-tight">Config</h1>
 <p class="text-muted-foreground mt-1 text-sm">
-	Effective configuration from the API (secrets redacted). Runtime fields can be edited and saved.
+	Effective configuration from the API (secrets redacted). Save applies TV show list and runtime
+	fields in one step.
 </p>
 
 {#if data.error}
@@ -29,216 +52,231 @@
 			</Alert>
 		{/if}
 
-		<Card>
-			<CardHeader class="pb-3">
-				<h2 class="text-lg font-semibold tracking-tight">Feeds</h2>
-			</CardHeader>
-			<CardContent class="pt-0">
-				{#if config.feeds.length === 0}
-					<p class="text-muted-foreground text-sm">No feeds configured.</p>
-				{:else}
-					<ul class="list-none space-y-3">
-						{#each config.feeds as feed}
-							<li class="border-border bg-card/50 rounded-md border p-3 text-sm">
-								<div class="text-foreground font-medium">{feed.name}</div>
-								<div class="text-muted-foreground mt-1">
-									<span class="mr-3">Type: {feed.mediaType}</span>
-									{#if feed.pollIntervalMinutes !== undefined}
-										<span class="mr-3">Poll: {feed.pollIntervalMinutes}m</span>
-									{/if}
-									<span class="break-all">URL: {feed.url}</span>
-								</div>
-							</li>
-						{/each}
-					</ul>
-				{/if}
-			</CardContent>
-		</Card>
+		<form method="POST" action="?/saveSettings" use:enhance class="space-y-6">
+			<input type="hidden" name="ifMatch" value={currentEtag ?? ''} />
 
-		<Card>
-			<CardHeader class="pb-3">
-				<h2 class="text-lg font-semibold tracking-tight">TV Rules</h2>
-			</CardHeader>
-			<CardContent class="pt-0">
-				{#if config.tv.length === 0}
-					<p class="text-muted-foreground text-sm">No TV rules configured.</p>
-				{:else}
-					<ul class="list-none space-y-3">
-						{#each config.tv as rule}
-							<li class="border-border bg-card/50 rounded-md border p-3 text-sm">
-								<div class="text-foreground font-medium">{rule.name}</div>
-								<div class="text-muted-foreground mt-1">
-									{#if rule.matchPattern}
-										<div>
-											Pattern: <code class="bg-muted text-foreground rounded px-1 font-mono"
-												>{rule.matchPattern}</code
-											>
-										</div>
-									{/if}
-									<div>Resolutions: {rule.resolutions.join(', ')}</div>
-									<div>Codecs: {rule.codecs.join(', ')}</div>
-								</div>
-							</li>
-						{/each}
-					</ul>
-				{/if}
-			</CardContent>
-		</Card>
-
-		<Card>
-			<CardHeader class="pb-3">
-				<h2 class="text-lg font-semibold tracking-tight">Movies</h2>
-			</CardHeader>
-			<CardContent class="pt-0">
-				<dl class="grid gap-2 text-sm">
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">Years:</dt>
-						<dd class="text-foreground">{config.movies.years.join(', ')}</dd>
-					</div>
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">Resolutions:</dt>
-						<dd class="text-foreground">{config.movies.resolutions.join(', ')}</dd>
-					</div>
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">Codecs:</dt>
-						<dd class="text-foreground">{config.movies.codecs.join(', ')}</dd>
-					</div>
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">Codec policy:</dt>
-						<dd class="text-foreground">{config.movies.codecPolicy}</dd>
-					</div>
-				</dl>
-			</CardContent>
-		</Card>
-
-		<Card>
-			<CardHeader class="pb-3">
-				<h2 class="text-lg font-semibold tracking-tight">Transmission</h2>
-			</CardHeader>
-			<CardContent class="pt-0">
-				<dl class="grid gap-2 text-sm">
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">URL:</dt>
-						<dd class="text-foreground">{config.transmission.url}</dd>
-					</div>
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">Username:</dt>
-						<dd class="text-foreground">{config.transmission.username}</dd>
-					</div>
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">Password:</dt>
-						<dd class="text-foreground">••••••••</dd>
-					</div>
-					{#if config.transmission.downloadDir}
-						<div class="flex flex-wrap gap-2">
-							<dt class="text-muted-foreground">Download dir:</dt>
-							<dd class="text-foreground">{config.transmission.downloadDir}</dd>
-						</div>
+			<Card>
+				<CardHeader class="pb-3">
+					<h2 class="text-lg font-semibold tracking-tight">Feeds</h2>
+				</CardHeader>
+				<CardContent class="pt-0">
+					{#if config.feeds.length === 0}
+						<p class="text-muted-foreground text-sm">No feeds configured.</p>
+					{:else}
+						<ul class="list-none space-y-3">
+							{#each config.feeds as feed}
+								<li class="border-border bg-card/50 rounded-md border p-3 text-sm">
+									<div class="text-foreground font-medium">{feed.name}</div>
+									<div class="text-muted-foreground mt-1">
+										<span class="mr-3">Type: {feed.mediaType}</span>
+										{#if feed.pollIntervalMinutes !== undefined}
+											<span class="mr-3">Poll: {feed.pollIntervalMinutes}m</span>
+										{/if}
+										<span class="break-all">URL: {feed.url}</span>
+									</div>
+								</li>
+							{/each}
+						</ul>
 					{/if}
-					{#if config.transmission.downloadDirs}
-						{#if config.transmission.downloadDirs.tv}
-							<div class="flex flex-wrap gap-2">
-								<dt class="text-muted-foreground">TV dir:</dt>
-								<dd class="text-foreground">{config.transmission.downloadDirs.tv}</dd>
-							</div>
-						{/if}
-						{#if config.transmission.downloadDirs.movie}
-							<div class="flex flex-wrap gap-2">
-								<dt class="text-muted-foreground">Movie dir:</dt>
-								<dd class="text-foreground">{config.transmission.downloadDirs.movie}</dd>
-							</div>
-						{/if}
-					{/if}
-				</dl>
-			</CardContent>
-		</Card>
+				</CardContent>
+			</Card>
 
-		<Card>
-			<CardHeader class="pb-3">
-				<h2 class="text-lg font-semibold tracking-tight">Runtime</h2>
-			</CardHeader>
-			<CardContent class="pt-0">
-				<form method="POST" action="?/saveRuntime" use:enhance class="grid gap-4 text-sm">
-					<input type="hidden" name="ifMatch" value={currentEtag ?? ''} />
-
-					<div class="grid gap-1">
-						<label class="text-muted-foreground" for="runIntervalMinutes"
-							>Run interval (minutes)</label
-						>
-						<input
-							id="runIntervalMinutes"
-							name="runIntervalMinutes"
-							type="number"
-							min="1"
-							step="1"
-							value={config.runtime.runIntervalMinutes}
-							class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-						/>
-					</div>
-
-					<div class="grid gap-1">
-						<label class="text-muted-foreground" for="reconcileIntervalMinutes">
-							Reconcile interval (minutes)
-						</label>
-						<input
-							id="reconcileIntervalMinutes"
-							name="reconcileIntervalMinutes"
-							type="number"
-							min="1"
-							step="1"
-							value={config.runtime.reconcileIntervalMinutes}
-							class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-						/>
-					</div>
-
-					<div class="grid gap-1">
-						<label class="text-muted-foreground" for="tmdbRefreshIntervalMinutes">
-							TMDB refresh interval (minutes, 0 disables)
-						</label>
-						<input
-							id="tmdbRefreshIntervalMinutes"
-							name="tmdbRefreshIntervalMinutes"
-							type="number"
-							min="0"
-							step="1"
-							value={config.runtime.tmdbRefreshIntervalMinutes ?? 0}
-							class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-						/>
-					</div>
-
-					<div class="grid gap-1">
-						<label class="text-muted-foreground" for="apiPort">API port (optional)</label>
-						<input
-							id="apiPort"
-							name="apiPort"
-							type="number"
-							min="1"
-							max="65535"
-							step="1"
-							value={config.runtime.apiPort ?? ''}
-							placeholder="unset"
-							class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-						/>
-					</div>
-
-					<div class="text-muted-foreground text-xs">
-						Revision: <code>{currentEtag ?? 'missing'}</code>
-					</div>
-					<p class="text-muted-foreground text-xs">
-						Saving writes config only. Restart the daemon process to apply new runtime intervals and
-						port changes.
+			<Card>
+				<CardHeader class="pb-3">
+					<h2 class="text-lg font-semibold tracking-tight">TV shows</h2>
+				</CardHeader>
+				<CardContent class="space-y-4 pt-0">
+					<p class="text-muted-foreground text-sm">
+						Each row is a tracked show title (inherits codec/resolution defaults from your config
+						file). Remove the last show by removing the feed instead.
 					</p>
+					<ul class="list-none space-y-3">
+						{#each showRows as name, i}
+							<li class="flex flex-wrap items-center gap-2">
+								<input
+									name="showName"
+									type="text"
+									value={name}
+									autocomplete="off"
+									aria-label={`TV show ${i + 1}`}
+									class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring min-w-[12rem] flex-1 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+									oninput={(e) => updateShowName(i, e.currentTarget.value)}
+								/>
+								<button
+									type="button"
+									class="border-border text-muted-foreground hover:bg-muted inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border text-sm font-medium"
+									disabled={showRows.length <= 1}
+									aria-label="Remove show"
+									onclick={() => removeShow(i)}>×</button
+								>
+							</li>
+						{/each}
+					</ul>
 					<div>
 						<button
-							type="submit"
-							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium"
-							disabled={!currentEtag}
+							type="button"
+							class="border-border bg-card hover:bg-muted/50 inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium"
+							onclick={addShow}
 						>
-							Save runtime settings
+							Add show
 						</button>
 					</div>
-				</form>
-			</CardContent>
-		</Card>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader class="pb-3">
+					<h2 class="text-lg font-semibold tracking-tight">Movies</h2>
+				</CardHeader>
+				<CardContent class="pt-0">
+					<dl class="grid gap-2 text-sm">
+						<div class="flex flex-wrap gap-2">
+							<dt class="text-muted-foreground">Years:</dt>
+							<dd class="text-foreground">{config.movies.years.join(', ')}</dd>
+						</div>
+						<div class="flex flex-wrap gap-2">
+							<dt class="text-muted-foreground">Resolutions:</dt>
+							<dd class="text-foreground">{config.movies.resolutions.join(', ')}</dd>
+						</div>
+						<div class="flex flex-wrap gap-2">
+							<dt class="text-muted-foreground">Codecs:</dt>
+							<dd class="text-foreground">{config.movies.codecs.join(', ')}</dd>
+						</div>
+						<div class="flex flex-wrap gap-2">
+							<dt class="text-muted-foreground">Codec policy:</dt>
+							<dd class="text-foreground">{config.movies.codecPolicy}</dd>
+						</div>
+					</dl>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader class="pb-3">
+					<h2 class="text-lg font-semibold tracking-tight">Transmission</h2>
+				</CardHeader>
+				<CardContent class="pt-0">
+					<dl class="grid gap-2 text-sm">
+						<div class="flex flex-wrap gap-2">
+							<dt class="text-muted-foreground">URL:</dt>
+							<dd class="text-foreground">{config.transmission.url}</dd>
+						</div>
+						<div class="flex flex-wrap gap-2">
+							<dt class="text-muted-foreground">Username:</dt>
+							<dd class="text-foreground">{config.transmission.username}</dd>
+						</div>
+						<div class="flex flex-wrap gap-2">
+							<dt class="text-muted-foreground">Password:</dt>
+							<dd class="text-foreground">••••••••</dd>
+						</div>
+						{#if config.transmission.downloadDir}
+							<div class="flex flex-wrap gap-2">
+								<dt class="text-muted-foreground">Download dir:</dt>
+								<dd class="text-foreground">{config.transmission.downloadDir}</dd>
+							</div>
+						{/if}
+						{#if config.transmission.downloadDirs}
+							{#if config.transmission.downloadDirs.tv}
+								<div class="flex flex-wrap gap-2">
+									<dt class="text-muted-foreground">TV dir:</dt>
+									<dd class="text-foreground">{config.transmission.downloadDirs.tv}</dd>
+								</div>
+							{/if}
+							{#if config.transmission.downloadDirs.movie}
+								<div class="flex flex-wrap gap-2">
+									<dt class="text-muted-foreground">Movie dir:</dt>
+									<dd class="text-foreground">{config.transmission.downloadDirs.movie}</dd>
+								</div>
+							{/if}
+						{/if}
+					</dl>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader class="pb-3">
+					<h2 class="text-lg font-semibold tracking-tight">Runtime</h2>
+				</CardHeader>
+				<CardContent class="pt-0">
+					<div class="grid gap-4 text-sm">
+						<div class="grid gap-1">
+							<label class="text-muted-foreground" for="runIntervalMinutes"
+								>Run interval (minutes)</label
+							>
+							<input
+								id="runIntervalMinutes"
+								name="runIntervalMinutes"
+								type="number"
+								min="1"
+								step="1"
+								value={config.runtime.runIntervalMinutes}
+								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+							/>
+						</div>
+
+						<div class="grid gap-1">
+							<label class="text-muted-foreground" for="reconcileIntervalMinutes">
+								Reconcile interval (minutes)
+							</label>
+							<input
+								id="reconcileIntervalMinutes"
+								name="reconcileIntervalMinutes"
+								type="number"
+								min="1"
+								step="1"
+								value={config.runtime.reconcileIntervalMinutes}
+								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+							/>
+						</div>
+
+						<div class="grid gap-1">
+							<label class="text-muted-foreground" for="tmdbRefreshIntervalMinutes">
+								TMDB refresh interval (minutes, 0 disables)
+							</label>
+							<input
+								id="tmdbRefreshIntervalMinutes"
+								name="tmdbRefreshIntervalMinutes"
+								type="number"
+								min="0"
+								step="1"
+								value={config.runtime.tmdbRefreshIntervalMinutes ?? 0}
+								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+							/>
+						</div>
+
+						<div class="grid gap-1">
+							<label class="text-muted-foreground" for="apiPort">API port (optional)</label>
+							<input
+								id="apiPort"
+								name="apiPort"
+								type="number"
+								min="1"
+								max="65535"
+								step="1"
+								value={config.runtime.apiPort ?? ''}
+								placeholder="unset"
+								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+							/>
+						</div>
+
+						<div class="text-muted-foreground text-xs">
+							Revision: <code>{currentEtag ?? 'missing'}</code>
+						</div>
+						<p class="text-muted-foreground text-xs">
+							TV show list updates apply on the next daemon run cycle without restart. Restart the
+							daemon to apply a new API port or timer intervals.
+						</p>
+						<div>
+							<button
+								type="submit"
+								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium"
+								disabled={!currentEtag}
+							>
+								Save settings
+							</button>
+						</div>
+					</div>
+				</CardContent>
+			</Card>
+		</form>
 	</div>
 {/if}

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -91,11 +91,9 @@ describe('/config', () => {
 				etag: '"rev-2"'
 			}
 		});
-		expect(
-			screen.getByText(/TV show list updates apply on the next daemon run cycle/i)
-		).toBeInTheDocument();
-		expect(
-			screen.getByText(/TV show list updates apply on the next daemon run cycle without restart/i)
-		).toBeInTheDocument();
+		expect(screen.getByRole('alert')).toHaveTextContent(
+			/TV show list updates apply on the next daemon run cycle/
+		);
+		expect(screen.getByText(/Daemon timers and the API listen port/i)).toBeInTheDocument();
 	});
 });

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -43,13 +43,13 @@ describe('/config', () => {
 	it('renders config sections with mock data', () => {
 		render(Page, { data: { config: mockConfig, error: null, etag: '"rev-1"' }, form: undefined });
 		expect(screen.getByRole('heading', { name: 'Feeds' })).toBeInTheDocument();
-		expect(screen.getByRole('heading', { name: 'TV Rules' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'TV shows' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Movies' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Transmission' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Runtime' })).toBeInTheDocument();
 		expect(screen.getByText('TestFeed')).toBeInTheDocument();
-		expect(screen.getByText('hd-tv')).toBeInTheDocument();
-		expect(screen.getByRole('button', { name: 'Save runtime settings' })).toBeInTheDocument();
+		expect(screen.getByDisplayValue('hd-tv')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Save settings' })).toBeInTheDocument();
 	});
 
 	it('renders error state when API is unreachable', () => {
@@ -60,7 +60,7 @@ describe('/config', () => {
 		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
 	});
 
-	it('renders empty state when feeds and tv rules are empty', () => {
+	it('renders when feeds list is empty and tv list is empty', () => {
 		render(Page, {
 			data: {
 				config: { ...mockConfig, feeds: [], tv: [] },
@@ -70,7 +70,7 @@ describe('/config', () => {
 			form: undefined
 		});
 		expect(screen.getByText('No feeds configured.')).toBeInTheDocument();
-		expect(screen.getByText('No TV rules configured.')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Add show' })).toBeInTheDocument();
 	});
 
 	it('renders save error message from action data', () => {
@@ -81,22 +81,21 @@ describe('/config', () => {
 		expect(screen.getByRole('alert')).toHaveTextContent('config revision conflict');
 	});
 
-	it('renders restart-required success messaging', () => {
+	it('renders success messaging for combined save', () => {
 		render(Page, {
 			data: { config: mockConfig, error: null, etag: '"rev-1"' },
 			form: {
 				success: true,
-				message: 'Settings saved. Restart the daemon for changes to take effect.',
+				message:
+					'Settings saved. TV show list updates apply on the next daemon run cycle. Restart the daemon to apply a new API port or timer intervals.',
 				etag: '"rev-2"'
 			}
 		});
-		expect(screen.getByRole('status')).toHaveTextContent(
-			'Restart the daemon for changes to take effect'
-		);
 		expect(
-			screen.getByText(
-				/Restart the daemon process to apply new runtime intervals and port changes/i
-			)
+			screen.getByText(/TV show list updates apply on the next daemon run cycle/i)
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(/TV show list updates apply on the next daemon run cycle without restart/i)
 		).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary
Standalone PR: editable TV show list on the Config page (add by name, remove with ×; × disabled when only one show), combined with runtime fields in one Save. PUT `/api/config` accepts `runtime` + `tv: { shows: string[] }` (rejects `tv.defaults`). Daemon keeps a shared `configHolder` so run cycles use the same config after PUT.

## Orchestrator (standalone PR)
After review of the diff:
1. `bun run deliver ai-review` or `bun run deliver ai-review --pr <number>`
2. Optional Telegram milestones: set `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` — orchestrator emits `standalone_review_started` when the ai-review run begins and `standalone_review_recorded` when it completes (see `docs/03-engineering/delivery-orchestrator.md` § Optional Telegram Notifications).

## Notes
- Saving string-only show names may drop per-row overrides (matchPattern, codecs) that were only in the file; defaults are unchanged on disk.

<!-- ai-review:start -->
## External AI Review

- outcome: `operator_input_needed`
- reviewed commit: [`da6eebeab7b0`](https://github.com/cesarnml/pirate_claw/commit/da6eebeab7b0aa0053463222b14dcd5584ecf116)
- current branch head: [`da6eebeab7b0`](https://github.com/cesarnml/pirate_claw/commit/da6eebeab7b0aa0053463222b14dcd5584ecf116)
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Use an unambiguous selector for the success copy. `web/src/routes/config/config.test.ts:99` [thread](https://github.com/cesarnml/pirate_claw/pull/116#discussion_r3057714360)

### Unresolved Review Findings

- [coderabbit] Do not silently drop existing per-show TV overrides. `src/api.ts:351` [thread](https://github.com/cesarnml/pirate_claw/pull/116#discussion_r3057714357)

- triage note: Actionable AI review findings were detected and still need follow-up.
- triage summary: Flagged 1 finding comment(s) for follow-up.

### No-Action Rationale

- Ignored 1 resolved or outdated unclear comment(s).
<!-- ai-review:end -->
