### PR TITLE
feat(p15-06): unmatched candidates view — /candidates/unmatched route with title search, nav link [P15.06]

### DIFF
--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -110,6 +110,15 @@ export type MovieBreakdown = {
 	tmdb?: TmdbMoviePublic;
 };
 
+export type SkippedOutcomeRecord = {
+	id: number;
+	runId: number;
+	status: 'skipped_no_match';
+	recordedAt: string;
+	title: string | null;
+	feedName: string | null;
+};
+
 export type FeedConfig = {
 	name: string;
 	url: string;

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -11,6 +11,7 @@
 
 	const nav = [
 		{ href: '/candidates', label: 'Candidates' },
+		{ href: '/candidates/unmatched', label: 'Unmatched' },
 		{ href: '/shows', label: 'Shows' },
 		{ href: '/movies', label: 'Movies' },
 		{ href: '/config', label: 'Config' }

--- a/web/src/routes/candidates/unmatched/+page.server.ts
+++ b/web/src/routes/candidates/unmatched/+page.server.ts
@@ -1,0 +1,18 @@
+import { apiFetch } from '$lib/server/api';
+import type { SkippedOutcomeRecord } from '$lib/types';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+	try {
+		const data = await apiFetch<{ outcomes: SkippedOutcomeRecord[] }>(
+			'/api/outcomes?status=skipped_no_match'
+		);
+		return { outcomes: data.outcomes, error: null };
+	} catch (err) {
+		console.error('[unmatched] failed to load /api/outcomes:', err);
+		return {
+			outcomes: [] as SkippedOutcomeRecord[],
+			error: 'Could not reach the API.'
+		};
+	}
+};

--- a/web/src/routes/candidates/unmatched/+page.svelte
+++ b/web/src/routes/candidates/unmatched/+page.svelte
@@ -50,7 +50,9 @@
 	</Card>
 {:else}
 	<div class="mt-6">
+		<label for="unmatched-search" class="sr-only">Search unmatched candidates by title</label>
 		<input
+			id="unmatched-search"
 			type="search"
 			placeholder="Search by title…"
 			bind:value={search}

--- a/web/src/routes/candidates/unmatched/+page.svelte
+++ b/web/src/routes/candidates/unmatched/+page.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
+	import { Card, CardContent } from '$lib/components/ui/card';
+	import {
+		Table,
+		TableBody,
+		TableCell,
+		TableHead,
+		TableHeader,
+		TableRow
+	} from '$lib/components/ui/table';
+	import type { PageData } from './$types';
+
+	let { data }: { data: PageData } = $props();
+
+	let search = $state('');
+
+	function formatDate(iso: string): string {
+		return new Date(iso).toLocaleString('en-US', {
+			dateStyle: 'medium',
+			timeStyle: 'short',
+			timeZone: 'UTC'
+		});
+	}
+
+	const filteredOutcomes = $derived(
+		search.trim() === ''
+			? data.outcomes
+			: data.outcomes.filter(
+					(o) => o.title !== null && o.title.toLowerCase().includes(search.trim().toLowerCase())
+				)
+	);
+</script>
+
+<h1 class="text-3xl font-bold tracking-tight">Unmatched Candidates</h1>
+<p class="text-muted-foreground mt-1 text-sm">
+	Feed items from the last 30 days that matched no policy rule.
+</p>
+
+{#if data.error}
+	<Alert variant="destructive" class="mt-6" role="alert">
+		<AlertTitle>API unavailable</AlertTitle>
+		<AlertDescription>{data.error}</AlertDescription>
+	</Alert>
+{:else if data.outcomes.length === 0}
+	<Card class="mt-6">
+		<CardContent class="pt-6">
+			<p class="text-muted-foreground text-sm">No unmatched candidates in the last 30 days.</p>
+		</CardContent>
+	</Card>
+{:else}
+	<div class="mt-6">
+		<input
+			type="search"
+			placeholder="Search by title…"
+			bind:value={search}
+			class="border-border bg-background text-foreground placeholder:text-muted-foreground focus:ring-ring w-full max-w-sm rounded-md border px-3 py-2 text-sm focus:ring-2 focus:outline-none"
+		/>
+	</div>
+
+	<div class="border-border mt-4 rounded-md border">
+		<Table>
+			<TableHeader>
+				<TableRow>
+					<TableHead>Title</TableHead>
+					<TableHead>Feed</TableHead>
+					<TableHead>Run ID</TableHead>
+					<TableHead>Recorded at</TableHead>
+				</TableRow>
+			</TableHeader>
+			<TableBody>
+				{#each filteredOutcomes as outcome (outcome.id)}
+					<TableRow>
+						<TableCell class="max-w-xs truncate text-sm">
+							{outcome.title ?? '—'}
+						</TableCell>
+						<TableCell class="text-muted-foreground text-sm">
+							{outcome.feedName ?? '—'}
+						</TableCell>
+						<TableCell class="font-mono text-xs">
+							{outcome.runId}
+						</TableCell>
+						<TableCell class="text-muted-foreground text-xs">
+							{formatDate(outcome.recordedAt)}
+						</TableCell>
+					</TableRow>
+				{/each}
+			</TableBody>
+		</Table>
+	</div>
+{/if}

--- a/web/src/routes/candidates/unmatched/unmatched.test.ts
+++ b/web/src/routes/candidates/unmatched/unmatched.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import Page from './+page.svelte';
+import type { SkippedOutcomeRecord } from '$lib/types';
+
+// Anchored to fixtures/api/outcomes-skipped-no-match.json
+const mockOutcomes: SkippedOutcomeRecord[] = [
+	{
+		id: 1,
+		runId: 42,
+		status: 'skipped_no_match',
+		recordedAt: '2026-04-10T12:00:00.000Z',
+		title: 'Stranger.Things.S05E01.4K.WEB.x265-GROUP',
+		feedName: 'main-tv'
+	},
+	{
+		id: 2,
+		runId: 42,
+		status: 'skipped_no_match',
+		recordedAt: '2026-04-10T12:00:05.000Z',
+		title: 'The.Brutalist.2025.2160p.WEB-DL.DDP5.1.Atmos.x265',
+		feedName: 'main-movies'
+	},
+	{
+		id: 3,
+		runId: 43,
+		status: 'skipped_no_match',
+		recordedAt: '2026-04-11T06:00:00.000Z',
+		title: null,
+		feedName: null
+	}
+];
+
+describe('/candidates/unmatched', () => {
+	it('renders table with correct columns', () => {
+		render(Page, { data: { outcomes: mockOutcomes, error: null } });
+		expect(screen.getByRole('heading', { name: 'Unmatched Candidates' })).toBeInTheDocument();
+		expect(screen.getByRole('columnheader', { name: 'Title' })).toBeInTheDocument();
+		expect(screen.getByRole('columnheader', { name: 'Feed' })).toBeInTheDocument();
+		expect(screen.getByRole('columnheader', { name: 'Run ID' })).toBeInTheDocument();
+		expect(screen.getByRole('columnheader', { name: 'Recorded at' })).toBeInTheDocument();
+		expect(screen.getByText('Stranger.Things.S05E01.4K.WEB.x265-GROUP')).toBeInTheDocument();
+		expect(screen.getByText('main-tv')).toBeInTheDocument();
+	});
+
+	it('renders null title and feedName as "—"', () => {
+		render(Page, { data: { outcomes: mockOutcomes, error: null } });
+		// Outcome id=3 has null title and feedName → both render as "—"
+		const dashes = screen.getAllByText('—');
+		expect(dashes.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it('title search filters rows by partial match (case-insensitive)', async () => {
+		render(Page, { data: { outcomes: mockOutcomes, error: null } });
+		const input = screen.getByPlaceholderText('Search by title…');
+		await fireEvent.input(input, { target: { value: 'brutalist' } });
+		expect(
+			screen.getByText('The.Brutalist.2025.2160p.WEB-DL.DDP5.1.Atmos.x265')
+		).toBeInTheDocument();
+		expect(screen.queryByText('Stranger.Things.S05E01.4K.WEB.x265-GROUP')).not.toBeInTheDocument();
+	});
+
+	it('title search with no match shows empty table body (not placeholder)', async () => {
+		render(Page, { data: { outcomes: mockOutcomes, error: null } });
+		const input = screen.getByPlaceholderText('Search by title…');
+		await fireEvent.input(input, { target: { value: 'xyznonexistent' } });
+		// Table still present but no data rows
+		expect(screen.getByRole('table')).toBeInTheDocument();
+		expect(
+			screen.queryByText('No unmatched candidates in the last 30 days.')
+		).not.toBeInTheDocument();
+	});
+
+	it('renders empty state when no outcomes', () => {
+		render(Page, { data: { outcomes: [], error: null } });
+		expect(screen.getByText('No unmatched candidates in the last 30 days.')).toBeInTheDocument();
+	});
+
+	it('renders error alert when error is set', () => {
+		render(Page, { data: { outcomes: [], error: 'Could not reach the API.' } });
+		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
+	});
+});

--- a/web/src/routes/candidates/unmatched/unmatched.test.ts
+++ b/web/src/routes/candidates/unmatched/unmatched.test.ts
@@ -65,7 +65,9 @@ describe('/candidates/unmatched', () => {
 		const input = screen.getByPlaceholderText('Search by title…');
 		await fireEvent.input(input, { target: { value: 'xyznonexistent' } });
 		// Table still present but no data rows
-		expect(screen.getByRole('table')).toBeInTheDocument();
+		const table = screen.getByRole('table');
+		expect(table).toBeInTheDocument();
+		expect(table.querySelectorAll('tbody tr')).toHaveLength(0);
 		expect(
 			screen.queryByText('No unmatched candidates in the last 30 days.')
 		).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- delivery ticket: `P15.06 Unmatched Candidates View`
- ticket file: [docs/02-delivery/phase-15/ticket-06-unmatched-candidates-view.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-15/ticket-06-unmatched-candidates-view.md)
- stacked base branch: `agents/p15-05-movies-view-filter-tabs-genre-filter-sort-and-progress`

## External AI Review

- outcome: `clean`
- reviewed commit: [`df407b570aeb`](https://github.com/cesarnml/pirate_claw/commit/df407b570aeb68f270f42b92668d5011fac01588)
- current branch head: [`df407b570aeb`](https://github.com/cesarnml/pirate_claw/commit/df407b570aeb68f270f42b92668d5011fac01588)
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Add an explicit label for the search field. `web/src/routes/candidates/unmatched/+page.svelte:60` [thread](https://github.com/cesarnml/pirate_claw/pull/130#discussion_r3068039446)
