### PR TITLE
feat(p15-05): movies view — filter tabs, sort, progress bar, speed/ETA (genre filter deferred: no genres in TmdbMoviePublic) [P15.05]

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -706,6 +706,8 @@ export function buildMovieBreakdowns(
       status: c.status,
       lifecycleStatus: c.lifecycleStatus,
       queuedAt: c.queuedAt,
+      transmissionPercentDone: c.transmissionPercentDone,
+      transmissionTorrentHash: c.transmissionTorrentHash,
     }))
     .sort((a, b) => a.normalizedTitle.localeCompare(b.normalizedTitle));
 }

--- a/src/movie-api-types.ts
+++ b/src/movie-api-types.ts
@@ -18,5 +18,7 @@ export type MovieBreakdown = {
   status: string;
   lifecycleStatus?: string;
   queuedAt?: string;
+  transmissionPercentDone?: number;
+  transmissionTorrentHash?: string;
   tmdb?: TmdbMoviePublic;
 };

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1432,6 +1432,21 @@ describe('buildMovieBreakdowns', () => {
     expect(movies[0].normalizedTitle).toBe('a movie');
     expect(movies[1].normalizedTitle).toBe('z movie');
   });
+
+  it('passes through transmissionPercentDone and transmissionTorrentHash', () => {
+    const candidates = [
+      {
+        ...movieCandidate({ identityKey: 'k1' }),
+        transmissionPercentDone: 0.55,
+        transmissionTorrentHash: 'abc123',
+      },
+    ];
+
+    const movies = buildMovieBreakdowns(candidates as never);
+
+    expect(movies[0].transmissionPercentDone).toBe(0.55);
+    expect(movies[0].transmissionTorrentHash).toBe('abc123');
+  });
 });
 
 describe('PUT /api/config/feeds', () => {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -105,6 +105,8 @@ export type MovieBreakdown = {
 	status: CandidateStatus;
 	lifecycleStatus?: string;
 	queuedAt?: string;
+	transmissionPercentDone?: number;
+	transmissionTorrentHash?: string;
 	tmdb?: TmdbMoviePublic;
 };
 

--- a/web/src/routes/movies/+page.server.ts
+++ b/web/src/routes/movies/+page.server.ts
@@ -1,12 +1,25 @@
 import { apiFetch } from '$lib/server/api';
-import type { MovieBreakdown } from '$lib/types';
+import type { MovieBreakdown, TorrentStatSnapshot } from '$lib/types';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-	try {
-		const data = await apiFetch<{ movies: MovieBreakdown[] }>('/api/movies');
-		return { movies: data.movies, error: null };
-	} catch {
-		return { movies: [] as MovieBreakdown[], error: 'Could not reach the API.' };
+	const [moviesResult, torrentsResult] = await Promise.allSettled([
+		apiFetch<{ movies: MovieBreakdown[] }>('/api/movies'),
+		apiFetch<{ torrents: TorrentStatSnapshot[] }>('/api/transmission/torrents')
+	]);
+
+	if (moviesResult.status === 'rejected') {
+		console.error('[movies] failed to load /api/movies:', moviesResult.reason);
+		return { movies: [] as MovieBreakdown[], torrents: null, error: 'Could not reach the API.' };
 	}
+
+	if (torrentsResult.status === 'rejected') {
+		console.error('[movies] failed to load /api/transmission/torrents:', torrentsResult.reason);
+	}
+
+	return {
+		movies: moviesResult.value.movies,
+		torrents: torrentsResult.status === 'fulfilled' ? torrentsResult.value.torrents : null,
+		error: null
+	};
 };

--- a/web/src/routes/movies/+page.svelte
+++ b/web/src/routes/movies/+page.svelte
@@ -2,14 +2,141 @@
 	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Card, CardContent } from '$lib/components/ui/card';
+	import type { CandidateStatus, MovieBreakdown, TorrentStatSnapshot } from '$lib/types';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
+
+	// Genre filter omitted: TmdbMoviePublic does not expose a genres field.
+	// If TMDB genre data becomes available in a future ticket, add the genre
+	// filter dropdown here.
+
+	type FilterTab = 'all' | 'downloading' | 'completed' | 'failed' | 'missing';
+	type SortKey = 'date' | 'title' | 'year' | 'resolution';
+
+	let activeTab = $state<FilterTab>('all');
+	let sortKey = $state<SortKey>('date');
+
+	const torrents = $derived(data.torrents ?? []);
+
+	function liveTorrent(movie: MovieBreakdown): TorrentStatSnapshot | undefined {
+		if (!movie.transmissionTorrentHash) return undefined;
+		return torrents.find((t) => t.hash === movie.transmissionTorrentHash);
+	}
 
 	function formatRating(v: number | undefined): string {
 		if (v === undefined) return '—';
 		return v.toFixed(1);
 	}
+
+	function formatSpeed(bytesPerSec: number): string {
+		if (bytesPerSec >= 1_048_576) return `${(bytesPerSec / 1_048_576).toFixed(1)} MB/s`;
+		return `${(bytesPerSec / 1024).toFixed(0)} KB/s`;
+	}
+
+	function formatEta(eta: number): string {
+		if (eta < 0) return '—';
+		if (eta < 60) return '<1m';
+		const hours = Math.floor(eta / 3600);
+		const minutes = Math.floor((eta % 3600) / 60);
+		if (hours > 0) return `${hours}h ${minutes}m`;
+		return `${minutes}m`;
+	}
+
+	function statusChipClass(status: CandidateStatus | string): string {
+		switch (status) {
+			case 'queued':
+				return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200';
+			case 'completed':
+				return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
+			case 'failed':
+				return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
+			case 'downloading':
+				return 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-200';
+			case 'duplicate':
+			case 'skipped':
+				return 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300';
+			default:
+				return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300';
+		}
+	}
+
+	function tabCount(tab: FilterTab): number {
+		const movies = data.movies;
+		switch (tab) {
+			case 'downloading':
+				return movies.filter((m) => m.lifecycleStatus === 'active').length;
+			case 'completed':
+				return movies.filter((m) => m.status === 'completed').length;
+			case 'failed':
+				return movies.filter((m) => m.status === 'failed').length;
+			case 'missing':
+				return movies.filter((m) => m.lifecycleStatus === 'missing_from_transmission').length;
+			default:
+				return movies.length;
+		}
+	}
+
+	const resolutionOrder: Record<string, number> = {
+		'2160p': 4,
+		'1080p': 3,
+		'720p': 2,
+		'480p': 1
+	};
+
+	const filteredMovies = $derived(
+		data.movies
+			.filter((m) => {
+				switch (activeTab) {
+					case 'downloading':
+						return m.lifecycleStatus === 'active';
+					case 'completed':
+						return m.status === 'completed';
+					case 'failed':
+						return m.status === 'failed';
+					case 'missing':
+						return m.lifecycleStatus === 'missing_from_transmission';
+					default:
+						return true;
+				}
+			})
+			.sort((a, b) => {
+				switch (sortKey) {
+					case 'title':
+						return (a.tmdb?.title ?? a.normalizedTitle).localeCompare(
+							b.tmdb?.title ?? b.normalizedTitle
+						);
+					case 'year':
+						return (b.year ?? 0) - (a.year ?? 0);
+					case 'resolution':
+						return (
+							(resolutionOrder[b.resolution ?? ''] ?? 0) -
+							(resolutionOrder[a.resolution ?? ''] ?? 0)
+						);
+					default:
+						// date desc — queuedAt descending; missing → oldest
+						if (!a.queuedAt && !b.queuedAt) return 0;
+						if (!a.queuedAt) return 1;
+						if (!b.queuedAt) return -1;
+						return b.queuedAt.localeCompare(a.queuedAt);
+				}
+			})
+	);
+
+	const tabs: { key: FilterTab; label: string }[] = [
+		{ key: 'all', label: 'All' },
+		{ key: 'downloading', label: 'Downloading' },
+		{ key: 'completed', label: 'Completed' },
+		{ key: 'failed', label: 'Failed' },
+		{ key: 'missing', label: 'Missing' }
+	];
+
+	const sorts: { key: SortKey; label: string }[] = [
+		{ key: 'date', label: 'Date added' },
+		{ key: 'title', label: 'Title (A–Z)' },
+		{ key: 'year', label: 'Year' },
+		{ key: 'resolution', label: 'Resolution' }
+	];
 </script>
 
 <h1 class="text-3xl font-bold tracking-tight">Movies</h1>
@@ -29,69 +156,140 @@
 		</CardContent>
 	</Card>
 {:else}
-	<ul class="mt-8 list-none space-y-4">
-		{#each data.movies as movie (movie.identityKey)}
-			<li>
-				<Card>
-					<CardContent class="flex flex-col gap-4 p-4 sm:flex-row sm:items-start">
-						{#if movie.tmdb?.posterUrl}
-							<img
-								src={movie.tmdb.posterUrl}
-								alt={`Poster for ${movie.tmdb?.title ?? movie.normalizedTitle}${movie.year ? ` (${movie.year})` : ''}`}
-								class="mx-auto h-48 w-32 shrink-0 rounded-md object-cover sm:mx-0"
-								loading="lazy"
-							/>
-						{:else}
-							<div
-								class="bg-muted text-muted-foreground mx-auto flex h-48 w-32 shrink-0 items-center justify-center rounded-md text-xs sm:mx-0"
-							>
-								No poster
-							</div>
-						{/if}
-						<div class="min-w-0 flex-1">
-							<div class="flex flex-wrap items-baseline gap-2">
-								<h2 class="text-lg font-semibold tracking-tight">
-									{movie.tmdb?.title ?? movie.normalizedTitle}
-								</h2>
-								{#if movie.year}
-									<span class="text-muted-foreground">({movie.year})</span>
-								{/if}
-								{#if movie.tmdb?.voteAverage !== undefined}
-									<Badge
-										variant="secondary"
-										aria-label="TMDB vote average: {formatRating(movie.tmdb.voteAverage)}"
-									>
-										★ {formatRating(movie.tmdb.voteAverage)}
-									</Badge>
-								{/if}
-							</div>
-							{#if movie.tmdb?.overview}
-								<p class="text-muted-foreground mt-2 text-sm leading-relaxed">
-									{movie.tmdb.overview}
-								</p>
-							{/if}
-							<dl class="text-muted-foreground mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs">
-								<div>
-									<dt class="inline">Status:</dt>
-									<dd class="text-foreground inline">{movie.status}</dd>
-								</div>
-								{#if movie.resolution}
-									<div>
-										<dt class="inline">Resolution:</dt>
-										<dd class="text-foreground inline">{movie.resolution}</dd>
-									</div>
-								{/if}
-								{#if movie.codec}
-									<div>
-										<dt class="inline">Codec:</dt>
-										<dd class="text-foreground inline">{movie.codec}</dd>
-									</div>
-								{/if}
-							</dl>
-						</div>
-					</CardContent>
-				</Card>
-			</li>
+	<!-- Filter tabs -->
+	<div class="border-border mt-6 flex gap-1 border-b" role="tablist">
+		{#each tabs as tab}
+			{@const count = tabCount(tab.key)}
+			<button
+				role="tab"
+				aria-selected={activeTab === tab.key}
+				class="border-b-2 px-3 pb-2 text-sm font-medium transition-colors {activeTab === tab.key
+					? 'border-primary text-foreground -mb-px'
+					: 'text-muted-foreground hover:text-foreground border-transparent'}"
+				onclick={() => (activeTab = tab.key)}
+			>
+				{tab.label}
+				<span class="text-muted-foreground ml-1 text-xs">({count})</span>
+			</button>
 		{/each}
-	</ul>
+	</div>
+
+	<!-- Sort -->
+	<div class="mt-4 flex items-center gap-2">
+		<span class="text-muted-foreground text-sm">Sort:</span>
+		{#each sorts as sort, i}
+			<button
+				class="text-sm font-medium underline-offset-2 {sortKey === sort.key
+					? 'text-foreground underline'
+					: 'text-muted-foreground hover:text-foreground'}"
+				onclick={() => (sortKey = sort.key)}
+			>
+				{sort.label}
+			</button>
+			{#if i < sorts.length - 1}
+				<span class="text-muted-foreground text-xs">·</span>
+			{/if}
+		{/each}
+	</div>
+
+	{#if filteredMovies.length === 0}
+		<p class="text-muted-foreground mt-6 text-sm">No movies match the current filter.</p>
+	{:else}
+		<ul class="mt-6 list-none space-y-4">
+			{#each filteredMovies as movie (movie.identityKey)}
+				{@const live = liveTorrent(movie)}
+				{@const pct = live ? live.percentDone * 100 : (movie.transmissionPercentDone ?? 0) * 100}
+				{@const isDownloading = live
+					? live.status === 'downloading'
+					: movie.status === 'downloading'}
+				{@const showProgress = live !== undefined || pct > 0}
+				<li>
+					<Card>
+						<CardContent class="flex flex-col gap-4 p-4 sm:flex-row sm:items-start">
+							<div class="relative mx-auto shrink-0 sm:mx-0">
+								{#if movie.tmdb?.posterUrl}
+									<img
+										src={movie.tmdb.posterUrl}
+										alt={`Poster for ${movie.tmdb?.title ?? movie.normalizedTitle}${movie.year ? ` (${movie.year})` : ''}`}
+										class="h-48 w-32 rounded-md object-cover"
+										loading="lazy"
+									/>
+								{:else}
+									<div
+										class="bg-muted text-muted-foreground flex h-48 w-32 items-center justify-center rounded-md text-xs"
+									>
+										No poster
+									</div>
+								{/if}
+								<!-- Status chip overlay -->
+								<span
+									class="absolute bottom-1 left-1 inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium {statusChipClass(
+										movie.status
+									)}"
+								>
+									{movie.status}
+								</span>
+							</div>
+							<div class="min-w-0 flex-1">
+								<div class="flex flex-wrap items-baseline gap-2">
+									<h2 class="text-lg font-semibold tracking-tight">
+										{movie.tmdb?.title ?? movie.normalizedTitle}
+									</h2>
+									{#if movie.year}
+										<span class="text-muted-foreground">({movie.year})</span>
+									{/if}
+									{#if movie.tmdb?.voteAverage !== undefined}
+										<Badge
+											variant="secondary"
+											aria-label="TMDB vote average: {formatRating(movie.tmdb.voteAverage)}"
+										>
+											★ {formatRating(movie.tmdb.voteAverage)}
+										</Badge>
+									{/if}
+								</div>
+								{#if movie.tmdb?.overview}
+									<p class="text-muted-foreground mt-2 text-sm leading-relaxed">
+										{movie.tmdb.overview}
+									</p>
+								{/if}
+								<dl class="text-muted-foreground mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs">
+									{#if movie.resolution}
+										<div>
+											<dt class="inline">Resolution:</dt>
+											<dd class="text-foreground inline">{movie.resolution}</dd>
+										</div>
+									{/if}
+									{#if movie.codec}
+										<div>
+											<dt class="inline">Codec:</dt>
+											<dd class="text-foreground inline">{movie.codec}</dd>
+										</div>
+									{/if}
+								</dl>
+								<!-- Progress bar -->
+								{#if showProgress}
+									<div class="mt-3">
+										<div class="flex items-center gap-2">
+											<div class="bg-muted h-1.5 flex-1 rounded-full">
+												<div
+													class="h-1.5 rounded-full {isDownloading ? 'bg-cyan-500' : 'bg-primary'}"
+													style="width: {pct.toFixed(0)}%"
+												></div>
+											</div>
+											<span class="text-muted-foreground shrink-0 text-xs">{pct.toFixed(0)}%</span>
+										</div>
+										{#if live && isDownloading}
+											<p class="text-muted-foreground mt-0.5 text-xs">
+												{formatSpeed(live.rateDownload)} · {formatEta(live.eta)}
+											</p>
+										{/if}
+									</div>
+								{/if}
+							</div>
+						</CardContent>
+					</Card>
+				</li>
+			{/each}
+		</ul>
+	{/if}
 {/if}

--- a/web/src/routes/movies/+page.svelte
+++ b/web/src/routes/movies/+page.svelte
@@ -61,11 +61,16 @@
 		}
 	}
 
+	/** Unified downloading predicate used in tab counts, filtering, and row rendering. */
+	function isMovieDownloading(m: MovieBreakdown): boolean {
+		return m.status === 'downloading' || m.lifecycleStatus === 'active';
+	}
+
 	function tabCount(tab: FilterTab): number {
 		const movies = data.movies;
 		switch (tab) {
 			case 'downloading':
-				return movies.filter((m) => m.lifecycleStatus === 'active').length;
+				return movies.filter(isMovieDownloading).length;
 			case 'completed':
 				return movies.filter((m) => m.status === 'completed').length;
 			case 'failed':
@@ -89,7 +94,7 @@
 			.filter((m) => {
 				switch (activeTab) {
 					case 'downloading':
-						return m.lifecycleStatus === 'active';
+						return isMovieDownloading(m);
 					case 'completed':
 						return m.status === 'completed';
 					case 'failed':
@@ -199,9 +204,7 @@
 			{#each filteredMovies as movie (movie.identityKey)}
 				{@const live = liveTorrent(movie)}
 				{@const pct = live ? live.percentDone * 100 : (movie.transmissionPercentDone ?? 0) * 100}
-				{@const isDownloading = live
-					? live.status === 'downloading'
-					: movie.status === 'downloading'}
+				{@const isDownloading = live ? live.status === 'downloading' : isMovieDownloading(movie)}
 				{@const showProgress = live !== undefined || pct > 0}
 				<li>
 					<Card>

--- a/web/src/routes/movies/movies.test.ts
+++ b/web/src/routes/movies/movies.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import Page from './+page.svelte';
-import type { MovieBreakdown } from '$lib/types';
+import type { MovieBreakdown, TorrentStatSnapshot } from '$lib/types';
 
-const mockMovie: MovieBreakdown = {
+const mockMovie = (overrides: Partial<MovieBreakdown> = {}): MovieBreakdown => ({
 	identityKey: 'movie-1',
 	normalizedTitle: 'Example Film',
 	status: 'queued',
@@ -15,12 +15,25 @@ const mockMovie: MovieBreakdown = {
 		posterUrl: 'https://example.com/poster.jpg',
 		overview: 'A test overview.',
 		voteAverage: 7.2
-	}
-};
+	},
+	...overrides
+});
+
+const mockTorrent = (overrides: Partial<TorrentStatSnapshot> = {}): TorrentStatSnapshot => ({
+	hash: 'abc123',
+	name: 'Example.Film.2020.1080p',
+	status: 'downloading',
+	percentDone: 0.55,
+	rateDownload: 2097152,
+	eta: 7200,
+	...overrides
+});
+
+const baseData = { movies: [mockMovie()], torrents: null, error: null };
 
 describe('/movies', () => {
 	it('renders movie cards with TMDB metadata', () => {
-		render(Page, { data: { movies: [mockMovie], error: null } });
+		render(Page, { data: baseData });
 		expect(screen.getByRole('heading', { name: 'Movies' })).toBeInTheDocument();
 		expect(screen.getByText('Example Film')).toBeInTheDocument();
 		expect(screen.getByText('A test overview.')).toBeInTheDocument();
@@ -28,13 +41,92 @@ describe('/movies', () => {
 		expect(screen.getByText('1080p')).toBeInTheDocument();
 	});
 
+	it('filter tabs render correct counts', () => {
+		const movies = [
+			mockMovie({ identityKey: 'a', status: 'completed' }),
+			mockMovie({ identityKey: 'b', status: 'failed' }),
+			mockMovie({ identityKey: 'c', status: 'queued' })
+		];
+		render(Page, { data: { movies, torrents: null, error: null } });
+		// All tab shows total count 3
+		expect(screen.getByRole('tab', { name: /^All/ })).toHaveTextContent('(3)');
+		expect(screen.getByRole('tab', { name: /^Completed/ })).toHaveTextContent('(1)');
+		expect(screen.getByRole('tab', { name: /^Failed/ })).toHaveTextContent('(1)');
+	});
+
+	it('tab click filters movie list', async () => {
+		const movies = [
+			mockMovie({
+				identityKey: 'a',
+				normalizedTitle: 'Alpha',
+				status: 'completed',
+				tmdb: undefined
+			}),
+			mockMovie({ identityKey: 'b', normalizedTitle: 'Beta', status: 'failed', tmdb: undefined })
+		];
+		render(Page, { data: { movies, torrents: null, error: null } });
+		// Both visible on All tab
+		expect(screen.getByText('Alpha')).toBeInTheDocument();
+		expect(screen.getByText('Beta')).toBeInTheDocument();
+
+		// Switch to Completed tab
+		await fireEvent.click(screen.getByRole('tab', { name: /^Completed/ }));
+		expect(screen.getByText('Alpha')).toBeInTheDocument();
+		expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+	});
+
+	it('sort by Title orders cards A–Z', async () => {
+		const movies = [
+			mockMovie({ identityKey: 'z', normalizedTitle: 'Zulu', tmdb: undefined }),
+			mockMovie({ identityKey: 'a', normalizedTitle: 'Alpha', tmdb: undefined })
+		];
+		render(Page, { data: { movies, torrents: null, error: null } });
+		await fireEvent.click(screen.getByRole('button', { name: 'Title (A–Z)' }));
+		const headings = screen.getAllByRole('heading', { level: 2 });
+		expect(headings[0]).toHaveTextContent('Alpha');
+		expect(headings[1]).toHaveTextContent('Zulu');
+	});
+
+	it('renders progress bar and speed/ETA for downloading movie', () => {
+		const movie = mockMovie({
+			identityKey: 'dl',
+			status: 'downloading',
+			transmissionTorrentHash: 'abc123',
+			transmissionPercentDone: 0.1
+		});
+		const torrent = mockTorrent();
+		render(Page, { data: { movies: [movie], torrents: [torrent], error: null } });
+		// 55% from live torrent
+		expect(screen.getByText('55%')).toBeInTheDocument();
+		// 2097152 B/s = 2.0 MB/s
+		expect(screen.getByText(/2\.0 MB\/s/)).toBeInTheDocument();
+		// ETA 7200s = 2h 0m
+		expect(screen.getByText(/2h 0m/)).toBeInTheDocument();
+	});
+
+	it('renders no progress bar when torrents is null', () => {
+		const movie = mockMovie({
+			identityKey: 'dl',
+			status: 'downloading',
+			transmissionTorrentHash: 'abc123'
+		});
+		render(Page, { data: { movies: [movie], torrents: null, error: null } });
+		expect(screen.queryByText(/MB\/s|KB\/s/)).not.toBeInTheDocument();
+	});
+
+	it('genre filter is hidden (TmdbMoviePublic has no genres field)', () => {
+		render(Page, { data: baseData });
+		// No genre dropdown should be present
+		expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+	});
+
 	it('renders empty state', () => {
-		render(Page, { data: { movies: [], error: null } });
+		render(Page, { data: { movies: [], torrents: null, error: null } });
 		expect(screen.getByText('No movie candidates yet.')).toBeInTheDocument();
 	});
 
 	it('renders error state', () => {
-		render(Page, { data: { movies: [], error: 'Could not reach the API.' } });
+		render(Page, { data: { movies: [], torrents: null, error: 'Could not reach the API.' } });
 		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
 	});
 });


### PR DESCRIPTION
## Summary

- delivery ticket: `P15.05 Movies View — Filter Tabs, Genre Filter, Sort, and Progress`
- ticket file: [docs/02-delivery/phase-15/ticket-05-movies-filter-sort-progress.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-15/ticket-05-movies-filter-sort-progress.md)
- stacked base branch: `agents/p15-04-tv-shows-view-progress-and-sort`
- post-verify self-audit: completed at 2026-04-11 12:59 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`b8508395d48c`](https://github.com/cesarnml/pirate_claw/commit/b8508395d48cd3e03fbe01809f4e6097b05affcf)
- current branch head: [`97e2e949d484`](https://github.com/cesarnml/pirate_claw/commit/97e2e949d4840e67ca7e31479635b48699f8ca16)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `b8508395d48c` address all findings from that review.
- vendors: `coderabbit`

### Resolved Review Findings

- [coderabbit] Unify the "downloading" predicate across tabs and cards. (native GitHub thread resolved) `web/src/routes/movies/+page.svelte:78` [thread](https://github.com/cesarnml/pirate_claw/pull/129#discussion_r3068027947)
