### PR TITLE
feat(delivery): add boundary mode plumbing and visibility [EE7.01]

### DIFF
--- a/docs/02-delivery/engineering-epic-07/ticket-01-boundary-policy-plumbing-and-visibility.md
+++ b/docs/02-delivery/engineering-epic-07/ticket-01-boundary-policy-plumbing-and-visibility.md
@@ -52,7 +52,11 @@ Behavioral constraint for this ticket:
 
 ## Rationale
 
-To be filled during implementation if behavior or trade-offs shift.
+Boundary mode is resolved at run start from repo config plus an optional CLI
+override, then surfaced through the existing `_config` path instead of being
+persisted into delivery state. That keeps EE7.01 plumbing-only: status and
+current-ticket output can report the effective mode for the active run without
+changing stored ticket state or boundary semantics yet.
 
 ## Notes
 

--- a/tools/delivery/cli.ts
+++ b/tools/delivery/cli.ts
@@ -6,6 +6,7 @@ export type ParsedCliArgs = {
   flags: Set<string>;
   planPath?: string;
   prNumber?: number;
+  boundaryMode?: 'cook' | 'gated' | 'glide';
 };
 
 export function getUsage(runDeliverInvocation: string): string {
@@ -26,12 +27,16 @@ export function getUsage(runDeliverInvocation: string): string {
     '  record-review <ticket-id> <clean|patched|operator_input_needed> [note]',
     '  advance',
     '  restack [ticket-id]',
+    '',
+    'Options:',
+    '  --boundary-mode <cook|gated|glide>',
   ].join('\n');
 }
 
 export function parseCliArgs(argv: string[], usage: string): ParsedCliArgs {
   let planPath: string | undefined;
   let prNumber: number | undefined;
+  let boundaryMode: ParsedCliArgs['boundaryMode'];
   const flags = new Set<string>();
   const positionals: string[] = [];
 
@@ -52,6 +57,18 @@ export function parseCliArgs(argv: string[], usage: string): ParsedCliArgs {
       }
 
       prNumber = Number(rawNumber);
+      index += 1;
+      continue;
+    }
+
+    if (value === '--boundary-mode') {
+      const rawMode = argv[index + 1];
+
+      if (rawMode !== 'cook' && rawMode !== 'gated' && rawMode !== 'glide') {
+        throw new Error('Pass --boundary-mode <cook|gated|glide>.');
+      }
+
+      boundaryMode = rawMode;
       index += 1;
       continue;
     }
@@ -82,6 +99,7 @@ export function parseCliArgs(argv: string[], usage: string): ParsedCliArgs {
     flags,
     planPath,
     prNumber,
+    boundaryMode,
   };
 }
 

--- a/tools/delivery/cli.ts
+++ b/tools/delivery/cli.ts
@@ -1,3 +1,4 @@
+import { VALID_TICKET_BOUNDARY_MODES, type TicketBoundaryMode } from './config';
 import type { OrchestratorOptions } from './orchestrator';
 
 export type ParsedCliArgs = {
@@ -6,8 +7,12 @@ export type ParsedCliArgs = {
   flags: Set<string>;
   planPath?: string;
   prNumber?: number;
-  boundaryMode?: 'cook' | 'gated' | 'glide';
+  boundaryMode?: TicketBoundaryMode;
 };
+
+function isValidBoundaryMode(mode: unknown): mode is TicketBoundaryMode {
+  return VALID_TICKET_BOUNDARY_MODES.includes(mode as TicketBoundaryMode);
+}
 
 export function getUsage(runDeliverInvocation: string): string {
   return [
@@ -64,8 +69,16 @@ export function parseCliArgs(argv: string[], usage: string): ParsedCliArgs {
     if (value === '--boundary-mode') {
       const rawMode = argv[index + 1];
 
-      if (rawMode !== 'cook' && rawMode !== 'gated' && rawMode !== 'glide') {
-        throw new Error('Pass --boundary-mode <cook|gated|glide>.');
+      if (rawMode === undefined) {
+        throw new Error(
+          `Missing value for --boundary-mode; pass one of <${VALID_TICKET_BOUNDARY_MODES.join('|')}>.`,
+        );
+      }
+
+      if (!isValidBoundaryMode(rawMode)) {
+        throw new Error(
+          `Pass --boundary-mode <${VALID_TICKET_BOUNDARY_MODES.join('|')}>.`,
+        );
       }
 
       boundaryMode = rawMode;

--- a/tools/delivery/config.ts
+++ b/tools/delivery/config.ts
@@ -7,6 +7,7 @@ export type OrchestratorConfig = {
   planRoot?: string;
   runtime?: 'bun' | 'node';
   packageManager?: 'bun' | 'npm' | 'pnpm' | 'yarn';
+  ticketBoundaryMode?: 'cook' | 'gated' | 'glide';
 };
 
 export type ResolvedOrchestratorConfig = {
@@ -14,10 +15,12 @@ export type ResolvedOrchestratorConfig = {
   planRoot: string;
   runtime: 'bun' | 'node';
   packageManager: 'bun' | 'npm' | 'pnpm' | 'yarn';
+  ticketBoundaryMode: 'cook' | 'gated' | 'glide';
 };
 
 const VALID_RUNTIMES = ['bun', 'node'] as const;
 const VALID_PACKAGE_MANAGERS = ['bun', 'npm', 'pnpm', 'yarn'] as const;
+const VALID_TICKET_BOUNDARY_MODES = ['cook', 'gated', 'glide'] as const;
 
 export async function loadOrchestratorConfig(
   cwd: string,
@@ -53,6 +56,17 @@ export async function loadOrchestratorConfig(
     );
   }
 
+  if (
+    raw.ticketBoundaryMode !== undefined &&
+    !VALID_TICKET_BOUNDARY_MODES.includes(
+      raw.ticketBoundaryMode as (typeof VALID_TICKET_BOUNDARY_MODES)[number],
+    )
+  ) {
+    throw new Error(
+      `Invalid ticketBoundaryMode "${String(raw.ticketBoundaryMode)}" in orchestrator.config.json. Expected: ${VALID_TICKET_BOUNDARY_MODES.join(', ')}`,
+    );
+  }
+
   const defaultBranch = optionalNonBlankString(
     raw.defaultBranch,
     'defaultBranch',
@@ -69,6 +83,8 @@ export async function loadOrchestratorConfig(
     planRoot,
     runtime: raw.runtime as OrchestratorConfig['runtime'],
     packageManager: raw.packageManager as OrchestratorConfig['packageManager'],
+    ticketBoundaryMode:
+      raw.ticketBoundaryMode as OrchestratorConfig['ticketBoundaryMode'],
   };
 }
 
@@ -91,6 +107,7 @@ export function resolveOrchestratorConfig(
     planRoot: raw.planRoot?.trim() || 'docs',
     runtime: raw.runtime ?? 'bun',
     packageManager: raw.packageManager ?? inferPackageManager(cwd),
+    ticketBoundaryMode: raw.ticketBoundaryMode ?? 'cook',
   };
 }
 

--- a/tools/delivery/config.ts
+++ b/tools/delivery/config.ts
@@ -2,12 +2,16 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
+export const VALID_TICKET_BOUNDARY_MODES = ['cook', 'gated', 'glide'] as const;
+
+export type TicketBoundaryMode = (typeof VALID_TICKET_BOUNDARY_MODES)[number];
+
 export type OrchestratorConfig = {
   defaultBranch?: string;
   planRoot?: string;
   runtime?: 'bun' | 'node';
   packageManager?: 'bun' | 'npm' | 'pnpm' | 'yarn';
-  ticketBoundaryMode?: 'cook' | 'gated' | 'glide';
+  ticketBoundaryMode?: TicketBoundaryMode;
 };
 
 export type ResolvedOrchestratorConfig = {
@@ -15,12 +19,11 @@ export type ResolvedOrchestratorConfig = {
   planRoot: string;
   runtime: 'bun' | 'node';
   packageManager: 'bun' | 'npm' | 'pnpm' | 'yarn';
-  ticketBoundaryMode: 'cook' | 'gated' | 'glide';
+  ticketBoundaryMode: TicketBoundaryMode;
 };
 
 const VALID_RUNTIMES = ['bun', 'node'] as const;
 const VALID_PACKAGE_MANAGERS = ['bun', 'npm', 'pnpm', 'yarn'] as const;
-const VALID_TICKET_BOUNDARY_MODES = ['cook', 'gated', 'glide'] as const;
 
 export async function loadOrchestratorConfig(
   cwd: string,

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -55,8 +55,10 @@ import {
   syncStateWithPlan,
   runProcessResult,
   formatCurrentTicketStatus,
+  formatStatus,
   type DeliveryState,
 } from './orchestrator';
+import { getUsage, parseCliArgs } from './cli';
 import { advanceToNextTicket } from './ticket-flow';
 import { normalizeDeliveryStateFromPersisted } from './state';
 import { resolveNativeReviewThreads } from './review';
@@ -114,6 +116,66 @@ describe('delivery orchestrator', () => {
       reviewPollIntervalMinutes: 6,
       reviewPollMaxWaitMinutes: 12,
     });
+  });
+
+  it('parses boundary-mode CLI override', () => {
+    const parsed = parseCliArgs(
+      [
+        '--plan',
+        'docs/02-delivery/phase-03/implementation-plan.md',
+        '--boundary-mode',
+        'gated',
+        'status',
+      ],
+      getUsage('bun run deliver'),
+    );
+
+    expect(parsed).toEqual({
+      command: 'status',
+      positionals: [],
+      flags: new Set<string>(),
+      planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+      prNumber: undefined,
+      boundaryMode: 'gated',
+    });
+  });
+
+  it('rejects invalid boundary-mode CLI override', () => {
+    expect(() =>
+      parseCliArgs(
+        [
+          '--plan',
+          'docs/02-delivery/phase-03/implementation-plan.md',
+          '--boundary-mode',
+          'sprint',
+          'status',
+        ],
+        getUsage('bun run deliver'),
+      ),
+    ).toThrow(/Pass --boundary-mode <cook\|gated\|glide>/);
+  });
+
+  it('formats status with the effective boundary mode', () => {
+    initOrchestratorConfig({
+      defaultBranch: 'main',
+      planRoot: 'docs',
+      runtime: 'bun',
+      packageManager: 'bun',
+      ticketBoundaryMode: 'glide',
+    });
+
+    expect(
+      formatStatus({
+        planKey: 'engineering-epic-07',
+        planPath: 'docs/02-delivery/engineering-epic-07/implementation-plan.md',
+        statePath: '.agents/delivery/engineering-epic-07/state.json',
+        reviewsDirPath: '.agents/delivery/engineering-epic-07/reviews',
+        handoffsDirPath: '.agents/delivery/engineering-epic-07/handoffs',
+        reviewPollIntervalMinutes: 6,
+        reviewPollMaxWaitMinutes: 12,
+        tickets: [],
+      }),
+    ).toContain('boundary_mode=glide');
   });
 
   it('syncs state while preserving runtime metadata and inferred branch chaining', () => {
@@ -3352,6 +3414,7 @@ describe('delivery orchestrator', () => {
           planRoot: undefined,
           runtime: 'node',
           packageManager: undefined,
+          ticketBoundaryMode: undefined,
         });
       } finally {
         await rm(tempDir, { recursive: true });
@@ -3384,6 +3447,22 @@ describe('delivery orchestrator', () => {
 
         await expect(loadOrchestratorConfig(tempDir)).rejects.toThrow(
           /Invalid packageManager "cargo"/,
+        );
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
+    it('throws on invalid ticketBoundaryMode value', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-cfg-'));
+      try {
+        await writeFile(
+          join(tempDir, 'orchestrator.config.json'),
+          JSON.stringify({ ticketBoundaryMode: 'sprint' }),
+        );
+
+        await expect(loadOrchestratorConfig(tempDir)).rejects.toThrow(
+          /Invalid ticketBoundaryMode "sprint"/,
         );
       } finally {
         await rm(tempDir, { recursive: true });
@@ -3460,6 +3539,7 @@ describe('delivery orchestrator', () => {
           planRoot: 'docs',
           runtime: 'bun',
           packageManager: 'npm',
+          ticketBoundaryMode: 'cook',
         });
       } finally {
         await rm(tempDir, { recursive: true });
@@ -3477,6 +3557,20 @@ describe('delivery orchestrator', () => {
         expect(resolved.planRoot).toBe('specifications');
         expect(resolved.runtime).toBe('bun');
         expect(resolved.packageManager).toBe('npm');
+        expect(resolved.ticketBoundaryMode).toBe('cook');
+      } finally {
+        await rm(tempDir, { recursive: true });
+      }
+    });
+
+    it('preserves configured ticketBoundaryMode when resolving config', async () => {
+      const tempDir = await mkdtemp(join(tmpdir(), 'orch-cfg-resolve-'));
+      try {
+        const resolved = resolveOrchestratorConfig(
+          { ticketBoundaryMode: 'gated' },
+          tempDir,
+        );
+        expect(resolved.ticketBoundaryMode).toBe('gated');
       } finally {
         await rm(tempDir, { recursive: true });
       }
@@ -3537,6 +3631,7 @@ describe('delivery orchestrator', () => {
         planRoot: 'docs',
         runtime: 'bun',
         packageManager: 'bun',
+        ticketBoundaryMode: 'cook',
       });
 
       try {
@@ -3565,6 +3660,7 @@ describe('delivery orchestrator', () => {
           planRoot: 'docs',
           runtime: 'bun',
           packageManager: 'bun',
+          ticketBoundaryMode: 'cook',
         });
       }
     });
@@ -3582,6 +3678,7 @@ describe('delivery orchestrator', () => {
       planRoot: 'docs',
       runtime: 'node',
       packageManager: 'bun',
+      ticketBoundaryMode: 'cook',
     });
 
     try {
@@ -3597,6 +3694,7 @@ describe('delivery orchestrator', () => {
         planRoot: 'docs',
         runtime: 'bun',
         packageManager: 'bun',
+        ticketBoundaryMode: 'cook',
       });
     }
   });

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -155,6 +155,19 @@ describe('delivery orchestrator', () => {
     ).toThrow(/Pass --boundary-mode <cook\|gated\|glide>/);
   });
 
+  it('rejects missing boundary-mode CLI value with a specific error', () => {
+    expect(() =>
+      parseCliArgs(
+        [
+          '--plan',
+          'docs/02-delivery/phase-03/implementation-plan.md',
+          '--boundary-mode',
+        ],
+        getUsage('bun run deliver'),
+      ),
+    ).toThrow(/Missing value for --boundary-mode/);
+  });
+
   it('formats status with the effective boundary mode', () => {
     initOrchestratorConfig({
       defaultBranch: 'main',

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -237,6 +237,7 @@ let _config: ResolvedOrchestratorConfig = {
   planRoot: 'docs',
   runtime: 'bun',
   packageManager: 'npm',
+  ticketBoundaryMode: 'cook',
 };
 
 export function initOrchestratorConfig(
@@ -443,19 +444,27 @@ export async function runDeliveryOrchestrator(
         flags: Set<string>;
         planPath?: string;
         prNumber?: number;
+        boundaryMode?: 'cook' | 'gated' | 'glide';
       }
     | undefined;
 
   try {
     const rawConfig = await loadOrchestratorConfig(cwd);
-    _config = resolveOrchestratorConfig(rawConfig, cwd);
-
     await ensureEnvReady(cwd);
-    const notifier = resolveNotifier();
     const usage = getUsage(
-      generateRunDeliverInvocation(_config.packageManager),
+      generateRunDeliverInvocation(
+        resolveOrchestratorConfig(rawConfig, cwd).packageManager,
+      ),
     );
     parsed = parseCliArgs(argv, usage);
+    _config = resolveOrchestratorConfig(
+      {
+        ...rawConfig,
+        ticketBoundaryMode: parsed.boundaryMode ?? rawConfig.ticketBoundaryMode,
+      },
+      cwd,
+    );
+    const notifier = resolveNotifier();
     if (parsed.command === 'ai-review') {
       const result = await runStandaloneAiReview(
         cwd,
@@ -1362,6 +1371,7 @@ export function formatStatus(state: DeliveryState): string {
     `handoffs=${state.handoffsDirPath}`,
     `review_poll_interval_minutes=${state.reviewPollIntervalMinutes}`,
     `review_poll_max_wait_minutes=${state.reviewPollMaxWaitMinutes}`,
+    `boundary_mode=${_config.ticketBoundaryMode}`,
     '',
     ...state.tickets.map((ticket) =>
       [
@@ -1417,6 +1427,7 @@ export function formatCurrentTicketStatus(
     'Delivery Orchestrator',
     `plan_key=${state.planKey}`,
     `plan=${state.planPath}`,
+    `boundary_mode=${_config.ticketBoundaryMode}`,
   ].join('\n');
 
   if (!ticket) {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -8,6 +8,7 @@ import {
   resolveOrchestratorConfig as resolveOrchestratorConfigImpl,
   type OrchestratorConfig,
   type ResolvedOrchestratorConfig,
+  type TicketBoundaryMode,
 } from './config';
 import {
   addWorktree as addPlatformWorktree,
@@ -444,7 +445,7 @@ export async function runDeliveryOrchestrator(
         flags: Set<string>;
         planPath?: string;
         prNumber?: number;
-        boundaryMode?: 'cook' | 'gated' | 'glide';
+        boundaryMode?: TicketBoundaryMode;
       }
     | undefined;
 


### PR DESCRIPTION
## Summary

- delivery ticket: `EE7.01 Boundary policy plumbing and visibility`
- ticket file: [docs/02-delivery/engineering-epic-07/ticket-01-boundary-policy-plumbing-and-visibility.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/engineering-epic-07/ticket-01-boundary-policy-plumbing-and-visibility.md)
- stacked base branch: `main`
- post-verify self-audit: completed at 2026-04-13 14:37 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`19e9445b4a88`](https://github.com/cesarnml/pirate_claw/commit/19e9445b4a88842d8a32063fabfdf72340b07dd5)
- current branch head: [`7047075b73da`](https://github.com/cesarnml/pirate_claw/commit/7047075b73da2432344b5ac361fb1ab12d686b52)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `19e9445b4a88` address all findings from that review.
- vendors: `coderabbit`

### Resolved Review Findings

- [coderabbit] Ensure spellcheck passes before committing. (native GitHub thread resolved) `docs/02-delivery/engineering-epic-07/ticket-01-boundary-policy-plumbing-and-visibility.md:59` [thread](https://github.com/cesarnml/pirate_claw/pull/144#discussion_r3073760055)
