### PR TITLE
feat(web): enhance Transmission card with status dot, test connection, and credential masking [P16.03]

### DIFF
--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -6,28 +6,31 @@ import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
 	const canWrite = !!env.PIRATE_CLAW_API_WRITE_TOKEN;
-	try {
-		const response = await apiRequest('/api/config');
-		if (!response.ok) {
-			throw new Error(`config load failed: ${response.status}`);
-		}
 
-		const config = (await response.json()) as AppConfig;
-		return {
-			config,
-			etag: response.headers.get('etag'),
-			canWrite,
-			error: null
-		};
-	} catch (err) {
-		console.error('[config] failed to load config:', err);
-		return {
-			config: null as AppConfig | null,
-			etag: null as string | null,
-			canWrite,
-			error: 'Could not reach the API.'
-		};
+	const [configResult, sessionResult] = await Promise.allSettled([
+		apiRequest('/api/config'),
+		apiRequest('/api/transmission/session')
+	]);
+
+	let config: AppConfig | null = null;
+	let etag: string | null = null;
+	let error: string | null = null;
+	let transmissionSession: { version: string } | null = null;
+
+	if (configResult.status === 'fulfilled' && configResult.value.ok) {
+		config = (await configResult.value.json()) as AppConfig;
+		etag = configResult.value.headers.get('etag');
+	} else {
+		console.error('[config] failed to load config');
+		error = 'Could not reach the API.';
 	}
+
+	if (sessionResult.status === 'fulfilled' && sessionResult.value.ok) {
+		const sessionData = (await sessionResult.value.json()) as { version: string };
+		transmissionSession = { version: sessionData.version };
+	}
+
+	return { config, etag, canWrite, error, transmissionSession };
 };
 
 function parseOptionalInt(input: unknown): number | undefined {
@@ -329,6 +332,37 @@ export const actions: Actions = {
 		} catch (error) {
 			console.error('[config] restartDaemon failed:', error);
 			return fail(502, { restartError: 'Could not reach the API to restart.' });
+		}
+	},
+
+	testConnection: async () => {
+		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+		if (!writeToken) {
+			return fail(403, { pingError: 'write token not configured; cannot test connection' });
+		}
+
+		try {
+			const response = await apiRequest('/api/transmission/ping', {
+				method: 'POST',
+				headers: { authorization: `Bearer ${writeToken}` }
+			});
+
+			if (!response.ok) {
+				let pingError = `Ping failed (${response.status}).`;
+				try {
+					const body = (await response.json()) as { error?: string };
+					if (body.error) pingError = body.error;
+				} catch {
+					// keep fallback
+				}
+				return fail(502, { pingError });
+			}
+
+			const data = (await response.json()) as { version: string };
+			return { pingOk: true, version: data.version };
+		} catch (error) {
+			console.error('[config] testConnection failed:', error);
+			return fail(502, { pingError: 'Could not reach the API.' });
 		}
 	},
 

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -29,6 +29,7 @@
 	let newFeedUrl = $state('');
 	let newFeedMediaType = $state<'tv' | 'movie'>('tv');
 	let feedsSubmitting = $state(false);
+	let testingConnection = $state(false);
 
 	let showRestartOffer = $state(false);
 	let restarting = $state(false);
@@ -513,6 +514,99 @@
 			</Card>
 		</form>
 
+		<Card>
+			<CardHeader class="pb-3">
+				<div class="flex items-center gap-2">
+					<span
+						class="inline-block h-2 w-2 rounded-full {data.transmissionSession
+							? 'bg-green-500'
+							: 'bg-red-500'}"
+						aria-label={data.transmissionSession ? 'connected' : 'disconnected'}
+					></span>
+					<h2 class="text-lg font-semibold tracking-tight">Transmission</h2>
+				</div>
+				{#if data.transmissionSession}
+					<p class="text-muted-foreground text-xs">
+						Transmission {data.transmissionSession.version}
+					</p>
+				{/if}
+			</CardHeader>
+			<CardContent class="space-y-4 pt-0">
+				<dl class="grid gap-2 text-sm">
+					<div class="flex flex-wrap gap-2">
+						<dt class="text-muted-foreground">URL:</dt>
+						<dd class="text-foreground">{config.transmission.url}</dd>
+					</div>
+					<div class="flex flex-wrap gap-2">
+						<dt class="text-muted-foreground">Username:</dt>
+						<dd class="text-foreground">
+							{config.transmission.username ? '[configured]' : '[not set]'}
+						</dd>
+					</div>
+					<div class="flex flex-wrap gap-2">
+						<dt class="text-muted-foreground">Password:</dt>
+						<dd class="text-foreground">[redacted]</dd>
+					</div>
+					{#if config.transmission.downloadDir}
+						<div class="flex flex-wrap gap-2">
+							<dt class="text-muted-foreground">Download dir:</dt>
+							<dd class="text-foreground">{config.transmission.downloadDir}</dd>
+						</div>
+					{/if}
+					{#if config.transmission.downloadDirs}
+						{#if config.transmission.downloadDirs.tv}
+							<div class="flex flex-wrap gap-2">
+								<dt class="text-muted-foreground">TV dir:</dt>
+								<dd class="text-foreground">{config.transmission.downloadDirs.tv}</dd>
+							</div>
+						{/if}
+						{#if config.transmission.downloadDirs.movie}
+							<div class="flex flex-wrap gap-2">
+								<dt class="text-muted-foreground">Movie dir:</dt>
+								<dd class="text-foreground">{config.transmission.downloadDirs.movie}</dd>
+							</div>
+						{/if}
+					{/if}
+				</dl>
+				<p class="text-muted-foreground text-xs">
+					Edit credentials in <code class="font-mono">.env</code>
+				</p>
+				<form
+					method="POST"
+					action="?/testConnection"
+					use:enhance={() => {
+						testingConnection = true;
+						return async ({ result, update }) => {
+							testingConnection = false;
+							if (result.type === 'success') {
+								const version = (result.data as { version?: string })?.version ?? '';
+								toast(`Transmission reachable — version ${version}`, 'success');
+							} else if (result.type === 'failure') {
+								const pingError = (result.data as { pingError?: string })?.pingError;
+								toast(
+									pingError ?? 'Transmission unreachable — check .env credentials and host',
+									'error'
+								);
+							}
+							await update({ reset: false });
+						};
+					}}
+				>
+					<button
+						type="submit"
+						class="border-border bg-card hover:bg-muted/50 inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-50"
+						disabled={testingConnection}
+					>
+						{#if testingConnection}
+							Checking…
+						{:else}
+							Test Connection
+						{/if}
+					</button>
+				</form>
+			</CardContent>
+		</Card>
+
 		<form
 			method="POST"
 			action="?/saveSettings"
@@ -575,48 +669,6 @@
 							Add show
 						</button>
 					</div>
-				</CardContent>
-			</Card>
-
-			<Card>
-				<CardHeader class="pb-3">
-					<h2 class="text-lg font-semibold tracking-tight">Transmission</h2>
-				</CardHeader>
-				<CardContent class="pt-0">
-					<dl class="grid gap-2 text-sm">
-						<div class="flex flex-wrap gap-2">
-							<dt class="text-muted-foreground">URL:</dt>
-							<dd class="text-foreground">{config.transmission.url}</dd>
-						</div>
-						<div class="flex flex-wrap gap-2">
-							<dt class="text-muted-foreground">Username:</dt>
-							<dd class="text-foreground">{config.transmission.username}</dd>
-						</div>
-						<div class="flex flex-wrap gap-2">
-							<dt class="text-muted-foreground">Password:</dt>
-							<dd class="text-foreground">••••••••</dd>
-						</div>
-						{#if config.transmission.downloadDir}
-							<div class="flex flex-wrap gap-2">
-								<dt class="text-muted-foreground">Download dir:</dt>
-								<dd class="text-foreground">{config.transmission.downloadDir}</dd>
-							</div>
-						{/if}
-						{#if config.transmission.downloadDirs}
-							{#if config.transmission.downloadDirs.tv}
-								<div class="flex flex-wrap gap-2">
-									<dt class="text-muted-foreground">TV dir:</dt>
-									<dd class="text-foreground">{config.transmission.downloadDirs.tv}</dd>
-								</div>
-							{/if}
-							{#if config.transmission.downloadDirs.movie}
-								<div class="flex flex-wrap gap-2">
-									<dt class="text-muted-foreground">Movie dir:</dt>
-									<dd class="text-foreground">{config.transmission.downloadDirs.movie}</dd>
-								</div>
-							{/if}
-						{/if}
-					</dl>
 				</CardContent>
 			</Card>
 

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -545,7 +545,9 @@
 					</div>
 					<div class="flex flex-wrap gap-2">
 						<dt class="text-muted-foreground">Password:</dt>
-						<dd class="text-foreground">[redacted]</dd>
+						<dd class="text-foreground">
+							{config.transmission.password ? '[redacted]' : '[not set]'}
+						</dd>
 					</div>
 					{#if config.transmission.downloadDir}
 						<div class="flex flex-wrap gap-2">

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -50,7 +50,7 @@ const mockConfig: AppConfig = {
 describe('/config', () => {
 	it('renders config sections with mock data', () => {
 		render(Page, {
-			data: { config: mockConfig, error: null, etag: '"rev-1"', canWrite: true },
+			data: { config: mockConfig, error: null, etag: '"rev-1"', canWrite: true, transmissionSession: null },
 			form: undefined
 		});
 		expect(screen.getByRole('heading', { name: 'Feeds' })).toBeInTheDocument();
@@ -65,7 +65,7 @@ describe('/config', () => {
 
 	it('renders error state when API is unreachable', () => {
 		render(Page, {
-			data: { config: null, error: 'Could not reach the API.', etag: null, canWrite: false },
+			data: { config: null, error: 'Could not reach the API.', etag: null, canWrite: false, transmissionSession: null },
 			form: undefined
 		});
 		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
@@ -77,7 +77,8 @@ describe('/config', () => {
 				config: { ...mockConfig, feeds: [], tv: [] },
 				error: null,
 				etag: '"rev-1"',
-				canWrite: true
+				canWrite: true,
+				transmissionSession: null
 			},
 			form: undefined
 		});
@@ -87,7 +88,7 @@ describe('/config', () => {
 
 	it('does not render restart offer by default', () => {
 		render(Page, {
-			data: { config: mockConfig, error: null, etag: '"rev-1"', canWrite: true },
+			data: { config: mockConfig, error: null, etag: '"rev-1"', canWrite: true, transmissionSession: null },
 			form: undefined
 		});
 		expect(screen.queryByRole('button', { name: /restart daemon/i })).not.toBeInTheDocument();

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -50,7 +50,13 @@ const mockConfig: AppConfig = {
 describe('/config', () => {
 	it('renders config sections with mock data', () => {
 		render(Page, {
-			data: { config: mockConfig, error: null, etag: '"rev-1"', canWrite: true, transmissionSession: null },
+			data: {
+				config: mockConfig,
+				error: null,
+				etag: '"rev-1"',
+				canWrite: true,
+				transmissionSession: null
+			},
 			form: undefined
 		});
 		expect(screen.getByRole('heading', { name: 'Feeds' })).toBeInTheDocument();
@@ -65,7 +71,13 @@ describe('/config', () => {
 
 	it('renders error state when API is unreachable', () => {
 		render(Page, {
-			data: { config: null, error: 'Could not reach the API.', etag: null, canWrite: false, transmissionSession: null },
+			data: {
+				config: null,
+				error: 'Could not reach the API.',
+				etag: null,
+				canWrite: false,
+				transmissionSession: null
+			},
 			form: undefined
 		});
 		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
@@ -88,7 +100,13 @@ describe('/config', () => {
 
 	it('does not render restart offer by default', () => {
 		render(Page, {
-			data: { config: mockConfig, error: null, etag: '"rev-1"', canWrite: true, transmissionSession: null },
+			data: {
+				config: mockConfig,
+				error: null,
+				etag: '"rev-1"',
+				canWrite: true,
+				transmissionSession: null
+			},
 			form: undefined
 		});
 		expect(screen.queryByRole('button', { name: /restart daemon/i })).not.toBeInTheDocument();

--- a/web/src/routes/config/page.server.test.ts
+++ b/web/src/routes/config/page.server.test.ts
@@ -11,6 +11,119 @@ describe('config page server actions', () => {
 		vi.resetModules();
 	});
 
+	describe('load', () => {
+		it('returns transmissionSession: null when session fetch fails', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { load } = await import('./+page.server');
+
+			apiRequestMock
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							feeds: [],
+							tv: [],
+							movies: { years: [], resolutions: [], codecs: [], codecPolicy: 'prefer' },
+							transmission: { url: 'http://localhost:9091', username: '', password: '' },
+							runtime: { runIntervalMinutes: 60, reconcileIntervalMinutes: 60, artifactDir: '/tmp', artifactRetentionDays: 7 }
+						}),
+						{ status: 200 }
+					)
+				)
+				.mockRejectedValueOnce(new Error('network error'));
+
+			const result = await load({} as never);
+			expect((result as { transmissionSession: unknown }).transmissionSession).toBeNull();
+		});
+
+		it('returns transmissionSession with version when session fetch succeeds', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { load } = await import('./+page.server');
+
+			apiRequestMock
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							feeds: [],
+							tv: [],
+							movies: { years: [], resolutions: [], codecs: [], codecPolicy: 'prefer' },
+							transmission: { url: 'http://localhost:9091', username: '', password: '' },
+							runtime: { runIntervalMinutes: 60, reconcileIntervalMinutes: 60, artifactDir: '/tmp', artifactRetentionDays: 7 }
+						}),
+						{ status: 200 }
+					)
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ version: '3.00 (bb6b5a062ef)' }), { status: 200 })
+				);
+
+			const result = await load({} as never);
+			expect((result as { transmissionSession: unknown }).transmissionSession).toEqual({ version: '3.00 (bb6b5a062ef)' });
+		});
+	});
+
+	describe('testConnection', () => {
+		it('returns pingOk: true with version on success', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(JSON.stringify({ ok: true, version: '3.00 (bb6b5a062ef)' }), { status: 200 })
+			);
+
+			const result = await actions.testConnection({
+				request: new Request('http://localhost/config', { method: 'POST' })
+			} as never);
+
+			expect((result as { pingOk?: boolean }).pingOk).toBe(true);
+			expect((result as { version?: string }).version).toBe('3.00 (bb6b5a062ef)');
+			expect(apiRequestMock).toHaveBeenCalledWith(
+				'/api/transmission/ping',
+				expect.objectContaining({ method: 'POST' })
+			);
+		});
+
+		it('returns fail(502) when Transmission is unreachable', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(JSON.stringify({ ok: false, error: 'connection refused' }), { status: 502 })
+			);
+
+			const result = await actions.testConnection({
+				request: new Request('http://localhost/config', { method: 'POST' })
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(502);
+			expect((result as { data?: { pingError?: string } }).data?.pingError).toContain(
+				'connection refused'
+			);
+		});
+
+		it('returns fail(403) when write token is not configured', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: {}
+			}));
+			const { actions } = await import('./+page.server');
+
+			const result = await actions.testConnection({
+				request: new Request('http://localhost/config', { method: 'POST' })
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(403);
+			expect((result as { data?: { pingError?: string } }).data?.pingError).toContain(
+				'write token not configured'
+			);
+			expect(apiRequestMock).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('saveSettings', () => {
 		it('rejects out-of-scope fields before API call', async () => {
 			vi.doMock('$env/dynamic/private', () => ({

--- a/web/src/routes/config/page.server.test.ts
+++ b/web/src/routes/config/page.server.test.ts
@@ -26,7 +26,12 @@ describe('config page server actions', () => {
 							tv: [],
 							movies: { years: [], resolutions: [], codecs: [], codecPolicy: 'prefer' },
 							transmission: { url: 'http://localhost:9091', username: '', password: '' },
-							runtime: { runIntervalMinutes: 60, reconcileIntervalMinutes: 60, artifactDir: '/tmp', artifactRetentionDays: 7 }
+							runtime: {
+								runIntervalMinutes: 60,
+								reconcileIntervalMinutes: 60,
+								artifactDir: '/tmp',
+								artifactRetentionDays: 7
+							}
 						}),
 						{ status: 200 }
 					)
@@ -51,7 +56,12 @@ describe('config page server actions', () => {
 							tv: [],
 							movies: { years: [], resolutions: [], codecs: [], codecPolicy: 'prefer' },
 							transmission: { url: 'http://localhost:9091', username: '', password: '' },
-							runtime: { runIntervalMinutes: 60, reconcileIntervalMinutes: 60, artifactDir: '/tmp', artifactRetentionDays: 7 }
+							runtime: {
+								runIntervalMinutes: 60,
+								reconcileIntervalMinutes: 60,
+								artifactDir: '/tmp',
+								artifactRetentionDays: 7
+							}
 						}),
 						{ status: 200 }
 					)
@@ -61,7 +71,9 @@ describe('config page server actions', () => {
 				);
 
 			const result = await load({} as never);
-			expect((result as { transmissionSession: unknown }).transmissionSession).toEqual({ version: '3.00 (bb6b5a062ef)' });
+			expect((result as { transmissionSession: unknown }).transmissionSession).toEqual({
+				version: '3.00 (bb6b5a062ef)'
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary

- delivery ticket: `P16.03 Transmission Card`
- ticket file: [docs/02-delivery/phase-16/ticket-03-transmission-card.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-16/ticket-03-transmission-card.md)
- stacked base branch: `agents/p16-02-toast-utility-and-save-feedback`

## External AI Review

- outcome: `patched`
- reviewed commit: [`0abb14b8c7ab`](https://github.com/cesarnml/pirate_claw/commit/0abb14b8c7ab3a9f4b44509fb371038cd72b97d3)
- current branch head: [`b2f67a898072`](https://github.com/cesarnml/pirate_claw/commit/b2f67a8980729c571eff525306b6c6083f309663)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `0abb14b8c7ab` address all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Render the unset password state explicitly. (native GitHub thread resolved) `web/src/routes/config/+page.svelte:549` [thread](https://github.com/cesarnml/pirate_claw/pull/135#discussion_r3072376232)
