### PR TITLE
feat(web): add TV defaults resolutions/codecs controls to config page [P14.03]

### DIFF
--- a/docs/02-delivery/phase-14/ticket-03-tv-section-ui.md
+++ b/docs/02-delivery/phase-14/ticket-03-tv-section-ui.md
@@ -33,4 +33,12 @@ The TV config section in the dashboard includes working resolutions and codecs d
 
 ## Rationale
 
-_To be filled in after implementation._
+`canWrite` is derived server-side from `!!env.PIRATE_CLAW_API_WRITE_TOKEN` in the load function and passed to the page as `data.canWrite`. This is the single source of truth for write availability — the same env var the action checks before forwarding to the API. Client-side components just read `data.canWrite`; they never re-derive write availability from the config payload.
+
+TV defaults are in a separate `<form action="?/saveTvDefaults">` outside the existing `saveSettings` form. Nested HTML forms are invalid, so the TV defaults card could not live inside the existing form without restructuring. The `saveTvDefaults` form is placed visually before `saveSettings` in the layout. The `saveSettings` form is left exactly as Phase 13 committed it.
+
+`tvDefaultsEtag` is returned by the `saveTvDefaults` action and folded into `currentEtag` alongside the existing `form?.etag`. This ensures that after a TV defaults save, the next `saveSettings` submission uses the updated revision, avoiding a 409 conflict on the combined save.
+
+Multi-select state (`tvResolutions`, `tvCodecs`) is tracked in Svelte `$state` arrays. Hidden inputs carry the selected values into the form body; toggle buttons flip array membership. The fixed option sets (`ALL_RESOLUTIONS`, `ALL_CODECS`) match the allowed values enforced by `validateCompactTvDefaults` in `src/config.ts` — no duplication of validation logic is needed on the client since the server rejects any invalid value with a 400.
+
+Disabled state uses the HTML `disabled` attribute on buttons and the `title` attribute on the container divs for tooltip text — no tooltip component dependency added.

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -5,6 +5,7 @@ import type { AppConfig } from '$lib/types';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
+	const canWrite = !!env.PIRATE_CLAW_API_WRITE_TOKEN;
 	try {
 		const response = await apiRequest('/api/config');
 		if (!response.ok) {
@@ -15,6 +16,7 @@ export const load: PageServerLoad = async () => {
 		return {
 			config,
 			etag: response.headers.get('etag'),
+			canWrite,
 			error: null
 		};
 	} catch (err) {
@@ -22,6 +24,7 @@ export const load: PageServerLoad = async () => {
 		return {
 			config: null as AppConfig | null,
 			etag: null as string | null,
+			canWrite,
 			error: 'Could not reach the API.'
 		};
 	}
@@ -170,6 +173,59 @@ export const actions: Actions = {
 		} catch (error) {
 			console.error('[config] save failed:', error);
 			return fail(500, { message: 'Could not save settings.' });
+		}
+	},
+
+	saveTvDefaults: async ({ request }) => {
+		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+		if (!writeToken) {
+			return fail(403, { tvDefaultsMessage: 'Config writes are disabled.' });
+		}
+
+		const formData = await request.formData();
+		const ifMatch = String(formData.get('tvDefaultsIfMatch') ?? '').trim();
+		if (!ifMatch) {
+			return fail(400, { tvDefaultsMessage: 'Missing config revision. Reload and try again.' });
+		}
+
+		const resolutions = formData.getAll('tvResolution').map(String);
+		const codecs = formData.getAll('tvCodec').map(String);
+
+		const payload = { resolutions, codecs };
+
+		try {
+			const response = await apiRequest('/api/config/tv/defaults', {
+				method: 'PUT',
+				headers: {
+					'content-type': 'application/json',
+					authorization: `Bearer ${writeToken}`,
+					'if-match': ifMatch
+				},
+				body: JSON.stringify(payload)
+			});
+
+			if (!response.ok) {
+				let tvDefaultsMessage = `Save failed (${response.status}).`;
+				try {
+					const body = (await response.json()) as { error?: string };
+					if (body.error) tvDefaultsMessage = body.error;
+				} catch {
+					// keep fallback message
+				}
+				return fail(response.status, {
+					tvDefaultsMessage,
+					tvDefaultsEtag: response.headers.get('etag')
+				});
+			}
+
+			return {
+				tvDefaultsSuccess: true,
+				tvDefaultsMessage: 'TV defaults saved.',
+				tvDefaultsEtag: response.headers.get('etag')
+			};
+		} catch (error) {
+			console.error('[config] saveTvDefaults failed:', error);
+			return fail(500, { tvDefaultsMessage: 'Could not save TV defaults.' });
 		}
 	}
 };

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -4,10 +4,17 @@
 	import { Card, CardContent, CardHeader } from '$lib/components/ui/card';
 	import type { ActionData, PageData } from './$types';
 
+	const ALL_RESOLUTIONS = ['2160p', '1080p', '720p', '480p'];
+	const ALL_CODECS = ['x264', 'x265'];
+	const WRITE_DISABLED_TOOLTIP = 'Configure PIRATE_CLAW_API_WRITE_TOKEN to enable editing';
+
 	const { data, form }: { data: PageData; form?: ActionData } = $props();
-	const currentEtag = $derived(form?.etag ?? data.etag ?? null);
+	const currentEtag = $derived(form?.tvDefaultsEtag ?? form?.etag ?? data.etag ?? null);
+	const canWrite = $derived(data.canWrite);
 
 	let showRows = $state<string[]>([]);
+	let tvResolutions = $state<string[]>([]);
+	let tvCodecs = $state<string[]>([]);
 
 	$effect(() => {
 		const c = data.config;
@@ -28,6 +35,22 @@
 	function updateShowName(index: number, value: string) {
 		showRows = showRows.map((row, j) => (j === index ? value : row));
 	}
+
+	function toggleResolution(res: string) {
+		if (tvResolutions.includes(res)) {
+			tvResolutions = tvResolutions.filter((r) => r !== res);
+		} else {
+			tvResolutions = [...tvResolutions, res];
+		}
+	}
+
+	function toggleCodec(codec: string) {
+		if (tvCodecs.includes(codec)) {
+			tvCodecs = tvCodecs.filter((c) => c !== codec);
+		} else {
+			tvCodecs = [...tvCodecs, codec];
+		}
+	}
 </script>
 
 <h1 class="text-3xl font-bold tracking-tight">Config</h1>
@@ -45,12 +68,91 @@
 	{@const config = data.config}
 
 	<div class="mt-8 space-y-6 pr-1">
-		{#if form?.message}
+		{#if form?.tvDefaultsMessage}
+			<Alert variant={form?.tvDefaultsSuccess ? 'default' : 'destructive'}>
+				<AlertTitle>{form?.tvDefaultsSuccess ? 'Save complete' : 'Save failed'}</AlertTitle>
+				<AlertDescription>{form.tvDefaultsMessage}</AlertDescription>
+			</Alert>
+		{:else if form?.message}
 			<Alert variant={form?.success ? 'default' : 'destructive'}>
 				<AlertTitle>{form?.success ? 'Save complete' : 'Save failed'}</AlertTitle>
 				<AlertDescription>{form.message}</AlertDescription>
 			</Alert>
 		{/if}
+
+		<form method="POST" action="?/saveTvDefaults" use:enhance class="space-y-6">
+			<input type="hidden" name="tvDefaultsIfMatch" value={currentEtag ?? ''} />
+			{#each tvResolutions as res}
+				<input type="hidden" name="tvResolution" value={res} />
+			{/each}
+			{#each tvCodecs as codec}
+				<input type="hidden" name="tvCodec" value={codec} />
+			{/each}
+			<Card>
+				<CardHeader class="pb-3">
+					<h2 class="text-lg font-semibold tracking-tight">TV defaults</h2>
+				</CardHeader>
+				<CardContent class="space-y-4 pt-0">
+					<p class="text-muted-foreground text-sm">
+						Global resolution and codec defaults inherited by all TV shows.
+					</p>
+					<div class="space-y-2">
+						<p class="text-muted-foreground text-sm font-medium">Resolutions</p>
+						<div
+							class="flex flex-wrap gap-2"
+							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+						>
+							{#each ALL_RESOLUTIONS as res}
+								<button
+									type="button"
+									class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {tvResolutions.includes(
+										res
+									)
+										? 'bg-primary text-primary-foreground border-primary'
+										: 'border-border text-muted-foreground hover:bg-muted'}"
+									disabled={!canWrite}
+									onclick={() => toggleResolution(res)}
+								>
+									{res}
+								</button>
+							{/each}
+						</div>
+					</div>
+					<div class="space-y-2">
+						<p class="text-muted-foreground text-sm font-medium">Codecs</p>
+						<div
+							class="flex flex-wrap gap-2"
+							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+						>
+							{#each ALL_CODECS as codec}
+								<button
+									type="button"
+									class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {tvCodecs.includes(
+										codec
+									)
+										? 'bg-primary text-primary-foreground border-primary'
+										: 'border-border text-muted-foreground hover:bg-muted'}"
+									disabled={!canWrite}
+									onclick={() => toggleCodec(codec)}
+								>
+									{codec}
+								</button>
+							{/each}
+						</div>
+					</div>
+					<div>
+						<button
+							type="submit"
+							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
+							disabled={!canWrite || !currentEtag}
+							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+						>
+							Save TV defaults
+						</button>
+					</div>
+				</CardContent>
+			</Card>
+		</form>
 
 		<form method="POST" action="?/saveSettings" use:enhance class="space-y-6">
 			<input type="hidden" name="ifMatch" value={currentEtag ?? ''} />

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -41,7 +41,10 @@ const mockConfig: AppConfig = {
 
 describe('/config', () => {
 	it('renders config sections with mock data', () => {
-		render(Page, { data: { config: mockConfig, error: null, etag: '"rev-1"' }, form: undefined });
+		render(Page, {
+			data: { config: mockConfig, error: null, etag: '"rev-1"', canWrite: true },
+			form: undefined
+		});
 		expect(screen.getByRole('heading', { name: 'Feeds' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'TV shows' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Movies' })).toBeInTheDocument();
@@ -54,7 +57,7 @@ describe('/config', () => {
 
 	it('renders error state when API is unreachable', () => {
 		render(Page, {
-			data: { config: null, error: 'Could not reach the API.', etag: null },
+			data: { config: null, error: 'Could not reach the API.', etag: null, canWrite: false },
 			form: undefined
 		});
 		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
@@ -65,7 +68,8 @@ describe('/config', () => {
 			data: {
 				config: { ...mockConfig, feeds: [], tv: [] },
 				error: null,
-				etag: '"rev-1"'
+				etag: '"rev-1"',
+				canWrite: true
 			},
 			form: undefined
 		});
@@ -75,7 +79,7 @@ describe('/config', () => {
 
 	it('renders save error message from action data', () => {
 		render(Page, {
-			data: { config: mockConfig, error: null, etag: '"rev-1"' },
+			data: { config: mockConfig, error: null, etag: '"rev-1"', canWrite: true },
 			form: { message: 'config revision conflict' }
 		});
 		expect(screen.getByRole('alert')).toHaveTextContent('config revision conflict');
@@ -83,7 +87,7 @@ describe('/config', () => {
 
 	it('renders success messaging for combined save', () => {
 		render(Page, {
-			data: { config: mockConfig, error: null, etag: '"rev-1"' },
+			data: { config: mockConfig, error: null, etag: '"rev-1"', canWrite: true },
 			form: {
 				success: true,
 				message:


### PR DESCRIPTION
## Summary

- delivery ticket: `P14.03 TV Section UI`
- ticket file: [docs/02-delivery/phase-14/ticket-03-tv-section-ui.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-14/ticket-03-tv-section-ui.md)
- stacked base branch: `agents/p14-02-feeds-write-endpoint`
- post-verify self-audit: completed at 2026-04-10 07:24 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`0d21826d8187`](https://github.com/cesarnml/pirate_claw/commit/0d21826d8187f250777f512f9d5d568d70cba5bd)
- current branch head: [`0d21826d8187`](https://github.com/cesarnml/pirate_claw/commit/0d21826d8187f250777f512f9d5d568d70cba5bd)
- vendors: `coderabbit`, `sonarqube`
