### PR TITLE
feat(delivery): add gated boundary reset guidance [EE7.02]

### DIFF
--- a/docs/02-delivery/engineering-epic-07/ticket-02-gated-boundary-semantics-and-resume-prompt.md
+++ b/docs/02-delivery/engineering-epic-07/ticket-02-gated-boundary-semantics-and-resume-prompt.md
@@ -55,7 +55,11 @@ state; the operator should not have to compose it manually.
 
 ## Rationale
 
-To be filled during implementation if behavior or trade-offs shift.
+The gated reset text now lives in `formatAdvanceBoundaryGuidance(state,
+nextState)` and is only emitted when the effective mode is `gated`. That keeps
+EE7.02 focused on the operator/agent output contract while preserving EE6's
+existing `advanceToNextTicket` behavior and `start`-owned handoff creation for
+the next slice.
 
 ## Notes
 

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -55,6 +55,7 @@ import {
   syncStateWithPlan,
   runProcessResult,
   formatCurrentTicketStatus,
+  formatAdvanceBoundaryGuidance,
   formatStatus,
   type DeliveryState,
 } from './orchestrator';
@@ -3861,6 +3862,94 @@ describe('delivery orchestrator', () => {
           updatePullRequestBody: () => {},
         }),
       ).rejects.toThrow('No reviewed ticket is ready to advance.');
+    });
+  });
+
+  describe('formatAdvanceBoundaryGuidance (EE7 gated output)', () => {
+    const baseState: DeliveryState = {
+      planKey: 'engineering-epic-07',
+      planPath: 'docs/02-delivery/engineering-epic-07/implementation-plan.md',
+      statePath: '.agents/delivery/engineering-epic-07/state.json',
+      reviewsDirPath: '.agents/delivery/engineering-epic-07/reviews',
+      handoffsDirPath: '.agents/delivery/engineering-epic-07/handoffs',
+      reviewPollIntervalMinutes: 6,
+      reviewPollMaxWaitMinutes: 12,
+      tickets: [
+        {
+          id: 'EE7.01',
+          title: 'Boundary policy plumbing and visibility',
+          slug: 'boundary-policy-plumbing-and-visibility',
+          ticketFile:
+            'docs/02-delivery/engineering-epic-07/ticket-01-boundary-policy-plumbing-and-visibility.md',
+          status: 'reviewed',
+          branch: 'agents/ee7-01-boundary-policy-plumbing-and-visibility',
+          baseBranch: 'main',
+          worktreePath: '/tmp/ee7_01',
+          reviewOutcome: 'patched',
+        },
+        {
+          id: 'EE7.02',
+          title: 'Gated boundary semantics and resume prompt',
+          slug: 'gated-boundary-semantics-and-resume-prompt',
+          ticketFile:
+            'docs/02-delivery/engineering-epic-07/ticket-02-gated-boundary-semantics-and-resume-prompt.md',
+          status: 'pending',
+          branch: 'agents/ee7-02-gated-boundary-semantics-and-resume-prompt',
+          baseBranch: 'agents/ee7-01-boundary-policy-plumbing-and-visibility',
+          worktreePath: '/tmp/ee7_02',
+        },
+      ],
+    };
+
+    it('emits gated reset guidance and the canonical resume prompt', () => {
+      initOrchestratorConfig({
+        defaultBranch: 'main',
+        planRoot: 'docs',
+        runtime: 'bun',
+        packageManager: 'bun',
+        ticketBoundaryMode: 'gated',
+      });
+
+      const nextState: DeliveryState = {
+        ...baseState,
+        tickets: baseState.tickets.map((ticket) =>
+          ticket.id === 'EE7.01'
+            ? { ...ticket, status: 'done' as const }
+            : ticket,
+        ),
+      };
+
+      const output = formatAdvanceBoundaryGuidance(baseState, nextState);
+
+      expect(output).toContain('context_reset_required=true');
+      expect(output).toContain('GATED BOUNDARY before starting EE7.02.');
+      expect(output).toContain('Prefer /clear for minimum token use');
+      expect(output).toContain(
+        'resume_prompt=Immediately execute `bun run deliver --plan docs/02-delivery/engineering-epic-07/implementation-plan.md start`, read the generated handoff artifact as the source of truth for context, and implement EE7.02.',
+      );
+    });
+
+    it('emits no boundary guidance outside gated mode', () => {
+      initOrchestratorConfig({
+        defaultBranch: 'main',
+        planRoot: 'docs',
+        runtime: 'bun',
+        packageManager: 'bun',
+        ticketBoundaryMode: 'cook',
+      });
+
+      const nextState: DeliveryState = {
+        ...baseState,
+        tickets: baseState.tickets.map((ticket) =>
+          ticket.id === 'EE7.01'
+            ? { ...ticket, status: 'done' as const }
+            : ticket,
+        ),
+      };
+
+      expect(formatAdvanceBoundaryGuidance(baseState, nextState)).toBe(
+        undefined,
+      );
     });
   });
 

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -652,28 +652,14 @@ export async function runDeliveryOrchestrator(
         const nextState = await advanceToNextTicketImpl(state, cwd);
         await saveState(cwd, nextState);
         console.log(formatStatus(nextState));
-
-        const nextPending = nextState.tickets.find(
-          (t) =>
-            t.status === 'pending' &&
-            state.tickets.find((prev) => prev.id === t.id)?.status ===
-              'pending',
-        );
-        const justDone = nextState.tickets.find(
-          (t) =>
-            t.status === 'done' &&
-            state.tickets.find((prev) => prev.id === t.id)?.status !== 'done',
+        const boundaryGuidance = formatAdvanceBoundaryGuidance(
+          state,
+          nextState,
         );
 
-        if (justDone && nextPending) {
+        if (boundaryGuidance) {
           console.log('');
-          console.log('compaction_required=true');
-          console.log(
-            `CONTEXT COMPACTION REQUIRED before starting ${nextPending.id}.`,
-          );
-          console.log(
-            `Call /compact or equivalent now. Then run: ${generateRunDeliverInvocation(_config.packageManager)} --plan ${state.planPath} start`,
-          );
+          console.log(boundaryGuidance);
         }
 
         await emitNotificationWarnings(
@@ -1404,6 +1390,40 @@ export function formatStatus(state: DeliveryState): string {
         .filter((value): value is string => value !== undefined)
         .join('\n'),
     ),
+  ].join('\n');
+}
+
+export function formatAdvanceBoundaryGuidance(
+  state: DeliveryState,
+  nextState: DeliveryState,
+): string | undefined {
+  const nextPending = nextState.tickets.find(
+    (t) =>
+      t.status === 'pending' &&
+      state.tickets.find((prev) => prev.id === t.id)?.status === 'pending',
+  );
+  const justDone = nextState.tickets.find(
+    (t) =>
+      t.status === 'done' &&
+      state.tickets.find((prev) => prev.id === t.id)?.status !== 'done',
+  );
+
+  if (!justDone || !nextPending) {
+    return undefined;
+  }
+
+  if (_config.ticketBoundaryMode !== 'gated') {
+    return undefined;
+  }
+
+  const invocation = `${generateRunDeliverInvocation(_config.packageManager)} --plan ${state.planPath} start`;
+  const resumePrompt = `Immediately execute \`${invocation}\`, read the generated handoff artifact as the source of truth for context, and implement ${nextPending.id}.`;
+
+  return [
+    'context_reset_required=true',
+    `GATED BOUNDARY before starting ${nextPending.id}.`,
+    'Reset context now. Prefer /clear for minimum token use; use /compact only if you intentionally want compressed carry-forward context.',
+    `resume_prompt=${resumePrompt}`,
   ].join('\n');
 }
 


### PR DESCRIPTION
## Summary

- delivery ticket: `EE7.02 Gated boundary semantics and resume prompt`
- ticket file: [docs/02-delivery/engineering-epic-07/ticket-02-gated-boundary-semantics-and-resume-prompt.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/engineering-epic-07/ticket-02-gated-boundary-semantics-and-resume-prompt.md)
- stacked base branch: `agents/ee7-01-boundary-policy-plumbing-and-visibility`
- post-verify self-audit: completed at 2026-04-13 14:54 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`a9b3223ae5c3`](https://github.com/cesarnml/pirate_claw/commit/a9b3223ae5c3a3ad2858331d224ff2aba492d451)
- current branch head: [`a9b3223ae5c3`](https://github.com/cesarnml/pirate_claw/commit/a9b3223ae5c3a3ad2858331d224ff2aba492d451)
- vendors: `coderabbit`, `sonarqube`
