### PR TITLE
feat(web): split saveSettings into saveShows and saveRuntime actions [P16.07]

### DIFF
--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -71,36 +71,67 @@ function validateRuntimeBounds(
 }
 
 export const actions: Actions = {
-	saveSettings: async ({ request }) => {
+	saveShows: async ({ request }) => {
 		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
 		if (!writeToken) {
-			return fail(500, { message: 'Server write token is not configured.' });
+			return fail(500, { showsMessage: 'Server write token is not configured.' });
 		}
 
 		const formData = await request.formData();
-		const allowedFields = new Set([
-			'ifMatch',
-			'showName',
-			'runIntervalMinutes',
-			'reconcileIntervalMinutes',
-			'tmdbRefreshIntervalMinutes',
-			'apiPort'
-		]);
-		for (const key of formData.keys()) {
-			if (!allowedFields.has(key)) {
-				return fail(400, { message: `Field "${key}" is not allowed.` });
-			}
-		}
-
 		const ifMatch = String(formData.get('ifMatch') ?? '').trim();
 		if (!ifMatch) {
-			return fail(400, { message: 'Missing config revision. Reload and try again.' });
+			return fail(400, { showsMessage: 'Missing config revision. Reload and try again.' });
 		}
 
 		const rawShowNames = formData.getAll('showName').map((v) => String(v).trim());
 		const showNames = rawShowNames.filter((n) => n.length > 0);
 		if (showNames.length < 1) {
-			return fail(400, { message: 'At least one TV show name is required.' });
+			return fail(400, { showsMessage: 'At least one TV show name is required.' });
+		}
+
+		try {
+			const response = await apiRequest('/api/config', {
+				method: 'PUT',
+				headers: {
+					'content-type': 'application/json',
+					authorization: `Bearer ${writeToken}`,
+					'if-match': ifMatch
+				},
+				body: JSON.stringify({ tv: { shows: showNames } })
+			});
+
+			if (!response.ok) {
+				let showsMessage = `Save failed (${response.status}).`;
+				try {
+					const body = (await response.json()) as { error?: string };
+					if (body.error) showsMessage = body.error;
+				} catch {
+					// keep fallback message
+				}
+				return fail(response.status, { showsMessage, showsEtag: response.headers.get('etag') });
+			}
+
+			return {
+				showsSuccess: true,
+				message: 'TV shows saved.',
+				showsEtag: response.headers.get('etag')
+			};
+		} catch (error) {
+			console.error('[config] saveShows failed:', error);
+			return fail(500, { showsMessage: 'Could not save TV shows.' });
+		}
+	},
+
+	saveRuntime: async ({ request }) => {
+		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+		if (!writeToken) {
+			return fail(500, { runtimeMessage: 'Server write token is not configured.' });
+		}
+
+		const formData = await request.formData();
+		const ifMatch = String(formData.get('runtimeIfMatch') ?? '').trim();
+		if (!ifMatch) {
+			return fail(400, { runtimeMessage: 'Missing config revision. Reload and try again.' });
 		}
 
 		const runIntervalMinutes = parseOptionalInt(formData.get('runIntervalMinutes'));
@@ -115,7 +146,7 @@ export const actions: Actions = {
 			apiPort
 		].some((value) => Number.isNaN(value));
 		if (invalidRuntimeField) {
-			return fail(400, { message: 'Runtime fields must be whole numbers.' });
+			return fail(400, { runtimeMessage: 'Runtime fields must be whole numbers.' });
 		}
 
 		for (const [field, value] of [
@@ -126,7 +157,7 @@ export const actions: Actions = {
 		] as const) {
 			const result = validateRuntimeBounds(field, value);
 			if (!result.ok) {
-				return fail(400, { message: result.message });
+				return fail(400, { runtimeMessage: result.message });
 			}
 		}
 
@@ -136,9 +167,6 @@ export const actions: Actions = {
 				reconcileIntervalMinutes,
 				tmdbRefreshIntervalMinutes: tmdbRefreshIntervalMinutes ?? 0,
 				...(apiPort === undefined ? {} : { apiPort })
-			},
-			tv: {
-				shows: showNames
 			}
 		};
 
@@ -154,28 +182,24 @@ export const actions: Actions = {
 			});
 
 			if (!response.ok) {
-				let message = `Save failed (${response.status}).`;
+				let runtimeMessage = `Save failed (${response.status}).`;
 				try {
 					const body = (await response.json()) as { error?: string };
-					if (body.error) message = body.error;
+					if (body.error) runtimeMessage = body.error;
 				} catch {
 					// keep fallback message
 				}
-				return fail(response.status, {
-					message,
-					etag: response.headers.get('etag')
-				});
+				return fail(response.status, { runtimeMessage, runtimeEtag: response.headers.get('etag') });
 			}
 
 			return {
-				success: true,
-				message:
-					'Settings saved. TV show list updates apply on the next daemon run cycle. Restart the daemon to apply a new API port or timer intervals.',
-				etag: response.headers.get('etag')
+				runtimeSuccess: true,
+				message: 'Runtime settings saved.',
+				runtimeEtag: response.headers.get('etag')
 			};
 		} catch (error) {
-			console.error('[config] save failed:', error);
-			return fail(500, { message: 'Could not save settings.' });
+			console.error('[config] saveRuntime failed:', error);
+			return fail(500, { runtimeMessage: 'Could not save runtime settings.' });
 		}
 	},
 

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -97,7 +97,7 @@ export const actions: Actions = {
 					authorization: `Bearer ${writeToken}`,
 					'if-match': ifMatch
 				},
-				body: JSON.stringify({ tv: { shows: showNames } })
+				body: JSON.stringify({ runtime: {}, tv: { shows: showNames } })
 			});
 
 			if (!response.ok) {
@@ -134,6 +134,14 @@ export const actions: Actions = {
 			return fail(400, { runtimeMessage: 'Missing config revision. Reload and try again.' });
 		}
 
+		const currentShows = formData
+			.getAll('currentShow')
+			.map((v) => String(v).trim())
+			.filter(Boolean);
+		if (currentShows.length < 1) {
+			return fail(400, { runtimeMessage: 'Missing current TV shows. Reload and try again.' });
+		}
+
 		const runIntervalMinutes = parseOptionalInt(formData.get('runIntervalMinutes'));
 		const reconcileIntervalMinutes = parseOptionalInt(formData.get('reconcileIntervalMinutes'));
 		const tmdbRefreshIntervalMinutes = parseOptionalInt(formData.get('tmdbRefreshIntervalMinutes'));
@@ -167,7 +175,8 @@ export const actions: Actions = {
 				reconcileIntervalMinutes,
 				tmdbRefreshIntervalMinutes: tmdbRefreshIntervalMinutes ?? 0,
 				...(apiPort === undefined ? {} : { apiPort })
-			}
+			},
+			tv: { shows: currentShows }
 		};
 
 		try {

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -12,7 +12,13 @@
 
 	const { data, form }: { data: PageData; form?: ActionData } = $props();
 	const currentEtag = $derived(
-		form?.feedsEtag ?? form?.moviesEtag ?? form?.tvDefaultsEtag ?? form?.etag ?? data.etag ?? null
+		form?.feedsEtag ??
+			form?.moviesEtag ??
+			form?.tvDefaultsEtag ??
+			form?.showsEtag ??
+			form?.runtimeEtag ??
+			data.etag ??
+			null
 	);
 	const canWrite = $derived(data.canWrite);
 
@@ -617,12 +623,11 @@
 
 		<form
 			method="POST"
-			action="?/saveSettings"
+			action="?/saveShows"
 			use:enhance={() => {
 				return async ({ result, update }) => {
 					if (result.type === 'success') {
-						toast('Saved — restart the daemon for this change to take effect', 'success');
-						offerRestart();
+						toast('TV shows saved.', 'success');
 					} else if (result.type === 'failure') {
 						if (result.status === 409) {
 							toast('Config changed elsewhere — reload and try again', 'error');
@@ -677,8 +682,43 @@
 							Add show
 						</button>
 					</div>
+					{#if form?.showsMessage}
+						<p class="text-destructive text-xs">{form.showsMessage}</p>
+					{/if}
+					<div>
+						<button
+							type="submit"
+							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
+							disabled={!currentEtag}
+						>
+							Save shows
+						</button>
+					</div>
 				</CardContent>
 			</Card>
+		</form>
+
+		<form
+			method="POST"
+			action="?/saveRuntime"
+			use:enhance={() => {
+				return async ({ result, update }) => {
+					if (result.type === 'success') {
+						toast('Saved — restart the daemon for this change to take effect', 'success');
+						offerRestart();
+					} else if (result.type === 'failure') {
+						if (result.status === 409) {
+							toast('Config changed elsewhere — reload and try again', 'error');
+						} else {
+							toast('Save failed — see errors above', 'error');
+						}
+					}
+					await update();
+				};
+			}}
+			class="space-y-6"
+		>
+			<input type="hidden" name="runtimeIfMatch" value={currentEtag ?? ''} />
 
 			<Card>
 				<CardHeader class="pb-3">
@@ -751,16 +791,18 @@
 						</div>
 						<p class="text-muted-foreground text-xs">
 							Daemon timers and the API listen port are fixed at process start — restart after
-							changing those fields. TV show titles above apply on the next run cycle without
-							restart.
+							changing those fields.
 						</p>
+						{#if form?.runtimeMessage}
+							<p class="text-destructive text-xs">{form.runtimeMessage}</p>
+						{/if}
 						<div class="flex flex-wrap items-center gap-3">
 							<button
 								type="submit"
 								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium"
 								disabled={!currentEtag}
 							>
-								Save settings
+								Save runtime
 							</button>
 						</div>
 					</div>

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -689,7 +689,8 @@
 						<button
 							type="submit"
 							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
-							disabled={!currentEtag}
+							disabled={!canWrite || !currentEtag}
+							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
 						>
 							Save shows
 						</button>
@@ -719,6 +720,9 @@
 			class="space-y-6"
 		>
 			<input type="hidden" name="runtimeIfMatch" value={currentEtag ?? ''} />
+			{#each showRows as name}
+				<input type="hidden" name="currentShow" value={name} />
+			{/each}
 
 			<Card>
 				<CardHeader class="pb-3">
@@ -799,8 +803,9 @@
 						<div class="flex flex-wrap items-center gap-3">
 							<button
 								type="submit"
-								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium"
-								disabled={!currentEtag}
+								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
+								disabled={!canWrite || !currentEtag}
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
 							>
 								Save runtime
 							</button>

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -66,7 +66,8 @@ describe('/config', () => {
 		expect(screen.getByRole('heading', { name: 'Runtime' })).toBeInTheDocument();
 		expect(screen.getByText('TestFeed')).toBeInTheDocument();
 		expect(screen.getByDisplayValue('hd-tv')).toBeInTheDocument();
-		expect(screen.getByRole('button', { name: 'Save settings' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Save shows' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Save runtime' })).toBeInTheDocument();
 	});
 
 	it('renders error state when API is unreachable', () => {

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -65,7 +65,7 @@ describe('/config', () => {
 		expect(screen.getByRole('heading', { name: 'Transmission' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Runtime' })).toBeInTheDocument();
 		expect(screen.getByText('TestFeed')).toBeInTheDocument();
-		expect(screen.getByDisplayValue('hd-tv')).toBeInTheDocument();
+		expect(screen.getByRole('textbox', { name: 'TV show 1' })).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Save shows' })).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Save runtime' })).toBeInTheDocument();
 	});

--- a/web/src/routes/config/page.server.test.ts
+++ b/web/src/routes/config/page.server.test.ts
@@ -136,8 +136,8 @@ describe('config page server actions', () => {
 		});
 	});
 
-	describe('saveSettings', () => {
-		it('rejects out-of-scope fields before API call', async () => {
+	describe('saveShows', () => {
+		it('returns fail(400) when no show names provided', async () => {
 			vi.doMock('$env/dynamic/private', () => ({
 				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
 			}));
@@ -145,10 +145,8 @@ describe('config page server actions', () => {
 
 			const body = new URLSearchParams();
 			body.set('ifMatch', '"rev-1"');
-			body.set('runIntervalMinutes', '15');
-			body.set('feeds', '[]');
 
-			const result = await actions.saveSettings({
+			const result = await actions.saveShows({
 				request: new Request('http://localhost/config', {
 					method: 'POST',
 					headers: { 'content-type': 'application/x-www-form-urlencoded' },
@@ -157,22 +155,22 @@ describe('config page server actions', () => {
 			} as never);
 
 			expect((result as { status?: number }).status).toBe(400);
-			expect((result as { data?: { message?: string } }).data?.message).toContain('not allowed');
+			expect((result as { data?: { showsMessage?: string } }).data?.showsMessage).toContain(
+				'At least one TV show name is required'
+			);
 			expect(apiRequestMock).not.toHaveBeenCalled();
 		});
 
-		it('rejects out-of-range runtime values', async () => {
+		it('returns fail(400) when ifMatch is missing', async () => {
 			vi.doMock('$env/dynamic/private', () => ({
 				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
 			}));
 			const { actions } = await import('./+page.server');
 
 			const body = new URLSearchParams();
-			body.set('ifMatch', '"rev-1"');
 			body.set('showName', 'Test Show');
-			body.set('runIntervalMinutes', '0');
 
-			const result = await actions.saveSettings({
+			const result = await actions.saveShows({
 				request: new Request('http://localhost/config', {
 					method: 'POST',
 					headers: { 'content-type': 'application/x-www-form-urlencoded' },
@@ -181,10 +179,124 @@ describe('config page server actions', () => {
 			} as never);
 
 			expect((result as { status?: number }).status).toBe(400);
-			expect((result as { data?: { message?: string } }).data?.message).toContain(
+			expect((result as { data?: { showsMessage?: string } }).data?.showsMessage).toContain(
+				'Missing config revision'
+			);
+			expect(apiRequestMock).not.toHaveBeenCalled();
+		});
+
+		it('returns showsSuccess: true on happy path', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(null, { status: 200, headers: { etag: '"rev-2"' } })
+			);
+
+			const body = new URLSearchParams();
+			body.set('ifMatch', '"rev-1"');
+			body.set('showName', 'Breaking Bad');
+
+			const result = await actions.saveShows({
+				request: new Request('http://localhost/config', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { showsSuccess?: boolean }).showsSuccess).toBe(true);
+			expect((result as { showsEtag?: string }).showsEtag).toBe('"rev-2"');
+			expect(apiRequestMock).toHaveBeenCalledWith(
+				'/api/config',
+				expect.objectContaining({
+					method: 'PUT',
+					body: JSON.stringify({ tv: { shows: ['Breaking Bad'] } })
+				})
+			);
+		});
+	});
+
+	describe('saveRuntime', () => {
+		it('returns fail(400) when runtimeIfMatch is missing', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+
+			const body = new URLSearchParams();
+			body.set('runIntervalMinutes', '15');
+
+			const result = await actions.saveRuntime({
+				request: new Request('http://localhost/config', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(400);
+			expect((result as { data?: { runtimeMessage?: string } }).data?.runtimeMessage).toContain(
+				'Missing config revision'
+			);
+			expect(apiRequestMock).not.toHaveBeenCalled();
+		});
+
+		it('returns fail(400) on out-of-range runIntervalMinutes', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+
+			const body = new URLSearchParams();
+			body.set('runtimeIfMatch', '"rev-1"');
+			body.set('runIntervalMinutes', '0');
+
+			const result = await actions.saveRuntime({
+				request: new Request('http://localhost/config', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(400);
+			expect((result as { data?: { runtimeMessage?: string } }).data?.runtimeMessage).toContain(
 				'runIntervalMinutes'
 			);
 			expect(apiRequestMock).not.toHaveBeenCalled();
+		});
+
+		it('returns runtimeSuccess: true on happy path with ETag update', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(null, { status: 200, headers: { etag: '"rev-2"' } })
+			);
+
+			const body = new URLSearchParams();
+			body.set('runtimeIfMatch', '"rev-1"');
+			body.set('runIntervalMinutes', '30');
+			body.set('reconcileIntervalMinutes', '60');
+			body.set('tmdbRefreshIntervalMinutes', '0');
+
+			const result = await actions.saveRuntime({
+				request: new Request('http://localhost/config', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { runtimeSuccess?: boolean }).runtimeSuccess).toBe(true);
+			expect((result as { runtimeEtag?: string }).runtimeEtag).toBe('"rev-2"');
+			expect(apiRequestMock).toHaveBeenCalledWith(
+				'/api/config',
+				expect.objectContaining({ method: 'PUT' })
+			);
 		});
 	});
 

--- a/web/src/routes/config/page.server.test.ts
+++ b/web/src/routes/config/page.server.test.ts
@@ -212,7 +212,7 @@ describe('config page server actions', () => {
 				'/api/config',
 				expect.objectContaining({
 					method: 'PUT',
-					body: JSON.stringify({ tv: { shows: ['Breaking Bad'] } })
+					body: JSON.stringify({ runtime: {}, tv: { shows: ['Breaking Bad'] } })
 				})
 			);
 		});
@@ -252,6 +252,7 @@ describe('config page server actions', () => {
 			const body = new URLSearchParams();
 			body.set('runtimeIfMatch', '"rev-1"');
 			body.set('runIntervalMinutes', '0');
+			body.append('currentShow', 'Test Show');
 
 			const result = await actions.saveRuntime({
 				request: new Request('http://localhost/config', {
@@ -282,6 +283,8 @@ describe('config page server actions', () => {
 			body.set('runIntervalMinutes', '30');
 			body.set('reconcileIntervalMinutes', '60');
 			body.set('tmdbRefreshIntervalMinutes', '0');
+			body.append('currentShow', 'Breaking Bad');
+			body.append('currentShow', 'Better Call Saul');
 
 			const result = await actions.saveRuntime({
 				request: new Request('http://localhost/config', {
@@ -295,8 +298,36 @@ describe('config page server actions', () => {
 			expect((result as { runtimeEtag?: string }).runtimeEtag).toBe('"rev-2"');
 			expect(apiRequestMock).toHaveBeenCalledWith(
 				'/api/config',
-				expect.objectContaining({ method: 'PUT' })
+				expect.objectContaining({
+					method: 'PUT',
+					body: expect.stringContaining('"shows":["Breaking Bad","Better Call Saul"]')
+				})
 			);
+		});
+
+		it('returns fail(400) when no currentShow values provided', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+
+			const body = new URLSearchParams();
+			body.set('runtimeIfMatch', '"rev-1"');
+			body.set('runIntervalMinutes', '30');
+
+			const result = await actions.saveRuntime({
+				request: new Request('http://localhost/config', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(400);
+			expect((result as { data?: { runtimeMessage?: string } }).data?.runtimeMessage).toContain(
+				'Missing current TV shows'
+			);
+			expect(apiRequestMock).not.toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
## Summary

- delivery ticket: `P16.07 Runtime and TV Shows Split`
- ticket file: [docs/02-delivery/phase-16/ticket-07-runtime-tv-shows-split.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-16/ticket-07-runtime-tv-shows-split.md)
- stacked base branch: `agents/p16-06-movie-policy-card`

## External AI Review

- outcome: `patched`
- reviewed commit: [`4b860083a13b`](https://github.com/cesarnml/pirate_claw/commit/4b860083a13b1838eb39863782b3de2f7f0b5e40)
- current branch head: [`73eee72b8a8c`](https://github.com/cesarnml/pirate_claw/commit/73eee72b8a8c4df33aac426c98084fa7b0f0c46f)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `4b860083a13b` address all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] These `PUT /api/config` bodies no longer satisfy the backend contract. (native GitHub thread resolved) `web/src/routes/config/+page.server.ts:101` [thread](https://github.com/cesarnml/pirate_claw/pull/139#discussion_r3072693635)
- [coderabbit] Disable the new save actions when writes are unavailable. (native GitHub thread resolved) `web/src/routes/config/+page.svelte:695` [thread](https://github.com/cesarnml/pirate_claw/pull/139#discussion_r3072693638)
- [coderabbit] These happy-path mocks no longer match the real `/api/config` contract. (native GitHub thread resolved) `web/src/routes/config/page.server.test.ts:217` [thread](https://github.com/cesarnml/pirate_claw/pull/139#discussion_r3072693640)
