### PR TITLE
feat(p15.02): transmission proxy endpoints — GET /api/transmission/torrents and session [P15.02]

### DIFF
--- a/fixtures/api/transmission-session.json
+++ b/fixtures/api/transmission-session.json
@@ -1,0 +1,6 @@
+{
+  "version": "3.00 (bb6b5a062ef)",
+  "downloadSpeed": 2097152,
+  "uploadSpeed": 524288,
+  "activeTorrentCount": 3
+}

--- a/fixtures/api/transmission-torrents.json
+++ b/fixtures/api/transmission-torrents.json
@@ -1,0 +1,20 @@
+{
+  "torrents": [
+    {
+      "hash": "abc123def456abc123def456abc123def456abc1",
+      "name": "Breaking.Bad.S01E01.720p.BluRay.x264",
+      "status": "downloading",
+      "percentDone": 0.42,
+      "rateDownload": 1048576,
+      "eta": 3600
+    },
+    {
+      "hash": "bcd234ef0567bcd234ef0567bcd234ef0567bcd2",
+      "name": "The.Shawshank.Redemption.1994.1080p.x265",
+      "status": "seeding",
+      "percentDone": 1.0,
+      "rateDownload": 0,
+      "eta": -1
+    }
+  ]
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { renameSync, writeFileSync } from 'node:fs';
+import { fetchSessionInfo, fetchTorrentStats } from './transmission';
 import type {
   AppConfig,
   CompactTvDefaults,
@@ -596,6 +597,43 @@ export function createApiFetch(
       return safeJson(() => ({
         outcomes: repository.listSkippedNoMatchOutcomes(30),
       }));
+    }
+
+    if (path === '/api/transmission/torrents' && request.method === 'GET') {
+      const candidates = repository.listCandidateStates();
+      const hashes = candidates
+        .map((c) => c.transmissionTorrentHash)
+        .filter((h): h is string => h !== undefined);
+
+      if (hashes.length === 0) {
+        return Response.json({ torrents: [] });
+      }
+
+      const result = await fetchTorrentStats(activeConfig.transmission, hashes);
+
+      if (!result.ok) {
+        return Response.json(
+          { error: 'transmission unavailable', detail: result.message },
+          { status: 502 },
+        );
+      }
+
+      const hashSet = new Set(hashes);
+      const torrents = result.torrents.filter((t) => hashSet.has(t.hash));
+      return Response.json({ torrents });
+    }
+
+    if (path === '/api/transmission/session' && request.method === 'GET') {
+      const result = await fetchSessionInfo(activeConfig.transmission);
+
+      if (!result.ok) {
+        return Response.json(
+          { error: 'transmission unavailable', detail: result.message },
+          { status: 502 },
+        );
+      }
+
+      return Response.json(result.session);
     }
 
     return Response.json({ error: 'not found' }, { status: 404 });

--- a/src/transmission.ts
+++ b/src/transmission.ts
@@ -57,6 +57,30 @@ export type Downloader = {
   lookupTorrents?(input: LookupTorrentsInput): Promise<LookupTorrentsResult>;
 };
 
+export type TorrentStatSnapshot = {
+  hash: string;
+  name: string;
+  status: 'downloading' | 'seeding' | 'stopped' | 'error';
+  percentDone: number;
+  rateDownload: number;
+  eta: number;
+};
+
+export type FetchTorrentStatsResult =
+  | { ok: true; torrents: TorrentStatSnapshot[] }
+  | SubmissionFailure;
+
+export type SessionInfo = {
+  version: string;
+  downloadSpeed: number;
+  uploadSpeed: number;
+  activeTorrentCount: number;
+};
+
+export type FetchSessionInfoResult =
+  | { ok: true; session: SessionInfo }
+  | SubmissionFailure;
+
 export type DownloaderOptions = {
   warn?: (message: string) => void;
 };
@@ -171,6 +195,165 @@ async function lookupTorrentsInTransmission(
   }
 
   return parseLookupTorrentsResult(parsed);
+}
+
+export async function fetchTorrentStats(
+  config: TransmissionConfig,
+  hashes: string[],
+): Promise<FetchTorrentStatsResult> {
+  const body = {
+    method: 'torrent-get',
+    arguments: {
+      ids: hashes,
+      fields: [
+        'id',
+        'name',
+        'hashString',
+        'status',
+        'percentDone',
+        'rateDownload',
+        'eta',
+      ],
+    },
+  };
+
+  const firstResponse = await sendRpcRequest(config, body);
+  if (!firstResponse.ok) {
+    return firstResponse.error;
+  }
+
+  let response = firstResponse.response;
+
+  if (response.status === 409) {
+    const sessionId = response.headers.get('x-transmission-session-id');
+    if (!sessionId) {
+      return {
+        ok: false,
+        code: 'session_error',
+        message:
+          'Transmission session negotiation failed: missing X-Transmission-Session-Id header.',
+      };
+    }
+    const retryResponse = await sendRpcRequest(config, body, sessionId);
+    if (!retryResponse.ok) {
+      return retryResponse.error;
+    }
+    response = retryResponse.response;
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      code: 'http_error',
+      message: `Transmission RPC request failed with HTTP ${response.status}.`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await response.json();
+  } catch {
+    return {
+      ok: false,
+      code: 'invalid_response',
+      message: 'Transmission RPC response was not valid JSON.',
+    };
+  }
+
+  return parseTorrentStatsResult(parsed);
+}
+
+export async function fetchSessionInfo(
+  config: TransmissionConfig,
+): Promise<FetchSessionInfoResult> {
+  const [sessionGetResult, sessionStatsResult] = await Promise.all([
+    sendRpcRequest(config, { method: 'session-get', arguments: {} }),
+    sendRpcRequest(config, { method: 'session-stats', arguments: {} }),
+  ]);
+
+  if (!sessionGetResult.ok) {
+    return sessionGetResult.error;
+  }
+  if (!sessionStatsResult.ok) {
+    return sessionStatsResult.error;
+  }
+
+  const resolveResponse = async (
+    result: { ok: true; response: Response },
+    config: TransmissionConfig,
+    body: unknown,
+  ): Promise<
+    { ok: true; parsed: unknown } | { ok: false; error: SubmissionFailure }
+  > => {
+    let response = result.response;
+
+    if (response.status === 409) {
+      const sessionId = response.headers.get('x-transmission-session-id');
+      if (!sessionId) {
+        return {
+          ok: false,
+          error: {
+            ok: false,
+            code: 'session_error',
+            message:
+              'Transmission session negotiation failed: missing X-Transmission-Session-Id header.',
+          },
+        };
+      }
+      const retryResult = await sendRpcRequest(config, body, sessionId);
+      if (!retryResult.ok) {
+        return { ok: false, error: retryResult.error };
+      }
+      response = retryResult.response;
+    }
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: {
+          ok: false,
+          code: 'http_error',
+          message: `Transmission RPC request failed with HTTP ${response.status}.`,
+        },
+      };
+    }
+
+    try {
+      return { ok: true, parsed: await response.json() };
+    } catch {
+      return {
+        ok: false,
+        error: {
+          ok: false,
+          code: 'invalid_response',
+          message: 'Transmission RPC response was not valid JSON.',
+        },
+      };
+    }
+  };
+
+  const [sessionGetParsed, sessionStatsParsed] = await Promise.all([
+    resolveResponse(sessionGetResult, config, {
+      method: 'session-get',
+      arguments: {},
+    }),
+    resolveResponse(sessionStatsResult, config, {
+      method: 'session-stats',
+      arguments: {},
+    }),
+  ]);
+
+  if (!sessionGetParsed.ok) {
+    return sessionGetParsed.error;
+  }
+  if (!sessionStatsParsed.ok) {
+    return sessionStatsParsed.error;
+  }
+
+  return parseSessionInfoResult(
+    sessionGetParsed.parsed,
+    sessionStatsParsed.parsed,
+  );
 }
 
 async function sendRpcRequest(
@@ -563,3 +746,192 @@ type TransmissionTorrentGetResponse = {
     torrents: TransmissionTorrent[];
   };
 };
+
+type TransmissionStatTorrent = {
+  id?: number;
+  name?: string;
+  hashString?: string;
+  status?: number;
+  percentDone?: number;
+  rateDownload?: number;
+  eta?: number;
+};
+
+type TransmissionTorrentStatResponse = {
+  result: string;
+  arguments: {
+    torrents: TransmissionStatTorrent[];
+  };
+};
+
+type TransmissionSessionGetResponse = {
+  result: string;
+  arguments: {
+    version?: string;
+  };
+};
+
+type TransmissionSessionStatsResponse = {
+  result: string;
+  arguments: {
+    'download-speed'?: number;
+    'upload-speed'?: number;
+    'active-torrent-count'?: number;
+  };
+};
+
+function mapStatusCode(
+  code: number | undefined,
+): TorrentStatSnapshot['status'] {
+  if (code === 4) return 'downloading';
+  if (code === 6) return 'seeding';
+  if (code === 7) return 'error';
+  return 'stopped';
+}
+
+function parseTorrentStatsResult(parsed: unknown): FetchTorrentStatsResult {
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    !('result' in parsed) ||
+    !('arguments' in parsed)
+  ) {
+    return {
+      ok: false,
+      code: 'invalid_response',
+      message:
+        'Transmission RPC torrent-get response was missing required fields.',
+    };
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const args = record.arguments;
+
+  if (
+    !args ||
+    typeof args !== 'object' ||
+    !('torrents' in (args as object)) ||
+    !Array.isArray((args as Record<string, unknown>).torrents)
+  ) {
+    return {
+      ok: false,
+      code: 'invalid_response',
+      message:
+        'Transmission RPC torrent-get response was missing required fields.',
+    };
+  }
+
+  const typed = parsed as TransmissionTorrentStatResponse;
+
+  if (typed.result !== 'success') {
+    return {
+      ok: false,
+      code: 'rpc_error',
+      message: `Transmission rejected torrent-get: ${typed.result}.`,
+      rpcResult: typed.result,
+    };
+  }
+
+  const torrents: TorrentStatSnapshot[] = [];
+
+  for (const torrent of typed.arguments.torrents) {
+    if (
+      typeof torrent.hashString !== 'string' ||
+      typeof torrent.name !== 'string'
+    ) {
+      return {
+        ok: false,
+        code: 'invalid_response',
+        message:
+          'Transmission RPC torrent-get response contained a torrent missing hashString or name.',
+      };
+    }
+
+    torrents.push({
+      hash: torrent.hashString,
+      name: torrent.name,
+      status: mapStatusCode(
+        typeof torrent.status === 'number' ? torrent.status : undefined,
+      ),
+      percentDone:
+        typeof torrent.percentDone === 'number' ? torrent.percentDone : 0,
+      rateDownload:
+        typeof torrent.rateDownload === 'number' ? torrent.rateDownload : 0,
+      eta: typeof torrent.eta === 'number' ? torrent.eta : -1,
+    });
+  }
+
+  return { ok: true, torrents };
+}
+
+function parseSessionInfoResult(
+  sessionGet: unknown,
+  sessionStats: unknown,
+): FetchSessionInfoResult {
+  if (
+    !sessionGet ||
+    typeof sessionGet !== 'object' ||
+    !('result' in sessionGet) ||
+    !('arguments' in sessionGet)
+  ) {
+    return {
+      ok: false,
+      code: 'invalid_response',
+      message: 'Transmission session-get response was malformed.',
+    };
+  }
+
+  if (
+    !sessionStats ||
+    typeof sessionStats !== 'object' ||
+    !('result' in sessionStats) ||
+    !('arguments' in sessionStats)
+  ) {
+    return {
+      ok: false,
+      code: 'invalid_response',
+      message: 'Transmission session-stats response was malformed.',
+    };
+  }
+
+  const get = sessionGet as TransmissionSessionGetResponse;
+  const stats = sessionStats as TransmissionSessionStatsResponse;
+
+  if (get.result !== 'success') {
+    return {
+      ok: false,
+      code: 'rpc_error',
+      message: `Transmission session-get failed: ${get.result}.`,
+      rpcResult: get.result,
+    };
+  }
+
+  if (stats.result !== 'success') {
+    return {
+      ok: false,
+      code: 'rpc_error',
+      message: `Transmission session-stats failed: ${stats.result}.`,
+      rpcResult: stats.result,
+    };
+  }
+
+  return {
+    ok: true,
+    session: {
+      version:
+        typeof get.arguments.version === 'string' ? get.arguments.version : '',
+      downloadSpeed:
+        typeof stats.arguments['download-speed'] === 'number'
+          ? stats.arguments['download-speed']
+          : 0,
+      uploadSpeed:
+        typeof stats.arguments['upload-speed'] === 'number'
+          ? stats.arguments['upload-speed']
+          : 0,
+      activeTorrentCount:
+        typeof stats.arguments['active-torrent-count'] === 'number'
+          ? stats.arguments['active-torrent-count']
+          : 0,
+    },
+  };
+}

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1822,6 +1822,89 @@ describe('GET /api/outcomes', () => {
   });
 });
 
+describe('GET /api/transmission/torrents', () => {
+  it('returns empty torrents when no candidates have a hash', async () => {
+    const deps = createDeps({
+      listCandidateStates: () => [],
+    });
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/transmission/torrents'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ torrents: [] });
+  });
+
+  it('returns 502 when Transmission is unreachable', async () => {
+    const mockCandidate = {
+      identityKey: 'tv:breaking bad|s01e01',
+      mediaType: 'tv' as const,
+      status: 'queued' as const,
+      transmissionTorrentHash: 'abc123',
+      ruleName: 'Breaking Bad',
+      score: 10,
+      reasons: [],
+      rawTitle: 'Breaking.Bad.S01E01',
+      normalizedTitle: 'Breaking Bad',
+      feedName: 'tv-feed',
+      guidOrLink: 'https://example.test/1',
+      publishedAt: '2026-04-01T00:00:00Z',
+      downloadUrl: 'https://example.test/1.torrent',
+      firstSeenRunId: 1,
+      lastSeenRunId: 1,
+      updatedAt: '2026-04-01T00:00:00Z',
+    };
+
+    const deps = createDeps({
+      listCandidateStates: () => [mockCandidate],
+    });
+
+    deps.config = {
+      ...deps.config,
+      transmission: {
+        url: 'http://127.0.0.1:1/transmission/rpc',
+        username: 'u',
+        password: 'p',
+      },
+    };
+
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/transmission/torrents'),
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({
+      error: 'transmission unavailable',
+    });
+  });
+});
+
+describe('GET /api/transmission/session', () => {
+  it('returns 502 when Transmission is unreachable', async () => {
+    const deps = createDeps();
+    deps.config = {
+      ...deps.config,
+      transmission: {
+        url: 'http://127.0.0.1:1/transmission/rpc',
+        username: 'u',
+        password: 'p',
+      },
+    };
+
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/transmission/session'),
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({
+      error: 'transmission unavailable',
+    });
+  });
+});
+
 describe('redactConfig', () => {
   it('redacts transmission username and password', () => {
     const config = stubConfig();

--- a/test/transmission.test.ts
+++ b/test/transmission.test.ts
@@ -3,8 +3,11 @@ import { afterEach, describe, expect, it } from 'bun:test';
 import type { TransmissionConfig } from '../src/config';
 import {
   createTransmissionDownloader,
+  fetchSessionInfo,
+  fetchTorrentStats,
   type SubmissionFailure,
   type SubmissionFailureCode,
+  type TorrentStatSnapshot,
 } from '../src/transmission';
 
 const servers: Array<ReturnType<typeof Bun.serve>> = [];
@@ -600,6 +603,209 @@ describe('Transmission adapter', () => {
         ],
       },
     });
+  });
+});
+
+describe('fetchTorrentStats', () => {
+  afterEach(() => {
+    while (servers.length > 0) {
+      servers.pop()?.stop(true);
+    }
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns mapped TorrentStatSnapshot[] on success', async () => {
+    const server = startTransmissionServer(() =>
+      Response.json({
+        result: 'success',
+        arguments: {
+          torrents: [
+            {
+              id: 1,
+              hashString: 'abc123',
+              name: 'Breaking.Bad.S01E01',
+              status: 4,
+              percentDone: 0.42,
+              rateDownload: 1048576,
+              eta: 3600,
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = await fetchTorrentStats(
+      createTransmissionConfig(server.url.origin),
+      ['abc123'],
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      torrents: [
+        {
+          hash: 'abc123',
+          name: 'Breaking.Bad.S01E01',
+          status: 'downloading',
+          percentDone: 0.42,
+          rateDownload: 1048576,
+          eta: 3600,
+        },
+      ],
+    });
+  });
+
+  it('maps status codes correctly', async () => {
+    const statusCases: Array<{
+      code: number;
+      expected: TorrentStatSnapshot['status'];
+    }> = [
+      { code: 4, expected: 'downloading' },
+      { code: 6, expected: 'seeding' },
+      { code: 7, expected: 'error' },
+      { code: 0, expected: 'stopped' },
+      { code: 1, expected: 'stopped' },
+      { code: 5, expected: 'stopped' },
+    ];
+
+    for (const { code, expected } of statusCases) {
+      const server = startTransmissionServer(() =>
+        Response.json({
+          result: 'success',
+          arguments: {
+            torrents: [
+              {
+                id: 1,
+                hashString: 'hash1',
+                name: 'Test Torrent',
+                status: code,
+                percentDone: 0,
+                rateDownload: 0,
+                eta: -1,
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await fetchTorrentStats(
+        createTransmissionConfig(server.url.origin),
+        ['hash1'],
+      );
+
+      expect(result).toMatchObject({ ok: true });
+      if (result.ok) {
+        expect(result.torrents[0].status).toBe(expected);
+      }
+    }
+  });
+
+  it('handles 409 session negotiation', async () => {
+    let requestCount = 0;
+    const server = startTransmissionServer(() => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        return new Response(null, {
+          status: 409,
+          headers: { 'x-transmission-session-id': 'session-abc' },
+        });
+      }
+      return Response.json({
+        result: 'success',
+        arguments: {
+          torrents: [
+            {
+              id: 1,
+              hashString: 'hash1',
+              name: 'Test',
+              status: 4,
+              percentDone: 0.5,
+              rateDownload: 512000,
+              eta: 1800,
+            },
+          ],
+        },
+      });
+    });
+
+    const result = await fetchTorrentStats(
+      createTransmissionConfig(server.url.origin),
+      ['hash1'],
+    );
+
+    expect(result).toMatchObject({ ok: true });
+    expect(requestCount).toBe(2);
+  });
+
+  it('returns SubmissionFailure when Transmission is unreachable', async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(new Error('ECONNREFUSED'))) as unknown as typeof fetch;
+
+    const result = await fetchTorrentStats(
+      {
+        url: 'http://127.0.0.1:1/transmission/rpc',
+        username: 'u',
+        password: 'p',
+      },
+      ['hash1'],
+    );
+
+    expect(result).toMatchObject({ ok: false, code: 'network_error' });
+  });
+});
+
+describe('fetchSessionInfo', () => {
+  afterEach(() => {
+    while (servers.length > 0) {
+      servers.pop()?.stop(true);
+    }
+    globalThis.fetch = originalFetch;
+  });
+
+  it('merges session-get and session-stats into SessionInfo', async () => {
+    const server = startTransmissionServer(async (request) => {
+      const body = (await request.json()) as { method: string };
+      if (body.method === 'session-get') {
+        return Response.json({
+          result: 'success',
+          arguments: { version: '3.00 (bb6b5a062ef)' },
+        });
+      }
+      return Response.json({
+        result: 'success',
+        arguments: {
+          'download-speed': 2097152,
+          'upload-speed': 524288,
+          'active-torrent-count': 3,
+        },
+      });
+    });
+
+    const result = await fetchSessionInfo(
+      createTransmissionConfig(server.url.origin),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      session: {
+        version: '3.00 (bb6b5a062ef)',
+        downloadSpeed: 2097152,
+        uploadSpeed: 524288,
+        activeTorrentCount: 3,
+      },
+    });
+  });
+
+  it('returns SubmissionFailure when Transmission is unreachable', async () => {
+    globalThis.fetch = (() =>
+      Promise.reject(new Error('ECONNREFUSED'))) as unknown as typeof fetch;
+
+    const result = await fetchSessionInfo({
+      url: 'http://127.0.0.1:1/transmission/rpc',
+      username: 'u',
+      password: 'p',
+    });
+
+    expect(result).toMatchObject({ ok: false, code: 'network_error' });
   });
 });
 


### PR DESCRIPTION
## Summary

- delivery ticket: `P15.02 Transmission Proxy Endpoints — GET /api/transmission/torrents and GET /api/transmission/session`
- ticket file: [docs/02-delivery/phase-15/ticket-02-transmission-proxy-endpoints.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-15/ticket-02-transmission-proxy-endpoints.md)
- stacked base branch: `agents/p15-01-get-api-outcomes-skipped-no-match-outcomes-endpoint`
- post-verify self-audit: completed at 2026-04-11 12:16 UTC

## External AI Review

- outcome: `clean`
- current branch head: [`1a5006cf0bbe`](https://github.com/cesarnml/pirate_claw/commit/1a5006cf0bbe8ff7e5f1ca366ba320a5913239a2)
- no prudent follow-up changes were required.
