### PR TITLE
feat(delivery): restore cook continuation and glide fallback [EE7.03]

### DIFF
--- a/docs/02-delivery/engineering-epic-07/ticket-03-cook-continuation-and-glide-fallback.md
+++ b/docs/02-delivery/engineering-epic-07/ticket-03-cook-continuation-and-glide-fallback.md
@@ -55,7 +55,18 @@ Repo default requirement:
 
 ## Rationale
 
-To be filled during implementation if behavior or trade-offs shift.
+`cook` continuation now composes the existing advance and start paths instead of
+reimplementing ticket-start mechanics inside `advance`. That keeps handoff
+generation, worktree bootstrap, branch setup, and local environment copying
+aligned with the existing `start` contract.
+
+`glide` remains selectable but resolves explicitly to `gated` in repo-local
+code. That preserves the third operator-facing mode without pretending the
+orchestrator can perform host-runtime context resets it does not control.
+
+The repo now carries an explicit root `orchestrator.config.json` with
+`ticketBoundaryMode: "cook"` so Son-of-Anton's continuation bias is a visible
+default instead of an implicit assumption.
 
 ## Notes
 

--- a/orchestrator.config.json
+++ b/orchestrator.config.json
@@ -1,0 +1,3 @@
+{
+  "ticketBoundaryMode": "cook"
+}

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -56,7 +56,9 @@ import {
   runProcessResult,
   formatCurrentTicketStatus,
   formatAdvanceBoundaryGuidance,
+  applyAdvanceBoundaryMode,
   formatStatus,
+  resolveEffectiveAdvanceBoundaryMode,
   type DeliveryState,
 } from './orchestrator';
 import { getUsage, parseCliArgs } from './cli';
@@ -3865,7 +3867,120 @@ describe('delivery orchestrator', () => {
     });
   });
 
-  describe('formatAdvanceBoundaryGuidance (EE7 gated output)', () => {
+  describe('applyAdvanceBoundaryMode (EE7 cook continuation)', () => {
+    const baseState: DeliveryState = {
+      planKey: 'engineering-epic-07',
+      planPath: 'docs/02-delivery/engineering-epic-07/implementation-plan.md',
+      statePath: '.agents/delivery/engineering-epic-07/state.json',
+      reviewsDirPath: '.agents/delivery/engineering-epic-07/reviews',
+      handoffsDirPath: '.agents/delivery/engineering-epic-07/handoffs',
+      reviewPollIntervalMinutes: 6,
+      reviewPollMaxWaitMinutes: 12,
+      tickets: [
+        {
+          id: 'EE7.01',
+          title: 'Boundary policy plumbing and visibility',
+          slug: 'boundary-policy-plumbing-and-visibility',
+          ticketFile:
+            'docs/02-delivery/engineering-epic-07/ticket-01-boundary-policy-plumbing-and-visibility.md',
+          status: 'reviewed',
+          branch: 'agents/ee7-01-boundary-policy-plumbing-and-visibility',
+          baseBranch: 'main',
+          worktreePath: '/tmp/ee7_01',
+          reviewOutcome: 'patched',
+        },
+        {
+          id: 'EE7.02',
+          title: 'Cook continuation and glide fallback',
+          slug: 'cook-continuation-and-glide-fallback',
+          ticketFile:
+            'docs/02-delivery/engineering-epic-07/ticket-03-cook-continuation-and-glide-fallback.md',
+          status: 'pending',
+          branch: 'agents/ee7-03-cook-continuation-and-glide-fallback',
+          baseBranch: 'agents/ee7-01-boundary-policy-plumbing-and-visibility',
+          worktreePath: '/tmp/ee7_03',
+        },
+      ],
+    };
+
+    it('auto-starts the next ticket in cook mode', async () => {
+      initOrchestratorConfig({
+        defaultBranch: 'main',
+        planRoot: 'docs',
+        runtime: 'bun',
+        packageManager: 'bun',
+        ticketBoundaryMode: 'cook',
+      });
+
+      const advancedState: DeliveryState = {
+        ...baseState,
+        tickets: baseState.tickets.map((ticket) =>
+          ticket.id === 'EE7.01'
+            ? { ...ticket, status: 'done' as const }
+            : ticket,
+        ),
+      };
+
+      const nextState = await applyAdvanceBoundaryMode(
+        baseState,
+        advancedState,
+        '/tmp',
+        {
+          startTicket: async () => ({
+            ...advancedState,
+            tickets: advancedState.tickets.map((ticket) =>
+              ticket.id === 'EE7.02'
+                ? {
+                    ...ticket,
+                    status: 'in_progress' as const,
+                    handoffPath:
+                      '.agents/delivery/engineering-epic-07/handoffs/ee7-03-handoff.md',
+                  }
+                : ticket,
+            ),
+          }),
+        },
+      );
+
+      expect(
+        nextState.tickets.find((ticket) => ticket.id === 'EE7.02')?.status,
+      ).toBe('in_progress');
+    });
+
+    it('does not auto-start the next ticket for glide fallback', async () => {
+      initOrchestratorConfig({
+        defaultBranch: 'main',
+        planRoot: 'docs',
+        runtime: 'bun',
+        packageManager: 'bun',
+        ticketBoundaryMode: 'glide',
+      });
+
+      const advancedState: DeliveryState = {
+        ...baseState,
+        tickets: baseState.tickets.map((ticket) =>
+          ticket.id === 'EE7.01'
+            ? { ...ticket, status: 'done' as const }
+            : ticket,
+        ),
+      };
+
+      const nextState = await applyAdvanceBoundaryMode(
+        baseState,
+        advancedState,
+        '/tmp',
+        {
+          startTicket: async () => {
+            throw new Error('should not start');
+          },
+        },
+      );
+
+      expect(nextState).toEqual(advancedState);
+    });
+  });
+
+  describe('formatAdvanceBoundaryGuidance (EE7 boundary output)', () => {
     const baseState: DeliveryState = {
       planKey: 'engineering-epic-07',
       planPath: 'docs/02-delivery/engineering-epic-07/implementation-plan.md',
@@ -3901,6 +4016,15 @@ describe('delivery orchestrator', () => {
       ],
     };
 
+    const advancedState: DeliveryState = {
+      ...baseState,
+      tickets: baseState.tickets.map((ticket) =>
+        ticket.id === 'EE7.01'
+          ? { ...ticket, status: 'done' as const }
+          : ticket,
+      ),
+    };
+
     it('emits gated reset guidance and the canonical resume prompt', () => {
       initOrchestratorConfig({
         defaultBranch: 'main',
@@ -3910,16 +4034,11 @@ describe('delivery orchestrator', () => {
         ticketBoundaryMode: 'gated',
       });
 
-      const nextState: DeliveryState = {
-        ...baseState,
-        tickets: baseState.tickets.map((ticket) =>
-          ticket.id === 'EE7.01'
-            ? { ...ticket, status: 'done' as const }
-            : ticket,
-        ),
-      };
-
-      const output = formatAdvanceBoundaryGuidance(baseState, nextState);
+      const output = formatAdvanceBoundaryGuidance(
+        baseState,
+        advancedState,
+        advancedState,
+      );
 
       expect(output).toContain('context_reset_required=true');
       expect(output).toContain('GATED BOUNDARY before starting EE7.02.');
@@ -3929,7 +4048,7 @@ describe('delivery orchestrator', () => {
       );
     });
 
-    it('emits no boundary guidance outside gated mode', () => {
+    it('emits cook continuation guidance with the next handoff path', () => {
       initOrchestratorConfig({
         defaultBranch: 'main',
         planRoot: 'docs',
@@ -3939,16 +4058,52 @@ describe('delivery orchestrator', () => {
       });
 
       const nextState: DeliveryState = {
-        ...baseState,
-        tickets: baseState.tickets.map((ticket) =>
-          ticket.id === 'EE7.01'
-            ? { ...ticket, status: 'done' as const }
+        ...advancedState,
+        tickets: advancedState.tickets.map((ticket) =>
+          ticket.id === 'EE7.02'
+            ? {
+                ...ticket,
+                status: 'in_progress' as const,
+                handoffPath:
+                  '.agents/delivery/engineering-epic-07/handoffs/ee7-02-handoff.md',
+              }
             : ticket,
         ),
       };
 
-      expect(formatAdvanceBoundaryGuidance(baseState, nextState)).toBe(
-        undefined,
+      const output = formatAdvanceBoundaryGuidance(
+        baseState,
+        advancedState,
+        nextState,
+      );
+
+      expect(output).toContain('continuation_mode=cook');
+      expect(output).toContain('COOK CONTINUATION started EE7.02.');
+      expect(output).toContain(
+        'next_handoff=.agents/delivery/engineering-epic-07/handoffs/ee7-02-handoff.md',
+      );
+    });
+
+    it('emits explicit glide fallback guidance', () => {
+      initOrchestratorConfig({
+        defaultBranch: 'main',
+        planRoot: 'docs',
+        runtime: 'bun',
+        packageManager: 'bun',
+        ticketBoundaryMode: 'glide',
+      });
+
+      const output = formatAdvanceBoundaryGuidance(
+        baseState,
+        advancedState,
+        advancedState,
+      );
+
+      expect(output).toContain('context_reset_required=true');
+      expect(output).toContain('glide_fallback=gated');
+      expect(output).toContain('GLIDE FALLBACK before starting EE7.02.');
+      expect(output).toContain(
+        'Host/runtime self-reset is not supported here, so Son-of-Anton is using gated boundary behavior instead.',
       );
     });
   });
@@ -4121,4 +4276,9 @@ describe('delivery orchestrator', () => {
       expect(output).toContain('[coderabbit]');
     });
   });
+});
+it('resolves glide to gated as the effective advance boundary mode', () => {
+  expect(resolveEffectiveAdvanceBoundaryMode('cook')).toBe('cook');
+  expect(resolveEffectiveAdvanceBoundaryMode('gated')).toBe('gated');
+  expect(resolveEffectiveAdvanceBoundaryMode('glide')).toBe('gated');
 });

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -3891,14 +3891,14 @@ describe('delivery orchestrator', () => {
         },
         {
           id: 'EE7.02',
-          title: 'Cook continuation and glide fallback',
-          slug: 'cook-continuation-and-glide-fallback',
+          title: 'Gated boundary semantics and resume prompt',
+          slug: 'gated-boundary-semantics-and-resume-prompt',
           ticketFile:
-            'docs/02-delivery/engineering-epic-07/ticket-03-cook-continuation-and-glide-fallback.md',
+            'docs/02-delivery/engineering-epic-07/ticket-02-gated-boundary-semantics-and-resume-prompt.md',
           status: 'pending',
-          branch: 'agents/ee7-03-cook-continuation-and-glide-fallback',
+          branch: 'agents/ee7-02-gated-boundary-semantics-and-resume-prompt',
           baseBranch: 'agents/ee7-01-boundary-policy-plumbing-and-visibility',
-          worktreePath: '/tmp/ee7_03',
+          worktreePath: '/tmp/ee7_02',
         },
       ],
     };
@@ -3921,27 +3921,34 @@ describe('delivery orchestrator', () => {
         ),
       };
 
+      let startedTicketId: string | undefined;
+
       const nextState = await applyAdvanceBoundaryMode(
         baseState,
         advancedState,
         '/tmp',
         {
-          startTicket: async () => ({
-            ...advancedState,
-            tickets: advancedState.tickets.map((ticket) =>
-              ticket.id === 'EE7.02'
-                ? {
-                    ...ticket,
-                    status: 'in_progress' as const,
-                    handoffPath:
-                      '.agents/delivery/engineering-epic-07/handoffs/ee7-03-handoff.md',
-                  }
-                : ticket,
-            ),
-          }),
+          startTicket: async (_state, _cwd, ticketId) => {
+            startedTicketId = ticketId;
+
+            return {
+              ...advancedState,
+              tickets: advancedState.tickets.map((ticket) =>
+                ticket.id === 'EE7.02'
+                  ? {
+                      ...ticket,
+                      status: 'in_progress' as const,
+                      handoffPath:
+                        '.agents/delivery/engineering-epic-07/handoffs/ee7-02-handoff.md',
+                    }
+                  : ticket,
+              ),
+            };
+          },
         },
       );
 
+      expect(startedTicketId).toBe('EE7.02');
       expect(
         nextState.tickets.find((ticket) => ticket.id === 'EE7.02')?.status,
       ).toBe('in_progress');

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -649,11 +649,17 @@ export async function runDeliveryOrchestrator(
         return 0;
       }
       case 'advance': {
-        const nextState = await advanceToNextTicketImpl(state, cwd);
+        const advancedState = await advanceToNextTicketImpl(state, cwd);
+        const nextState = await applyAdvanceBoundaryMode(
+          state,
+          advancedState,
+          cwd,
+        );
         await saveState(cwd, nextState);
         console.log(formatStatus(nextState));
         const boundaryGuidance = formatAdvanceBoundaryGuidance(
           state,
+          advancedState,
           nextState,
         );
 
@@ -1116,6 +1122,48 @@ async function advanceToNextTicketImpl(
   });
 }
 
+export function resolveEffectiveAdvanceBoundaryMode(
+  mode: TicketBoundaryMode,
+): 'cook' | 'gated' {
+  return mode === 'glide' ? 'gated' : mode;
+}
+
+export async function applyAdvanceBoundaryMode(
+  state: DeliveryState,
+  advancedState: DeliveryState,
+  cwd: string,
+  dependencies: {
+    startTicket: (
+      state: DeliveryState,
+      cwd: string,
+      ticketId?: string,
+    ) => Promise<DeliveryState>;
+  } = {
+    startTicket,
+  },
+): Promise<DeliveryState> {
+  const nextPending = advancedState.tickets.find(
+    (ticket) =>
+      ticket.status === 'pending' &&
+      state.tickets.find((previous) => previous.id === ticket.id)?.status ===
+        'pending',
+  );
+
+  if (!nextPending) {
+    return advancedState;
+  }
+
+  const effectiveMode = resolveEffectiveAdvanceBoundaryMode(
+    _config.ticketBoundaryMode,
+  );
+
+  if (effectiveMode !== 'cook') {
+    return advancedState;
+  }
+
+  return dependencies.startTicket(advancedState, cwd);
+}
+
 async function restackTicket(
   state: DeliveryState,
   cwd: string,
@@ -1395,14 +1443,15 @@ export function formatStatus(state: DeliveryState): string {
 
 export function formatAdvanceBoundaryGuidance(
   state: DeliveryState,
+  advancedState: DeliveryState,
   nextState: DeliveryState,
 ): string | undefined {
-  const nextPending = nextState.tickets.find(
+  const nextPending = advancedState.tickets.find(
     (t) =>
       t.status === 'pending' &&
       state.tickets.find((prev) => prev.id === t.id)?.status === 'pending',
   );
-  const justDone = nextState.tickets.find(
+  const justDone = advancedState.tickets.find(
     (t) =>
       t.status === 'done' &&
       state.tickets.find((prev) => prev.id === t.id)?.status !== 'done',
@@ -1412,19 +1461,43 @@ export function formatAdvanceBoundaryGuidance(
     return undefined;
   }
 
-  if (_config.ticketBoundaryMode !== 'gated') {
-    return undefined;
-  }
-
+  const effectiveMode = resolveEffectiveAdvanceBoundaryMode(
+    _config.ticketBoundaryMode,
+  );
   const invocation = `${generateRunDeliverInvocation(_config.packageManager)} --plan ${state.planPath} start`;
   const resumePrompt = `Immediately execute \`${invocation}\`, read the generated handoff artifact as the source of truth for context, and implement ${nextPending.id}.`;
 
+  if (effectiveMode === 'cook') {
+    const startedTicket = nextState.tickets.find(
+      (ticket) => ticket.id === nextPending.id,
+    );
+
+    return [
+      'continuation_mode=cook',
+      `COOK CONTINUATION started ${nextPending.id}.`,
+      startedTicket?.handoffPath
+        ? `next_handoff=${startedTicket.handoffPath}`
+        : undefined,
+      'Read the generated handoff artifact and continue implementation in the started ticket worktree.',
+    ]
+      .filter((line): line is string => line !== undefined)
+      .join('\n');
+  }
+
   return [
     'context_reset_required=true',
-    `GATED BOUNDARY before starting ${nextPending.id}.`,
+    _config.ticketBoundaryMode === 'glide' ? 'glide_fallback=gated' : undefined,
+    _config.ticketBoundaryMode === 'glide'
+      ? `GLIDE FALLBACK before starting ${nextPending.id}.`
+      : `GATED BOUNDARY before starting ${nextPending.id}.`,
+    _config.ticketBoundaryMode === 'glide'
+      ? 'Host/runtime self-reset is not supported here, so Son-of-Anton is using gated boundary behavior instead.'
+      : undefined,
     'Reset context now. Prefer /clear for minimum token use; use /compact only if you intentionally want compressed carry-forward context.',
     `resume_prompt=${resumePrompt}`,
-  ].join('\n');
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join('\n');
 }
 
 /**

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -1161,7 +1161,7 @@ export async function applyAdvanceBoundaryMode(
     return advancedState;
   }
 
-  return dependencies.startTicket(advancedState, cwd);
+  return dependencies.startTicket(advancedState, cwd, nextPending.id);
 }
 
 async function restackTicket(


### PR DESCRIPTION
## Summary

- delivery ticket: `EE7.03 Cook continuation and glide fallback`
- ticket file: [docs/02-delivery/engineering-epic-07/ticket-03-cook-continuation-and-glide-fallback.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/engineering-epic-07/ticket-03-cook-continuation-and-glide-fallback.md)
- stacked base branch: `agents/ee7-02-gated-boundary-semantics-and-resume-prompt`
- post-verify self-audit: completed at 2026-04-13 15:11 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`32a514ccf266`](https://github.com/cesarnml/pirate_claw/commit/32a514ccf2663e36fbebc0d04886a782352e5b6e)
- current branch head: [`33930b405676`](https://github.com/cesarnml/pirate_claw/commit/33930b4056769d1f81c3cbba0477cfe044605909)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `32a514ccf266` address all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Align this fixture to one ticket. (native GitHub thread resolved) `tools/delivery/orchestrator.test.ts:3901` [thread](https://github.com/cesarnml/pirate_claw/pull/146#discussion_r3074011379)
