### PR TITLE
fix(web): populate tvResolutions and tvCodecs from config.tvDefaults on load [P16.05]

### DIFF
--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -53,6 +53,8 @@
 		const c = data.config;
 		if (c) {
 			showRows = c.tv.map((r) => r.name);
+			tvResolutions = [...(c.tvDefaults?.resolutions ?? [])];
+			tvCodecs = [...(c.tvDefaults?.codecs ?? [])];
 			movieYears = [...c.movies.years];
 			movieResolutions = [...c.movies.resolutions];
 			movieCodecs = [...c.movies.codecs];

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -98,6 +98,29 @@ describe('/config', () => {
 		expect(screen.getByRole('button', { name: 'Add show' })).toBeInTheDocument();
 	});
 
+	it('renders TV defaults chips pre-populated from config.tvDefaults', () => {
+		render(Page, {
+			data: {
+				config: {
+					...mockConfig,
+					tvDefaults: { resolutions: ['1080p', '720p'], codecs: ['x265'] }
+				},
+				error: null,
+				etag: '"rev-1"',
+				canWrite: true,
+				transmissionSession: null
+			},
+			form: undefined
+		});
+		const resolutionButtons = screen
+			.getAllByRole('button', { name: /2160p|1080p|720p|480p/ })
+			.filter((b) => !b.closest('form[action*="saveMovies"]'));
+		const selected = resolutionButtons.filter((b) => b.className.includes('bg-primary'));
+		expect(selected.map((b) => b.textContent?.trim())).toEqual(
+			expect.arrayContaining(['1080p', '720p'])
+		);
+	});
+
 	it('does not render restart offer by default', () => {
 		render(Page, {
 			data: {


### PR DESCRIPTION
## Summary

- delivery ticket: `P16.05 TV Configuration Card`
- ticket file: [docs/02-delivery/phase-16/ticket-05-tv-configuration-card.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-16/ticket-05-tv-configuration-card.md)
- stacked base branch: `agents/p16-04-rss-feeds-card`
- post-verify self-audit: completed at 2026-04-13 10:59 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`b2ff5eb9c2ae`](https://github.com/cesarnml/pirate_claw/commit/b2ff5eb9c2ae588c9ea853ff1b1ef45d5d96b355)
- current branch head: [`b2ff5eb9c2ae`](https://github.com/cesarnml/pirate_claw/commit/b2ff5eb9c2ae588c9ea853ff1b1ef45d5d96b355)
- vendors: `coderabbit`, `sonarqube`
