### PR TITLE
fix(delivery): enforce conventional PR title fallback

### DIFF
--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -475,6 +475,12 @@ describe('delivery orchestrator', () => {
         title: 'Reconcile Torrent Lifecycle From Transmission',
       }),
     ).toBe('feat: reconcile torrent lifecycle from transmission [P3.02]');
+    expect(
+      buildPullRequestTitle(
+        { id: 'P16.03', title: 'Transmission Card' },
+        'P16.03 Transmission Card',
+      ),
+    ).toBe('feat: transmission card [P16.03]');
   });
 
   it('resolves the notifier from Telegram env vars', () => {

--- a/tools/delivery/pr-metadata.ts
+++ b/tools/delivery/pr-metadata.ts
@@ -976,12 +976,21 @@ export function buildPullRequestTitle(
   commitSubject?: string,
 ): string {
   const fallbackSubject = `feat: ${ticket.title.toLowerCase()}`;
-  const baseSubject = (commitSubject?.trim() || fallbackSubject).replace(
+  const normalizedSubject = (commitSubject?.trim() || '').replace(
     /\s+\[[A-Z0-9.]+\]$/,
     '',
   );
+  const baseSubject = isConventionalCommitSubject(normalizedSubject)
+    ? normalizedSubject
+    : fallbackSubject;
 
   return `${baseSubject} [${ticket.id}]`;
+}
+
+function isConventionalCommitSubject(subject: string): boolean {
+  return /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?!?:\s+\S/.test(
+    subject,
+  );
 }
 
 export function updatePullRequestBody(


### PR DESCRIPTION
## Summary
- guard `buildPullRequestTitle` so malformed non-Conventional-Commit subjects cannot leak into PR titles
- fall back to a ticket-derived `feat:` title when the input subject is invalid
- add a regression test using the bare `P16.03 Transmission Card` shape seen in the Phase 16 stack

<!-- ai-review:start -->
## External AI Review

- outcome: `clean`
- reviewed commit: [`2f704621fc06`](https://github.com/cesarnml/pirate_claw/commit/2f704621fc066ed317ea229878c18c265866ce6e)
- current branch head: [`2f704621fc06`](https://github.com/cesarnml/pirate_claw/commit/2f704621fc066ed317ea229878c18c265866ce6e)
- vendors: `coderabbit`
<!-- ai-review:end -->
