### PR TITLE
fix(web): align feeds 409 check to canonical result.status pattern [P16.04]

### DIFF
--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -151,7 +151,7 @@
 						newFeedMediaType = 'tv';
 						toast('Saved', 'success');
 					} else if (result.type === 'failure') {
-						if (result.data?.status === 409 || result.status === 409) {
+						if (result.status === 409) {
 							toast('Config changed elsewhere — reload and try again', 'error');
 						} else {
 							toast('Save failed — see errors above', 'error');


### PR DESCRIPTION
## Summary

- delivery ticket: `P16.04 RSS Feeds Card`
- ticket file: [docs/02-delivery/phase-16/ticket-04-feeds-card.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-16/ticket-04-feeds-card.md)
- stacked base branch: `agents/p16-03-transmission-card`
- post-verify self-audit: completed at 2026-04-13 10:48 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`031e539f639c`](https://github.com/cesarnml/pirate_claw/commit/031e539f639c329c91e55716927f7688c4e7dec6)
- current branch head: [`031e539f639c`](https://github.com/cesarnml/pirate_claw/commit/031e539f639c329c91e55716927f7688c4e7dec6)
- vendors: `coderabbit`, `sonarqube`
