### PR TITLE
feat(web): wire Movie Policy card toasts with specific error descriptions [P16.06]

### DIFF
--- a/web/src/lib/toast.ts
+++ b/web/src/lib/toast.ts
@@ -1,9 +1,10 @@
 import { toast as sonnerToast } from 'svelte-sonner';
 
-export function toast(message: string, variant: 'success' | 'error'): void {
+export function toast(message: string, variant: 'success' | 'error', description?: string): void {
+	const opts = description ? { description } : undefined;
 	if (variant === 'success') {
-		sonnerToast.success(message);
+		sonnerToast.success(message, opts);
 	} else {
-		sonnerToast.error(message);
+		sonnerToast.error(message, opts);
 	}
 }

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -366,7 +366,11 @@
 						if (result.status === 409) {
 							toast('Config changed elsewhere — reload and try again', 'error');
 						} else {
-							toast('Save failed — see errors above', 'error');
+							const detail =
+								result.data && 'moviesMessage' in result.data
+									? String(result.data.moviesMessage)
+									: undefined;
+							toast('Save failed — see errors above', 'error', detail);
 						}
 					}
 					await update();

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -367,8 +367,8 @@
 							toast('Config changed elsewhere — reload and try again', 'error');
 						} else {
 							const detail =
-								result.data && 'moviesMessage' in result.data
-									? String(result.data.moviesMessage)
+								typeof result.data?.moviesMessage === 'string'
+									? result.data.moviesMessage
 									: undefined;
 							toast('Save failed — see errors above', 'error', detail);
 						}


### PR DESCRIPTION
## Summary

- delivery ticket: `P16.06 Movie Policy Card`
- ticket file: [docs/02-delivery/phase-16/ticket-06-movie-policy-card.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-16/ticket-06-movie-policy-card.md)
- stacked base branch: `agents/p16-05-tv-configuration-card`

## External AI Review

- outcome: `patched`
- reviewed commit: [`406e290471f6`](https://github.com/cesarnml/pirate_claw/commit/406e290471f69f583bc145404d78a92929be25ea)
- current branch head: [`79b1cf38148a`](https://github.com/cesarnml/pirate_claw/commit/79b1cf38148abd1002731d677e6a7b2d9b69863a)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `406e290471f6` address all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Avoid coercing non-string `moviesMessage` into toast text. (native GitHub thread resolved) `web/src/routes/config/+page.svelte:374` [thread](https://github.com/cesarnml/pirate_claw/pull/138#discussion_r3072586614)
