### PR TITLE
feat(web): add collapsible config cards and read-only audit [P16.08]

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -13,6 +13,7 @@
         "tw-animate-css": "^1.4.0",
       },
       "devDependencies": {
+        "@internationalized/date": "^3.12.0",
         "@sveltejs/adapter-node": "^5.2.12",
         "@sveltejs/kit": "^2.20.3",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "pirate-claw-web",
       "dependencies": {
+        "@internationalized/date": "^3.12.0",
         "@lucide/svelte": "^1.8.0",
         "bits-ui": "^2.17.3",
         "clsx": "^2.1.1",
@@ -13,7 +14,6 @@
         "tw-animate-css": "^1.4.0",
       },
       "devDependencies": {
-        "@internationalized/date": "^3.12.0",
         "@sveltejs/adapter-node": "^5.2.12",
         "@sveltejs/kit": "^2.20.3",
         "@sveltejs/vite-plugin-svelte": "^5.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
 		"test": "vitest run"
 	},
 	"devDependencies": {
+		"@internationalized/date": "^3.12.0",
 		"@sveltejs/adapter-node": "^5.2.12",
 		"@sveltejs/kit": "^2.20.3",
 		"@sveltejs/vite-plugin-svelte": "^5.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,6 @@
 		"test": "vitest run"
 	},
 	"devDependencies": {
-		"@internationalized/date": "^3.12.0",
 		"@sveltejs/adapter-node": "^5.2.12",
 		"@sveltejs/kit": "^2.20.3",
 		"@sveltejs/vite-plugin-svelte": "^5.0.3",
@@ -41,6 +40,7 @@
 		"vitest": "^3.1.1"
 	},
 	"dependencies": {
+		"@internationalized/date": "^3.12.0",
 		"@lucide/svelte": "^1.8.0",
 		"bits-ui": "^2.17.3",
 		"clsx": "^2.1.1",

--- a/web/src/lib/components/ui/accordion/accordion-content.svelte
+++ b/web/src/lib/components/ui/accordion/accordion-content.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { Accordion as AccordionPrimitive } from 'bits-ui';
+	import { cn, type WithoutChild } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithoutChild<AccordionPrimitive.ContentProps> = $props();
+</script>
+
+<AccordionPrimitive.Content
+	bind:ref
+	data-slot="accordion-content"
+	class="data-open:animate-accordion-down data-closed:animate-accordion-up overflow-hidden text-sm"
+	{...restProps}
+>
+	<div
+		class={cn(
+			'[&_a]:hover:text-foreground pt-0 pb-2.5 [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4',
+			className
+		)}
+	>
+		{@render children?.()}
+	</div>
+</AccordionPrimitive.Content>

--- a/web/src/lib/components/ui/accordion/accordion-content.svelte
+++ b/web/src/lib/components/ui/accordion/accordion-content.svelte
@@ -6,6 +6,7 @@
 		ref = $bindable(null),
 		class: className,
 		children,
+		style: styleValue,
 		...restProps
 	}: WithoutChild<AccordionPrimitive.ContentProps> = $props();
 </script>
@@ -14,6 +15,7 @@
 	bind:ref
 	data-slot="accordion-content"
 	class="data-open:animate-accordion-down data-closed:animate-accordion-up overflow-hidden text-sm"
+	style={`${styleValue ? `${styleValue}; ` : ''}--radix-accordion-content-height: var(--bits-accordion-content-height);`}
 	{...restProps}
 >
 	<div

--- a/web/src/lib/components/ui/accordion/accordion-item.svelte
+++ b/web/src/lib/components/ui/accordion/accordion-item.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Accordion as AccordionPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AccordionPrimitive.ItemProps = $props();
+</script>
+
+<AccordionPrimitive.Item
+	bind:ref
+	data-slot="accordion-item"
+	class={cn('not-last:border-b', className)}
+	{...restProps}
+/>

--- a/web/src/lib/components/ui/accordion/accordion-trigger.svelte
+++ b/web/src/lib/components/ui/accordion/accordion-trigger.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { Accordion as AccordionPrimitive } from 'bits-ui';
+	import { cn, type WithoutChild } from '$lib/utils.js';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+	import ChevronUpIcon from '@lucide/svelte/icons/chevron-up';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		level = 3,
+		children,
+		...restProps
+	}: WithoutChild<AccordionPrimitive.TriggerProps> & {
+		level?: AccordionPrimitive.HeaderProps['level'];
+	} = $props();
+</script>
+
+<AccordionPrimitive.Header {level} class="flex">
+	<AccordionPrimitive.Trigger
+		data-slot="accordion-trigger"
+		bind:ref
+		class={cn(
+			'focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground group/accordion-trigger relative flex flex-1 items-start justify-between rounded-lg border border-transparent py-2.5 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-3 disabled:pointer-events-none disabled:opacity-50 **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4',
+			className
+		)}
+		{...restProps}
+	>
+		{@render children?.()}
+		<ChevronDownIcon
+			data-slot="accordion-trigger-icon"
+			class="cn-accordion-trigger-icon pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
+		/>
+		<ChevronUpIcon
+			data-slot="accordion-trigger-icon"
+			class="cn-accordion-trigger-icon pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"
+		/>
+	</AccordionPrimitive.Trigger>
+</AccordionPrimitive.Header>

--- a/web/src/lib/components/ui/accordion/accordion.svelte
+++ b/web/src/lib/components/ui/accordion/accordion.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { Accordion as AccordionPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		class: className,
+		...restProps
+	}: AccordionPrimitive.RootProps = $props();
+</script>
+
+<AccordionPrimitive.Root
+	bind:ref
+	bind:value={value as never}
+	data-slot="accordion"
+	class={cn('cn-accordion flex w-full flex-col', className)}
+	{...restProps}
+/>

--- a/web/src/lib/components/ui/accordion/index.ts
+++ b/web/src/lib/components/ui/accordion/index.ts
@@ -1,0 +1,16 @@
+import Root from './accordion.svelte';
+import Content from './accordion-content.svelte';
+import Item from './accordion-item.svelte';
+import Trigger from './accordion-trigger.svelte';
+
+export {
+	Root,
+	Content,
+	Item,
+	Trigger,
+	//
+	Root as Accordion,
+	Content as AccordionContent,
+	Item as AccordionItem,
+	Trigger as AccordionTrigger
+};

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -6,6 +6,9 @@ export type WithElementRef<T, U extends HTMLElement = HTMLElement> = T & {
 	ref?: U | null;
 };
 
+/** Local helper for bits-ui wrappers that render children directly instead of using the `child` prop. */
+export type WithoutChild<T> = Omit<T, 'child'>;
+
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs));
 }

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
-	import { Card, CardContent, CardHeader } from '$lib/components/ui/card';
+	import {
+		Accordion,
+		AccordionContent,
+		AccordionItem,
+		AccordionTrigger
+	} from '$lib/components/ui/accordion';
 	import { toast } from '$lib/toast';
 	import type { ActionData, PageData } from './$types';
 	import type { FeedConfig } from '$lib/types';
@@ -40,6 +45,15 @@
 	let showRestartOffer = $state(false);
 	let restarting = $state(false);
 	let restartOfferId = $state<ReturnType<typeof setTimeout> | null>(null);
+
+	let accordionValue = $state<string[]>([
+		'feeds',
+		'tv-configuration',
+		'movie-policy',
+		'transmission',
+		'tv-shows',
+		'runtime'
+	]);
 
 	function offerRestart() {
 		showRestartOffer = true;
@@ -133,8 +147,7 @@
 
 <h1 class="text-3xl font-bold tracking-tight">Config</h1>
 <p class="text-muted-foreground mt-1 text-sm">
-	Effective configuration from the API (secrets redacted). Save applies TV show list and runtime
-	fields in one step.
+	Effective configuration from the API (secrets redacted).
 </p>
 
 {#if data.error}
@@ -145,591 +158,597 @@
 {:else if data.config}
 	{@const config = data.config}
 
-	<div class="mt-8 space-y-6 pr-1">
-		<form
-			method="POST"
-			action="?/saveFeeds"
-			use:enhance={() => {
-				feedsSubmitting = true;
-				return async ({ result, update }) => {
-					feedsSubmitting = false;
-					if (result.type === 'success') {
-						newFeedName = '';
-						newFeedUrl = '';
-						newFeedMediaType = 'tv';
-						toast('Saved', 'success');
-					} else if (result.type === 'failure') {
-						if (result.status === 409) {
-							toast('Config changed elsewhere — reload and try again', 'error');
-						} else {
-							toast('Save failed — see errors above', 'error');
+	<Accordion type="multiple" bind:value={accordionValue} class="mt-8 space-y-3 pr-1">
+		<!-- RSS Feeds -->
+		<AccordionItem value="feeds" class="border-border bg-card rounded-lg border px-4">
+			<form
+				method="POST"
+				action="?/saveFeeds"
+				use:enhance={() => {
+					feedsSubmitting = true;
+					return async ({ result, update }) => {
+						feedsSubmitting = false;
+						if (result.type === 'success') {
+							newFeedName = '';
+							newFeedUrl = '';
+							newFeedMediaType = 'tv';
+							toast('Saved', 'success');
+						} else if (result.type === 'failure') {
+							if (result.status === 409) {
+								toast('Config changed elsewhere — reload and try again', 'error');
+							} else {
+								toast('Save failed — see errors above', 'error');
+							}
 						}
-					}
-					await update();
-				};
-			}}
-			class="space-y-6"
-		>
-			<input type="hidden" name="feedsIfMatch" value={currentEtag ?? ''} />
-			<input type="hidden" name="existingFeedsJson" value={JSON.stringify(feedsList)} />
-			<Card>
-				<CardHeader class="pb-3">
-					<h2 class="text-lg font-semibold tracking-tight">Feeds</h2>
-				</CardHeader>
-				<CardContent class="space-y-4 pt-0">
-					{#if feedsList.length === 0}
-						<p class="text-muted-foreground text-sm">No feeds configured.</p>
-					{:else}
-						<ul class="list-none space-y-2">
-							{#each feedsList as feed, i}
-								<li
-									class="border-border bg-card/50 flex items-start justify-between gap-3 rounded-md border p-3 text-sm"
-								>
-									<div class="min-w-0 flex-1">
-										<div class="text-foreground font-medium">{feed.name}</div>
-										<div class="text-muted-foreground mt-1 flex flex-wrap items-center gap-2">
-											<span
-												class="border-border rounded-full border px-2 py-0.5 text-xs font-medium"
-												>{feed.mediaType}</span
-											>
-											<span class="break-all">{feed.url}</span>
-											{#if feed.pollIntervalMinutes !== undefined}
-												<span>Poll: {feed.pollIntervalMinutes}m</span>
-											{/if}
-										</div>
-									</div>
-									<button
-										type="button"
-										class="text-muted-foreground hover:text-foreground shrink-0 disabled:opacity-40"
-										disabled={!canWrite || feedsSubmitting}
-										aria-label="Remove feed {feed.name}"
-										onclick={() => removeFeed(i)}
+						await update();
+					};
+				}}
+			>
+				<input type="hidden" name="feedsIfMatch" value={currentEtag ?? ''} />
+				<input type="hidden" name="existingFeedsJson" value={JSON.stringify(feedsList)} />
+				<AccordionTrigger class="text-base font-semibold">RSS Feeds</AccordionTrigger>
+				<AccordionContent>
+					<div class="space-y-4 pb-4">
+						{#if feedsList.length === 0}
+							<p class="text-muted-foreground text-sm">No feeds configured.</p>
+						{:else}
+							<ul class="list-none space-y-2">
+								{#each feedsList as feed, i}
+									<li
+										class="border-border bg-card/50 flex items-start justify-between gap-3 rounded-md border p-3 text-sm"
 									>
-										×
-									</button>
-								</li>
-							{/each}
-						</ul>
-					{/if}
-					<div
-						class="border-border space-y-3 rounded-md border p-3"
-						title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-					>
-						<p class="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-							Add feed
-						</p>
-						<div class="grid gap-2">
-							<input
-								name="newFeedName"
-								type="text"
-								placeholder="Feed name"
-								bind:value={newFeedName}
-								disabled={!canWrite || feedsSubmitting}
-								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
-							/>
-							<div class="space-y-1">
+										<div class="min-w-0 flex-1">
+											<div class="text-foreground font-medium">{feed.name}</div>
+											<div class="text-muted-foreground mt-1 flex flex-wrap items-center gap-2">
+												<span
+													class="border-border rounded-full border px-2 py-0.5 text-xs font-medium"
+													>{feed.mediaType}</span
+												>
+												<span class="break-all">{feed.url}</span>
+												{#if feed.pollIntervalMinutes !== undefined}
+													<span>Poll: {feed.pollIntervalMinutes}m</span>
+												{/if}
+											</div>
+										</div>
+										<button
+											type="button"
+											class="text-muted-foreground hover:text-foreground shrink-0 disabled:opacity-40"
+											disabled={!canWrite || feedsSubmitting}
+											title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+											aria-label="Remove feed {feed.name}"
+											onclick={() => removeFeed(i)}
+										>
+											×
+										</button>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+						<div
+							class="border-border space-y-3 rounded-md border p-3"
+							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+						>
+							<p class="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+								Add feed
+							</p>
+							<div class="grid gap-2">
 								<input
-									name="newFeedUrl"
-									type="url"
-									placeholder="https://example.com/feed.rss"
-									bind:value={newFeedUrl}
+									name="newFeedName"
+									type="text"
+									placeholder="Feed name"
+									bind:value={newFeedName}
 									disabled={!canWrite || feedsSubmitting}
 									class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
 								/>
-								{#if form?.feedsUrlError}
-									<p class="text-destructive text-xs">{form.feedsUrlError}</p>
-								{/if}
+								<div class="space-y-1">
+									<input
+										name="newFeedUrl"
+										type="url"
+										placeholder="https://example.com/feed.rss"
+										bind:value={newFeedUrl}
+										disabled={!canWrite || feedsSubmitting}
+										class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+									/>
+									{#if form?.feedsUrlError}
+										<p class="text-destructive text-xs">{form.feedsUrlError}</p>
+									{/if}
+								</div>
+								<select
+									name="newFeedMediaType"
+									bind:value={newFeedMediaType}
+									disabled={!canWrite || feedsSubmitting}
+									class="border-input bg-background ring-offset-background focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+								>
+									<option value="tv">TV</option>
+									<option value="movie">Movie</option>
+								</select>
 							</div>
-							<select
-								name="newFeedMediaType"
-								bind:value={newFeedMediaType}
-								disabled={!canWrite || feedsSubmitting}
-								class="border-input bg-background ring-offset-background focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
-							>
-								<option value="tv">TV</option>
-								<option value="movie">Movie</option>
-							</select>
 						</div>
-					</div>
-					<div>
-						<button
-							type="submit"
-							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
-							disabled={!canWrite || !currentEtag || feedsSubmitting}
-							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-						>
-							{#if feedsSubmitting}
-								Saving…
-							{:else}
-								Save feeds
-							{/if}
-						</button>
-					</div>
-				</CardContent>
-			</Card>
-		</form>
-
-		<form
-			method="POST"
-			action="?/saveTvDefaults"
-			use:enhance={() => {
-				return async ({ result, update }) => {
-					if (result.type === 'success') {
-						toast('Saved', 'success');
-					} else if (result.type === 'failure') {
-						if (result.status === 409) {
-							toast('Config changed elsewhere — reload and try again', 'error');
-						} else {
-							toast('Save failed — see errors above', 'error');
-						}
-					}
-					await update();
-				};
-			}}
-			class="space-y-6"
-		>
-			<input type="hidden" name="tvDefaultsIfMatch" value={currentEtag ?? ''} />
-			{#each tvResolutions as res}
-				<input type="hidden" name="tvResolution" value={res} />
-			{/each}
-			{#each tvCodecs as codec}
-				<input type="hidden" name="tvCodec" value={codec} />
-			{/each}
-			<Card>
-				<CardHeader class="pb-3">
-					<h2 class="text-lg font-semibold tracking-tight">TV defaults</h2>
-				</CardHeader>
-				<CardContent class="space-y-4 pt-0">
-					<p class="text-muted-foreground text-sm">
-						Global resolution and codec defaults inherited by all TV shows.
-					</p>
-					<div class="space-y-2">
-						<p class="text-muted-foreground text-sm font-medium">Resolutions</p>
-						<div
-							class="flex flex-wrap gap-2"
-							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-						>
-							{#each ALL_RESOLUTIONS as res}
-								<button
-									type="button"
-									class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {tvResolutions.includes(
-										res
-									)
-										? 'bg-primary text-primary-foreground border-primary'
-										: 'border-border text-muted-foreground hover:bg-muted'}"
-									disabled={!canWrite}
-									onclick={() => toggleResolution(res)}
-								>
-									{res}
-								</button>
-							{/each}
-						</div>
-					</div>
-					<div class="space-y-2">
-						<p class="text-muted-foreground text-sm font-medium">Codecs</p>
-						<div
-							class="flex flex-wrap gap-2"
-							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-						>
-							{#each ALL_CODECS as codec}
-								<button
-									type="button"
-									class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {tvCodecs.includes(
-										codec
-									)
-										? 'bg-primary text-primary-foreground border-primary'
-										: 'border-border text-muted-foreground hover:bg-muted'}"
-									disabled={!canWrite}
-									onclick={() => toggleCodec(codec)}
-								>
-									{codec}
-								</button>
-							{/each}
-						</div>
-					</div>
-					<div>
-						<button
-							type="submit"
-							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
-							disabled={!canWrite || !currentEtag}
-							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-						>
-							Save TV defaults
-						</button>
-					</div>
-				</CardContent>
-			</Card>
-		</form>
-
-		<form
-			method="POST"
-			action="?/saveMovies"
-			use:enhance={() => {
-				return async ({ result, update }) => {
-					if (result.type === 'success') {
-						toast('Saved', 'success');
-					} else if (result.type === 'failure') {
-						if (result.status === 409) {
-							toast('Config changed elsewhere — reload and try again', 'error');
-						} else {
-							const detail =
-								typeof result.data?.moviesMessage === 'string'
-									? result.data.moviesMessage
-									: undefined;
-							toast('Save failed — see errors above', 'error', detail);
-						}
-					}
-					await update();
-				};
-			}}
-			class="space-y-6"
-		>
-			<input type="hidden" name="moviesIfMatch" value={currentEtag ?? ''} />
-			{#each movieYears as year}
-				<input type="hidden" name="movieYear" value={year} />
-			{/each}
-			{#each movieResolutions as res}
-				<input type="hidden" name="movieResolution" value={res} />
-			{/each}
-			{#each movieCodecs as codec}
-				<input type="hidden" name="movieCodec" value={codec} />
-			{/each}
-			<input type="hidden" name="movieCodecPolicy" value={movieCodecPolicy} />
-			<Card>
-				<CardHeader class="pb-3">
-					<h2 class="text-lg font-semibold tracking-tight">Movies</h2>
-				</CardHeader>
-				<CardContent class="space-y-4 pt-0">
-					<div class="space-y-2">
-						<p class="text-muted-foreground text-sm font-medium">Years</p>
-						<div class="flex flex-wrap gap-2">
-							{#each movieYears as year}
-								<span
-									class="border-border bg-card/50 inline-flex h-8 items-center gap-1 rounded-full border px-3 text-sm"
-								>
-									{year}
-									<button
-										type="button"
-										class="text-muted-foreground hover:text-foreground ml-1"
-										disabled={!canWrite}
-										aria-label="Remove year {year}"
-										onclick={() => removeMovieYear(year)}>×</button
-									>
-								</span>
-							{/each}
-						</div>
-						<div class="flex gap-2" title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}>
-							<input
-								type="number"
-								min="1900"
-								max="2100"
-								step="1"
-								placeholder="e.g. 2025"
-								bind:value={movieYearInput}
-								disabled={!canWrite}
-								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-32 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
-								onkeydown={(e) => {
-									if (e.key === 'Enter') {
-										e.preventDefault();
-										addMovieYear();
-									}
-								}}
-							/>
+						<div>
 							<button
-								type="button"
-								class="border-border bg-card hover:bg-muted/50 inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-50"
-								disabled={!canWrite}
-								onclick={addMovieYear}
+								type="submit"
+								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
+								disabled={!canWrite || !currentEtag || feedsSubmitting}
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
 							>
-								Add year
+								{#if feedsSubmitting}
+									Saving…
+								{:else}
+									Save feeds
+								{/if}
 							</button>
 						</div>
 					</div>
-					<div class="space-y-2">
-						<p class="text-muted-foreground text-sm font-medium">Resolutions</p>
-						<div
-							class="flex flex-wrap gap-2"
-							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-						>
-							{#each ALL_RESOLUTIONS as res}
-								<button
-									type="button"
-									class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {movieResolutions.includes(
-										res
-									)
-										? 'bg-primary text-primary-foreground border-primary'
-										: 'border-border text-muted-foreground hover:bg-muted'}"
-									disabled={!canWrite}
-									onclick={() => toggleMovieResolution(res)}
-								>
-									{res}
-								</button>
-							{/each}
-						</div>
-					</div>
-					<div class="space-y-2">
-						<p class="text-muted-foreground text-sm font-medium">Codecs</p>
-						<div
-							class="flex flex-wrap gap-2"
-							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-						>
-							{#each ALL_CODECS as codec}
-								<button
-									type="button"
-									class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {movieCodecs.includes(
-										codec
-									)
-										? 'bg-primary text-primary-foreground border-primary'
-										: 'border-border text-muted-foreground hover:bg-muted'}"
-									disabled={!canWrite}
-									onclick={() => toggleMovieCodec(codec)}
-								>
-									{codec}
-								</button>
-							{/each}
-						</div>
-					</div>
-					<div class="space-y-2">
-						<p class="text-muted-foreground text-sm font-medium">Codec policy</p>
-						<div
-							class="flex gap-0 overflow-hidden rounded-md border"
-							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-						>
-							{#each ['prefer', 'require'] as policy}
-								<button
-									type="button"
-									class="flex-1 px-4 py-2 text-sm font-medium transition-colors {movieCodecPolicy ===
-									policy
-										? 'bg-primary text-primary-foreground'
-										: 'text-muted-foreground hover:bg-muted'}"
-									disabled={!canWrite}
-									onclick={() => {
-										movieCodecPolicy = policy as 'prefer' | 'require';
-									}}
-								>
-									{policy.charAt(0).toUpperCase() + policy.slice(1)}
-								</button>
-							{/each}
-						</div>
-					</div>
-					<div>
-						<button
-							type="submit"
-							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
-							disabled={!canWrite || !currentEtag}
-							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-						>
-							Save movies policy
-						</button>
-					</div>
-				</CardContent>
-			</Card>
-		</form>
+				</AccordionContent>
+			</form>
+		</AccordionItem>
 
-		<Card>
-			<CardHeader class="pb-3">
-				<div class="flex items-center gap-2">
+		<!-- TV Configuration (defaults) -->
+		<AccordionItem value="tv-configuration" class="border-border bg-card rounded-lg border px-4">
+			<form
+				method="POST"
+				action="?/saveTvDefaults"
+				use:enhance={() => {
+					return async ({ result, update }) => {
+						if (result.type === 'success') {
+							toast('Saved', 'success');
+						} else if (result.type === 'failure') {
+							if (result.status === 409) {
+								toast('Config changed elsewhere — reload and try again', 'error');
+							} else {
+								toast('Save failed — see errors above', 'error');
+							}
+						}
+						await update();
+					};
+				}}
+			>
+				<input type="hidden" name="tvDefaultsIfMatch" value={currentEtag ?? ''} />
+				{#each tvResolutions as res}
+					<input type="hidden" name="tvResolution" value={res} />
+				{/each}
+				{#each tvCodecs as codec}
+					<input type="hidden" name="tvCodec" value={codec} />
+				{/each}
+				<AccordionTrigger class="text-base font-semibold">TV Configuration</AccordionTrigger>
+				<AccordionContent>
+					<div class="space-y-4 pb-4">
+						<p class="text-muted-foreground text-sm">
+							Global resolution and codec defaults inherited by all TV shows.
+						</p>
+						<div class="space-y-2">
+							<p class="text-muted-foreground text-sm font-medium">Resolutions</p>
+							<div
+								class="flex flex-wrap gap-2"
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								{#each ALL_RESOLUTIONS as res}
+									<button
+										type="button"
+										class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {tvResolutions.includes(
+											res
+										)
+											? 'bg-primary text-primary-foreground border-primary'
+											: 'border-border text-muted-foreground hover:bg-muted'}"
+										disabled={!canWrite}
+										onclick={() => toggleResolution(res)}
+									>
+										{res}
+									</button>
+								{/each}
+							</div>
+						</div>
+						<div class="space-y-2">
+							<p class="text-muted-foreground text-sm font-medium">Codecs</p>
+							<div
+								class="flex flex-wrap gap-2"
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								{#each ALL_CODECS as codec}
+									<button
+										type="button"
+										class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {tvCodecs.includes(
+											codec
+										)
+											? 'bg-primary text-primary-foreground border-primary'
+											: 'border-border text-muted-foreground hover:bg-muted'}"
+										disabled={!canWrite}
+										onclick={() => toggleCodec(codec)}
+									>
+										{codec}
+									</button>
+								{/each}
+							</div>
+						</div>
+						<div>
+							<button
+								type="submit"
+								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
+								disabled={!canWrite || !currentEtag}
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								Save TV defaults
+							</button>
+						</div>
+					</div>
+				</AccordionContent>
+			</form>
+		</AccordionItem>
+
+		<!-- Movie Policy -->
+		<AccordionItem value="movie-policy" class="border-border bg-card rounded-lg border px-4">
+			<form
+				method="POST"
+				action="?/saveMovies"
+				use:enhance={() => {
+					return async ({ result, update }) => {
+						if (result.type === 'success') {
+							toast('Saved', 'success');
+						} else if (result.type === 'failure') {
+							if (result.status === 409) {
+								toast('Config changed elsewhere — reload and try again', 'error');
+							} else {
+								const detail =
+									typeof result.data?.moviesMessage === 'string'
+										? result.data.moviesMessage
+										: undefined;
+								toast('Save failed — see errors above', 'error', detail);
+							}
+						}
+						await update();
+					};
+				}}
+			>
+				<input type="hidden" name="moviesIfMatch" value={currentEtag ?? ''} />
+				{#each movieYears as year}
+					<input type="hidden" name="movieYear" value={year} />
+				{/each}
+				{#each movieResolutions as res}
+					<input type="hidden" name="movieResolution" value={res} />
+				{/each}
+				{#each movieCodecs as codec}
+					<input type="hidden" name="movieCodec" value={codec} />
+				{/each}
+				<input type="hidden" name="movieCodecPolicy" value={movieCodecPolicy} />
+				<AccordionTrigger class="text-base font-semibold">Movie Policy</AccordionTrigger>
+				<AccordionContent>
+					<div class="space-y-4 pb-4">
+						<div class="space-y-2">
+							<p class="text-muted-foreground text-sm font-medium">Years</p>
+							<div class="flex flex-wrap gap-2">
+								{#each movieYears as year}
+									<span
+										class="border-border bg-card/50 inline-flex h-8 items-center gap-1 rounded-full border px-3 text-sm"
+									>
+										{year}
+										<button
+											type="button"
+											class="text-muted-foreground hover:text-foreground ml-1"
+											disabled={!canWrite}
+											title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+											aria-label="Remove year {year}"
+											onclick={() => removeMovieYear(year)}>×</button
+										>
+									</span>
+								{/each}
+							</div>
+							<div class="flex gap-2" title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}>
+								<input
+									type="number"
+									min="1900"
+									max="2100"
+									step="1"
+									placeholder="e.g. 2025"
+									bind:value={movieYearInput}
+									disabled={!canWrite}
+									class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-32 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+									onkeydown={(e) => {
+										if (e.key === 'Enter') {
+											e.preventDefault();
+											addMovieYear();
+										}
+									}}
+								/>
+								<button
+									type="button"
+									class="border-border bg-card hover:bg-muted/50 inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-50"
+									disabled={!canWrite}
+									onclick={addMovieYear}
+								>
+									Add year
+								</button>
+							</div>
+						</div>
+						<div class="space-y-2">
+							<p class="text-muted-foreground text-sm font-medium">Resolutions</p>
+							<div
+								class="flex flex-wrap gap-2"
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								{#each ALL_RESOLUTIONS as res}
+									<button
+										type="button"
+										class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {movieResolutions.includes(
+											res
+										)
+											? 'bg-primary text-primary-foreground border-primary'
+											: 'border-border text-muted-foreground hover:bg-muted'}"
+										disabled={!canWrite}
+										onclick={() => toggleMovieResolution(res)}
+									>
+										{res}
+									</button>
+								{/each}
+							</div>
+						</div>
+						<div class="space-y-2">
+							<p class="text-muted-foreground text-sm font-medium">Codecs</p>
+							<div
+								class="flex flex-wrap gap-2"
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								{#each ALL_CODECS as codec}
+									<button
+										type="button"
+										class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {movieCodecs.includes(
+											codec
+										)
+											? 'bg-primary text-primary-foreground border-primary'
+											: 'border-border text-muted-foreground hover:bg-muted'}"
+										disabled={!canWrite}
+										onclick={() => toggleMovieCodec(codec)}
+									>
+										{codec}
+									</button>
+								{/each}
+							</div>
+						</div>
+						<div class="space-y-2">
+							<p class="text-muted-foreground text-sm font-medium">Codec policy</p>
+							<div
+								class="flex gap-0 overflow-hidden rounded-md border"
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								{#each ['prefer', 'require'] as policy}
+									<button
+										type="button"
+										class="flex-1 px-4 py-2 text-sm font-medium transition-colors {movieCodecPolicy ===
+										policy
+											? 'bg-primary text-primary-foreground'
+											: 'text-muted-foreground hover:bg-muted'}"
+										disabled={!canWrite}
+										onclick={() => {
+											movieCodecPolicy = policy as 'prefer' | 'require';
+										}}
+									>
+										{policy.charAt(0).toUpperCase() + policy.slice(1)}
+									</button>
+								{/each}
+							</div>
+						</div>
+						<div>
+							<button
+								type="submit"
+								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
+								disabled={!canWrite || !currentEtag}
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								Save movies policy
+							</button>
+						</div>
+					</div>
+				</AccordionContent>
+			</form>
+		</AccordionItem>
+
+		<!-- Transmission -->
+		<AccordionItem value="transmission" class="border-border bg-card rounded-lg border px-4">
+			<AccordionTrigger class="text-base font-semibold">
+				<span class="flex items-center gap-2">
 					<span
 						class="inline-block h-2 w-2 rounded-full {data.transmissionSession
 							? 'bg-green-500'
 							: 'bg-red-500'}"
 						aria-label={data.transmissionSession ? 'connected' : 'disconnected'}
 					></span>
-					<h2 class="text-lg font-semibold tracking-tight">Transmission</h2>
-				</div>
-				{#if data.transmissionSession}
-					<p class="text-muted-foreground text-xs">
-						Transmission {data.transmissionSession.version}
-					</p>
-				{/if}
-			</CardHeader>
-			<CardContent class="space-y-4 pt-0">
-				<dl class="grid gap-2 text-sm">
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">URL:</dt>
-						<dd class="text-foreground">{config.transmission.url}</dd>
-					</div>
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">Username:</dt>
-						<dd class="text-foreground">
-							{config.transmission.username ? '[configured]' : '[not set]'}
-						</dd>
-					</div>
-					<div class="flex flex-wrap gap-2">
-						<dt class="text-muted-foreground">Password:</dt>
-						<dd class="text-foreground">
-							{config.transmission.password ? '[redacted]' : '[not set]'}
-						</dd>
-					</div>
-					{#if config.transmission.downloadDir}
-						<div class="flex flex-wrap gap-2">
-							<dt class="text-muted-foreground">Download dir:</dt>
-							<dd class="text-foreground">{config.transmission.downloadDir}</dd>
-						</div>
-					{/if}
-					{#if config.transmission.downloadDirs}
-						{#if config.transmission.downloadDirs.tv}
-							<div class="flex flex-wrap gap-2">
-								<dt class="text-muted-foreground">TV dir:</dt>
-								<dd class="text-foreground">{config.transmission.downloadDirs.tv}</dd>
-							</div>
-						{/if}
-						{#if config.transmission.downloadDirs.movie}
-							<div class="flex flex-wrap gap-2">
-								<dt class="text-muted-foreground">Movie dir:</dt>
-								<dd class="text-foreground">{config.transmission.downloadDirs.movie}</dd>
-							</div>
-						{/if}
-					{/if}
-				</dl>
-				<p class="text-muted-foreground text-xs">
-					Edit credentials in <code class="font-mono">.env</code>
-				</p>
-				<form
-					method="POST"
-					action="?/testConnection"
-					use:enhance={() => {
-						testingConnection = true;
-						return async ({ result, update }) => {
-							testingConnection = false;
-							if (result.type === 'success') {
-								const version = (result.data as { version?: string })?.version ?? '';
-								toast(`Transmission reachable — version ${version}`, 'success');
-							} else if (result.type === 'failure') {
-								const pingError = (result.data as { pingError?: string })?.pingError;
-								toast(
-									pingError ?? 'Transmission unreachable — check .env credentials and host',
-									'error'
-								);
-							}
-							await update({ reset: false });
-						};
-					}}
-				>
-					<button
-						type="submit"
-						class="border-border bg-card hover:bg-muted/50 inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-50"
-						disabled={testingConnection}
-					>
-						{#if testingConnection}
-							Checking…
-						{:else}
-							Test Connection
-						{/if}
-					</button>
-				</form>
-			</CardContent>
-		</Card>
-
-		<form
-			method="POST"
-			action="?/saveShows"
-			use:enhance={() => {
-				return async ({ result, update }) => {
-					if (result.type === 'success') {
-						toast('TV shows saved.', 'success');
-					} else if (result.type === 'failure') {
-						if (result.status === 409) {
-							toast('Config changed elsewhere — reload and try again', 'error');
-						} else {
-							toast('Save failed — see errors above', 'error');
-						}
-					}
-					await update();
-				};
-			}}
-			class="space-y-6"
-		>
-			<input type="hidden" name="ifMatch" value={currentEtag ?? ''} />
-
-			<Card>
-				<CardHeader class="pb-3">
-					<h2 class="text-lg font-semibold tracking-tight">TV shows</h2>
-				</CardHeader>
-				<CardContent class="space-y-4 pt-0">
-					<p class="text-muted-foreground text-sm">
-						Each row is a tracked show title (inherits codec/resolution defaults from your config
-						file). Remove the last show by removing the feed instead.
-					</p>
-					<ul class="list-none space-y-3">
-						{#each showRows as name, i}
-							<li class="flex flex-wrap items-center gap-2">
-								<input
-									name="showName"
-									type="text"
-									value={name}
-									autocomplete="off"
-									aria-label={`TV show ${i + 1}`}
-									class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring min-w-[12rem] flex-1 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-									oninput={(e) => updateShowName(i, e.currentTarget.value)}
-								/>
-								<button
-									type="button"
-									class="border-border text-muted-foreground hover:bg-muted inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border text-sm font-medium"
-									disabled={showRows.length <= 1}
-									aria-label="Remove show"
-									onclick={() => removeShow(i)}>×</button
-								>
-							</li>
-						{/each}
-					</ul>
-					<div>
-						<button
-							type="button"
-							class="border-border bg-card hover:bg-muted/50 inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium"
-							onclick={addShow}
+					Transmission
+					{#if data.transmissionSession}
+						<span class="text-muted-foreground text-xs font-normal"
+							>v{data.transmissionSession.version}</span
 						>
-							Add show
-						</button>
-					</div>
-					{#if form?.showsMessage}
-						<p class="text-destructive text-xs">{form.showsMessage}</p>
 					{/if}
-					<div>
+				</span>
+			</AccordionTrigger>
+			<AccordionContent>
+				<div class="space-y-4 pb-4">
+					<dl class="grid gap-2 text-sm">
+						<div class="flex flex-wrap gap-2">
+							<dt class="text-muted-foreground">URL:</dt>
+							<dd class="text-foreground">{config.transmission.url}</dd>
+						</div>
+						<div class="flex flex-wrap gap-2">
+							<dt class="text-muted-foreground">Username:</dt>
+							<dd class="text-foreground">
+								{config.transmission.username ? '[configured]' : '[not set]'}
+							</dd>
+						</div>
+						<div class="flex flex-wrap gap-2">
+							<dt class="text-muted-foreground">Password:</dt>
+							<dd class="text-foreground">
+								{config.transmission.password ? '[redacted]' : '[not set]'}
+							</dd>
+						</div>
+						{#if config.transmission.downloadDir}
+							<div class="flex flex-wrap gap-2">
+								<dt class="text-muted-foreground">Download dir:</dt>
+								<dd class="text-foreground">{config.transmission.downloadDir}</dd>
+							</div>
+						{/if}
+						{#if config.transmission.downloadDirs}
+							{#if config.transmission.downloadDirs.tv}
+								<div class="flex flex-wrap gap-2">
+									<dt class="text-muted-foreground">TV dir:</dt>
+									<dd class="text-foreground">{config.transmission.downloadDirs.tv}</dd>
+								</div>
+							{/if}
+							{#if config.transmission.downloadDirs.movie}
+								<div class="flex flex-wrap gap-2">
+									<dt class="text-muted-foreground">Movie dir:</dt>
+									<dd class="text-foreground">{config.transmission.downloadDirs.movie}</dd>
+								</div>
+							{/if}
+						{/if}
+					</dl>
+					<p class="text-muted-foreground text-xs">
+						Edit credentials in <code class="font-mono">.env</code>
+					</p>
+					<form
+						method="POST"
+						action="?/testConnection"
+						use:enhance={() => {
+							testingConnection = true;
+							return async ({ result, update }) => {
+								testingConnection = false;
+								if (result.type === 'success') {
+									const version = (result.data as { version?: string })?.version ?? '';
+									toast(`Transmission reachable — version ${version}`, 'success');
+								} else if (result.type === 'failure') {
+									const pingError = (result.data as { pingError?: string })?.pingError;
+									toast(
+										pingError ?? 'Transmission unreachable — check .env credentials and host',
+										'error'
+									);
+								}
+								await update({ reset: false });
+							};
+						}}
+					>
 						<button
 							type="submit"
-							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
-							disabled={!canWrite || !currentEtag}
-							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							class="border-border bg-card hover:bg-muted/50 inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-50"
+							disabled={testingConnection}
 						>
-							Save shows
+							{#if testingConnection}
+								Checking…
+							{:else}
+								Test Connection
+							{/if}
 						</button>
-					</div>
-				</CardContent>
-			</Card>
-		</form>
+					</form>
+				</div>
+			</AccordionContent>
+		</AccordionItem>
 
-		<form
-			method="POST"
-			action="?/saveRuntime"
-			use:enhance={() => {
-				return async ({ result, update }) => {
-					if (result.type === 'success') {
-						toast('Saved — restart the daemon for this change to take effect', 'success');
-						offerRestart();
-					} else if (result.type === 'failure') {
-						if (result.status === 409) {
-							toast('Config changed elsewhere — reload and try again', 'error');
-						} else {
-							toast('Save failed — see errors above', 'error');
+		<!-- TV Shows -->
+		<AccordionItem value="tv-shows" class="border-border bg-card rounded-lg border px-4">
+			<form
+				method="POST"
+				action="?/saveShows"
+				use:enhance={() => {
+					return async ({ result, update }) => {
+						if (result.type === 'success') {
+							toast('TV shows saved.', 'success');
+						} else if (result.type === 'failure') {
+							if (result.status === 409) {
+								toast('Config changed elsewhere — reload and try again', 'error');
+							} else {
+								toast('Save failed — see errors above', 'error');
+							}
 						}
-					}
-					await update();
-				};
-			}}
-			class="space-y-6"
-		>
-			<input type="hidden" name="runtimeIfMatch" value={currentEtag ?? ''} />
-			{#each showRows as name}
-				<input type="hidden" name="currentShow" value={name} />
-			{/each}
+						await update();
+					};
+				}}
+			>
+				<input type="hidden" name="ifMatch" value={currentEtag ?? ''} />
+				<AccordionTrigger class="text-base font-semibold">TV Shows</AccordionTrigger>
+				<AccordionContent>
+					<div class="space-y-4 pb-4">
+						<p class="text-muted-foreground text-sm">
+							Each row is a tracked show title (inherits codec/resolution defaults from your config
+							file). Remove the last show by removing the feed instead.
+						</p>
+						<ul class="list-none space-y-3">
+							{#each showRows as name, i}
+								<li class="flex flex-wrap items-center gap-2">
+									<input
+										name="showName"
+										type="text"
+										value={name}
+										autocomplete="off"
+										aria-label={`TV show ${i + 1}`}
+										disabled={!canWrite}
+										title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+										class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring min-w-[12rem] flex-1 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+										oninput={(e) => updateShowName(i, e.currentTarget.value)}
+									/>
+									<button
+										type="button"
+										class="border-border text-muted-foreground hover:bg-muted inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border text-sm font-medium disabled:opacity-50"
+										disabled={!canWrite || showRows.length <= 1}
+										title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+										aria-label="Remove show"
+										onclick={() => removeShow(i)}>×</button
+									>
+								</li>
+							{/each}
+						</ul>
+						<div>
+							<button
+								type="button"
+								class="border-border bg-card hover:bg-muted/50 inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-50"
+								disabled={!canWrite}
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+								onclick={addShow}
+							>
+								Add show
+							</button>
+						</div>
+						{#if form?.showsMessage}
+							<p class="text-destructive text-xs">{form.showsMessage}</p>
+						{/if}
+						<div>
+							<button
+								type="submit"
+								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
+								disabled={!canWrite || !currentEtag}
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								Save shows
+							</button>
+						</div>
+					</div>
+				</AccordionContent>
+			</form>
+		</AccordionItem>
 
-			<Card>
-				<CardHeader class="pb-3">
-					<h2 class="text-lg font-semibold tracking-tight">Runtime</h2>
-				</CardHeader>
-				<CardContent class="pt-0">
-					<div class="grid gap-4 text-sm">
+		<!-- Runtime -->
+		<AccordionItem value="runtime" class="border-border bg-card rounded-lg border px-4">
+			<form
+				method="POST"
+				action="?/saveRuntime"
+				use:enhance={() => {
+					return async ({ result, update }) => {
+						if (result.type === 'success') {
+							toast('Saved — restart the daemon for this change to take effect', 'success');
+							offerRestart();
+						} else if (result.type === 'failure') {
+							if (result.status === 409) {
+								toast('Config changed elsewhere — reload and try again', 'error');
+							} else {
+								toast('Save failed — see errors above', 'error');
+							}
+						}
+						await update();
+					};
+				}}
+			>
+				<input type="hidden" name="runtimeIfMatch" value={currentEtag ?? ''} />
+				{#each showRows as name}
+					<input type="hidden" name="currentShow" value={name} />
+				{/each}
+				<AccordionTrigger class="text-base font-semibold">Runtime</AccordionTrigger>
+				<AccordionContent>
+					<div class="grid gap-4 pb-4 text-sm">
 						<div class="grid gap-1">
 							<label class="text-muted-foreground" for="runIntervalMinutes"
 								>Run interval (minutes)</label
@@ -741,7 +760,9 @@
 								min="1"
 								step="1"
 								value={config.runtime.runIntervalMinutes}
-								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+								disabled={!canWrite}
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
 							/>
 						</div>
 
@@ -756,7 +777,9 @@
 								min="1"
 								step="1"
 								value={config.runtime.reconcileIntervalMinutes}
-								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+								disabled={!canWrite}
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
 							/>
 						</div>
 
@@ -771,7 +794,9 @@
 								min="0"
 								step="1"
 								value={config.runtime.tmdbRefreshIntervalMinutes ?? 0}
-								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+								disabled={!canWrite}
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
 							/>
 						</div>
 
@@ -786,7 +811,9 @@
 								step="1"
 								value={config.runtime.apiPort ?? ''}
 								placeholder="unset"
-								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+								disabled={!canWrite}
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
 							/>
 						</div>
 
@@ -811,45 +838,47 @@
 							</button>
 						</div>
 					</div>
-				</CardContent>
-			</Card>
-		</form>
-
-		{#if showRestartOffer}
-			<form
-				method="POST"
-				action="?/restartDaemon"
-				use:enhance={() => {
-					restarting = true;
-					return async ({ result, update }) => {
-						showRestartOffer = false;
-						restarting = false;
-						if (result.type === 'success') {
-							toast('Restarting… the page may become temporarily unavailable', 'success');
-						} else {
-							toast('Restart failed — try again or restart manually', 'error');
-						}
-						await update({ reset: false });
-					};
-				}}
-			>
-				<div class="border-border bg-card/50 flex items-center gap-3 rounded-md border p-3 text-sm">
-					<p class="text-muted-foreground flex-1">
-						Restart the daemon for your changes to take effect.
-					</p>
-					<button
-						type="submit"
-						class="border-border hover:bg-muted inline-flex h-8 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-50"
-						disabled={restarting}
-					>
-						{#if restarting}
-							Restarting…
-						{:else}
-							Restart Daemon
-						{/if}
-					</button>
-				</div>
+				</AccordionContent>
 			</form>
-		{/if}
-	</div>
+		</AccordionItem>
+	</Accordion>
+
+	{#if showRestartOffer}
+		<form
+			method="POST"
+			action="?/restartDaemon"
+			class="mt-3 pr-1"
+			use:enhance={() => {
+				restarting = true;
+				return async ({ result, update }) => {
+					showRestartOffer = false;
+					restarting = false;
+					if (result.type === 'success') {
+						toast('Restarting… the page may become temporarily unavailable', 'success');
+					} else {
+						toast('Restart failed — try again or restart manually', 'error');
+					}
+					await update({ reset: false });
+				};
+			}}
+		>
+			<div class="border-border bg-card/50 flex items-center gap-3 rounded-md border p-3 text-sm">
+				<p class="text-muted-foreground flex-1">
+					Restart the daemon for your changes to take effect.
+				</p>
+				<button
+					type="submit"
+					class="border-border hover:bg-muted inline-flex h-8 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-50"
+					disabled={!canWrite || restarting}
+					title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+				>
+					{#if restarting}
+						Restarting…
+					{:else}
+						Restart Daemon
+					{/if}
+				</button>
+			</div>
+		</form>
+	{/if}
 {/if}

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -59,11 +59,12 @@ describe('/config', () => {
 			},
 			form: undefined
 		});
-		expect(screen.getByRole('heading', { name: 'Feeds' })).toBeInTheDocument();
-		expect(screen.getByRole('heading', { name: 'TV shows' })).toBeInTheDocument();
-		expect(screen.getByRole('heading', { name: 'Movies' })).toBeInTheDocument();
-		expect(screen.getByRole('heading', { name: 'Transmission' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'RSS Feeds' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'TV Configuration' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Movie Policy' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'TV Shows' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Runtime' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: /Transmission/ })).toBeInTheDocument();
 		expect(screen.getByText('TestFeed')).toBeInTheDocument();
 		expect(screen.getByRole('textbox', { name: 'TV show 1' })).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Save shows' })).toBeInTheDocument();
@@ -134,5 +135,66 @@ describe('/config', () => {
 			form: undefined
 		});
 		expect(screen.queryByRole('button', { name: /restart daemon/i })).not.toBeInTheDocument();
+	});
+
+	it('renders all accordion items open on load', () => {
+		render(Page, {
+			data: {
+				config: mockConfig,
+				error: null,
+				etag: '"rev-1"',
+				canWrite: true,
+				transmissionSession: null
+			},
+			form: undefined
+		});
+
+		expect(screen.getByRole('button', { name: 'RSS Feeds' })).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
+		expect(screen.getByRole('button', { name: 'TV Configuration' })).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
+		expect(screen.getByRole('button', { name: 'Movie Policy' })).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
+		expect(screen.getByRole('button', { name: /Transmission/ })).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
+		expect(screen.getByRole('button', { name: 'TV Shows' })).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
+		expect(screen.getByRole('button', { name: 'Runtime' })).toHaveAttribute(
+			'aria-expanded',
+			'true'
+		);
+	});
+
+	it('disables all write controls in read-only mode but keeps Test Connection enabled', () => {
+		render(Page, {
+			data: {
+				config: mockConfig,
+				error: null,
+				etag: '"rev-1"',
+				canWrite: false,
+				transmissionSession: null
+			},
+			form: undefined
+		});
+
+		expect(screen.getByRole('button', { name: 'Save feeds' })).toBeDisabled();
+		expect(screen.getByRole('button', { name: 'Save TV defaults' })).toBeDisabled();
+		expect(screen.getByRole('button', { name: 'Save movies policy' })).toBeDisabled();
+		expect(screen.getByRole('button', { name: 'Save shows' })).toBeDisabled();
+		expect(screen.getByRole('button', { name: 'Save runtime' })).toBeDisabled();
+		expect(screen.getByRole('button', { name: 'Add show' })).toBeDisabled();
+		expect(screen.getByRole('textbox', { name: 'TV show 1' })).toBeDisabled();
+		expect(screen.getByRole('spinbutton', { name: 'Run interval (minutes)' })).toBeDisabled();
+		expect(screen.getByRole('button', { name: 'Test Connection' })).toBeEnabled();
 	});
 });


### PR DESCRIPTION
## Summary

- delivery ticket: `P16.08 Collapsible Cards and Read-Only Audit`
- ticket file: [docs/02-delivery/phase-16/ticket-08-collapsible-cards-readonly.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-16/ticket-08-collapsible-cards-readonly.md)
- stacked base branch: `agents/p16-07-runtime-and-tv-shows-split`
- post-verify self-audit: completed at 2026-04-13 13:02 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`bf7ac122ebe6`](https://github.com/cesarnml/pirate_claw/commit/bf7ac122ebe6adb15cfbba46b1338b3611ec2920)
- current branch head: [`ab714d238585`](https://github.com/cesarnml/pirate_claw/commit/ab714d23858570b436c34404f693cf7eef3004bb)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `bf7ac122ebe6` address all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Move `@internationalized/date` to `dependencies`. (native GitHub thread resolved) `web/package.json:18` [thread](https://github.com/cesarnml/pirate_claw/pull/140#discussion_r3073202169)
- [coderabbit] Critical: Accordion animations require CSS variable configuration to function (native GitHub thread resolved) `web/src/lib/components/ui/accordion/accordion-content.svelte:27` [thread](https://github.com/cesarnml/pirate_claw/pull/140#discussion_r3073202185)
