### PR TITLE
feat(p15-04): TV shows view — progress and sort (transmissionPercentDone, transmissionTorrentHash, sort control, speed/ETA) [P15.04]

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -669,6 +669,8 @@ export function buildShowBreakdowns(
       status: c.status,
       lifecycleStatus: c.lifecycleStatus,
       queuedAt: c.queuedAt,
+      transmissionPercentDone: c.transmissionPercentDone,
+      transmissionTorrentHash: c.transmissionTorrentHash,
     });
   }
 

--- a/src/tv-api-types.ts
+++ b/src/tv-api-types.ts
@@ -24,6 +24,8 @@ export type ShowEpisode = {
   status: string;
   lifecycleStatus?: string;
   queuedAt?: string;
+  transmissionPercentDone?: number;
+  transmissionTorrentHash?: string;
   tmdb?: TmdbTvEpisodeMeta;
 };
 

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1402,6 +1402,22 @@ describe('buildShowBreakdowns', () => {
     expect(shows[0].seasons[0].episodes).toHaveLength(1);
     expect(shows[0].seasons[0].episodes[0].identityKey).toBe('k1');
   });
+
+  it('passes through transmissionPercentDone and transmissionTorrentHash', () => {
+    const candidates = [
+      {
+        ...tvCandidate({ identityKey: 'k1', season: 1, episode: 1 }),
+        transmissionPercentDone: 0.42,
+        transmissionTorrentHash: 'abc123',
+      },
+    ];
+
+    const shows = buildShowBreakdowns(candidates as never);
+    const ep = shows[0].seasons[0].episodes[0];
+
+    expect(ep.transmissionPercentDone).toBe(0.42);
+    expect(ep.transmissionTorrentHash).toBe('abc123');
+  });
 });
 
 describe('buildMovieBreakdowns', () => {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -70,6 +70,8 @@ export type ShowEpisode = {
 	status: CandidateStatus;
 	lifecycleStatus?: string;
 	queuedAt?: string;
+	transmissionPercentDone?: number;
+	transmissionTorrentHash?: string;
 	tmdb?: TmdbTvEpisodeMeta;
 };
 

--- a/web/src/routes/shows/+page.server.ts
+++ b/web/src/routes/shows/+page.server.ts
@@ -1,16 +1,25 @@
 import { apiFetch } from '$lib/server/api';
-import type { ShowBreakdown } from '$lib/types';
+import type { ShowBreakdown, TorrentStatSnapshot } from '$lib/types';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-	try {
-		const data = await apiFetch<{ shows: ShowBreakdown[] }>('/api/shows');
-		return { shows: data.shows, error: null };
-	} catch (err) {
-		console.error('[shows list] failed to load /api/shows:', err);
-		return {
-			shows: [] as ShowBreakdown[],
-			error: 'Could not reach the API.'
-		};
+	const [showsResult, torrentsResult] = await Promise.allSettled([
+		apiFetch<{ shows: ShowBreakdown[] }>('/api/shows'),
+		apiFetch<{ torrents: TorrentStatSnapshot[] }>('/api/transmission/torrents')
+	]);
+
+	if (showsResult.status === 'rejected') {
+		console.error('[shows list] failed to load /api/shows:', showsResult.reason);
+		return { shows: [] as ShowBreakdown[], torrents: null, error: 'Could not reach the API.' };
 	}
+
+	if (torrentsResult.status === 'rejected') {
+		console.error('[shows list] failed to load /api/transmission/torrents:', torrentsResult.reason);
+	}
+
+	return {
+		shows: showsResult.value.shows,
+		torrents: torrentsResult.status === 'fulfilled' ? torrentsResult.value.torrents : null,
+		error: null
+	};
 };

--- a/web/src/routes/shows/+page.svelte
+++ b/web/src/routes/shows/+page.svelte
@@ -2,11 +2,15 @@
 	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Card, CardContent } from '$lib/components/ui/card';
+	import type { ShowBreakdown } from '$lib/types';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
 
-	function showHref(show: (typeof data.shows)[number]): string {
+	type SortKey = 'title' | 'progress';
+	let sortKey = $state<SortKey>('title');
+
+	function showHref(show: ShowBreakdown): string {
 		return `/shows/${encodeURIComponent(show.normalizedTitle.toLowerCase())}`;
 	}
 
@@ -14,9 +18,38 @@
 		return v.toFixed(1);
 	}
 
-	function displayTitle(show: (typeof data.shows)[number]): string {
+	function displayTitle(show: ShowBreakdown): string {
 		return show.tmdb?.name ?? show.normalizedTitle;
 	}
+
+	function episodeCount(show: ShowBreakdown): number {
+		return show.seasons.reduce((sum, s) => sum + s.episodes.length, 0);
+	}
+
+	function completionPct(show: ShowBreakdown): number | null {
+		const eps = show.seasons.flatMap((s) => s.episodes);
+		if (eps.length === 0) return null;
+		const done = eps.filter((e) => e.status === 'completed').length;
+		return Math.round((done / eps.length) * 100);
+	}
+
+	/** Max transmissionPercentDone across all episodes (for progress sort) */
+	function maxProgress(show: ShowBreakdown): number {
+		let max = 0;
+		for (const s of show.seasons) {
+			for (const e of s.episodes) {
+				if ((e.transmissionPercentDone ?? 0) > max) max = e.transmissionPercentDone ?? 0;
+			}
+		}
+		return max;
+	}
+
+	const sortedShows = $derived(
+		[...data.shows].sort((a, b) => {
+			if (sortKey === 'progress') return maxProgress(b) - maxProgress(a);
+			return displayTitle(a).localeCompare(displayTitle(b));
+		})
+	);
 </script>
 
 <h1 class="text-3xl font-bold tracking-tight">Shows</h1>
@@ -36,8 +69,31 @@
 		</CardContent>
 	</Card>
 {:else}
-	<ul class="mt-8 grid list-none gap-4 sm:grid-cols-2 lg:grid-cols-3">
-		{#each data.shows as show (show.normalizedTitle)}
+	<div class="mt-6 flex items-center gap-2">
+		<span class="text-muted-foreground text-sm">Sort:</span>
+		<button
+			class="text-sm font-medium underline-offset-2 {sortKey === 'title'
+				? 'text-foreground underline'
+				: 'text-muted-foreground hover:text-foreground'}"
+			onclick={() => (sortKey = 'title')}
+		>
+			Title (A–Z)
+		</button>
+		<span class="text-muted-foreground text-xs">·</span>
+		<button
+			class="text-sm font-medium underline-offset-2 {sortKey === 'progress'
+				? 'text-foreground underline'
+				: 'text-muted-foreground hover:text-foreground'}"
+			onclick={() => (sortKey = 'progress')}
+		>
+			Progress
+		</button>
+	</div>
+
+	<ul class="mt-6 grid list-none gap-4 sm:grid-cols-2 lg:grid-cols-3">
+		{#each sortedShows as show (show.normalizedTitle)}
+			{@const pct = completionPct(show)}
+			{@const count = episodeCount(show)}
 			<li>
 				<a
 					href={showHref(show)}
@@ -77,6 +133,14 @@
 										</span>
 									{/if}
 								</div>
+								{#if count > 0}
+									<p class="text-muted-foreground mt-2 text-xs">
+										{count} episode{count === 1 ? '' : 's'}
+										{#if pct !== null}
+											· {pct}% complete
+										{/if}
+									</p>
+								{/if}
 							</div>
 						</CardContent>
 					</Card>

--- a/web/src/routes/shows/[slug]/+page.server.ts
+++ b/web/src/routes/shows/[slug]/+page.server.ts
@@ -11,6 +11,7 @@ export const load: PageServerLoad = async ({ params }) => {
 	]);
 
 	if (showsResult.status === 'rejected') {
+		console.error('[shows detail] failed to load /api/shows:', showsResult.reason);
 		return {
 			show: null as ShowBreakdown | null,
 			torrents: null,

--- a/web/src/routes/shows/[slug]/+page.server.ts
+++ b/web/src/routes/shows/[slug]/+page.server.ts
@@ -1,15 +1,37 @@
 import { apiFetch } from '$lib/server/api';
-import type { ShowBreakdown } from '$lib/types';
+import type { ShowBreakdown, TorrentStatSnapshot } from '$lib/types';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params }) => {
 	const title = params.slug;
-	try {
-		const data = await apiFetch<{ shows: ShowBreakdown[] }>('/api/shows');
-		const show =
-			data.shows.find((s) => s.normalizedTitle.toLowerCase() === title.toLowerCase()) ?? null;
-		return { show, error: null };
-	} catch {
-		return { show: null as ShowBreakdown | null, error: 'Could not reach the API.' };
+
+	const [showsResult, torrentsResult] = await Promise.allSettled([
+		apiFetch<{ shows: ShowBreakdown[] }>('/api/shows'),
+		apiFetch<{ torrents: TorrentStatSnapshot[] }>('/api/transmission/torrents')
+	]);
+
+	if (showsResult.status === 'rejected') {
+		return {
+			show: null as ShowBreakdown | null,
+			torrents: null,
+			error: 'Could not reach the API.'
+		};
 	}
+
+	if (torrentsResult.status === 'rejected') {
+		console.error(
+			'[shows detail] failed to load /api/transmission/torrents:',
+			torrentsResult.reason
+		);
+	}
+
+	const show =
+		showsResult.value.shows.find((s) => s.normalizedTitle.toLowerCase() === title.toLowerCase()) ??
+		null;
+
+	return {
+		show,
+		torrents: torrentsResult.status === 'fulfilled' ? torrentsResult.value.torrents : null,
+		error: null
+	};
 };

--- a/web/src/routes/shows/[slug]/+page.svelte
+++ b/web/src/routes/shows/[slug]/+page.svelte
@@ -172,7 +172,9 @@
 							<TableBody>
 								{#each season.episodes as ep (ep.identityKey)}
 									{@const live = liveTorrent(ep)}
-									{@const active = isActive(ep)}
+									{@const active = live ? live.status === 'downloading' : isActive(ep)}
+									{@const hasProgress =
+										live !== undefined || active || (ep.transmissionPercentDone ?? 0) > 0}
 									{@const pct = live
 										? live.percentDone * 100
 										: (ep.transmissionPercentDone ?? 0) * 100}
@@ -218,7 +220,7 @@
 											{/if}
 										</TableCell>
 										<TableCell class="align-top">
-											{#if active || (ep.transmissionPercentDone ?? 0) > 0}
+											{#if hasProgress}
 												<div class="min-w-[6rem]">
 													<div class="flex items-center gap-2">
 														<div class="bg-muted h-1.5 flex-1 rounded-full">
@@ -231,7 +233,7 @@
 															>{pct.toFixed(0)}%</span
 														>
 													</div>
-													{#if live && active}
+													{#if live && live.status === 'downloading'}
 														<p class="text-muted-foreground mt-0.5 text-xs">
 															{formatSpeed(live.rateDownload)} · {formatEta(live.eta)}
 														</p>

--- a/web/src/routes/shows/[slug]/+page.svelte
+++ b/web/src/routes/shows/[slug]/+page.svelte
@@ -11,9 +11,12 @@
 		TableHeader,
 		TableRow
 	} from '$lib/components/ui/table';
+	import type { CandidateStatus, ShowEpisode, TorrentStatSnapshot } from '$lib/types';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
+
+	const torrents = $derived(data.torrents ?? []);
 
 	function formatRating(v: number | undefined): string {
 		if (v === undefined) return '—';
@@ -24,7 +27,6 @@
 		return show.tmdb?.name ?? show.normalizedTitle;
 	}
 
-	/** Only allow https URLs in inline `background: url(...)` to avoid CSS injection from malformed strings. */
 	function safeHttpsBackgroundUrl(raw: string | undefined): string | undefined {
 		if (!raw) return undefined;
 		try {
@@ -33,6 +35,51 @@
 			return u.href;
 		} catch {
 			return undefined;
+		}
+	}
+
+	function formatSpeed(bytesPerSec: number): string {
+		if (bytesPerSec >= 1_048_576) return `${(bytesPerSec / 1_048_576).toFixed(1)} MB/s`;
+		return `${(bytesPerSec / 1024).toFixed(0)} KB/s`;
+	}
+
+	function formatEta(eta: number): string {
+		if (eta < 0) return '—';
+		if (eta < 60) return '<1m';
+		const hours = Math.floor(eta / 3600);
+		const minutes = Math.floor((eta % 3600) / 60);
+		if (hours > 0) return `${hours}h ${minutes}m`;
+		return `${minutes}m`;
+	}
+
+	function liveTorrent(ep: ShowEpisode): TorrentStatSnapshot | undefined {
+		if (!ep.transmissionTorrentHash) return undefined;
+		return torrents.find((t) => t.hash === ep.transmissionTorrentHash);
+	}
+
+	function isActive(ep: ShowEpisode): boolean {
+		return (
+			ep.lifecycleStatus === 'active' ||
+			ep.status === 'downloading' ||
+			(ep.status === 'queued' && (ep.transmissionPercentDone ?? 0) > 0)
+		);
+	}
+
+	function statusChipClass(status: CandidateStatus | string): string {
+		switch (status) {
+			case 'queued':
+				return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200';
+			case 'completed':
+				return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
+			case 'failed':
+				return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
+			case 'downloading':
+				return 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-200';
+			case 'duplicate':
+			case 'skipped':
+				return 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300';
+			default:
+				return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300';
 		}
 	}
 </script>
@@ -119,11 +166,16 @@
 									<TableHead>Episode</TableHead>
 									<TableHead>Title</TableHead>
 									<TableHead>Status</TableHead>
-									<TableHead>Queued At</TableHead>
+									<TableHead>Progress</TableHead>
 								</TableRow>
 							</TableHeader>
 							<TableBody>
 								{#each season.episodes as ep (ep.identityKey)}
+									{@const live = liveTorrent(ep)}
+									{@const active = isActive(ep)}
+									{@const pct = live
+										? live.percentDone * 100
+										: (ep.transmissionPercentDone ?? 0) * 100}
 									<TableRow>
 										<TableCell class="align-top">
 											{#if ep.tmdb?.stillUrl}
@@ -152,16 +204,43 @@
 											{/if}
 										</TableCell>
 										<TableCell class="align-top">
-											{ep.status}
+											<span
+												class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium {statusChipClass(
+													ep.status
+												)}"
+											>
+												{ep.status}
+											</span>
 											{#if ep.lifecycleStatus}
 												<span class="text-muted-foreground ml-1 text-xs"
 													>({ep.lifecycleStatus})</span
 												>
 											{/if}
 										</TableCell>
-										<TableCell class="text-muted-foreground align-top"
-											>{ep.queuedAt ?? '—'}</TableCell
-										>
+										<TableCell class="align-top">
+											{#if active || (ep.transmissionPercentDone ?? 0) > 0}
+												<div class="min-w-[6rem]">
+													<div class="flex items-center gap-2">
+														<div class="bg-muted h-1.5 flex-1 rounded-full">
+															<div
+																class="h-1.5 rounded-full {active ? 'bg-cyan-500' : 'bg-primary'}"
+																style="width: {pct.toFixed(0)}%"
+															></div>
+														</div>
+														<span class="text-muted-foreground shrink-0 text-xs"
+															>{pct.toFixed(0)}%</span
+														>
+													</div>
+													{#if live && active}
+														<p class="text-muted-foreground mt-0.5 text-xs">
+															{formatSpeed(live.rateDownload)} · {formatEta(live.eta)}
+														</p>
+													{/if}
+												</div>
+											{:else}
+												<span class="text-muted-foreground text-xs">—</span>
+											{/if}
+										</TableCell>
 									</TableRow>
 								{/each}
 							</TableBody>

--- a/web/src/routes/shows/[slug]/shows.test.ts
+++ b/web/src/routes/shows/[slug]/shows.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import Page from './+page.svelte';
-import type { ShowBreakdown } from '$lib/types';
+import type { ShowBreakdown, TorrentStatSnapshot } from '$lib/types';
 
 const mockShow: ShowBreakdown = {
 	normalizedTitle: 'The Show',
@@ -12,7 +12,10 @@ const mockShow: ShowBreakdown = {
 				{
 					episode: 1,
 					identityKey: 'key-s01e01',
-					status: 'queued',
+					status: 'downloading',
+					lifecycleStatus: 'active',
+					transmissionPercentDone: 0.42,
+					transmissionTorrentHash: 'abc123',
 					queuedAt: '2024-01-01T00:00:00Z'
 				},
 				{
@@ -26,21 +29,47 @@ const mockShow: ShowBreakdown = {
 	]
 };
 
+const mockTorrent: TorrentStatSnapshot = {
+	hash: 'abc123',
+	name: 'The.Show.S01E01.720p',
+	status: 'downloading',
+	percentDone: 0.42,
+	rateDownload: 1048576,
+	eta: 3600
+};
+
 describe('/shows/[slug]', () => {
 	it('renders show name and season section', () => {
-		render(Page, { data: { show: mockShow, error: null } });
+		render(Page, { data: { show: mockShow, torrents: null, error: null } });
 		expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('The Show');
 		expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Season 1');
 		expect(screen.getByText('E01')).toBeInTheDocument();
 	});
 
+	it('renders progress bar and speed/ETA for active downloading episode', () => {
+		render(Page, { data: { show: mockShow, torrents: [mockTorrent], error: null } });
+		// 42% progress from live torrent
+		expect(screen.getByText('42%')).toBeInTheDocument();
+		// Speed: 1048576 B/s = 1.0 MB/s
+		expect(screen.getByText(/1\.0 MB\/s/)).toBeInTheDocument();
+		// ETA: 3600s = 1h 0m
+		expect(screen.getByText(/1h 0m/)).toBeInTheDocument();
+	});
+
+	it('does not render speed/ETA for completed episodes', () => {
+		render(Page, { data: { show: mockShow, torrents: [mockTorrent], error: null } });
+		// E02 is completed — only one speed/ETA row should exist (E01)
+		const speedRows = screen.getAllByText(/MB\/s|KB\/s/);
+		expect(speedRows).toHaveLength(1);
+	});
+
 	it('renders not-found state when show is null', () => {
-		render(Page, { data: { show: null, error: null } });
+		render(Page, { data: { show: null, torrents: null, error: null } });
 		expect(screen.getByText('Show not found.')).toBeInTheDocument();
 	});
 
 	it('renders error state when API is unreachable', () => {
-		render(Page, { data: { show: null, error: 'Could not reach the API.' } });
+		render(Page, { data: { show: null, torrents: null, error: 'Could not reach the API.' } });
 		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
 	});
 });

--- a/web/src/routes/shows/shows.test.ts
+++ b/web/src/routes/shows/shows.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import Page from './+page.svelte';
 import type { ShowBreakdown } from '$lib/types';
 
@@ -8,7 +8,21 @@ const mockShow: ShowBreakdown = {
 	seasons: [
 		{
 			season: 1,
-			episodes: []
+			episodes: [
+				{
+					episode: 1,
+					identityKey: 'key-s01e01',
+					status: 'completed',
+					transmissionPercentDone: 1.0
+				},
+				{
+					episode: 2,
+					identityKey: 'key-s01e02',
+					status: 'downloading',
+					transmissionPercentDone: 0.5,
+					transmissionTorrentHash: 'abc123'
+				}
+			]
 		}
 	],
 	tmdb: {
@@ -19,9 +33,27 @@ const mockShow: ShowBreakdown = {
 	}
 };
 
+const mockShow2: ShowBreakdown = {
+	normalizedTitle: 'Another Show',
+	seasons: [
+		{
+			season: 1,
+			episodes: [
+				{
+					episode: 1,
+					identityKey: 'key2-s01e01',
+					status: 'downloading',
+					transmissionPercentDone: 0.8,
+					transmissionTorrentHash: 'def456'
+				}
+			]
+		}
+	]
+};
+
 describe('/shows', () => {
 	it('renders show cards with TMDB metadata and link to detail', () => {
-		render(Page, { data: { shows: [mockShow], error: null } });
+		render(Page, { data: { shows: [mockShow], torrents: null, error: null } });
 		expect(screen.getByRole('heading', { name: 'Shows' })).toBeInTheDocument();
 		expect(screen.getByText('The Example Show')).toBeInTheDocument();
 		expect(screen.getByTitle('TMDB vote average')).toHaveTextContent('★ 8.1');
@@ -31,13 +63,35 @@ describe('/shows', () => {
 		);
 	});
 
+	it('renders episode count and completion % on show card', () => {
+		render(Page, { data: { shows: [mockShow], torrents: null, error: null } });
+		// 2 episodes, 1 completed → 50%
+		expect(screen.getByText(/2 episodes/)).toBeInTheDocument();
+		expect(screen.getByText(/50% complete/)).toBeInTheDocument();
+	});
+
+	it('sort by Progress orders shows by max transmissionPercentDone desc', async () => {
+		render(Page, {
+			data: { shows: [mockShow, mockShow2], torrents: null, error: null }
+		});
+		const links = screen.getAllByRole('link');
+		// Default title sort: "Another Show" before "The Example Show"
+		expect(links[0]).toHaveTextContent('Another Show');
+
+		// Click Progress sort
+		await fireEvent.click(screen.getByRole('button', { name: 'Progress' }));
+		const linksAfter = screen.getAllByRole('link');
+		// mockShow has max 1.0 (100%), mockShow2 has max 0.8 (80%) → mockShow first
+		expect(linksAfter[0]).toHaveTextContent('The Example Show');
+	});
+
 	it('renders empty state when there are no shows', () => {
-		render(Page, { data: { shows: [], error: null } });
+		render(Page, { data: { shows: [], torrents: null, error: null } });
 		expect(screen.getByText('No shows recorded yet.')).toBeInTheDocument();
 	});
 
 	it('renders error state when API is unreachable', () => {
-		render(Page, { data: { shows: [], error: 'Could not reach the API.' } });
+		render(Page, { data: { shows: [], torrents: null, error: 'Could not reach the API.' } });
 		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
 	});
 });


### PR DESCRIPTION
## Summary

- delivery ticket: `P15.04 TV Shows View — Progress and Sort`
- ticket file: [docs/02-delivery/phase-15/ticket-04-tv-shows-progress-and-sort.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-15/ticket-04-tv-shows-progress-and-sort.md)
- stacked base branch: `agents/p15-03-dashboard-overview-enhancement`
- post-verify self-audit: completed at 2026-04-11 12:44 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`21a346c0a64c`](https://github.com/cesarnml/pirate_claw/commit/21a346c0a64c042eb5c8506e27cd81899718a3cc)
- current branch head: [`6eca95ea27de`](https://github.com/cesarnml/pirate_claw/commit/6eca95ea27dea76dded1074b8e63b2e1bf688547)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `21a346c0a64c` address all findings from that review.
- vendors: `coderabbit`

### Resolved Review Findings

- [coderabbit] Live torrent progress can be hidden when episode state is stale. (native GitHub thread resolved) `web/src/routes/shows/[slug]/+page.svelte:178` [thread](https://github.com/cesarnml/pirate_claw/pull/128#discussion_r3068013327)
