### PR TITLE
feat(web): add Movies policy editable section to config page [P14.04]

### DIFF
--- a/docs/02-delivery/phase-14/ticket-04-movies-policy-ui.md
+++ b/docs/02-delivery/phase-14/ticket-04-movies-policy-ui.md
@@ -36,4 +36,12 @@ The Movies section is present and functional in the dashboard config page. All f
 
 ## Rationale
 
-_To be filled in after implementation._
+`saveMovies` follows the same shape as `saveTvDefaults`: server-side write token check, ETag extraction, payload forwarding to the daemon API, and distinct return keys (`moviesMessage`, `moviesEtag`, `moviesSuccess`) so the alert block can distinguish which action's result is being shown. `moviesEtag` is folded into `currentEtag` with the highest priority so that the ETag stays current across any sequence of partial saves.
+
+The display-only Movies card that was previously inside the `saveSettings` form was removed and replaced by the new editable `saveMovies` form. The two forms are siblings in the outer `space-y-6` container, which keeps HTML valid (no nested forms) while preserving the visual section grouping.
+
+Years management uses Svelte `$state` array + hidden inputs: toggle buttons only flip chip membership, and an add-year text input + "Add year" button append validated integers. The server independently validates each year (1900–2100) before forwarding the payload. Invalid year input is rejected at the server with a 400.
+
+The codecPolicy segmented control tracks state as `'prefer' | 'require'` with a single hidden input. It initializes from `config.movies.codecPolicy` via the same `$effect` that initializes `movieYears`, `movieResolutions`, and `movieCodecs` from the loaded config.
+
+Two pre-existing web test regressions were fixed as part of this ticket: the `page.server.test.ts` was calling a stale action name (`saveRuntime` vs `saveSettings`), and the `config.test.ts` success alert test used `getByRole('alert')` when the shadcn-svelte Alert's 'default' variant actually renders with `role="status"`, not `role="alert"`.

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -227,5 +227,73 @@ export const actions: Actions = {
 			console.error('[config] saveTvDefaults failed:', error);
 			return fail(500, { tvDefaultsMessage: 'Could not save TV defaults.' });
 		}
+	},
+
+	saveMovies: async ({ request }) => {
+		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+		if (!writeToken) {
+			return fail(403, { moviesMessage: 'Config writes are disabled.' });
+		}
+
+		const formData = await request.formData();
+		const ifMatch = String(formData.get('moviesIfMatch') ?? '').trim();
+		if (!ifMatch) {
+			return fail(400, { moviesMessage: 'Missing config revision. Reload and try again.' });
+		}
+
+		const rawYears = formData.getAll('movieYear').map(String);
+		const years: number[] = [];
+		for (const y of rawYears) {
+			const n = Number(y);
+			if (!Number.isInteger(n) || n < 1900 || n > 2100) {
+				return fail(400, { moviesMessage: 'Years must be whole numbers between 1900 and 2100.' });
+			}
+			years.push(n);
+		}
+
+		const resolutions = formData.getAll('movieResolution').map(String);
+		const codecs = formData.getAll('movieCodec').map(String);
+		const codecPolicy = String(formData.get('movieCodecPolicy') ?? '').trim();
+
+		if (codecPolicy !== 'prefer' && codecPolicy !== 'require') {
+			return fail(400, { moviesMessage: 'Codec policy must be "prefer" or "require".' });
+		}
+
+		const payload = { years, resolutions, codecs, codecPolicy };
+
+		try {
+			const response = await apiRequest('/api/config/movies', {
+				method: 'PUT',
+				headers: {
+					'content-type': 'application/json',
+					authorization: `Bearer ${writeToken}`,
+					'if-match': ifMatch
+				},
+				body: JSON.stringify(payload)
+			});
+
+			if (!response.ok) {
+				let moviesMessage = `Save failed (${response.status}).`;
+				try {
+					const body = (await response.json()) as { error?: string };
+					if (body.error) moviesMessage = body.error;
+				} catch {
+					// keep fallback message
+				}
+				return fail(response.status, {
+					moviesMessage,
+					moviesEtag: response.headers.get('etag')
+				});
+			}
+
+			return {
+				moviesSuccess: true,
+				moviesMessage: 'Movies policy saved.',
+				moviesEtag: response.headers.get('etag')
+			};
+		} catch (error) {
+			console.error('[config] saveMovies failed:', error);
+			return fail(500, { moviesMessage: 'Could not save movies policy.' });
+		}
 	}
 };

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -9,17 +9,28 @@
 	const WRITE_DISABLED_TOOLTIP = 'Configure PIRATE_CLAW_API_WRITE_TOKEN to enable editing';
 
 	const { data, form }: { data: PageData; form?: ActionData } = $props();
-	const currentEtag = $derived(form?.tvDefaultsEtag ?? form?.etag ?? data.etag ?? null);
+	const currentEtag = $derived(
+		form?.moviesEtag ?? form?.tvDefaultsEtag ?? form?.etag ?? data.etag ?? null
+	);
 	const canWrite = $derived(data.canWrite);
 
 	let showRows = $state<string[]>([]);
 	let tvResolutions = $state<string[]>([]);
 	let tvCodecs = $state<string[]>([]);
+	let movieYears = $state<number[]>([]);
+	let movieResolutions = $state<string[]>([]);
+	let movieCodecs = $state<string[]>([]);
+	let movieCodecPolicy = $state<'prefer' | 'require'>('prefer');
+	let movieYearInput = $state('');
 
 	$effect(() => {
 		const c = data.config;
 		if (c) {
 			showRows = c.tv.map((r) => r.name);
+			movieYears = [...c.movies.years];
+			movieResolutions = [...c.movies.resolutions];
+			movieCodecs = [...c.movies.codecs];
+			movieCodecPolicy = c.movies.codecPolicy;
 		}
 	});
 
@@ -51,6 +62,34 @@
 			tvCodecs = [...tvCodecs, codec];
 		}
 	}
+
+	function addMovieYear() {
+		const n = Number(movieYearInput.trim());
+		if (Number.isInteger(n) && n >= 1900 && n <= 2100 && !movieYears.includes(n)) {
+			movieYears = [...movieYears, n].sort((a, b) => a - b);
+			movieYearInput = '';
+		}
+	}
+
+	function removeMovieYear(year: number) {
+		movieYears = movieYears.filter((y) => y !== year);
+	}
+
+	function toggleMovieResolution(res: string) {
+		if (movieResolutions.includes(res)) {
+			movieResolutions = movieResolutions.filter((r) => r !== res);
+		} else {
+			movieResolutions = [...movieResolutions, res];
+		}
+	}
+
+	function toggleMovieCodec(codec: string) {
+		if (movieCodecs.includes(codec)) {
+			movieCodecs = movieCodecs.filter((c) => c !== codec);
+		} else {
+			movieCodecs = [...movieCodecs, codec];
+		}
+	}
 </script>
 
 <h1 class="text-3xl font-bold tracking-tight">Config</h1>
@@ -72,6 +111,11 @@
 			<Alert variant={form?.tvDefaultsSuccess ? 'default' : 'destructive'}>
 				<AlertTitle>{form?.tvDefaultsSuccess ? 'Save complete' : 'Save failed'}</AlertTitle>
 				<AlertDescription>{form.tvDefaultsMessage}</AlertDescription>
+			</Alert>
+		{:else if form?.moviesMessage}
+			<Alert variant={form?.moviesSuccess ? 'default' : 'destructive'}>
+				<AlertTitle>{form?.moviesSuccess ? 'Save complete' : 'Save failed'}</AlertTitle>
+				<AlertDescription>{form.moviesMessage}</AlertDescription>
 			</Alert>
 		{:else if form?.message}
 			<Alert variant={form?.success ? 'default' : 'destructive'}>
@@ -154,6 +198,149 @@
 			</Card>
 		</form>
 
+		<form method="POST" action="?/saveMovies" use:enhance class="space-y-6">
+			<input type="hidden" name="moviesIfMatch" value={currentEtag ?? ''} />
+			{#each movieYears as year}
+				<input type="hidden" name="movieYear" value={year} />
+			{/each}
+			{#each movieResolutions as res}
+				<input type="hidden" name="movieResolution" value={res} />
+			{/each}
+			{#each movieCodecs as codec}
+				<input type="hidden" name="movieCodec" value={codec} />
+			{/each}
+			<input type="hidden" name="movieCodecPolicy" value={movieCodecPolicy} />
+			<Card>
+				<CardHeader class="pb-3">
+					<h2 class="text-lg font-semibold tracking-tight">Movies</h2>
+				</CardHeader>
+				<CardContent class="space-y-4 pt-0">
+					<div class="space-y-2">
+						<p class="text-muted-foreground text-sm font-medium">Years</p>
+						<div class="flex flex-wrap gap-2">
+							{#each movieYears as year}
+								<span
+									class="border-border bg-card/50 inline-flex h-8 items-center gap-1 rounded-full border px-3 text-sm"
+								>
+									{year}
+									<button
+										type="button"
+										class="text-muted-foreground hover:text-foreground ml-1"
+										disabled={!canWrite}
+										aria-label="Remove year {year}"
+										onclick={() => removeMovieYear(year)}>×</button
+									>
+								</span>
+							{/each}
+						</div>
+						<div class="flex gap-2" title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}>
+							<input
+								type="number"
+								min="1900"
+								max="2100"
+								step="1"
+								placeholder="e.g. 2025"
+								bind:value={movieYearInput}
+								disabled={!canWrite}
+								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-32 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+								onkeydown={(e) => {
+									if (e.key === 'Enter') {
+										e.preventDefault();
+										addMovieYear();
+									}
+								}}
+							/>
+							<button
+								type="button"
+								class="border-border bg-card hover:bg-muted/50 inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-50"
+								disabled={!canWrite}
+								onclick={addMovieYear}
+							>
+								Add year
+							</button>
+						</div>
+					</div>
+					<div class="space-y-2">
+						<p class="text-muted-foreground text-sm font-medium">Resolutions</p>
+						<div
+							class="flex flex-wrap gap-2"
+							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+						>
+							{#each ALL_RESOLUTIONS as res}
+								<button
+									type="button"
+									class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {movieResolutions.includes(
+										res
+									)
+										? 'bg-primary text-primary-foreground border-primary'
+										: 'border-border text-muted-foreground hover:bg-muted'}"
+									disabled={!canWrite}
+									onclick={() => toggleMovieResolution(res)}
+								>
+									{res}
+								</button>
+							{/each}
+						</div>
+					</div>
+					<div class="space-y-2">
+						<p class="text-muted-foreground text-sm font-medium">Codecs</p>
+						<div
+							class="flex flex-wrap gap-2"
+							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+						>
+							{#each ALL_CODECS as codec}
+								<button
+									type="button"
+									class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {movieCodecs.includes(
+										codec
+									)
+										? 'bg-primary text-primary-foreground border-primary'
+										: 'border-border text-muted-foreground hover:bg-muted'}"
+									disabled={!canWrite}
+									onclick={() => toggleMovieCodec(codec)}
+								>
+									{codec}
+								</button>
+							{/each}
+						</div>
+					</div>
+					<div class="space-y-2">
+						<p class="text-muted-foreground text-sm font-medium">Codec policy</p>
+						<div
+							class="flex gap-0 overflow-hidden rounded-md border"
+							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+						>
+							{#each ['prefer', 'require'] as policy}
+								<button
+									type="button"
+									class="flex-1 px-4 py-2 text-sm font-medium transition-colors {movieCodecPolicy ===
+									policy
+										? 'bg-primary text-primary-foreground'
+										: 'text-muted-foreground hover:bg-muted'}"
+									disabled={!canWrite}
+									onclick={() => {
+										movieCodecPolicy = policy as 'prefer' | 'require';
+									}}
+								>
+									{policy.charAt(0).toUpperCase() + policy.slice(1)}
+								</button>
+							{/each}
+						</div>
+					</div>
+					<div>
+						<button
+							type="submit"
+							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
+							disabled={!canWrite || !currentEtag}
+							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+						>
+							Save movies policy
+						</button>
+					</div>
+				</CardContent>
+			</Card>
+		</form>
+
 		<form method="POST" action="?/saveSettings" use:enhance class="space-y-6">
 			<input type="hidden" name="ifMatch" value={currentEtag ?? ''} />
 
@@ -223,32 +410,6 @@
 							Add show
 						</button>
 					</div>
-				</CardContent>
-			</Card>
-
-			<Card>
-				<CardHeader class="pb-3">
-					<h2 class="text-lg font-semibold tracking-tight">Movies</h2>
-				</CardHeader>
-				<CardContent class="pt-0">
-					<dl class="grid gap-2 text-sm">
-						<div class="flex flex-wrap gap-2">
-							<dt class="text-muted-foreground">Years:</dt>
-							<dd class="text-foreground">{config.movies.years.join(', ')}</dd>
-						</div>
-						<div class="flex flex-wrap gap-2">
-							<dt class="text-muted-foreground">Resolutions:</dt>
-							<dd class="text-foreground">{config.movies.resolutions.join(', ')}</dd>
-						</div>
-						<div class="flex flex-wrap gap-2">
-							<dt class="text-muted-foreground">Codecs:</dt>
-							<dd class="text-foreground">{config.movies.codecs.join(', ')}</dd>
-						</div>
-						<div class="flex flex-wrap gap-2">
-							<dt class="text-muted-foreground">Codec policy:</dt>
-							<dd class="text-foreground">{config.movies.codecPolicy}</dd>
-						</div>
-					</dl>
 				</CardContent>
 			</Card>
 

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -95,7 +95,8 @@ describe('/config', () => {
 				etag: '"rev-2"'
 			}
 		});
-		expect(screen.getByRole('alert')).toHaveTextContent(
+		// success variant renders with role="status" (not "alert")
+		expect(screen.getByRole('status')).toHaveTextContent(
 			/TV show list updates apply on the next daemon run cycle/
 		);
 		expect(screen.getByText(/Daemon timers and the API listen port/i)).toBeInTheDocument();

--- a/web/src/routes/config/page.server.test.ts
+++ b/web/src/routes/config/page.server.test.ts
@@ -21,7 +21,7 @@ describe('config page server actions', () => {
 		body.set('runIntervalMinutes', '15');
 		body.set('feeds', '[]');
 
-		const result = await actions.saveRuntime({
+		const result = await actions.saveSettings({
 			request: new Request('http://localhost/config', {
 				method: 'POST',
 				headers: { 'content-type': 'application/x-www-form-urlencoded' },
@@ -40,9 +40,10 @@ describe('config page server actions', () => {
 
 		const body = new URLSearchParams();
 		body.set('ifMatch', '"rev-1"');
+		body.set('showName', 'Test Show');
 		body.set('runIntervalMinutes', '0');
 
-		const result = await actions.saveRuntime({
+		const result = await actions.saveSettings({
 			request: new Request('http://localhost/config', {
 				method: 'POST',
 				headers: { 'content-type': 'application/x-www-form-urlencoded' },


### PR DESCRIPTION
## Summary

- delivery ticket: `P14.04 Movies Policy UI`
- ticket file: [docs/02-delivery/phase-14/ticket-04-movies-policy-ui.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-14/ticket-04-movies-policy-ui.md)
- stacked base branch: `agents/p14-03-tv-section-ui`
- post-verify self-audit: completed at 2026-04-10 07:42 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`b196c9dea859`](https://github.com/cesarnml/pirate_claw/commit/b196c9dea859500a54007279c5e0e1a208e3ae83)
- current branch head: [`b196c9dea859`](https://github.com/cesarnml/pirate_claw/commit/b196c9dea859500a54007279c5e0e1a208e3ae83)
- vendors: `sonarqube`
