### PR TITLE
feat(web): add Feeds editable section with blocking URL validation feedback [P14.05]

### DIFF
--- a/docs/02-delivery/phase-14/ticket-05-feeds-ui.md
+++ b/docs/02-delivery/phase-14/ticket-05-feeds-ui.md
@@ -40,4 +40,12 @@ The Feeds section is present in the dashboard config page. Adding a feed trigger
 
 ## Rationale
 
-_To be filled in after implementation._
+`saveFeeds` receives the full current feeds array as hidden inputs (`feedName[]`, `feedUrl[]`, `feedMediaType[]`) plus optional `newFeedName`, `newFeedUrl`, `newFeedMediaType` for an add-in-progress entry. The server zips these into a `{ name, url, mediaType }[]` array and sends it as the raw JSON body to `PUT /api/config/feeds` (which expects an array, not a wrapped object). If `newFeedUrl` is empty the new-feed fields are silently ignored — this allows save-removes-only without requiring a new feed entry.
+
+`use:enhance` with a custom callback tracks `feedsSubmitting` state for the in-flight spinner. The button changes to "Saving…" while the action is running; on completion (success or error) the state resets. On success, `newFeedName`, `newFeedUrl`, and `newFeedMediaType` are cleared before `update()` re-runs the load. `update()` invalidates all page data, so `data.config.feeds` refreshes and the `$effect` reinitializes `feedsList` from the server-confirmed state.
+
+`feedsEtag` from the action result is folded into `currentEtag` at the highest priority, keeping the ETag current for subsequent saves on other sections.
+
+400 responses from the feeds endpoint always indicate either invalid feed format or a URL fetch failure. Both are surfaced as `feedsUrlError` (shown under the URL input) rather than a generic alert. Other non-2xx status codes use `feedsMessage` and appear in the general alert area. The 404/409/403 handling follows the same pattern as other sections.
+
+Remove buttons update `feedsList` state locally (no immediate save). The updated list is included in the next submit, which persists the removal atomically.

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -295,5 +295,76 @@ export const actions: Actions = {
 			console.error('[config] saveMovies failed:', error);
 			return fail(500, { moviesMessage: 'Could not save movies policy.' });
 		}
+	},
+
+	saveFeeds: async ({ request }) => {
+		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+		if (!writeToken) {
+			return fail(403, { feedsMessage: 'Config writes are disabled.' });
+		}
+
+		const formData = await request.formData();
+		const ifMatch = String(formData.get('feedsIfMatch') ?? '').trim();
+		if (!ifMatch) {
+			return fail(400, { feedsMessage: 'Missing config revision. Reload and try again.' });
+		}
+
+		const feedNames = formData.getAll('feedName').map(String);
+		const feedUrls = formData.getAll('feedUrl').map(String);
+		const feedMediaTypes = formData.getAll('feedMediaType').map(String);
+
+		const feeds: { name: string; url: string; mediaType: string }[] = feedNames.map((name, i) => ({
+			name,
+			url: feedUrls[i] ?? '',
+			mediaType: feedMediaTypes[i] ?? 'tv'
+		}));
+
+		const newName = String(formData.get('newFeedName') ?? '').trim();
+		const newUrl = String(formData.get('newFeedUrl') ?? '').trim();
+		const newMediaType = String(formData.get('newFeedMediaType') ?? 'tv').trim();
+		if (newUrl) {
+			feeds.push({ name: newName, url: newUrl, mediaType: newMediaType });
+		}
+
+		try {
+			const response = await apiRequest('/api/config/feeds', {
+				method: 'PUT',
+				headers: {
+					'content-type': 'application/json',
+					authorization: `Bearer ${writeToken}`,
+					'if-match': ifMatch
+				},
+				body: JSON.stringify(feeds)
+			});
+
+			if (!response.ok) {
+				let errorText = `Save failed (${response.status}).`;
+				try {
+					const body = (await response.json()) as { error?: string };
+					if (body.error) errorText = body.error;
+				} catch {
+					// keep fallback
+				}
+				if (response.status === 400) {
+					return fail(400, {
+						feedsUrlError: errorText,
+						feedsEtag: response.headers.get('etag')
+					});
+				}
+				return fail(response.status, {
+					feedsMessage: errorText,
+					feedsEtag: response.headers.get('etag')
+				});
+			}
+
+			return {
+				feedsSuccess: true,
+				feedsMessage: 'Feeds saved.',
+				feedsEtag: response.headers.get('etag')
+			};
+		} catch (error) {
+			console.error('[config] saveFeeds failed:', error);
+			return fail(500, { feedsMessage: 'Could not save feeds.' });
+		}
 	}
 };

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -309,15 +309,20 @@ export const actions: Actions = {
 			return fail(400, { feedsMessage: 'Missing config revision. Reload and try again.' });
 		}
 
-		const feedNames = formData.getAll('feedName').map(String);
-		const feedUrls = formData.getAll('feedUrl').map(String);
-		const feedMediaTypes = formData.getAll('feedMediaType').map(String);
-
-		const feeds: { name: string; url: string; mediaType: string }[] = feedNames.map((name, i) => ({
-			name,
-			url: feedUrls[i] ?? '',
-			mediaType: feedMediaTypes[i] ?? 'tv'
-		}));
+		const existingFeedsJson = String(formData.get('existingFeedsJson') ?? '[]');
+		let feeds: {
+			name: string;
+			url: string;
+			mediaType: string;
+			pollIntervalMinutes?: number;
+			parserHints?: Record<string, unknown>;
+		}[];
+		try {
+			const parsed = JSON.parse(existingFeedsJson);
+			feeds = Array.isArray(parsed) ? parsed : [];
+		} catch {
+			feeds = [];
+		}
 
 		const newName = String(formData.get('newFeedName') ?? '').trim();
 		const newUrl = String(formData.get('newFeedUrl') ?? '').trim();

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -3,6 +3,7 @@
 	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
 	import { Card, CardContent, CardHeader } from '$lib/components/ui/card';
 	import type { ActionData, PageData } from './$types';
+	import type { FeedConfig } from '$lib/types';
 
 	const ALL_RESOLUTIONS = ['2160p', '1080p', '720p', '480p'];
 	const ALL_CODECS = ['x264', 'x265'];
@@ -10,7 +11,7 @@
 
 	const { data, form }: { data: PageData; form?: ActionData } = $props();
 	const currentEtag = $derived(
-		form?.moviesEtag ?? form?.tvDefaultsEtag ?? form?.etag ?? data.etag ?? null
+		form?.feedsEtag ?? form?.moviesEtag ?? form?.tvDefaultsEtag ?? form?.etag ?? data.etag ?? null
 	);
 	const canWrite = $derived(data.canWrite);
 
@@ -22,6 +23,11 @@
 	let movieCodecs = $state<string[]>([]);
 	let movieCodecPolicy = $state<'prefer' | 'require'>('prefer');
 	let movieYearInput = $state('');
+	let feedsList = $state<FeedConfig[]>([]);
+	let newFeedName = $state('');
+	let newFeedUrl = $state('');
+	let newFeedMediaType = $state<'tv' | 'movie'>('tv');
+	let feedsSubmitting = $state(false);
 
 	$effect(() => {
 		const c = data.config;
@@ -31,6 +37,7 @@
 			movieResolutions = [...c.movies.resolutions];
 			movieCodecs = [...c.movies.codecs];
 			movieCodecPolicy = c.movies.codecPolicy;
+			feedsList = [...c.feeds];
 		}
 	});
 
@@ -90,6 +97,10 @@
 			movieCodecs = [...movieCodecs, codec];
 		}
 	}
+
+	function removeFeed(index: number) {
+		feedsList = feedsList.filter((_, i) => i !== index);
+	}
 </script>
 
 <h1 class="text-3xl font-bold tracking-tight">Config</h1>
@@ -107,7 +118,12 @@
 	{@const config = data.config}
 
 	<div class="mt-8 space-y-6 pr-1">
-		{#if form?.tvDefaultsMessage}
+		{#if form?.feedsMessage}
+			<Alert variant={form?.feedsSuccess ? 'default' : 'destructive'}>
+				<AlertTitle>{form?.feedsSuccess ? 'Save complete' : 'Save failed'}</AlertTitle>
+				<AlertDescription>{form.feedsMessage}</AlertDescription>
+			</Alert>
+		{:else if form?.tvDefaultsMessage}
 			<Alert variant={form?.tvDefaultsSuccess ? 'default' : 'destructive'}>
 				<AlertTitle>{form?.tvDefaultsSuccess ? 'Save complete' : 'Save failed'}</AlertTitle>
 				<AlertDescription>{form.tvDefaultsMessage}</AlertDescription>
@@ -123,6 +139,126 @@
 				<AlertDescription>{form.message}</AlertDescription>
 			</Alert>
 		{/if}
+
+		<form
+			method="POST"
+			action="?/saveFeeds"
+			use:enhance={() => {
+				feedsSubmitting = true;
+				return async ({ result, update }) => {
+					feedsSubmitting = false;
+					if (result.type === 'success') {
+						newFeedName = '';
+						newFeedUrl = '';
+						newFeedMediaType = 'tv';
+					}
+					await update();
+				};
+			}}
+			class="space-y-6"
+		>
+			<input type="hidden" name="feedsIfMatch" value={currentEtag ?? ''} />
+			{#each feedsList as feed}
+				<input type="hidden" name="feedName" value={feed.name} />
+				<input type="hidden" name="feedUrl" value={feed.url} />
+				<input type="hidden" name="feedMediaType" value={feed.mediaType} />
+			{/each}
+			<Card>
+				<CardHeader class="pb-3">
+					<h2 class="text-lg font-semibold tracking-tight">Feeds</h2>
+				</CardHeader>
+				<CardContent class="space-y-4 pt-0">
+					{#if feedsList.length === 0}
+						<p class="text-muted-foreground text-sm">No feeds configured.</p>
+					{:else}
+						<ul class="list-none space-y-2">
+							{#each feedsList as feed, i}
+								<li
+									class="border-border bg-card/50 flex items-start justify-between gap-3 rounded-md border p-3 text-sm"
+								>
+									<div class="min-w-0 flex-1">
+										<div class="text-foreground font-medium">{feed.name}</div>
+										<div class="text-muted-foreground mt-1 flex flex-wrap items-center gap-2">
+											<span
+												class="border-border rounded-full border px-2 py-0.5 text-xs font-medium"
+												>{feed.mediaType}</span
+											>
+											<span class="break-all">{feed.url}</span>
+											{#if feed.pollIntervalMinutes !== undefined}
+												<span>Poll: {feed.pollIntervalMinutes}m</span>
+											{/if}
+										</div>
+									</div>
+									<button
+										type="button"
+										class="text-muted-foreground hover:text-foreground shrink-0 disabled:opacity-40"
+										disabled={!canWrite}
+										aria-label="Remove feed {feed.name}"
+										onclick={() => removeFeed(i)}
+									>
+										×
+									</button>
+								</li>
+							{/each}
+						</ul>
+					{/if}
+					<div
+						class="border-border space-y-3 rounded-md border p-3"
+						title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+					>
+						<p class="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+							Add feed
+						</p>
+						<div class="grid gap-2">
+							<input
+								name="newFeedName"
+								type="text"
+								placeholder="Feed name"
+								bind:value={newFeedName}
+								disabled={!canWrite}
+								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+							/>
+							<div class="space-y-1">
+								<input
+									name="newFeedUrl"
+									type="url"
+									placeholder="https://example.com/feed.rss"
+									bind:value={newFeedUrl}
+									disabled={!canWrite}
+									class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+								/>
+								{#if form?.feedsUrlError}
+									<p class="text-destructive text-xs">{form.feedsUrlError}</p>
+								{/if}
+							</div>
+							<select
+								name="newFeedMediaType"
+								bind:value={newFeedMediaType}
+								disabled={!canWrite}
+								class="border-input bg-background ring-offset-background focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+							>
+								<option value="tv">TV</option>
+								<option value="movie">Movie</option>
+							</select>
+						</div>
+					</div>
+					<div>
+						<button
+							type="submit"
+							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
+							disabled={!canWrite || !currentEtag || feedsSubmitting}
+							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+						>
+							{#if feedsSubmitting}
+								Saving…
+							{:else}
+								Save feeds
+							{/if}
+						</button>
+					</div>
+				</CardContent>
+			</Card>
+		</form>
 
 		<form method="POST" action="?/saveTvDefaults" use:enhance class="space-y-6">
 			<input type="hidden" name="tvDefaultsIfMatch" value={currentEtag ?? ''} />
@@ -343,32 +479,6 @@
 
 		<form method="POST" action="?/saveSettings" use:enhance class="space-y-6">
 			<input type="hidden" name="ifMatch" value={currentEtag ?? ''} />
-
-			<Card>
-				<CardHeader class="pb-3">
-					<h2 class="text-lg font-semibold tracking-tight">Feeds</h2>
-				</CardHeader>
-				<CardContent class="pt-0">
-					{#if config.feeds.length === 0}
-						<p class="text-muted-foreground text-sm">No feeds configured.</p>
-					{:else}
-						<ul class="list-none space-y-3">
-							{#each config.feeds as feed}
-								<li class="border-border bg-card/50 rounded-md border p-3 text-sm">
-									<div class="text-foreground font-medium">{feed.name}</div>
-									<div class="text-muted-foreground mt-1">
-										<span class="mr-3">Type: {feed.mediaType}</span>
-										{#if feed.pollIntervalMinutes !== undefined}
-											<span class="mr-3">Poll: {feed.pollIntervalMinutes}m</span>
-										{/if}
-										<span class="break-all">URL: {feed.url}</span>
-									</div>
-								</li>
-							{/each}
-						</ul>
-					{/if}
-				</CardContent>
-			</Card>
 
 			<Card>
 				<CardHeader class="pb-3">

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -158,11 +158,7 @@
 			class="space-y-6"
 		>
 			<input type="hidden" name="feedsIfMatch" value={currentEtag ?? ''} />
-			{#each feedsList as feed}
-				<input type="hidden" name="feedName" value={feed.name} />
-				<input type="hidden" name="feedUrl" value={feed.url} />
-				<input type="hidden" name="feedMediaType" value={feed.mediaType} />
-			{/each}
+			<input type="hidden" name="existingFeedsJson" value={JSON.stringify(feedsList)} />
 			<Card>
 				<CardHeader class="pb-3">
 					<h2 class="text-lg font-semibold tracking-tight">Feeds</h2>
@@ -192,7 +188,7 @@
 									<button
 										type="button"
 										class="text-muted-foreground hover:text-foreground shrink-0 disabled:opacity-40"
-										disabled={!canWrite}
+										disabled={!canWrite || feedsSubmitting}
 										aria-label="Remove feed {feed.name}"
 										onclick={() => removeFeed(i)}
 									>
@@ -215,7 +211,7 @@
 								type="text"
 								placeholder="Feed name"
 								bind:value={newFeedName}
-								disabled={!canWrite}
+								disabled={!canWrite || feedsSubmitting}
 								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
 							/>
 							<div class="space-y-1">
@@ -224,7 +220,7 @@
 									type="url"
 									placeholder="https://example.com/feed.rss"
 									bind:value={newFeedUrl}
-									disabled={!canWrite}
+									disabled={!canWrite || feedsSubmitting}
 									class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
 								/>
 								{#if form?.feedsUrlError}
@@ -234,7 +230,7 @@
 							<select
 								name="newFeedMediaType"
 								bind:value={newFeedMediaType}
-								disabled={!canWrite}
+								disabled={!canWrite || feedsSubmitting}
 								class="border-input bg-background ring-offset-background focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
 							>
 								<option value="tv">TV</option>


### PR DESCRIPTION
## Summary

- delivery ticket: `P14.05 Feeds UI`
- ticket file: [docs/02-delivery/phase-14/ticket-05-feeds-ui.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-14/ticket-05-feeds-ui.md)
- stacked base branch: `agents/p14-04-movies-policy-ui`
- post-verify self-audit: completed at 2026-04-10 07:50 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`971eeec06b77`](https://github.com/cesarnml/pirate_claw/commit/971eeec06b77b57487d83fe7c8803e2480fd8a11)
- current branch head: [`9ba22b16e1f9`](https://github.com/cesarnml/pirate_claw/commit/9ba22b16e1f9fd1ac2bebaa872bdc2128c38ac67)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `971eeec06b77` address all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Preserve the full feed object when rebuilding this payload. (native GitHub thread resolved) `web/src/routes/config/+page.server.ts:337` [thread](https://github.com/cesarnml/pirate_claw/pull/121#discussion_r3062938889)
- [coderabbit] Freeze the feeds editor while the save is in flight. (native GitHub thread resolved) `web/src/routes/config/+page.svelte:157` [thread](https://github.com/cesarnml/pirate_claw/pull/121#discussion_r3062938893)
