### PR TITLE
feat(p15.01): GET /api/outcomes — skipped no-match outcomes endpoint [P15.01]

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -36,6 +36,7 @@
     "retarget",
     "retryability",
     "sabaai",
+    "Shawshank",
     "SARIF",
     "shadcn",
     "sonarcloud",

--- a/docs/02-delivery/phase-15/implementation-plan.md
+++ b/docs/02-delivery/phase-15/implementation-plan.md
@@ -1,0 +1,97 @@
+# Phase 15 Implementation Plan
+
+Phase 15 adds the visibility layer that makes pirate-claw useful to monitor day-to-day. Phase 13 and 14 unlock config writes; Phase 15 answers "what is it actually doing right now?" by surfacing live Transmission state alongside pirate-claw's own candidate and lifecycle data.
+
+## Epic
+
+- `Phase 15 Rich Visual State and Activity Views`
+
+Follow the shared guidance in [`docs/02-delivery/phase-implementation-guidance.md`](../phase-implementation-guidance.md) when shaping or revising tickets for this phase.
+
+## Product contract
+
+- [`docs/01-product/phase-15-rich-visual-state-and-activity-views.md`](../../01-product/phase-15-rich-visual-state-and-activity-views.md)
+
+## Grill-Me decisions locked for this phase
+
+- **Framework**: SvelteKit 2 + Svelte 5 runes throughout `web/`. Not React+Vite. All web tickets use `+page.server.ts`, `$props()`, `@testing-library/svelte`, and vitest.
+- **Transmission torrents scope (Decision B)**: `GET /api/transmission/torrents` returns only pirate-claw-managed torrents — those with a non-null `transmission_torrent_hash` in `candidate_state`. No unrelated Transmission torrents are exposed.
+- **Status code mapping**: Transmission integer status → string: `4 → 'downloading'`, `6 → 'seeding'`, `7 → 'error'`, all others → `'stopped'`.
+- **NULL feedName/title in outcomes**: `GET /api/outcomes` LEFT JOINs to `feed_items`. When `feed_item_id` is NULL, `feedName` and `title` are returned as `null`. UI renders "—".
+- **Separate Transmission types**: New `TorrentStatSnapshot` type (adds `rateDownload`, `eta`) and new `fetchTorrentStats` function in `src/transmission.ts`. Existing `TorrentSnapshot` and `lookupTorrents` are not modified — they serve the reconcile path.
+- **"View all" link**: The Overview Active Downloads "View all" links to `/candidates` (existing Candidates route). No new route.
+- **Archive Commit grid**: Derived client-side from the full `GET /api/candidates` payload (filter `lifecycleStatus === 'completed'`, sort by `transmissionDoneDate` desc, take 6). No new API endpoint or query params.
+- **Transmission session failure**: `GET /api/transmission/session` returns HTTP 502 if Transmission is unreachable. The dashboard `+page.server.ts` catches this and returns `transmissionSession: null`, rendering a graceful "Transmission unavailable" state in the header strip.
+- **Fixture snapshots**: `fixtures/api/transmission-torrents.json`, `fixtures/api/transmission-session.json`, and `fixtures/api/outcomes-skipped-no-match.json` must be committed before any UI ticket that reads those endpoints begins implementation.
+- **Join key for speed/progress**: `transmissionTorrentHash` is added to `ShowEpisode` and `MovieBreakdown` (both `src/` types and `web/src/lib/types.ts`) and passed through the build functions. Show and movie pages join to `GET /api/transmission/torrents` by hash to surface live `rateDownload` and `eta`.
+
+## Stack
+
+- Bun + TypeScript daemon/API in `src/`
+- SvelteKit 2 + Svelte 5 + TypeScript in `web/`
+- Existing transmission client in [`src/transmission.ts`](../../../src/transmission.ts)
+- Existing API layer in [`src/api.ts`](../../../src/api.ts): `createApiFetch`, `ApiFetchDeps`, `buildShowBreakdowns`, `buildMovieBreakdowns`
+- Existing show/movie types in [`src/tv-api-types.ts`](../../../src/tv-api-types.ts) and [`src/movie-api-types.ts`](../../../src/movie-api-types.ts)
+- Existing web types in [`web/src/lib/types.ts`](../../../web/src/lib/types.ts)
+- Existing `apiFetch` helper in [`web/src/lib/server/api.ts`](../../../web/src/lib/server/api.ts)
+- SQLite `feed_item_outcomes` table — LEFT JOINable to `feed_items` via `feed_item_id`
+
+## Ticket Order
+
+1. `P15.01 GET /api/outcomes — Skipped No-Match Outcomes Endpoint`
+2. `P15.02 Transmission Proxy Endpoints — GET /api/transmission/torrents and GET /api/transmission/session`
+3. `P15.03 Dashboard Overview Enhancement`
+4. `P15.04 TV Shows View — Progress and Sort`
+5. `P15.05 Movies View — Filter Tabs, Genre Filter, Sort, and Progress`
+6. `P15.06 Unmatched Candidates View`
+7. `P15.07 Docs and Phase Exit`
+
+## Ticket Files
+
+- `ticket-01-outcomes-endpoint.md`
+- `ticket-02-transmission-proxy-endpoints.md`
+- `ticket-03-dashboard-overview-enhancement.md`
+- `ticket-04-tv-shows-progress-and-sort.md`
+- `ticket-05-movies-filter-sort-progress.md`
+- `ticket-06-unmatched-candidates-view.md`
+- `ticket-07-docs-and-phase-exit.md`
+
+## Exit Condition
+
+An operator can open the dashboard and immediately see what is actively downloading, what completed recently, what was skipped by policy and why, and browse their full TV/movie library with TMDB enrichment — all without touching the terminal. All views refresh on demand via page reload. No real-time push.
+
+## Review Rules
+
+Review and merge in ticket order.
+
+Do not start the next ticket until:
+
+- tests/checks for the current ticket are green
+- fixture snapshots for new endpoints are committed before any dependent UI ticket begins
+- ticket rationale is updated for any behavior or tradeoff changes discovered during implementation
+
+## Explicit Deferrals
+
+- Server-side filtering query params on `GET /api/candidates` or `GET /api/outcomes` (beyond the single `status=skipped_no_match` in P15)
+- Real-time WebSocket or SSE push for live download updates
+- Disk/storage usage (no filesystem API available)
+- Audio format metadata (Dolby Atmos, channel count, FPS) — not in Transmission RPC or pirate-claw data
+- Global throttle controls or seed ratio management (Transmission session writes out of scope)
+- `GET /api/candidates?lifecycle=completed&limit=N` query param — archive grid uses client-side filtering
+- Transmission offline fallback handling (always-on NAS assumption holds)
+
+## Stop Conditions
+
+Pause for review if:
+
+- the Transmission RPC shape for `torrent-get` (all-torrent variant) differs significantly from what `buildLookupRequestBody` already handles — surface the delta before proceeding
+- `transmissionTorrentHash` is null for candidates that are actively downloading (unexpected reconciliation gap) — diagnose before wiring the join
+- any UI ticket requires exposing `config.transmission.password` or other credentials through the web layer
+
+## Developer approval gate
+
+**Do not begin implementation** until this implementation plan and all Phase 15 ticket docs are merged to `main` and explicitly approved for delivery.
+
+## Delivery status
+
+Planning/decomposition only. Implementation has not started.

--- a/docs/02-delivery/phase-15/ticket-01-outcomes-endpoint.md
+++ b/docs/02-delivery/phase-15/ticket-01-outcomes-endpoint.md
@@ -1,0 +1,75 @@
+# P15.01 GET /api/outcomes — Skipped No-Match Outcomes Endpoint
+
+## Goal
+
+Add `GET /api/outcomes` to the daemon API, returning `feed_item_outcomes` records where `status = 'skipped_no_match'` for the last 30 days. This endpoint feeds the Unmatched Candidates view and anchors the fixture snapshot required before P15.06 begins.
+
+## Scope
+
+### Repository
+
+- Add `listSkippedNoMatchOutcomes(days: number): SkippedOutcomeRecord[]` to the `Repository` interface and `createRepository` implementation in [`src/repository.ts`](../../../src/repository.ts).
+- SQL: `SELECT fo.id, fo.run_id, fo.status, fo.created_at, fi.raw_title AS title, fi.feed_name FROM feed_item_outcomes fo LEFT JOIN feed_items fi ON fo.feed_item_id = fi.id WHERE fo.status = 'skipped_no_match' AND fo.created_at >= datetime('now', '-' || ? || ' days') ORDER BY fo.created_at DESC`
+- Return type:
+  ```typescript
+  export type SkippedOutcomeRecord = {
+    id: number;
+    runId: number;
+    status: 'skipped_no_match';
+    recordedAt: string;
+    title: string | null;    // null when feed_item_id is NULL on the outcome row
+    feedName: string | null; // null when feed_item_id is NULL on the outcome row
+  };
+  ```
+- Add `listSkippedNoMatchOutcomes` to the `Repository` type definition.
+
+### API
+
+- Add `GET /api/outcomes` handler to [`src/api.ts`](../../../src/api.ts).
+- Query param `?status=skipped_no_match` is the only supported value in P15; other values return `400 { "error": "unsupported status filter" }`. No param defaults to `skipped_no_match` (require explicit param — unambiguous).
+- Calls `repository.listSkippedNoMatchOutcomes(30)`.
+- Response shape:
+  ```json
+  {
+    "outcomes": [
+      {
+        "title": "Some.Show.S01E01.720p",
+        "feedName": "main-tv",
+        "runId": 42,
+        "status": "skipped_no_match",
+        "recordedAt": "2026-04-01T12:00:00.000Z"
+      }
+    ]
+  }
+  ```
+  `title` and `feedName` may be `null`.
+
+### Fixture Snapshot
+
+- Commit `fixtures/api/outcomes-skipped-no-match.json` — a representative `GET /api/outcomes?status=skipped_no_match` response with at least 3 entries (mix of null and non-null `title`/`feedName`) for use by P15.06.
+
+### Tests
+
+- Repository unit tests:
+  - returns only `skipped_no_match` rows
+  - respects the 30-day window (rows older than 30 days excluded)
+  - LEFT JOIN: title and feedName are populated when `feed_item_id` is non-null, null when it is null
+- API handler tests:
+  - `GET /api/outcomes?status=skipped_no_match` → 200 with correct shape
+  - `GET /api/outcomes?status=other` → 400
+  - `GET /api/outcomes` (no param) → 400 (require explicit param)
+  - empty result when no matching outcomes → `{ "outcomes": [] }`
+
+## Out of Scope
+
+- Additional `status` filter values (P16+)
+- Pagination or server-side search
+- Any web UI (P15.06)
+
+## Exit Condition
+
+`GET /api/outcomes?status=skipped_no_match` is live, returns the correct shape, tests are green, and `fixtures/api/outcomes-skipped-no-match.json` is committed and readable by P15.06.
+
+## Rationale
+
+_(Update this section after implementation with any behavior or tradeoff changes discovered.)_

--- a/docs/02-delivery/phase-15/ticket-01-outcomes-endpoint.md
+++ b/docs/02-delivery/phase-15/ticket-01-outcomes-endpoint.md
@@ -17,7 +17,7 @@ Add `GET /api/outcomes` to the daemon API, returning `feed_item_outcomes` record
     runId: number;
     status: 'skipped_no_match';
     recordedAt: string;
-    title: string | null;    // null when feed_item_id is NULL on the outcome row
+    title: string | null; // null when feed_item_id is NULL on the outcome row
     feedName: string | null; // null when feed_item_id is NULL on the outcome row
   };
   ```

--- a/docs/02-delivery/phase-15/ticket-02-transmission-proxy-endpoints.md
+++ b/docs/02-delivery/phase-15/ticket-02-transmission-proxy-endpoints.md
@@ -1,0 +1,156 @@
+# P15.02 Transmission Proxy Endpoints
+
+## Goal
+
+Add `GET /api/transmission/torrents` and `GET /api/transmission/session` to the daemon API. These proxy Transmission RPC calls and return pirate-claw-shaped responses. Fixture snapshots for both endpoints must be committed before any UI ticket reads them (P15.03, P15.04, P15.05).
+
+## Scope
+
+### New Types in `src/transmission.ts`
+
+```typescript
+export type TorrentStatSnapshot = {
+  hash: string;
+  name: string;
+  status: 'downloading' | 'seeding' | 'stopped' | 'error';
+  percentDone: number;
+  rateDownload: number; // bytes/second
+  eta: number;          // seconds; -1 when unknown
+};
+
+export type FetchTorrentStatsResult =
+  | { ok: true; torrents: TorrentStatSnapshot[] }
+  | SubmissionFailure;
+
+export type SessionInfo = {
+  version: string;
+  downloadSpeed: number;  // bytes/second
+  uploadSpeed: number;    // bytes/second
+  activeTorrentCount: number;
+};
+
+export type FetchSessionInfoResult =
+  | { ok: true; session: SessionInfo }
+  | SubmissionFailure;
+```
+
+Do **not** modify `TorrentSnapshot`, `LookupTorrentsResult`, or `lookupTorrentsInTransmission` — those serve the reconcile path and must remain stable.
+
+### Status Code Mapping
+
+Transmission integer `status` → string:
+
+| Code | Mapped to |
+|------|-----------|
+| 4    | `'downloading'` |
+| 6    | `'seeding'` |
+| 7    | `'error'` |
+| 0, 1, 2, 3, 5, other | `'stopped'` |
+
+### New Functions in `src/transmission.ts`
+
+**`fetchTorrentStats(config: TransmissionConfig, hashes: string[]): Promise<FetchTorrentStatsResult>`**
+
+- Calls Transmission RPC `torrent-get` with `ids: hashes` (Transmission accepts hash strings as ids) and fields: `['id', 'name', 'hashString', 'status', 'percentDone', 'rateDownload', 'eta']`.
+- Handles 409 session negotiation (same pattern as existing `lookupTorrentsInTransmission`).
+- Maps `statusCode` integer to the string union above.
+- Returns `{ ok: true, torrents: TorrentStatSnapshot[] }` on success.
+- Returns a `SubmissionFailure` on network, HTTP, or RPC error.
+
+**`fetchSessionInfo(config: TransmissionConfig): Promise<FetchSessionInfoResult>`**
+
+- Fires two RPC calls in parallel: `{ method: 'session-get', arguments: {} }` and `{ method: 'session-stats', arguments: {} }`.
+- Extracts `version` from `session-get` response (`arguments.version`).
+- Extracts `downloadSpeed` (`arguments['download-speed']`), `uploadSpeed` (`arguments['upload-speed']`), and `activeTorrentCount` (`arguments['active-torrent-count']`) from `session-stats` response.
+- If either call fails, returns `SubmissionFailure`.
+- Returns `{ ok: true, session: SessionInfo }` on success.
+
+### API Routes in `src/api.ts`
+
+**`GET /api/transmission/torrents`**
+
+1. Query `repository.listCandidateStates()`.
+2. Filter to candidates with `transmissionTorrentHash !== undefined`.
+3. If no candidates have a hash, return `{ torrents: [] }` immediately (no Transmission call).
+4. Call `fetchTorrentStats(config.transmission, hashes)`.
+5. If the Transmission call fails → `502 { "error": "transmission unavailable", "detail": "..." }`.
+6. Build response: for each Transmission torrent, find the matching candidate by hash. Only return torrents that match a pirate-claw candidate.
+7. Response: `{ torrents: TorrentStatSnapshot[] }`.
+
+**`GET /api/transmission/session`**
+
+1. Call `fetchSessionInfo(config.transmission)`.
+2. If fails → `502 { "error": "transmission unavailable", "detail": "..." }`.
+3. Response: `{ version, downloadSpeed, uploadSpeed, activeTorrentCount }`.
+
+Both endpoints read `config.transmission` from the existing `ApiFetchDeps.config` — no changes to `ApiFetchDeps` are required.
+
+### Fixture Snapshots
+
+Commit before P15.03 begins:
+
+**`fixtures/api/transmission-torrents.json`**
+```json
+{
+  "torrents": [
+    {
+      "hash": "abc123def456abc123def456abc123def456abc1",
+      "name": "Breaking.Bad.S01E01.720p.BluRay.x264",
+      "status": "downloading",
+      "percentDone": 0.42,
+      "rateDownload": 1048576,
+      "eta": 3600
+    },
+    {
+      "hash": "bcd234ef0567bcd234ef0567bcd234ef0567bcd2",
+      "name": "The.Shawshank.Redemption.1994.1080p.x265",
+      "status": "seeding",
+      "percentDone": 1.0,
+      "rateDownload": 0,
+      "eta": -1
+    }
+  ]
+}
+```
+
+**`fixtures/api/transmission-session.json`**
+```json
+{
+  "version": "3.00 (bb6b5a062ef)",
+  "downloadSpeed": 2097152,
+  "uploadSpeed": 524288,
+  "activeTorrentCount": 3
+}
+```
+
+### Tests
+
+- `fetchTorrentStats`:
+  - happy path: returns mapped `TorrentStatSnapshot[]` with correct status strings
+  - status code mapping: code 4 → `'downloading'`, code 6 → `'seeding'`, code 7 → `'error'`, code 0 → `'stopped'`
+  - 409 session negotiation handled
+  - Transmission unreachable → returns `SubmissionFailure`
+- `fetchSessionInfo`:
+  - happy path: merges session-get + session-stats into `SessionInfo`
+  - one RPC call fails → returns `SubmissionFailure`
+- API handler `GET /api/transmission/torrents`:
+  - no candidates with hash → `{ torrents: [] }`, no Transmission call made
+  - Transmission fails → 502
+  - happy path: only torrents matching pirate-claw candidates returned
+- API handler `GET /api/transmission/session`:
+  - Transmission fails → 502
+  - happy path: correct `SessionInfo` shape
+
+## Out of Scope
+
+- Any web UI (P15.03–P15.05)
+- Caching or rate-limiting of Transmission proxy calls
+- Transmission write operations (throttle, ratio management)
+
+## Exit Condition
+
+Both endpoints are live. Tests are green. Both fixture snapshots are committed and readable by P15.03.
+
+## Rationale
+
+_(Update this section after implementation with any behavior or tradeoff changes discovered.)_

--- a/docs/02-delivery/phase-15/ticket-02-transmission-proxy-endpoints.md
+++ b/docs/02-delivery/phase-15/ticket-02-transmission-proxy-endpoints.md
@@ -15,7 +15,7 @@ export type TorrentStatSnapshot = {
   status: 'downloading' | 'seeding' | 'stopped' | 'error';
   percentDone: number;
   rateDownload: number; // bytes/second
-  eta: number;          // seconds; -1 when unknown
+  eta: number; // seconds; -1 when unknown
 };
 
 export type FetchTorrentStatsResult =
@@ -24,8 +24,8 @@ export type FetchTorrentStatsResult =
 
 export type SessionInfo = {
   version: string;
-  downloadSpeed: number;  // bytes/second
-  uploadSpeed: number;    // bytes/second
+  downloadSpeed: number; // bytes/second
+  uploadSpeed: number; // bytes/second
   activeTorrentCount: number;
 };
 
@@ -40,12 +40,12 @@ Do **not** modify `TorrentSnapshot`, `LookupTorrentsResult`, or `lookupTorrentsI
 
 Transmission integer `status` → string:
 
-| Code | Mapped to |
-|------|-----------|
-| 4    | `'downloading'` |
-| 6    | `'seeding'` |
-| 7    | `'error'` |
-| 0, 1, 2, 3, 5, other | `'stopped'` |
+| Code                 | Mapped to       |
+| -------------------- | --------------- |
+| 4                    | `'downloading'` |
+| 6                    | `'seeding'`     |
+| 7                    | `'error'`       |
+| 0, 1, 2, 3, 5, other | `'stopped'`     |
 
 ### New Functions in `src/transmission.ts`
 
@@ -90,6 +90,7 @@ Both endpoints read `config.transmission` from the existing `ApiFetchDeps.config
 Commit before P15.03 begins:
 
 **`fixtures/api/transmission-torrents.json`**
+
 ```json
 {
   "torrents": [
@@ -114,6 +115,7 @@ Commit before P15.03 begins:
 ```
 
 **`fixtures/api/transmission-session.json`**
+
 ```json
 {
   "version": "3.00 (bb6b5a062ef)",

--- a/docs/02-delivery/phase-15/ticket-03-dashboard-overview-enhancement.md
+++ b/docs/02-delivery/phase-15/ticket-03-dashboard-overview-enhancement.md
@@ -1,0 +1,117 @@
+# P15.03 Dashboard Overview Enhancement
+
+## Goal
+
+Enhance the existing Overview dashboard (`/`) to surface active downloads, a candidate event log, summary stats, an archive commit grid, and a Transmission session header strip. All data is loaded on page load (manual refresh via browser reload). No real-time updates.
+
+## Prerequisites
+
+- P15.01 (outcomes endpoint) merged
+- P15.02 (transmission proxy endpoints) merged
+- `fixtures/api/transmission-torrents.json` and `fixtures/api/transmission-session.json` committed
+
+## Scope
+
+### `web/src/routes/+page.server.ts`
+
+Load four data sources in parallel. Fail open for each — a failing call returns null/empty, not a page error:
+
+```typescript
+const [health, transmissionSession, transmissionTorrents, candidates] =
+  await Promise.allSettled([
+    apiFetch<DaemonHealth>('/api/health'),
+    apiFetch<SessionInfo>('/api/transmission/session'),
+    apiFetch<{ torrents: TorrentStatSnapshot[] }>('/api/transmission/torrents'),
+    apiFetch<{ candidates: CandidateStateRecord[] }>('/api/candidates'),
+  ]);
+```
+
+Return:
+- `health: DaemonHealth | null`
+- `transmissionSession: SessionInfo | null`
+- `transmissionTorrents: TorrentStatSnapshot[]`
+- `candidates: CandidateStateRecord[]`
+- `error: string | null` (set if health fails; health is the only hard dependency)
+
+### `web/src/lib/types.ts`
+
+Add new types (anchored to `fixtures/api/transmission-session.json`):
+
+```typescript
+export type TorrentStatSnapshot = {
+  hash: string;
+  name: string;
+  status: 'downloading' | 'seeding' | 'stopped' | 'error';
+  percentDone: number;
+  rateDownload: number;
+  eta: number;
+};
+
+export type SessionInfo = {
+  version: string;
+  downloadSpeed: number;
+  uploadSpeed: number;
+  activeTorrentCount: number;
+};
+```
+
+### `web/src/routes/+page.svelte`
+
+Replace the current Daemon card + Recent Runs table with the full dashboard layout:
+
+**Header strip** (always shown when health loads):
+- Daemon: uptime, startedAt, lastRunCycle, lastReconcileCycle (existing fields)
+- Transmission: version, downloadSpeed, uploadSpeed, activeTorrentCount — from `transmissionSession`; render "Transmission unavailable" when `transmissionSession` is null
+
+**Active Downloads section**:
+- Filter `transmissionTorrents` where `status === 'downloading'`
+- Show max 5 rows. Each row: TMDB poster thumbnail (from matching candidate's `tmdb?.posterUrl`; fallback: colored initial box using normalizedTitle first char), title (from matching candidate's `normalizedTitle`), progress bar (`percentDone * 100`%), download speed (`rateDownload` formatted as KB/s or MB/s), ETA (formatted as "Xh Ym" or "—" when eta is -1)
+- Match torrents to candidates: `torrent.hash === candidate.transmissionTorrentHash`
+- "View all" link → `/candidates` (Candidates page)
+- Section hidden when `transmissionTorrents` is empty
+
+**Event Log**:
+- Last 10 candidates from `candidates` sorted by `updatedAt` desc
+- Table: title | status chip | updatedAt
+- Status chip colors: `queued` → blue, `completed` → green, `failed` → red, `skipped_duplicate` → slate, `skipped_no_match` → gray, `downloading` → cyan
+- "No candidates yet" placeholder when empty
+
+**Stats row** (derived client-side from `candidates`):
+- Total tracked: `candidates.length`
+- Completed this week: candidates where `lifecycleStatus === 'completed'` and `transmissionDoneDate` is within the last 7 calendar days (UTC)
+- Failed: candidates where `status === 'failed'`
+- Skipped (no match): `candidates.filter(c => c.status === 'skipped_no_match').length` — note: skipped_no_match candidates are not currently stored in candidate_state (they go to feed_item_outcomes); if this count is always 0, omit the stat rather than show misleading zeros. Document in rationale.
+
+**Archive Commit grid**:
+- Filter `candidates` where `lifecycleStatus === 'completed'`
+- Sort by `transmissionDoneDate` desc
+- Take 6
+- Each card: TMDB poster (`tmdb?.posterUrl`; graceful placeholder "No poster" when TMDB unconfigured), title, `completedAt` date formatted as "MMM D, YYYY"
+- Grid hidden when no completed candidates
+
+### `web/src/routes/dashboard.test.ts`
+
+Update existing test file with new mock shapes anchored to the fixture snapshots. Add tests for:
+- Renders Transmission header strip when `transmissionSession` is populated
+- Renders "Transmission unavailable" when `transmissionSession` is null
+- Active Downloads renders max 5 rows; renders "View all" link to `/candidates`
+- Active Downloads section hidden when `transmissionTorrents` is empty
+- Event Log renders last 10 candidates sorted by updatedAt
+- Stats row derived correctly (total, failed counts)
+- Archive Commit grid renders top 6 completed, hidden when none
+- Error state renders alert when health is null
+
+## Out of Scope
+
+- Real-time / WebSocket updates
+- Clickable torrent rows (navigation to show/movie detail is P15.04/P15.05)
+- Disk usage stats
+- Candidates route filter state (`/candidates?filter=downloading` URL handling — just the link target)
+
+## Exit Condition
+
+The Overview dashboard renders all six sections. `transmissionSession` and `transmissionTorrents` fail gracefully when Transmission is unreachable. Tests are green anchored to fixture snapshots.
+
+## Rationale
+
+_(Update this section after implementation with any behavior or tradeoff changes discovered. In particular: whether `skipped_no_match` candidates are stored in `candidate_state` or only in `feed_item_outcomes` — this determines whether the "Skipped" stat in the stats row is meaningful.)_

--- a/docs/02-delivery/phase-15/ticket-03-dashboard-overview-enhancement.md
+++ b/docs/02-delivery/phase-15/ticket-03-dashboard-overview-enhancement.md
@@ -27,6 +27,7 @@ const [health, transmissionSession, transmissionTorrents, candidates] =
 ```
 
 Return:
+
 - `health: DaemonHealth | null`
 - `transmissionSession: SessionInfo | null`
 - `transmissionTorrents: TorrentStatSnapshot[]`
@@ -60,10 +61,12 @@ export type SessionInfo = {
 Replace the current Daemon card + Recent Runs table with the full dashboard layout:
 
 **Header strip** (always shown when health loads):
+
 - Daemon: uptime, startedAt, lastRunCycle, lastReconcileCycle (existing fields)
 - Transmission: version, downloadSpeed, uploadSpeed, activeTorrentCount — from `transmissionSession`; render "Transmission unavailable" when `transmissionSession` is null
 
 **Active Downloads section**:
+
 - Filter `transmissionTorrents` where `status === 'downloading'`
 - Show max 5 rows. Each row: TMDB poster thumbnail (from matching candidate's `tmdb?.posterUrl`; fallback: colored initial box using normalizedTitle first char), title (from matching candidate's `normalizedTitle`), progress bar (`percentDone * 100`%), download speed (`rateDownload` formatted as KB/s or MB/s), ETA (formatted as "Xh Ym" or "—" when eta is -1)
 - Match torrents to candidates: `torrent.hash === candidate.transmissionTorrentHash`
@@ -71,18 +74,21 @@ Replace the current Daemon card + Recent Runs table with the full dashboard layo
 - Section hidden when `transmissionTorrents` is empty
 
 **Event Log**:
+
 - Last 10 candidates from `candidates` sorted by `updatedAt` desc
 - Table: title | status chip | updatedAt
 - Status chip colors: `queued` → blue, `completed` → green, `failed` → red, `skipped_duplicate` → slate, `skipped_no_match` → gray, `downloading` → cyan
 - "No candidates yet" placeholder when empty
 
 **Stats row** (derived client-side from `candidates`):
+
 - Total tracked: `candidates.length`
 - Completed this week: candidates where `lifecycleStatus === 'completed'` and `transmissionDoneDate` is within the last 7 calendar days (UTC)
 - Failed: candidates where `status === 'failed'`
 - Skipped (no match): `candidates.filter(c => c.status === 'skipped_no_match').length` — note: skipped_no_match candidates are not currently stored in candidate_state (they go to feed_item_outcomes); if this count is always 0, omit the stat rather than show misleading zeros. Document in rationale.
 
 **Archive Commit grid**:
+
 - Filter `candidates` where `lifecycleStatus === 'completed'`
 - Sort by `transmissionDoneDate` desc
 - Take 6
@@ -92,6 +98,7 @@ Replace the current Daemon card + Recent Runs table with the full dashboard layo
 ### `web/src/routes/dashboard.test.ts`
 
 Update existing test file with new mock shapes anchored to the fixture snapshots. Add tests for:
+
 - Renders Transmission header strip when `transmissionSession` is populated
 - Renders "Transmission unavailable" when `transmissionSession` is null
 - Active Downloads renders max 5 rows; renders "View all" link to `/candidates`

--- a/docs/02-delivery/phase-15/ticket-04-tv-shows-progress-and-sort.md
+++ b/docs/02-delivery/phase-15/ticket-04-tv-shows-progress-and-sort.md
@@ -1,0 +1,119 @@
+# P15.04 TV Shows View — Progress and Sort
+
+## Goal
+
+Enhance the TV Shows view to show per-episode progress bars and live download speed for active episodes, add client-side sort (title / progress), and surface the `transmissionTorrentHash` join key through the `ShowEpisode` type.
+
+## Prerequisites
+
+- P15.02 (transmission proxy endpoints) merged
+- `fixtures/api/transmission-torrents.json` committed
+
+## Scope
+
+### `src/tv-api-types.ts`
+
+Add two fields to `ShowEpisode`:
+
+```typescript
+export type ShowEpisode = {
+  episode: number;
+  identityKey: string;
+  status: string;
+  lifecycleStatus?: string;
+  queuedAt?: string;
+  transmissionPercentDone?: number;      // last reconciled percent (0–1)
+  transmissionTorrentHash?: string;      // join key for live Transmission stats
+  tmdb?: TmdbTvEpisodeMeta;
+};
+```
+
+### `src/api.ts` — `buildShowBreakdowns`
+
+Pass the new fields from `CandidateStateRecord` when building episodes:
+
+```typescript
+seasonMap.get(season)!.push({
+  episode: c.episode,
+  identityKey: c.identityKey,
+  status: c.status,
+  lifecycleStatus: c.lifecycleStatus,
+  queuedAt: c.queuedAt,
+  transmissionPercentDone: c.transmissionPercentDone,
+  transmissionTorrentHash: c.transmissionTorrentHash,
+});
+```
+
+### `web/src/lib/types.ts`
+
+Mirror the same additions to `ShowEpisode`:
+
+```typescript
+export type ShowEpisode = {
+  episode: number;
+  identityKey: string;
+  status: CandidateStatus;
+  lifecycleStatus?: string;
+  queuedAt?: string;
+  transmissionPercentDone?: number;
+  transmissionTorrentHash?: string;
+  tmdb?: TmdbTvEpisodeMeta;
+};
+```
+
+### `web/src/routes/shows/+page.server.ts`
+
+Load shows and transmission torrents in parallel. Fail open for torrents:
+
+```typescript
+const [showsData, torrentsData] = await Promise.allSettled([
+  apiFetch<{ shows: ShowBreakdown[] }>('/api/shows'),
+  apiFetch<{ torrents: TorrentStatSnapshot[] }>('/api/transmission/torrents'),
+]);
+
+return {
+  shows: showsData resolved value or [],
+  torrents: torrentsData resolved value or [],
+  error: null or error string,
+};
+```
+
+### `web/src/routes/shows/+page.svelte`
+
+**Show grid cards** — add sort control:
+- Sort options: "Title (A–Z)" (default) and "Progress" (descending by max episode `transmissionPercentDone` across all seasons)
+- Sort is client-side, reactive state with `$state()`
+- Each card shows: TMDB poster (placeholder when unavailable), show title, episode count, completion % (completed episodes ÷ total episodes tracked; label omitted when 0 episodes tracked)
+
+### `web/src/routes/shows/[slug]/+page.server.ts`
+
+Same pattern: load `/api/shows` and `/api/transmission/torrents` in parallel. Pass both to the page.
+
+### `web/src/routes/shows/[slug]/+page.svelte`
+
+**Season accordion / episode rows**:
+- For episodes where `lifecycleStatus === 'downloading'` (or `status === 'queued'` and `transmissionPercentDone > 0`): show progress bar using `transmissionPercentDone`
+- For live speed: join `episode.transmissionTorrentHash` to `torrents` array from `GET /api/transmission/torrents`. Display `rateDownload` formatted as MB/s or KB/s, and ETA as "Xh Ym" or "—"
+- TMDB still image thumbnail per episode when `episode.tmdb?.stillUrl` is available
+- Status chip using existing color scheme from P15.03 (reuse the chip logic; extract to a shared Svelte snippet if both P15.03 and P15.04 need it)
+- Episodes with no active download: show `transmissionPercentDone` as a static progress bar (last known percent from reconcile)
+
+### Tests
+
+- `web/src/routes/shows/shows.test.ts`: add test that progress bar renders for active episodes; sort control changes card order
+- `web/src/routes/shows/[slug]/shows.test.ts`: add test that speed/eta row appears for active episodes; hidden for completed episodes
+- `src/api.test.ts` or equivalent: `buildShowBreakdowns` passes through `transmissionPercentDone` and `transmissionTorrentHash`
+
+## Out of Scope
+
+- TMDB network badge (TMDB `networks` field not in current schema — defer)
+- TMDB `totalEpisodes` completion ratio (requires TMDB episode count; not currently stored — omit the completion % if data is unavailable; never show 0/0)
+- Per-season download in bulk
+
+## Exit Condition
+
+The TV Shows list has sort controls. The show detail page shows progress bars and live speed for active episodes joined from the transmission proxy. Tests are green.
+
+## Rationale
+
+_(Update this section after implementation with any behavior or tradeoff changes discovered. In particular: whether completion % is viable given the TMDB data available in the cache.)_

--- a/docs/02-delivery/phase-15/ticket-04-tv-shows-progress-and-sort.md
+++ b/docs/02-delivery/phase-15/ticket-04-tv-shows-progress-and-sort.md
@@ -22,8 +22,8 @@ export type ShowEpisode = {
   status: string;
   lifecycleStatus?: string;
   queuedAt?: string;
-  transmissionPercentDone?: number;      // last reconciled percent (0–1)
-  transmissionTorrentHash?: string;      // join key for live Transmission stats
+  transmissionPercentDone?: number; // last reconciled percent (0–1)
+  transmissionTorrentHash?: string; // join key for live Transmission stats
   tmdb?: TmdbTvEpisodeMeta;
 };
 ```
@@ -81,6 +81,7 @@ return {
 ### `web/src/routes/shows/+page.svelte`
 
 **Show grid cards** — add sort control:
+
 - Sort options: "Title (A–Z)" (default) and "Progress" (descending by max episode `transmissionPercentDone` across all seasons)
 - Sort is client-side, reactive state with `$state()`
 - Each card shows: TMDB poster (placeholder when unavailable), show title, episode count, completion % (completed episodes ÷ total episodes tracked; label omitted when 0 episodes tracked)
@@ -92,6 +93,7 @@ Same pattern: load `/api/shows` and `/api/transmission/torrents` in parallel. Pa
 ### `web/src/routes/shows/[slug]/+page.svelte`
 
 **Season accordion / episode rows**:
+
 - For episodes where `lifecycleStatus === 'downloading'` (or `status === 'queued'` and `transmissionPercentDone > 0`): show progress bar using `transmissionPercentDone`
 - For live speed: join `episode.transmissionTorrentHash` to `torrents` array from `GET /api/transmission/torrents`. Display `rateDownload` formatted as MB/s or KB/s, and ETA as "Xh Ym" or "—"
 - TMDB still image thumbnail per episode when `episode.tmdb?.stillUrl` is available

--- a/docs/02-delivery/phase-15/ticket-05-movies-filter-sort-progress.md
+++ b/docs/02-delivery/phase-15/ticket-05-movies-filter-sort-progress.md
@@ -25,8 +25,8 @@ export type MovieBreakdown = {
   status: string;
   lifecycleStatus?: string;
   queuedAt?: string;
-  transmissionPercentDone?: number;      // last reconciled percent (0–1)
-  transmissionTorrentHash?: string;      // join key for live Transmission stats
+  transmissionPercentDone?: number; // last reconciled percent (0–1)
+  transmissionTorrentHash?: string; // join key for live Transmission stats
   tmdb?: TmdbMoviePublic;
 };
 ```
@@ -90,6 +90,7 @@ return {
 ### `web/src/routes/movies/+page.svelte`
 
 **Filter tabs** (client-side, reactive with `$state()`):
+
 - All | Downloading | Completed | Failed | Missing
 - "Missing" tab: `lifecycleStatus === 'missing_from_transmission'`
 - "Downloading": `lifecycleStatus === 'downloading'`
@@ -98,18 +99,21 @@ return {
 - Tab counts shown in parentheses
 
 **Genre filter dropdown**:
+
 - Populated from `movies.flatMap(m => m.tmdb?.genres ?? [])` — deduplicated, sorted
 - Visible only when at least one movie has TMDB genre data
 - "All genres" default; client-side filter applied on top of tab filter
 - `TmdbMoviePublic` currently does not include a `genres` field — check `src/movie-api-types.ts`. If absent, skip the genre filter in P15 and note it in rationale. Do not add TMDB fields not already in the type.
 
 **Sort** (client-side, reactive with `$state()`):
+
 - Date added (default, desc by `queuedAt`)
 - Title (A–Z)
 - Year (desc)
 - Resolution
 
 **Movie cards** — add to existing card layout:
+
 - Progress bar when `transmissionPercentDone > 0 && transmissionPercentDone < 1`
 - Live speed: join `movie.transmissionTorrentHash` to `torrents` from the page data. Display `rateDownload` as MB/s or KB/s when `status === 'downloading'`
 - ETA: formatted as "Xh Ym" or "—" when eta is -1
@@ -119,6 +123,7 @@ return {
 ### `web/src/routes/movies/movies.test.ts`
 
 Update tests to cover:
+
 - Filter tabs render correct counts; tab click filters the movie list
 - Sort options reorder cards correctly
 - Progress bar and speed rendered for downloading movie

--- a/docs/02-delivery/phase-15/ticket-05-movies-filter-sort-progress.md
+++ b/docs/02-delivery/phase-15/ticket-05-movies-filter-sort-progress.md
@@ -1,0 +1,140 @@
+# P15.05 Movies View — Filter Tabs, Genre Filter, Sort, and Progress
+
+## Goal
+
+Enhance the Movies view with client-side filter tabs, a genre filter dropdown (TMDB-powered), sort options, and progress bar + speed for actively downloading movies. Mirrors the approach from P15.04 for the Transmission join.
+
+## Prerequisites
+
+- P15.02 (transmission proxy endpoints) merged
+- `fixtures/api/transmission-torrents.json` committed
+
+## Scope
+
+### `src/movie-api-types.ts`
+
+Add two fields to `MovieBreakdown`:
+
+```typescript
+export type MovieBreakdown = {
+  normalizedTitle: string;
+  year?: number;
+  resolution?: string;
+  codec?: string;
+  identityKey: string;
+  status: string;
+  lifecycleStatus?: string;
+  queuedAt?: string;
+  transmissionPercentDone?: number;      // last reconciled percent (0–1)
+  transmissionTorrentHash?: string;      // join key for live Transmission stats
+  tmdb?: TmdbMoviePublic;
+};
+```
+
+### `src/api.ts` — `buildMovieBreakdowns`
+
+Pass the new fields through:
+
+```typescript
+.map((c) => ({
+  normalizedTitle: c.normalizedTitle,
+  year: c.year,
+  resolution: c.resolution,
+  codec: c.codec,
+  identityKey: c.identityKey,
+  status: c.status,
+  lifecycleStatus: c.lifecycleStatus,
+  queuedAt: c.queuedAt,
+  transmissionPercentDone: c.transmissionPercentDone,
+  transmissionTorrentHash: c.transmissionTorrentHash,
+}))
+```
+
+### `web/src/lib/types.ts`
+
+Mirror the additions to `MovieBreakdown`:
+
+```typescript
+export type MovieBreakdown = {
+  normalizedTitle: string;
+  year?: number;
+  resolution?: string;
+  codec?: string;
+  identityKey: string;
+  status: CandidateStatus;
+  lifecycleStatus?: string;
+  queuedAt?: string;
+  transmissionPercentDone?: number;
+  transmissionTorrentHash?: string;
+  tmdb?: TmdbMoviePublic;
+};
+```
+
+### `web/src/routes/movies/+page.server.ts`
+
+Load movies and transmission torrents in parallel. Fail open for torrents:
+
+```typescript
+const [moviesData, torrentsData] = await Promise.allSettled([
+  apiFetch<{ movies: MovieBreakdown[] }>('/api/movies'),
+  apiFetch<{ torrents: TorrentStatSnapshot[] }>('/api/transmission/torrents'),
+]);
+
+return {
+  movies: moviesData resolved value or [],
+  torrents: torrentsData resolved value or [],
+  error: null or error string,
+};
+```
+
+### `web/src/routes/movies/+page.svelte`
+
+**Filter tabs** (client-side, reactive with `$state()`):
+- All | Downloading | Completed | Failed | Missing
+- "Missing" tab: `lifecycleStatus === 'missing_from_transmission'`
+- "Downloading": `lifecycleStatus === 'downloading'`
+- "Completed": `lifecycleStatus === 'completed'`
+- "Failed": `status === 'failed'`
+- Tab counts shown in parentheses
+
+**Genre filter dropdown**:
+- Populated from `movies.flatMap(m => m.tmdb?.genres ?? [])` — deduplicated, sorted
+- Visible only when at least one movie has TMDB genre data
+- "All genres" default; client-side filter applied on top of tab filter
+- `TmdbMoviePublic` currently does not include a `genres` field — check `src/movie-api-types.ts`. If absent, skip the genre filter in P15 and note it in rationale. Do not add TMDB fields not already in the type.
+
+**Sort** (client-side, reactive with `$state()`):
+- Date added (default, desc by `queuedAt`)
+- Title (A–Z)
+- Year (desc)
+- Resolution
+
+**Movie cards** — add to existing card layout:
+- Progress bar when `transmissionPercentDone > 0 && transmissionPercentDone < 1`
+- Live speed: join `movie.transmissionTorrentHash` to `torrents` from the page data. Display `rateDownload` as MB/s or KB/s when `status === 'downloading'`
+- ETA: formatted as "Xh Ym" or "—" when eta is -1
+- Status overlay chip (same color scheme as P15.03)
+- Genre badge from `tmdb?.genres[0]` when available
+
+### `web/src/routes/movies/movies.test.ts`
+
+Update tests to cover:
+- Filter tabs render correct counts; tab click filters the movie list
+- Sort options reorder cards correctly
+- Progress bar and speed rendered for downloading movie
+- Genre filter hidden when no TMDB genre data; visible and functional when present
+- Transmission unavailable (empty `torrents`): cards render without progress bar
+
+## Out of Scope
+
+- Server-side filtering query params
+- Per-genre dedicated pages
+- Genre multi-select
+
+## Exit Condition
+
+Movies view has filter tabs, sort, and progress/speed for active downloads. All client-side. Tests are green.
+
+## Rationale
+
+_(Update this section after implementation. In particular: whether `TmdbMoviePublic` includes a `genres` field — if not, document the genre filter deferral and what TMDB data would be needed to add it.)_

--- a/docs/02-delivery/phase-15/ticket-06-unmatched-candidates-view.md
+++ b/docs/02-delivery/phase-15/ticket-06-unmatched-candidates-view.md
@@ -14,6 +14,7 @@ Add a read-only Unmatched Candidates view at `/candidates/unmatched` sourced fro
 ### New Route: `web/src/routes/candidates/unmatched/`
 
 Create:
+
 - `+page.server.ts`
 - `+page.svelte`
 - `unmatched.test.ts`
@@ -28,16 +29,20 @@ import type { PageServerLoad } from './$types';
 export const load: PageServerLoad = async () => {
   try {
     const data = await apiFetch<{ outcomes: SkippedOutcomeRecord[] }>(
-      '/api/outcomes?status=skipped_no_match'
+      '/api/outcomes?status=skipped_no_match',
     );
     return { outcomes: data.outcomes, error: null };
   } catch {
-    return { outcomes: [] as SkippedOutcomeRecord[], error: 'Could not reach the API.' };
+    return {
+      outcomes: [] as SkippedOutcomeRecord[],
+      error: 'Could not reach the API.',
+    };
   }
 };
 ```
 
 **`+page.svelte`**:
+
 - Heading: "Unmatched Candidates"
 - Subheading: "Feed items from the last 30 days that matched no policy rule."
 - Client-side title search: `<input>` filters `outcomes` by `title` (case-insensitive contains). Reactive with `$state()`.
@@ -72,6 +77,7 @@ Add "Unmatched" link to the navigation in `web/src/routes/+layout.svelte` under 
 ### `web/src/routes/candidates/unmatched/unmatched.test.ts`
 
 Tests anchored to `fixtures/api/outcomes-skipped-no-match.json`:
+
 - Renders table with correct columns
 - Null title/feedName renders as "—"
 - Title search filters rows by partial match (case-insensitive)

--- a/docs/02-delivery/phase-15/ticket-06-unmatched-candidates-view.md
+++ b/docs/02-delivery/phase-15/ticket-06-unmatched-candidates-view.md
@@ -1,0 +1,95 @@
+# P15.06 Unmatched Candidates View
+
+## Goal
+
+Add a read-only Unmatched Candidates view at `/candidates/unmatched` sourced from `GET /api/outcomes?status=skipped_no_match`. Operators use this to diagnose why feed items were not picked up by any policy.
+
+## Prerequisites
+
+- P15.01 (`GET /api/outcomes` endpoint) merged
+- `fixtures/api/outcomes-skipped-no-match.json` committed
+
+## Scope
+
+### New Route: `web/src/routes/candidates/unmatched/`
+
+Create:
+- `+page.server.ts`
+- `+page.svelte`
+- `unmatched.test.ts`
+
+**`+page.server.ts`**:
+
+```typescript
+import { apiFetch } from '$lib/server/api';
+import type { SkippedOutcomeRecord } from '$lib/types';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+  try {
+    const data = await apiFetch<{ outcomes: SkippedOutcomeRecord[] }>(
+      '/api/outcomes?status=skipped_no_match'
+    );
+    return { outcomes: data.outcomes, error: null };
+  } catch {
+    return { outcomes: [] as SkippedOutcomeRecord[], error: 'Could not reach the API.' };
+  }
+};
+```
+
+**`+page.svelte`**:
+- Heading: "Unmatched Candidates"
+- Subheading: "Feed items from the last 30 days that matched no policy rule."
+- Client-side title search: `<input>` filters `outcomes` by `title` (case-insensitive contains). Reactive with `$state()`.
+- Read-only table: title | feed | run id | recorded at
+  - `title`: render "—" when null
+  - `feedName`: render "—" when null
+  - `runId`: plain number
+  - `recordedAt`: formatted date (same `formatDate` utility as dashboard)
+- "No unmatched candidates in the last 30 days." empty state
+- Error alert when `error` is set
+- No action buttons — this is a diagnostic view
+
+### `web/src/lib/types.ts`
+
+Add:
+
+```typescript
+export type SkippedOutcomeRecord = {
+  id: number;
+  runId: number;
+  status: 'skipped_no_match';
+  recordedAt: string;
+  title: string | null;
+  feedName: string | null;
+};
+```
+
+### Navigation
+
+Add "Unmatched" link to the navigation in `web/src/routes/+layout.svelte` under Candidates (or as a sibling nav item). Match the existing nav link style.
+
+### `web/src/routes/candidates/unmatched/unmatched.test.ts`
+
+Tests anchored to `fixtures/api/outcomes-skipped-no-match.json`:
+- Renders table with correct columns
+- Null title/feedName renders as "—"
+- Title search filters rows by partial match (case-insensitive)
+- Title search with no match shows empty table body (not the empty-state placeholder)
+- Empty outcomes → renders "No unmatched candidates" placeholder
+- Error state → renders alert
+
+## Out of Scope
+
+- Pagination
+- Server-side search
+- Action buttons (re-run, flag for review)
+- Filtering by feed, run id, or date range
+
+## Exit Condition
+
+`/candidates/unmatched` is reachable from the nav, shows the outcomes table with client-side search, and handles null title/feedName gracefully. Tests are green anchored to the fixture snapshot.
+
+## Rationale
+
+_(Update this section after implementation with any behavior or tradeoff changes discovered.)_

--- a/docs/02-delivery/phase-15/ticket-07-docs-and-phase-exit.md
+++ b/docs/02-delivery/phase-15/ticket-07-docs-and-phase-exit.md
@@ -17,6 +17,7 @@ Update `Delivery status` section from "Planning/decomposition only" to "Delivere
 ### Example config / runbook (if one exists in `docs/`)
 
 If any existing runbook or API reference lists endpoints, add:
+
 - `GET /api/outcomes?status=skipped_no_match`
 - `GET /api/transmission/torrents`
 - `GET /api/transmission/session`
@@ -26,6 +27,7 @@ with a one-line description each.
 ### Retrospective
 
 Create `notes/public/p15-retrospective.md` with:
+
 - What shipped
 - Any explicit deferrals encountered during implementation (beyond those listed in the plan)
 - Any tradeoffs or surprises worth recording

--- a/docs/02-delivery/phase-15/ticket-07-docs-and-phase-exit.md
+++ b/docs/02-delivery/phase-15/ticket-07-docs-and-phase-exit.md
@@ -1,0 +1,44 @@
+# P15.07 Docs and Phase Exit
+
+## Goal
+
+Update documentation to reflect the Phase 15 additions: new API endpoints, type changes, and UI views. Mark the phase as delivered.
+
+## Scope
+
+### `docs/01-product/phase-15-rich-visual-state-and-activity-views.md`
+
+Add a `**Delivery status:** Delivered — P15.07` line at the top (below the title).
+
+### `docs/02-delivery/phase-15/implementation-plan.md`
+
+Update `Delivery status` section from "Planning/decomposition only" to "Delivered".
+
+### Example config / runbook (if one exists in `docs/`)
+
+If any existing runbook or API reference lists endpoints, add:
+- `GET /api/outcomes?status=skipped_no_match`
+- `GET /api/transmission/torrents`
+- `GET /api/transmission/session`
+
+with a one-line description each.
+
+### Retrospective
+
+Create `notes/public/p15-retrospective.md` with:
+- What shipped
+- Any explicit deferrals encountered during implementation (beyond those listed in the plan)
+- Any tradeoffs or surprises worth recording
+
+## Out of Scope
+
+- New runbook creation (if none exists)
+- API changelog (no public API consumers)
+
+## Exit Condition
+
+Docs updated. Retrospective committed. Phase marked delivered.
+
+## Rationale
+
+_(Update after implementation.)_

--- a/fixtures/api/outcomes-skipped-no-match.json
+++ b/fixtures/api/outcomes-skipped-no-match.json
@@ -1,0 +1,28 @@
+{
+  "outcomes": [
+    {
+      "id": 1,
+      "runId": 42,
+      "status": "skipped_no_match",
+      "recordedAt": "2026-04-10T12:00:00.000Z",
+      "title": "Stranger.Things.S05E01.4K.WEB.x265-GROUP",
+      "feedName": "main-tv"
+    },
+    {
+      "id": 2,
+      "runId": 42,
+      "status": "skipped_no_match",
+      "recordedAt": "2026-04-10T12:00:05.000Z",
+      "title": "The.Brutalist.2025.2160p.WEB-DL.DDP5.1.Atmos.x265",
+      "feedName": "main-movies"
+    },
+    {
+      "id": 3,
+      "runId": 43,
+      "status": "skipped_no_match",
+      "recordedAt": "2026-04-11T06:00:00.000Z",
+      "title": null,
+      "feedName": null
+    }
+  ]
+}

--- a/notes/public/ee5-retrospective.md
+++ b/notes/public/ee5-retrospective.md
@@ -1,0 +1,88 @@
+# EE5 Retrospective
+
+_Engineering Epic 05: Orchestrator Context Minimization — single standalone PR #124_
+
+---
+
+## Scope delivered
+
+Single PR on branch `engineering/ee05-orchestrator-context-minimization` covering all five scope items from `docs/03-engineering/epic-05-orchestrator-context-minimization.md`:
+
+1. `verify:quiet` script
+2. `modified_sections` handoff field
+3a. Suppress orchestrator poll stdout per check (`formatCurrentTicketStatus`)
+3b. Condense session-side review extract (via `formatCurrentTicketStatus` + triager summaries)
+4. Poll timing 6/12 + doc-only skip + no read-ahead directive
+5. Session compaction directive at `advance`
+
+---
+
+## What went well
+
+**All five scope items delivered in a single focused session.** No scope drift, no prerequisite gaps, no ambiguous acceptance criteria in practice. The epic document was tight enough that implementation could proceed without planning detours.
+
+**The Phase 14 retrospective was load-bearing.** The token spend breakdown (pain points 1–4) directly drove the implementation priority. Having quantified estimates (~15%, ~20%, ~10%, ~35–40%) gave a clear ranking: compaction directive first in design priority, `modified_sections` second, `formatCurrentTicketStatus` third, `verify:quiet` fourth.
+
+**The `partial_timeout` bug was caught and fixed.** Changing `DEFAULT_REVIEW_POLLING_PROFILE` to `extendByOneInterval: false` exposed a latent design gap: the `pollForAiReview` loop's final-boundary check (`checkMinute === extendedMaxWaitMinutes`) never triggered because `extendedMaxWaitMinutes = 18` but the last check was at `12`. The test suite failed with `clean` instead of `operator_input_needed`, making the bug unambiguous. The fix (`isAtFinalBoundary` using `||` between extended and non-extended cases) is cleaner than the original and more general.
+
+**235 tests, full verify clean on first run after formatting.** TypeScript caught nothing after edits; lint caught one unused import (`computeExtendedReviewPollMaxWaitMinutes` in `notifications.ts` after removing the "one final check" message line). No hidden integration failures.
+
+**Bulk test replacement via `sed` was the right tool.** 35 occurrences of `reviewPollIntervalMinutes: 2` and `reviewPollMaxWaitMinutes: 10` across two test files replaced in a single command. Four separate patterns for sleep millisecond assertions (`[120000, 240000]`, `[120000, 240000, 360000, 480000, 600000, 720000]`, `[120000, 240000, 360000, 480000, 600000]`, `[120000]`) replaced without incident.
+
+**CodeRabbit caught three real issues:**
+
+- `verify-quiet.ts:34` — `result.status ?? 0` silently exits 0 on signal-terminated subprocesses (`null` status). Fixed to `?? 1` with explicit `result.error` surface. This is the class of bug that integration tests won't catch because they don't kill the subprocess.
+- `orchestrator.ts` — `docOnly` detection gated on `status !== 'in_review'` at call time. If a PR is initially doc-only but gains code changes, rerunning `open-pr` would not clear the flag. Fixed: always recompute `docOnly` from the current diff on every `open-pr` call.
+- `delivery-orchestrator.md` — self-audit section still said `bun run verify` after the Typical Flow section was updated to prescribe `verify:quiet`. Fixed.
+
+All three were genuine issues worth the external review gate.
+
+**`formatCurrentTicketStatus` is structurally better than the quick-fix framing.** The name and shape (header + single ticket block) makes it usable as a future general purpose "show me just this ticket" output, not only for poll-review. It already exports cleanly and could be used in notifications or debugging contexts.
+
+---
+
+## Pain points
+
+**The `notifications.ts` coupling was a surprise cleanup.** `computeExtendedReviewPollMaxWaitMinutes` was imported into `notifications.ts` solely to compute the "one final check at N minutes" message line. When that line was removed (correct: it described behavior that no longer exists), the import became unused and lint failed. This required reading `notifications.ts` to understand the dependency before making the edit. Small but a reminder that helper imports often carry hidden coupling.
+
+**The `formatReviewWindowMessage` "one final check" line required a judgment call.** The function currently doesn't know whether `extendByOneInterval` is true or false — it just uses the state's poll interval and max. The line said "the orchestrator performs one final check at 18 minutes" which was incorrect with the new default. Rather than threading `extendByOneInterval` into the state or the function signature, I removed the line entirely. This is the right call (the extension behavior is disabled), but it's a case where the function's lack of awareness of the polling profile created a messaging inconsistency that only became visible when the default changed.
+
+**Sleep millisecond assertions are brittle by design.** The test suite hardcodes `120000`, `240000`, etc. as exact sleep values. These are correctly derived from the interval in minutes × 60000, but they create a O(n tests) update burden whenever the polling interval changes. A helper constant like `INTERVAL_MS = DEFAULT_REVIEW_POLLING_PROFILE.intervalMinutes * 60_000` used in assertions would survive future interval changes without needing sed. Not worth fixing now, but worth noting.
+
+**The doc-only detection is best-effort with no test coverage.** `isPrDocOnly` calls `gh pr diff --name-only` which requires an actual GitHub remote. It has a `try/catch` that returns `false` on failure, so failures are safe. But there's no unit test for this path — the function is pure platform I/O that can't easily be exercised without a real PR. The existing test structure doesn't mock `gh` commands at this level. Acceptable tradeoff for this scope.
+
+**Stale CR comment created a false `operator_input_needed` outcome.** The doc-consistency finding (CR flagged `delivery-orchestrator.md` self-audit section) was fixed in the patch commit, but CR's original comment thread wasn't marked outdated by GitHub. The second `ai-review` run saw the active thread and classified it as a finding. Required manual triage to confirm "already fixed." This is a fundamental limit of comment-thread staleness — the fetcher has no way to know a thread's content was addressed in a later commit unless GitHub marks it outdated. Expected behavior, but costs a triage step.
+
+---
+
+## Did we deliver on the token minimization premise?
+
+**Immediate measurable wins:**
+
+- `verify:quiet`: each verify pass on a clean repo now emits 0 lines instead of 60–120. For 2 verify passes per ticket × 6 tickets = ~1,000 lines suppressed per phase.
+- `formatCurrentTicketStatus` for `poll-review`: at P14.05, each check was dumping 5 prior tickets × 10–15 lines each = 50–75 lines of dead metadata. With 2 checks under the new 6/12 protocol = ~100–150 lines suppressed per ticket. Across a 6-ticket phase, ~600–900 lines.
+- `modified_sections`: quantifying this requires knowing how many times the agent reads which files, but the structural improvement is clear — a 650-line `+page.svelte` read 4 times was ~2,600 lines of context. Targeting a 50–100 line scope section keeps that to 200–400 lines.
+
+**The compaction directive is the highest-leverage change, but unmeasurable here.** The directive says "call /compact before reading the next handoff." Whether the agent actually compacts depends on the model and the user's workflow. Option 2 (in-session compact) is the right primitive for solo continuous runs. The improvement is real but deferred to the next multi-ticket phase to observe.
+
+**The 6/12 poll timing saves fewer tokens than it saves time.** As the P14 retro noted, poll wait time is free (LLM idle during subprocess sleep). The token savings from fewer checks come only from reduced subprocess output processing — roughly 2 checks × ~15 lines output each = ~30 lines suppressed per ticket vs. ~6 checks × ~15 lines = ~90 lines. Not the primary motivator, but directionally right.
+
+**Net estimate for a P14-scale 6-ticket phase:** roughly 1,000 (verify) + 800 (poll-review) + 2,000 (modified_sections, optimistically) + unknown (compaction) lines of context reduction. At Phase 14's burn rate (~14% per ticket at steady state), eliminating 3,800+ lines of structural overhead per phase should meaningfully extend the session ceiling. Whether this fits 8 tickets instead of 6 per session, or consistently gets through 6 without hitting 84%, will be visible in Phase 15.
+
+---
+
+## Improvements (follow-up)
+
+**Sleep millisecond test assertions should reference a constant.** Replace `120000` literal values with `DEFAULT_REVIEW_POLLING_PROFILE.intervalMinutes * 60_000` so interval changes don't require sed. Low priority but eliminates future brittleness.
+
+**`formatReviewWindowMessage` should be profile-aware.** The function currently omits the "one final check" line entirely (correct for `extendByOneInterval: false`). If a user ever configures a non-default polling profile with extension enabled, the function wouldn't surface that. Threading the full `ReviewPollingProfile` into the function (or accepting `extendByOneInterval` directly) would keep the message accurate regardless of configuration.
+
+**`isPrDocOnly` edge cases.** The current implementation returns `false` on any error, and `true` only if all files end in `.md`. This handles the common cases (no PR, no network, mixed files). One gap: if `gh pr diff --name-only` returns an empty string (e.g., empty PR), `files.length > 0` gates prevent a false positive. Confirmed correct behavior, but worth documenting explicitly.
+
+**The SonarQube cognitive complexity warnings (orchestrator.ts: 19, ticket-flow.ts: 16) are genuine.** Both are one level above the 15-allowed threshold after EE5 additions. The `runDeliveryOrchestrator` function grew with the doc-only skip path; `buildTicketHandoff` grew with the `modifiedSectionsNote` conditional block. Neither is immediately problematic, but they're candidates for helper extraction in a future engineering epic if the functions continue growing.
+
+**Consider a `bun run verify:quiet` pre-push hook variant.** The current pre-push hook runs `bun run verify`. If that's noisy in a hook context, `verify:quiet` would suppress passing output there too. Not urgent (hooks don't add to session context), but consistent with the principle.
+
+---
+
+_Created: 2026-04-10. PR #124 pending developer review._

--- a/notes/public/ee5-retrospective.md
+++ b/notes/public/ee5-retrospective.md
@@ -10,10 +10,10 @@ Single PR on branch `engineering/ee05-orchestrator-context-minimization` coverin
 
 1. `verify:quiet` script
 2. `modified_sections` handoff field
-3a. Suppress orchestrator poll stdout per check (`formatCurrentTicketStatus`)
-3b. Condense session-side review extract (via `formatCurrentTicketStatus` + triager summaries)
-4. Poll timing 6/12 + doc-only skip + no read-ahead directive
-5. Session compaction directive at `advance`
+   3a. Suppress orchestrator poll stdout per check (`formatCurrentTicketStatus`)
+   3b. Condense session-side review extract (via `formatCurrentTicketStatus` + triager summaries)
+3. Poll timing 6/12 + doc-only skip + no read-ahead directive
+4. Session compaction directive at `advance`
 
 ---
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -585,6 +585,19 @@ export function createApiFetch(
       }
     }
 
+    if (path === '/api/outcomes' && request.method === 'GET') {
+      const statusParam = new URL(request.url).searchParams.get('status');
+      if (statusParam !== 'skipped_no_match') {
+        return Response.json(
+          { error: 'unsupported status filter' },
+          { status: 400 },
+        );
+      }
+      return safeJson(() => ({
+        outcomes: repository.listSkippedNoMatchOutcomes(30),
+      }));
+    }
+
     return Response.json({ error: 'not found' }, { status: 404 });
   };
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -113,6 +113,15 @@ export type RecordFeedItemOutcomeInput = {
   createdAt?: string;
 };
 
+export type SkippedOutcomeRecord = {
+  id: number;
+  runId: number;
+  status: 'skipped_no_match';
+  recordedAt: string;
+  title: string | null;
+  feedName: string | null;
+};
+
 export type RecordCandidateReconciliationInput = {
   identityKey: string;
   lifecycleStatus: CandidateLifecycleStatus;
@@ -146,6 +155,7 @@ export type Repository = {
   listCandidateStates(limit?: number): CandidateStateRecord[];
   listReconcilableCandidates(limit?: number): CandidateStateRecord[];
   listRetryableCandidates(limit?: number): CandidateStateRecord[];
+  listSkippedNoMatchOutcomes(days: number): SkippedOutcomeRecord[];
 };
 
 export const DEFAULT_DATABASE_PATH = 'pirate-claw.db';
@@ -597,6 +607,21 @@ export function createRepository(database: Database): Repository {
     ORDER BY identity_key ASC
     LIMIT ?1`,
   );
+  const listSkippedNoMatchOutcomesStatement = database.prepare(
+    `SELECT
+      fo.id,
+      fo.run_id AS runId,
+      fo.status,
+      fo.created_at AS recordedAt,
+      fi.raw_title AS title,
+      fi.feed_name AS feedName
+    FROM feed_item_outcomes fo
+    LEFT JOIN feed_items fi ON fo.feed_item_id = fi.id
+    WHERE fo.status = 'skipped_no_match'
+      AND fo.created_at >= datetime('now', '-' || ?1 || ' days')
+    ORDER BY fo.created_at DESC`,
+  );
+
   const listRetryableCandidatesStatement = database.query(
     `SELECT
       identity_key AS identityKey,
@@ -829,6 +854,27 @@ export function createRepository(database: Database): Repository {
       return (
         listRetryableCandidatesStatement.all(limit) as CandidateStateRow[]
       ).map(mapCandidateStateRow);
+    },
+
+    listSkippedNoMatchOutcomes(days: number): SkippedOutcomeRecord[] {
+      type Row = {
+        id: number;
+        runId: number;
+        status: 'skipped_no_match';
+        recordedAt: string;
+        title: string | null;
+        feedName: string | null;
+      };
+      return (listSkippedNoMatchOutcomesStatement.all(days) as Row[]).map(
+        (row) => ({
+          id: Number(row.id),
+          runId: Number(row.runId),
+          status: row.status,
+          recordedAt: row.recordedAt,
+          title: row.title,
+          feedName: row.feedName,
+        }),
+      );
     },
   };
 }

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -38,6 +38,7 @@ function stubRepository(overrides: Partial<Repository> = {}): Repository {
     listCandidateStates: () => [],
     listReconcilableCandidates: () => [],
     listRetryableCandidates: () => [],
+    listSkippedNoMatchOutcomes: () => [],
     ...overrides,
   } as Repository;
 }
@@ -1744,6 +1745,80 @@ describe('buildFeedStatuses', () => {
     const statuses = buildFeedStatuses(feeds, pollState, runtime);
 
     expect(statuses[0].isDue).toBe(false);
+  });
+});
+
+describe('GET /api/outcomes', () => {
+  it('returns 400 when status param is missing', async () => {
+    const deps = createDeps();
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/outcomes'),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'unsupported status filter',
+    });
+  });
+
+  it('returns 400 when status param is not skipped_no_match', async () => {
+    const deps = createDeps();
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/outcomes?status=queued'),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'unsupported status filter',
+    });
+  });
+
+  it('returns outcomes from repository on valid request', async () => {
+    const mockOutcomes = [
+      {
+        id: 1,
+        runId: 42,
+        status: 'skipped_no_match' as const,
+        recordedAt: '2026-04-10T12:00:00.000Z',
+        title: 'Some.Show.S01E01.720p',
+        feedName: 'main-tv',
+      },
+      {
+        id: 2,
+        runId: 42,
+        status: 'skipped_no_match' as const,
+        recordedAt: '2026-04-10T12:00:05.000Z',
+        title: null,
+        feedName: null,
+      },
+    ];
+
+    const deps = createDeps({
+      listSkippedNoMatchOutcomes: () => mockOutcomes,
+    });
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/outcomes?status=skipped_no_match'),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({ outcomes: mockOutcomes });
+  });
+
+  it('returns empty outcomes array when repository returns none', async () => {
+    const deps = createDeps({
+      listSkippedNoMatchOutcomes: () => [],
+    });
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/outcomes?status=skipped_no_match'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ outcomes: [] });
   });
 });
 

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -568,6 +568,101 @@ describe('SQLite repository', () => {
       'tmdb_tv_season_cache',
     ]);
   });
+
+  describe('listSkippedNoMatchOutcomes', () => {
+    it('returns only skipped_no_match outcomes', async () => {
+      const repository = createTestRepository(await createDatabasePath());
+      const run = repository.startRun('2026-04-01T00:00:00.000Z');
+      const feedItem = repository.recordFeedItem(run.id, {
+        feedName: 'main-tv',
+        guidOrLink: 'https://example.test/item1',
+        rawTitle: 'Some.Show.S01E01.720p',
+        publishedAt: '2026-04-01T00:00:00.000Z',
+        downloadUrl: 'https://example.test/item1.torrent',
+      });
+
+      repository.recordFeedItemOutcome({
+        runId: run.id,
+        feedItemId: feedItem.id,
+        status: 'skipped_no_match',
+        createdAt: '2026-04-01T00:01:00.000Z',
+      });
+      repository.recordFeedItemOutcome({
+        runId: run.id,
+        status: 'queued',
+        createdAt: '2026-04-01T00:02:00.000Z',
+      });
+      repository.recordFeedItemOutcome({
+        runId: run.id,
+        status: 'failed',
+        createdAt: '2026-04-01T00:03:00.000Z',
+      });
+
+      const results = repository.listSkippedNoMatchOutcomes(30);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe('skipped_no_match');
+      expect(results[0].runId).toBe(run.id);
+      expect(results[0].title).toBe('Some.Show.S01E01.720p');
+      expect(results[0].feedName).toBe('main-tv');
+      expect(results[0].recordedAt).toBe('2026-04-01T00:01:00.000Z');
+    });
+
+    it('returns null title and feedName when feed_item_id is null', async () => {
+      const repository = createTestRepository(await createDatabasePath());
+      const run = repository.startRun('2026-04-01T00:00:00.000Z');
+
+      repository.recordFeedItemOutcome({
+        runId: run.id,
+        feedItemId: undefined,
+        status: 'skipped_no_match',
+        createdAt: '2026-04-01T00:01:00.000Z',
+      });
+
+      const results = repository.listSkippedNoMatchOutcomes(30);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBeNull();
+      expect(results[0].feedName).toBeNull();
+    });
+
+    it('excludes outcomes older than the specified day window', async () => {
+      const repository = createTestRepository(await createDatabasePath());
+      const run = repository.startRun('2026-04-01T00:00:00.000Z');
+
+      // Recent outcome (within window)
+      repository.recordFeedItemOutcome({
+        runId: run.id,
+        status: 'skipped_no_match',
+        createdAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+      });
+
+      // Old outcome (outside window)
+      repository.recordFeedItemOutcome({
+        runId: run.id,
+        status: 'skipped_no_match',
+        createdAt: new Date(
+          Date.now() - 35 * 24 * 60 * 60 * 1000,
+        ).toISOString(),
+      });
+
+      const results = repository.listSkippedNoMatchOutcomes(30);
+
+      expect(results).toHaveLength(1);
+    });
+
+    it('returns empty array when no matching outcomes', async () => {
+      const repository = createTestRepository(await createDatabasePath());
+      const run = repository.startRun('2026-04-01T00:00:00.000Z');
+      repository.recordFeedItemOutcome({
+        runId: run.id,
+        status: 'queued',
+        createdAt: '2026-04-01T00:01:00.000Z',
+      });
+
+      expect(repository.listSkippedNoMatchOutcomes(30)).toEqual([]);
+    });
+  });
 });
 
 function createTestRepository(path: string) {


### PR DESCRIPTION
## Summary

- delivery ticket: `P15.01 GET /api/outcomes — Skipped No-Match Outcomes Endpoint`
- ticket file: [docs/02-delivery/phase-15/ticket-01-outcomes-endpoint.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-15/ticket-01-outcomes-endpoint.md)
- stacked base branch: `main`
- post-verify self-audit: completed at 2026-04-11 12:06 UTC

## External AI Review

- outcome: `needs_patch`
- reviewed commit: [`3ddfd9eeda5e`](https://github.com/cesarnml/pirate_claw/commit/3ddfd9eeda5e38105ce74b1e7f0dd2cbb3c9ed5b)
- current branch head: [`3ddfd9eeda5e`](https://github.com/cesarnml/pirate_claw/commit/3ddfd9eeda5e38105ce74b1e7f0dd2cbb3c9ed5b)
- vendors: `coderabbit`

### Unresolved Review Findings

- [coderabbit] Delivery-status text appears stale for this PR. `docs/02-delivery/phase-15/implementation-plan.md:97` [thread](https://github.com/cesarnml/pirate_claw/pull/125#discussion_r3067978857)
- [coderabbit] Fill in the ticket rationale now that behavior has shipped. `docs/02-delivery/phase-15/ticket-01-outcomes-endpoint.md:75` [thread](https://github.com/cesarnml/pirate_claw/pull/125#discussion_r3067978859)
- [coderabbit] Remove status code 7 from the mapping—it is not a valid Transmission RPC status code. `docs/02-delivery/phase-15/ticket-02-transmission-proxy-endpoints.md:49` [thread](https://github.com/cesarnml/pirate_claw/pull/125#discussion_r3067978862)
- [coderabbit] Status values here don’t match the current `CandidateStatus` domain. `docs/02-delivery/phase-15/ticket-03-dashboard-overview-enhancement.md:88` [thread](https://github.com/cesarnml/pirate_claw/pull/125#discussion_r3067978865)
- [coderabbit] Update `docs/00-overview/roadmap.md` and `docs/00-overview/start-here.md` to reflect Phase 15 delivery status. `docs/02-delivery/phase-15/ticket-06-unmatched-candidates-view.md:101` [thread](https://github.com/cesarnml/pirate_claw/pull/125#discussion_r3067978868)
- [coderabbit] Run `bun run spellcheck` before merge. `docs/02-delivery/phase-15/ticket-07-docs-and-phase-exit.md:46` [thread](https://github.com/cesarnml/pirate_claw/pull/125#discussion_r3067978870)
- [coderabbit] Wrap both sides of the created_at comparison with `datetime()` to fix incorrect text-order filtering. `src/repository.ts:623` [thread](https://github.com/cesarnml/pirate_claw/pull/125#discussion_r3067978871)

- triage note: Actionable AI review findings were detected and still need follow-up.
- triage summary: Flagged 7 finding comment(s) for follow-up.
