### PR TITLE
feat(p15-03): dashboard overview enhancement — header strip, active downloads, event log, stats, archive grid [P15.03]

### DIFF
--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -153,6 +153,22 @@ export type AppConfig = {
 	runtime: RuntimeConfig;
 };
 
+export type TorrentStatSnapshot = {
+	hash: string;
+	name: string;
+	status: 'downloading' | 'seeding' | 'stopped' | 'error';
+	percentDone: number;
+	rateDownload: number;
+	eta: number;
+};
+
+export type SessionInfo = {
+	version: string;
+	downloadSpeed: number;
+	uploadSpeed: number;
+	activeTorrentCount: number;
+};
+
 export type FeedItemOutcomeStatus = 'queued' | 'failed' | 'skipped_duplicate' | 'skipped_no_match';
 
 export type RunStatus = 'running' | 'completed' | 'failed';

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -1,20 +1,38 @@
 import { apiFetch } from '$lib/server/api';
-import type { DaemonHealth, RunSummaryRecord } from '$lib/types';
+import type {
+	CandidateStateRecord,
+	DaemonHealth,
+	SessionInfo,
+	TorrentStatSnapshot
+} from '$lib/types';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-	try {
-		const [health, status] = await Promise.all([
-			apiFetch<DaemonHealth>('/api/health'),
-			apiFetch<{ runs: RunSummaryRecord[] }>('/api/status')
-		]);
-		return { health, runs: status.runs, error: null };
-	} catch (err) {
-		console.error('[dashboard] failed to load health/status:', err);
-		return {
-			health: null as DaemonHealth | null,
-			runs: [] as RunSummaryRecord[],
-			error: 'Could not reach the API.'
-		};
+	const [healthResult, sessionResult, torrentsResult, candidatesResult] = await Promise.allSettled([
+		apiFetch<DaemonHealth>('/api/health'),
+		apiFetch<SessionInfo>('/api/transmission/session'),
+		apiFetch<{ torrents: TorrentStatSnapshot[] }>('/api/transmission/torrents'),
+		apiFetch<{ candidates: CandidateStateRecord[] }>('/api/candidates')
+	]);
+
+	const health = healthResult.status === 'fulfilled' ? healthResult.value : null;
+	const transmissionSession = sessionResult.status === 'fulfilled' ? sessionResult.value : null;
+	const transmissionTorrents =
+		torrentsResult.status === 'fulfilled' ? torrentsResult.value.torrents : [];
+	const candidates =
+		candidatesResult.status === 'fulfilled' ? candidatesResult.value.candidates : [];
+
+	const error = health === null ? 'Could not reach the API.' : null;
+
+	if (health === null) {
+		console.error('[dashboard] failed to load /api/health');
 	}
+
+	return {
+		health,
+		transmissionSession,
+		transmissionTorrents,
+		candidates,
+		error
+	};
 };

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -18,14 +18,20 @@ export const load: PageServerLoad = async () => {
 	const health = healthResult.status === 'fulfilled' ? healthResult.value : null;
 	const transmissionSession = sessionResult.status === 'fulfilled' ? sessionResult.value : null;
 	const transmissionTorrents =
-		torrentsResult.status === 'fulfilled' ? torrentsResult.value.torrents : [];
+		torrentsResult.status === 'fulfilled' ? torrentsResult.value.torrents : null;
 	const candidates =
-		candidatesResult.status === 'fulfilled' ? candidatesResult.value.candidates : [];
+		candidatesResult.status === 'fulfilled' ? candidatesResult.value.candidates : null;
 
 	const error = health === null ? 'Could not reach the API.' : null;
 
 	if (health === null) {
 		console.error('[dashboard] failed to load /api/health');
+	}
+	if (torrentsResult.status === 'rejected') {
+		console.error('[dashboard] failed to load /api/transmission/torrents', torrentsResult.reason);
+	}
+	if (candidatesResult.status === 'rejected') {
+		console.error('[dashboard] failed to load /api/candidates', candidatesResult.reason);
 	}
 
 	return {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -48,6 +48,7 @@
 
 	function formatEta(eta: number): string {
 		if (eta < 0) return '—';
+		if (eta < 60) return '<1m';
 		const hours = Math.floor(eta / 3600);
 		const minutes = Math.floor((eta % 3600) / 60);
 		if (hours > 0) return `${hours}h ${minutes}m`;
@@ -76,8 +77,8 @@
 		return title.charAt(0).toUpperCase();
 	}
 
-	const candidates = $derived(data.candidates);
-	const torrents = $derived(data.transmissionTorrents);
+	const candidates = $derived(data.candidates ?? []);
+	const torrents = $derived(data.transmissionTorrents ?? []);
 
 	const activeDownloads = $derived(
 		torrents

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -9,6 +9,7 @@
 		TableHeader,
 		TableRow
 	} from '$lib/components/ui/table';
+	import type { CandidateStateRecord, CandidateStatus } from '$lib/types';
 	import type { PageData } from './$types';
 
 	const { data }: { data: PageData } = $props();
@@ -30,81 +31,279 @@
 			timeZone: 'UTC'
 		});
 	}
+
+	function formatShortDate(iso: string): string {
+		return new Date(iso).toLocaleDateString('en-US', {
+			month: 'short',
+			day: 'numeric',
+			year: 'numeric',
+			timeZone: 'UTC'
+		});
+	}
+
+	function formatSpeed(bytesPerSec: number): string {
+		if (bytesPerSec >= 1_048_576) return `${(bytesPerSec / 1_048_576).toFixed(1)} MB/s`;
+		return `${(bytesPerSec / 1024).toFixed(0)} KB/s`;
+	}
+
+	function formatEta(eta: number): string {
+		if (eta < 0) return '—';
+		const hours = Math.floor(eta / 3600);
+		const minutes = Math.floor((eta % 3600) / 60);
+		if (hours > 0) return `${hours}h ${minutes}m`;
+		return `${minutes}m`;
+	}
+
+	function statusBadgeClass(status: CandidateStatus): string {
+		switch (status) {
+			case 'queued':
+				return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200';
+			case 'completed':
+				return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
+			case 'failed':
+				return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
+			case 'duplicate':
+			case 'skipped':
+				return 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300';
+			case 'downloading':
+				return 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-200';
+			default:
+				return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300';
+		}
+	}
+
+	function initialBox(title: string): string {
+		return title.charAt(0).toUpperCase();
+	}
+
+	const candidates = $derived(data.candidates);
+	const torrents = $derived(data.transmissionTorrents);
+
+	const activeDownloads = $derived(
+		torrents
+			.filter((t) => t.status === 'downloading')
+			.slice(0, 5)
+			.map((t) => {
+				const candidate = candidates.find((c) => c.transmissionTorrentHash === t.hash);
+				return { torrent: t, candidate };
+			})
+	);
+
+	const recentCandidates = $derived(
+		[...candidates].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)).slice(0, 10)
+	);
+
+	const totalTracked = $derived(candidates.length);
+	const failedCount = $derived(candidates.filter((c) => c.status === 'failed').length);
+
+	const oneWeekAgo = $derived(new Date(Date.now() - 7 * 24 * 60 * 60 * 1000));
+	const completedThisWeek = $derived(
+		candidates.filter((c) => {
+			if (c.status !== 'completed' || !c.transmissionDoneDate) return false;
+			return new Date(c.transmissionDoneDate) >= oneWeekAgo;
+		}).length
+	);
+
+	const archiveItems = $derived(
+		candidates
+			.filter(
+				(c): c is CandidateStateRecord & { transmissionDoneDate: string } =>
+					c.status === 'completed' && !!c.transmissionDoneDate
+			)
+			.sort((a, b) => b.transmissionDoneDate.localeCompare(a.transmissionDoneDate))
+			.slice(0, 6)
+	);
 </script>
 
 <h1 class="text-3xl font-bold tracking-tight">Dashboard</h1>
 
 {#if data.error}
-	<Alert variant="destructive" class="mt-6">
+	<Alert variant="destructive" class="mt-6" role="alert">
 		<AlertTitle>API unavailable</AlertTitle>
 		<AlertDescription>{data.error}</AlertDescription>
 	</Alert>
 {:else if data.health}
 	{@const health = data.health}
-	{@const runs = data.runs}
+	{@const session = data.transmissionSession}
 
 	<section class="mt-8 space-y-6">
-		<Card>
-			<CardHeader class="pb-3">
-				<h2 class="text-lg font-semibold tracking-tight">Daemon</h2>
-			</CardHeader>
-			<CardContent>
-				<dl class="grid gap-3 text-sm">
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">Uptime</dt>
-						<dd class="font-medium">{formatUptime(health.uptime)}</dd>
-					</div>
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">Started at</dt>
-						<dd class="font-medium">{formatDate(health.startedAt)}</dd>
-					</div>
-					{#if health.lastRunCycle}
+		<!-- Header strip -->
+		<div class="grid gap-4 sm:grid-cols-2">
+			<Card>
+				<CardHeader class="pb-3">
+					<h2 class="text-lg font-semibold tracking-tight">Daemon</h2>
+				</CardHeader>
+				<CardContent>
+					<dl class="grid gap-2 text-sm">
 						<div class="flex flex-wrap gap-2">
-							<dt class="text-muted-foreground">Last run cycle</dt>
-							<dd class="font-medium">{formatDate(health.lastRunCycle.startedAt)}</dd>
+							<dt class="text-muted-foreground">Uptime</dt>
+							<dd class="font-medium">{formatUptime(health.uptime)}</dd>
 						</div>
-					{/if}
-					{#if health.lastReconcileCycle}
 						<div class="flex flex-wrap gap-2">
-							<dt class="text-muted-foreground">Last reconcile</dt>
-							<dd class="font-medium">{formatDate(health.lastReconcileCycle.startedAt)}</dd>
+							<dt class="text-muted-foreground">Started at</dt>
+							<dd class="font-medium">{formatDate(health.startedAt)}</dd>
 						</div>
-					{/if}
-				</dl>
-			</CardContent>
-		</Card>
+						{#if health.lastRunCycle}
+							<div class="flex flex-wrap gap-2">
+								<dt class="text-muted-foreground">Last run</dt>
+								<dd class="font-medium">{formatDate(health.lastRunCycle.startedAt)}</dd>
+							</div>
+						{/if}
+						{#if health.lastReconcileCycle}
+							<div class="flex flex-wrap gap-2">
+								<dt class="text-muted-foreground">Last reconcile</dt>
+								<dd class="font-medium">{formatDate(health.lastReconcileCycle.startedAt)}</dd>
+							</div>
+						{/if}
+					</dl>
+				</CardContent>
+			</Card>
 
+			<Card>
+				<CardHeader class="pb-3">
+					<h2 class="text-lg font-semibold tracking-tight">Transmission</h2>
+				</CardHeader>
+				<CardContent>
+					{#if session}
+						<dl class="grid gap-2 text-sm">
+							<div class="flex flex-wrap gap-2">
+								<dt class="text-muted-foreground">Version</dt>
+								<dd class="font-medium">{session.version}</dd>
+							</div>
+							<div class="flex flex-wrap gap-2">
+								<dt class="text-muted-foreground">Download</dt>
+								<dd class="font-medium">{formatSpeed(session.downloadSpeed)}</dd>
+							</div>
+							<div class="flex flex-wrap gap-2">
+								<dt class="text-muted-foreground">Upload</dt>
+								<dd class="font-medium">{formatSpeed(session.uploadSpeed)}</dd>
+							</div>
+							<div class="flex flex-wrap gap-2">
+								<dt class="text-muted-foreground">Active torrents</dt>
+								<dd class="font-medium">{session.activeTorrentCount}</dd>
+							</div>
+						</dl>
+					{:else}
+						<p class="text-muted-foreground text-sm">Transmission unavailable</p>
+					{/if}
+				</CardContent>
+			</Card>
+		</div>
+
+		<!-- Stats row -->
+		<div class="grid grid-cols-3 gap-4">
+			<Card>
+				<CardContent class="pt-6">
+					<p class="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+						Total tracked
+					</p>
+					<p class="mt-1 text-3xl font-bold">{totalTracked}</p>
+				</CardContent>
+			</Card>
+			<Card>
+				<CardContent class="pt-6">
+					<p class="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+						Completed this week
+					</p>
+					<p class="mt-1 text-3xl font-bold">{completedThisWeek}</p>
+				</CardContent>
+			</Card>
+			<Card>
+				<CardContent class="pt-6">
+					<p class="text-muted-foreground text-xs font-medium tracking-wide uppercase">Failed</p>
+					<p class="mt-1 text-3xl font-bold">{failedCount}</p>
+				</CardContent>
+			</Card>
+		</div>
+
+		<!-- Active Downloads -->
+		{#if activeDownloads.length > 0}
+			<Card>
+				<CardHeader class="pb-3">
+					<div class="flex items-center justify-between">
+						<h2 class="text-lg font-semibold tracking-tight">Active Downloads</h2>
+						<a href="/candidates" class="text-primary text-sm hover:underline">View all</a>
+					</div>
+				</CardHeader>
+				<CardContent>
+					<ul class="space-y-4">
+						{#each activeDownloads as { torrent, candidate }}
+							{@const title = candidate?.normalizedTitle ?? torrent.name}
+							{@const posterUrl =
+								candidate?.tmdb && 'posterUrl' in candidate.tmdb ? candidate.tmdb.posterUrl : null}
+							<li class="flex items-center gap-3">
+								<!-- Poster / initial box -->
+								{#if posterUrl}
+									<img src={posterUrl} alt={title} class="h-12 w-8 shrink-0 rounded object-cover" />
+								{:else}
+									<div
+										class="bg-muted text-muted-foreground flex h-12 w-8 shrink-0 items-center justify-center rounded text-sm font-bold"
+									>
+										{initialBox(title)}
+									</div>
+								{/if}
+								<!-- Info -->
+								<div class="min-w-0 flex-1">
+									<p class="truncate text-sm font-medium">{title}</p>
+									<div class="mt-1 flex items-center gap-3 text-xs">
+										<div class="bg-muted h-1.5 flex-1 rounded-full">
+											<div
+												class="bg-primary h-1.5 rounded-full"
+												style="width: {(torrent.percentDone * 100).toFixed(0)}%"
+											></div>
+										</div>
+										<span class="text-muted-foreground shrink-0"
+											>{(torrent.percentDone * 100).toFixed(0)}%</span
+										>
+									</div>
+								</div>
+								<!-- Speed + ETA -->
+								<div class="text-muted-foreground shrink-0 text-right text-xs">
+									<p>{formatSpeed(torrent.rateDownload)}</p>
+									<p>{formatEta(torrent.eta)}</p>
+								</div>
+							</li>
+						{/each}
+					</ul>
+				</CardContent>
+			</Card>
+		{/if}
+
+		<!-- Event Log -->
 		<Card>
 			<CardHeader class="pb-3">
-				<h2 class="text-lg font-semibold tracking-tight">Recent Runs</h2>
+				<h2 class="text-lg font-semibold tracking-tight">Event Log</h2>
 			</CardHeader>
 			<CardContent>
-				{#if runs.length === 0}
-					<p class="text-muted-foreground text-sm">No runs recorded yet.</p>
+				{#if recentCandidates.length === 0}
+					<p class="text-muted-foreground text-sm">No candidates yet.</p>
 				{:else}
 					<div class="border-border rounded-md border">
 						<Table>
 							<TableHeader>
 								<TableRow>
-									<TableHead>ID</TableHead>
-									<TableHead>Started</TableHead>
+									<TableHead>Title</TableHead>
 									<TableHead>Status</TableHead>
-									<TableHead class="text-right">Queued</TableHead>
-									<TableHead class="text-right">Failed</TableHead>
-									<TableHead class="text-right">Skipped</TableHead>
+									<TableHead>Updated</TableHead>
 								</TableRow>
 							</TableHeader>
 							<TableBody>
-								{#each runs as run}
+								{#each recentCandidates as c}
 									<TableRow>
-										<TableCell class="font-mono text-xs">{run.id}</TableCell>
-										<TableCell>{formatDate(run.startedAt)}</TableCell>
-										<TableCell>{run.status}</TableCell>
-										<TableCell class="text-right">{run.counts.queued ?? 0}</TableCell>
-										<TableCell class="text-right">{run.counts.failed ?? 0}</TableCell>
-										<TableCell class="text-right"
-											>{(run.counts.skipped_duplicate ?? 0) +
-												(run.counts.skipped_no_match ?? 0)}</TableCell
+										<TableCell class="max-w-xs truncate text-sm font-medium"
+											>{c.normalizedTitle}</TableCell
+										>
+										<TableCell>
+											<span
+												class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {statusBadgeClass(
+													c.status
+												)}"
+											>
+												{c.status}
+											</span>
+										</TableCell>
+										<TableCell class="text-muted-foreground text-xs"
+											>{formatDate(c.updatedAt)}</TableCell
 										>
 									</TableRow>
 								{/each}
@@ -114,6 +313,39 @@
 				{/if}
 			</CardContent>
 		</Card>
+
+		<!-- Archive Commit grid -->
+		{#if archiveItems.length > 0}
+			<section data-testid="archive-grid">
+				<h2 class="mb-4 text-lg font-semibold tracking-tight">Recently Completed</h2>
+				<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+					{#each archiveItems as item}
+						{@const posterUrl = item.tmdb && 'posterUrl' in item.tmdb ? item.tmdb.posterUrl : null}
+						<div class="flex flex-col gap-2">
+							{#if posterUrl}
+								<img
+									src={posterUrl}
+									alt={item.normalizedTitle}
+									class="aspect-[2/3] w-full rounded object-cover"
+								/>
+							{:else}
+								<div
+									class="bg-muted text-muted-foreground flex aspect-[2/3] w-full items-center justify-center rounded text-xs"
+								>
+									No poster
+								</div>
+							{/if}
+							<div>
+								<p class="truncate text-xs font-medium">{item.normalizedTitle}</p>
+								<p class="text-muted-foreground text-xs">
+									{formatShortDate(item.transmissionDoneDate)}
+								</p>
+							</div>
+						</div>
+					{/each}
+				</div>
+			</section>
+		{/if}
 	</section>
 {:else}
 	<!-- Defensive: load currently returns either health or error, not both null -->

--- a/web/src/routes/dashboard.test.ts
+++ b/web/src/routes/dashboard.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import Page from './+page.svelte';
-import type { DaemonHealth, RunSummaryRecord } from '$lib/types';
+import type {
+	CandidateStateRecord,
+	DaemonHealth,
+	SessionInfo,
+	TorrentStatSnapshot
+} from '$lib/types';
 
 const mockHealth: DaemonHealth = {
 	uptime: 3661000,
@@ -10,32 +15,153 @@ const mockHealth: DaemonHealth = {
 	lastReconcileCycle: { status: 'completed', startedAt: '2024-01-01T01:00:30Z' }
 };
 
-const mockRun: RunSummaryRecord = {
-	id: 42,
-	startedAt: '2024-01-01T01:00:00Z',
+const mockSession: SessionInfo = {
+	version: '3.00 (bb6b5a062ef)',
+	downloadSpeed: 2097152,
+	uploadSpeed: 524288,
+	activeTorrentCount: 3
+};
+
+const mockCandidate = (overrides: Partial<CandidateStateRecord> = {}): CandidateStateRecord => ({
+	identityKey: 'test-key',
+	mediaType: 'tv',
 	status: 'completed',
-	completedAt: '2024-01-01T01:01:00Z',
-	counts: {
-		queued: 3,
-		failed: 0,
-		skipped_duplicate: 1,
-		skipped_no_match: 5
-	}
+	lifecycleStatus: 'seeding',
+	normalizedTitle: 'Breaking Bad',
+	rawTitle: 'Breaking.Bad.S01E01.720p',
+	ruleName: 'test-rule',
+	score: 10,
+	reasons: [],
+	feedName: 'test-feed',
+	guidOrLink: 'http://example.com/1',
+	publishedAt: '2024-01-01T00:00:00Z',
+	downloadUrl: 'http://example.com/dl/1',
+	firstSeenRunId: 1,
+	lastSeenRunId: 1,
+	updatedAt: '2024-01-08T12:00:00Z',
+	transmissionDoneDate: '2024-01-08T12:00:00Z',
+	transmissionTorrentHash: 'abc123',
+	...overrides
+});
+
+const mockTorrent = (overrides: Partial<TorrentStatSnapshot> = {}): TorrentStatSnapshot => ({
+	hash: 'abc123',
+	name: 'Breaking.Bad.S01E01.720p',
+	status: 'downloading',
+	percentDone: 0.42,
+	rateDownload: 1048576,
+	eta: 3600,
+	...overrides
+});
+
+const baseData = {
+	health: mockHealth,
+	transmissionSession: mockSession,
+	transmissionTorrents: [],
+	candidates: [],
+	error: null
 };
 
 describe('/', () => {
-	it('renders daemon summary and run table with mock data', () => {
-		render(Page, { data: { health: mockHealth, runs: [mockRun], error: null } });
+	it('renders Daemon header strip with uptime', () => {
+		render(Page, { data: baseData });
 		expect(screen.getByRole('heading', { name: 'Daemon' })).toBeInTheDocument();
-		expect(screen.getByRole('heading', { name: 'Recent Runs' })).toBeInTheDocument();
 		// uptime: 3661000ms = 1h 1m 1s
 		expect(screen.getByText('1h 1m 1s')).toBeInTheDocument();
-		// run ID appears in table
-		expect(screen.getByText('42')).toBeInTheDocument();
 	});
 
-	it('renders error state when API is unreachable', () => {
-		render(Page, { data: { health: null, runs: [], error: 'Could not reach the API.' } });
+	it('renders Transmission header strip when transmissionSession is populated', () => {
+		render(Page, { data: baseData });
+		expect(screen.getByRole('heading', { name: 'Transmission' })).toBeInTheDocument();
+		expect(screen.getByText('3.00 (bb6b5a062ef)')).toBeInTheDocument();
+		expect(screen.getByText('2.0 MB/s')).toBeInTheDocument();
+	});
+
+	it('renders "Transmission unavailable" when transmissionSession is null', () => {
+		render(Page, { data: { ...baseData, transmissionSession: null } });
+		expect(screen.getByText('Transmission unavailable')).toBeInTheDocument();
+	});
+
+	it('renders error state when health is null', () => {
+		render(Page, { data: { ...baseData, health: null, error: 'Could not reach the API.' } });
 		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
+	});
+
+	it('Active Downloads hidden when transmissionTorrents is empty', () => {
+		render(Page, { data: { ...baseData, transmissionTorrents: [] } });
+		expect(screen.queryByRole('heading', { name: 'Active Downloads' })).not.toBeInTheDocument();
+	});
+
+	it('Active Downloads renders max 5 rows and View all link', () => {
+		const torrents = Array.from({ length: 7 }, (_, i) =>
+			mockTorrent({ hash: `hash${i}`, name: `Show ${i}` })
+		);
+		const candidates = torrents.map((t, i) =>
+			mockCandidate({
+				identityKey: `key${i}`,
+				normalizedTitle: `Show ${i}`,
+				transmissionTorrentHash: t.hash,
+				status: 'downloading',
+				lifecycleStatus: 'active'
+			})
+		);
+		render(Page, { data: { ...baseData, transmissionTorrents: torrents, candidates } });
+		expect(screen.getByRole('heading', { name: 'Active Downloads' })).toBeInTheDocument();
+		// max 5 rows — count list items
+		const items = screen.getAllByRole('listitem');
+		expect(items.length).toBe(5);
+		const link = screen.getByRole('link', { name: 'View all' });
+		expect(link).toHaveAttribute('href', '/candidates');
+	});
+
+	it('Event Log renders last 10 candidates sorted by updatedAt', () => {
+		// Use status 'queued' so these candidates don't appear in the Archive grid
+		const candidates = Array.from({ length: 15 }, (_, i) =>
+			mockCandidate({
+				identityKey: `key${i}`,
+				normalizedTitle: `Title ${i}`,
+				status: 'queued',
+				lifecycleStatus: undefined,
+				transmissionDoneDate: undefined,
+				updatedAt: `2024-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`
+			})
+		);
+		render(Page, { data: { ...baseData, candidates } });
+		// Most recent 10: indices 5..14 (updatedAt days 6..15)
+		expect(screen.getByText('Title 14')).toBeInTheDocument();
+		expect(screen.queryByText('Title 4')).not.toBeInTheDocument();
+	});
+
+	it('Stats row shows correct total and failed counts', () => {
+		const candidates = [
+			mockCandidate({ identityKey: 'a', status: 'completed' }),
+			mockCandidate({ identityKey: 'b', status: 'failed', lifecycleStatus: undefined }),
+			mockCandidate({ identityKey: 'c', status: 'queued', lifecycleStatus: undefined })
+		];
+		render(Page, { data: { ...baseData, candidates } });
+		// Total tracked: 3 — use getAllByText since "3" may appear elsewhere (e.g. activeTorrentCount)
+		expect(screen.getAllByText('3').length).toBeGreaterThanOrEqual(1);
+		// Failed: 1
+		expect(screen.getAllByText('1').length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('Archive Commit grid renders top 6 completed, hidden when none', () => {
+		const { unmount } = render(Page, { data: baseData });
+		expect(screen.queryByText('Recently Completed')).not.toBeInTheDocument();
+		unmount();
+
+		const completed = Array.from({ length: 8 }, (_, i) =>
+			mockCandidate({
+				identityKey: `done${i}`,
+				normalizedTitle: `Movie ${i}`,
+				transmissionDoneDate: `2024-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`
+			})
+		);
+		render(Page, { data: { ...baseData, candidates: completed } });
+		expect(screen.getByText('Recently Completed')).toBeInTheDocument();
+		// Only 6 shown in archive grid; most recent first: Movie 7 .. Movie 2
+		const archiveGrid = screen.getByTestId('archive-grid');
+		expect(archiveGrid).toHaveTextContent('Movie 7');
+		expect(archiveGrid).not.toHaveTextContent('Movie 0');
 	});
 });

--- a/web/src/routes/dashboard.test.ts
+++ b/web/src/routes/dashboard.test.ts
@@ -139,10 +139,8 @@ describe('/', () => {
 			mockCandidate({ identityKey: 'c', status: 'queued', lifecycleStatus: undefined })
 		];
 		render(Page, { data: { ...baseData, candidates } });
-		// Total tracked: 3 — use getAllByText since "3" may appear elsewhere (e.g. activeTorrentCount)
-		expect(screen.getAllByText('3').length).toBeGreaterThanOrEqual(1);
-		// Failed: 1
-		expect(screen.getAllByText('1').length).toBeGreaterThanOrEqual(1);
+		expect(screen.getByText('Total tracked').parentElement).toHaveTextContent('3');
+		expect(screen.getByText('Failed').parentElement).toHaveTextContent('1');
 	});
 
 	it('Archive Commit grid renders top 6 completed, hidden when none', () => {
@@ -162,6 +160,8 @@ describe('/', () => {
 		// Only 6 shown in archive grid; most recent first: Movie 7 .. Movie 2
 		const archiveGrid = screen.getByTestId('archive-grid');
 		expect(archiveGrid).toHaveTextContent('Movie 7');
+		expect(archiveGrid).toHaveTextContent('Movie 2');
+		expect(archiveGrid).not.toHaveTextContent('Movie 1');
 		expect(archiveGrid).not.toHaveTextContent('Movie 0');
 	});
 });


### PR DESCRIPTION
## Summary

- delivery ticket: `P15.03 Dashboard Overview Enhancement`
- ticket file: [docs/02-delivery/phase-15/ticket-03-dashboard-overview-enhancement.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-15/ticket-03-dashboard-overview-enhancement.md)
- stacked base branch: `agents/p15-02-transmission-proxy-endpoints-get-api-transmission-torrents-and-get-api-transmission-session`
- post-verify self-audit: completed at 2026-04-11 12:27 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`a2fa2b2c7742`](https://github.com/cesarnml/pirate_claw/commit/a2fa2b2c77429168c7c36cff4c2d34a17b796ae8)
- current branch head: [`ab8eda3273fc`](https://github.com/cesarnml/pirate_claw/commit/ab8eda3273fc90d835e3ce94ac4058f3f1f037f3)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `a2fa2b2c7742` address all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Don’t collapse failed section fetches into empty data. (native GitHub thread resolved) `web/src/routes/+page.server.ts:29` [thread](https://github.com/cesarnml/pirate_claw/pull/127#discussion_r3067999443)
- [coderabbit] Handle sub-minute ETAs explicitly. (native GitHub thread resolved) `web/src/routes/+page.svelte:55` [thread](https://github.com/cesarnml/pirate_claw/pull/127#discussion_r3067999446)
- [coderabbit] Scope the stats assertions to the actual cards. (native GitHub thread resolved) `web/src/routes/dashboard.test.ts:145` [thread](https://github.com/cesarnml/pirate_claw/pull/127#discussion_r3067999449)
- [coderabbit] Assert the archive cap explicitly. (native GitHub thread resolved) `web/src/routes/dashboard.test.ts:165` [thread](https://github.com/cesarnml/pirate_claw/pull/127#discussion_r3067999451)
