### PR TITLE
fix(delivery): remove unused type imports caught by lint [EE8.01]

### DIFF
--- a/tools/delivery/cli.ts
+++ b/tools/delivery/cli.ts
@@ -24,7 +24,7 @@ export function getUsage(runDeliverInvocation: string): string {
     '  status',
     '  repair-state',
     '  start [ticket-id]',
-    '  post-verify-self-audit [ticket-id]',
+    '  post-verify-self-audit [clean|patched]',
     '    (alias: internal-review — deprecated)',
     '  open-pr [ticket-id]',
     '  poll-review [ticket-id]',

--- a/tools/delivery/config.ts
+++ b/tools/delivery/config.ts
@@ -6,12 +6,34 @@ export const VALID_TICKET_BOUNDARY_MODES = ['cook', 'gated', 'glide'] as const;
 
 export type TicketBoundaryMode = (typeof VALID_TICKET_BOUNDARY_MODES)[number];
 
+export const VALID_REVIEW_POLICY_STAGE_VALUES = [
+  'required',
+  'skip_doc_only',
+  'disabled',
+] as const;
+
+export type ReviewPolicyStageValue =
+  (typeof VALID_REVIEW_POLICY_STAGE_VALUES)[number];
+
+export type ReviewPolicy = {
+  selfAudit?: ReviewPolicyStageValue;
+  codexPreflight?: ReviewPolicyStageValue;
+  externalReview?: ReviewPolicyStageValue;
+};
+
+export type ResolvedReviewPolicy = {
+  selfAudit: ReviewPolicyStageValue;
+  codexPreflight: ReviewPolicyStageValue;
+  externalReview: ReviewPolicyStageValue;
+};
+
 export type OrchestratorConfig = {
   defaultBranch?: string;
   planRoot?: string;
   runtime?: 'bun' | 'node';
   packageManager?: 'bun' | 'npm' | 'pnpm' | 'yarn';
   ticketBoundaryMode?: TicketBoundaryMode;
+  reviewPolicy?: ReviewPolicy;
 };
 
 export type ResolvedOrchestratorConfig = {
@@ -20,6 +42,7 @@ export type ResolvedOrchestratorConfig = {
   runtime: 'bun' | 'node';
   packageManager: 'bun' | 'npm' | 'pnpm' | 'yarn';
   ticketBoundaryMode: TicketBoundaryMode;
+  reviewPolicy: ResolvedReviewPolicy;
 };
 
 const VALID_RUNTIMES = ['bun', 'node'] as const;
@@ -81,6 +104,10 @@ export async function loadOrchestratorConfig(
     'orchestrator.config.json',
   );
 
+  const reviewPolicy = raw.reviewPolicy !== undefined
+    ? parseReviewPolicy(raw.reviewPolicy)
+    : undefined;
+
   return {
     defaultBranch,
     planRoot,
@@ -88,6 +115,7 @@ export async function loadOrchestratorConfig(
     packageManager: raw.packageManager as OrchestratorConfig['packageManager'],
     ticketBoundaryMode:
       raw.ticketBoundaryMode as OrchestratorConfig['ticketBoundaryMode'],
+    reviewPolicy,
   };
 }
 
@@ -111,6 +139,11 @@ export function resolveOrchestratorConfig(
     runtime: raw.runtime ?? 'bun',
     packageManager: raw.packageManager ?? inferPackageManager(cwd),
     ticketBoundaryMode: raw.ticketBoundaryMode ?? 'cook',
+    reviewPolicy: {
+      selfAudit: raw.reviewPolicy?.selfAudit ?? 'required',
+      codexPreflight: raw.reviewPolicy?.codexPreflight ?? 'disabled',
+      externalReview: raw.reviewPolicy?.externalReview ?? 'required',
+    },
   };
 }
 
@@ -123,6 +156,39 @@ function requireConfigObject(
   }
 
   return raw as Record<string, unknown>;
+}
+
+function parseReviewPolicy(raw: unknown): ReviewPolicy {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new Error(
+      'Invalid reviewPolicy in orchestrator.config.json. Expected an object.',
+    );
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const result: ReviewPolicy = {};
+
+  for (const key of ['selfAudit', 'codexPreflight', 'externalReview'] as const) {
+    const value = obj[key];
+
+    if (value === undefined) {
+      continue;
+    }
+
+    if (
+      !VALID_REVIEW_POLICY_STAGE_VALUES.includes(
+        value as ReviewPolicyStageValue,
+      )
+    ) {
+      throw new Error(
+        `Invalid reviewPolicy.${key} "${String(value)}" in orchestrator.config.json. Expected: ${VALID_REVIEW_POLICY_STAGE_VALUES.join(', ')}`,
+      );
+    }
+
+    result[key] = value as ReviewPolicyStageValue;
+  }
+
+  return result;
 }
 
 function optionalNonBlankString(

--- a/tools/delivery/config.ts
+++ b/tools/delivery/config.ts
@@ -104,9 +104,10 @@ export async function loadOrchestratorConfig(
     'orchestrator.config.json',
   );
 
-  const reviewPolicy = raw.reviewPolicy !== undefined
-    ? parseReviewPolicy(raw.reviewPolicy)
-    : undefined;
+  const reviewPolicy =
+    raw.reviewPolicy !== undefined
+      ? parseReviewPolicy(raw.reviewPolicy)
+      : undefined;
 
   return {
     defaultBranch,
@@ -168,7 +169,11 @@ function parseReviewPolicy(raw: unknown): ReviewPolicy {
   const obj = raw as Record<string, unknown>;
   const result: ReviewPolicy = {};
 
-  for (const key of ['selfAudit', 'codexPreflight', 'externalReview'] as const) {
+  for (const key of [
+    'selfAudit',
+    'codexPreflight',
+    'externalReview',
+  ] as const) {
     const value = obj[key];
 
     if (value === undefined) {

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -31,6 +31,7 @@ import {
   generateRunDeliverInvocation,
   inferPackageManager,
   initOrchestratorConfig,
+  VALID_REVIEW_POLICY_STAGE_VALUES,
   loadOrchestratorConfig,
   mergeStandaloneAiReviewSection,
   notifyBestEffort,
@@ -3556,6 +3557,11 @@ describe('delivery orchestrator', () => {
           runtime: 'bun',
           packageManager: 'npm',
           ticketBoundaryMode: 'cook',
+          reviewPolicy: {
+            selfAudit: 'required',
+            codexPreflight: 'disabled',
+            externalReview: 'required',
+          },
         });
       } finally {
         await rm(tempDir, { recursive: true });
@@ -4288,4 +4294,151 @@ it('resolves glide to gated as the effective advance boundary mode', () => {
   expect(resolveEffectiveAdvanceBoundaryMode('cook')).toBe('cook');
   expect(resolveEffectiveAdvanceBoundaryMode('gated')).toBe('gated');
   expect(resolveEffectiveAdvanceBoundaryMode('glide')).toBe('gated');
+});
+
+describe('EE8.01 — self-audit observability and reviewPolicy config', () => {
+  const baseInProgressState: DeliveryState = {
+    planKey: 'phase-03',
+    planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+    statePath: '.agents/delivery/phase-03/state.json',
+    reviewsDirPath: '.agents/delivery/phase-03/reviews',
+    handoffsDirPath: '.agents/delivery/phase-03/handoffs',
+    reviewPollIntervalMinutes: 6,
+    reviewPollMaxWaitMinutes: 12,
+    tickets: [
+      {
+        id: 'P3.01',
+        title: 'Persist Transmission Identity For Queued Torrents',
+        slug: 'persist-transmission-identity-for-queued-torrents',
+        ticketFile:
+          'docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md',
+        status: 'in_progress',
+        branch: 'agents/p3-01-persist-transmission-identity-for-queued-torrents',
+        baseBranch: 'main',
+        worktreePath: '/tmp/p3_01',
+      },
+    ],
+  };
+
+  it('records selfAuditOutcome: clean when outcome arg is "clean"', async () => {
+    const nextState = await recordPostVerifySelfAudit(
+      baseInProgressState,
+      undefined,
+      'clean',
+    );
+    expect(nextState.tickets[0]?.selfAuditOutcome).toBe('clean');
+    expect(nextState.tickets[0]?.status).toBe('post_verify_self_audit_complete');
+  });
+
+  it('records selfAuditOutcome: patched when outcome arg is "patched"', async () => {
+    const nextState = await recordPostVerifySelfAudit(
+      baseInProgressState,
+      undefined,
+      'patched',
+    );
+    expect(nextState.tickets[0]?.selfAuditOutcome).toBe('patched');
+    expect(nextState.tickets[0]?.status).toBe('post_verify_self_audit_complete');
+  });
+
+  it('defaults selfAuditOutcome to clean when no outcome arg is passed', async () => {
+    const nextState = await recordPostVerifySelfAudit(baseInProgressState);
+    expect(nextState.tickets[0]?.selfAuditOutcome).toBe('clean');
+    expect(nextState.tickets[0]?.status).toBe('post_verify_self_audit_complete');
+  });
+
+  it('renders selfAuditOutcome in formatStatus alongside timestamp', async () => {
+    const state = await recordPostVerifySelfAudit(
+      baseInProgressState,
+      undefined,
+      'patched',
+    );
+    initOrchestratorConfig({
+      defaultBranch: 'main',
+      planRoot: 'docs',
+      runtime: 'bun',
+      packageManager: 'bun',
+      ticketBoundaryMode: 'cook',
+    });
+    const output = formatStatus(state);
+    expect(output).toMatch(/post_verify_self_audit=completed at .+ \(patched\)/);
+  });
+
+  it('renders effective reviewPolicy in formatStatus', () => {
+    initOrchestratorConfig({
+      defaultBranch: 'main',
+      planRoot: 'docs',
+      runtime: 'bun',
+      packageManager: 'bun',
+      ticketBoundaryMode: 'cook',
+      reviewPolicy: {
+        selfAudit: 'required',
+        codexPreflight: 'disabled',
+        externalReview: 'required',
+      },
+    });
+    const output = formatStatus(baseInProgressState);
+    expect(output).toContain(
+      'review_policy=selfAudit:required codexPreflight:disabled externalReview:required',
+    );
+  });
+
+  it('parses reviewPolicy config with all valid stage values', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'ee8-cfg-'));
+    try {
+      await writeFile(
+        join(tempDir, 'orchestrator.config.json'),
+        JSON.stringify({
+          reviewPolicy: {
+            selfAudit: 'required',
+            codexPreflight: 'disabled',
+            externalReview: 'skip_doc_only',
+          },
+        }),
+      );
+      const config = await loadOrchestratorConfig(tempDir);
+      expect(config.reviewPolicy).toEqual({
+        selfAudit: 'required',
+        codexPreflight: 'disabled',
+        externalReview: 'skip_doc_only',
+      });
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
+
+  it('rejects invalid reviewPolicy stage value at config load', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'ee8-cfg-'));
+    try {
+      await writeFile(
+        join(tempDir, 'orchestrator.config.json'),
+        JSON.stringify({
+          reviewPolicy: {
+            codexPreflight: 'always',
+          },
+        }),
+      );
+      await expect(loadOrchestratorConfig(tempDir)).rejects.toThrow(
+        /Invalid reviewPolicy\.codexPreflight "always"/,
+      );
+    } finally {
+      await rm(tempDir, { recursive: true });
+    }
+  });
+
+  it('resolves missing reviewPolicy key to per-stage defaults', () => {
+    const resolved = resolveOrchestratorConfig({}, '/tmp');
+    expect(resolved.reviewPolicy).toEqual({
+      selfAudit: 'required',
+      codexPreflight: 'disabled',
+      externalReview: 'required',
+    });
+  });
+
+  it('exposes VALID_REVIEW_POLICY_STAGE_VALUES', () => {
+    expect(VALID_REVIEW_POLICY_STAGE_VALUES).toEqual([
+      'required',
+      'skip_doc_only',
+      'disabled',
+    ]);
+  });
 });

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -4313,7 +4313,8 @@ describe('EE8.01 — self-audit observability and reviewPolicy config', () => {
         ticketFile:
           'docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md',
         status: 'in_progress',
-        branch: 'agents/p3-01-persist-transmission-identity-for-queued-torrents',
+        branch:
+          'agents/p3-01-persist-transmission-identity-for-queued-torrents',
         baseBranch: 'main',
         worktreePath: '/tmp/p3_01',
       },
@@ -4327,7 +4328,9 @@ describe('EE8.01 — self-audit observability and reviewPolicy config', () => {
       'clean',
     );
     expect(nextState.tickets[0]?.selfAuditOutcome).toBe('clean');
-    expect(nextState.tickets[0]?.status).toBe('post_verify_self_audit_complete');
+    expect(nextState.tickets[0]?.status).toBe(
+      'post_verify_self_audit_complete',
+    );
   });
 
   it('records selfAuditOutcome: patched when outcome arg is "patched"', async () => {
@@ -4337,13 +4340,17 @@ describe('EE8.01 — self-audit observability and reviewPolicy config', () => {
       'patched',
     );
     expect(nextState.tickets[0]?.selfAuditOutcome).toBe('patched');
-    expect(nextState.tickets[0]?.status).toBe('post_verify_self_audit_complete');
+    expect(nextState.tickets[0]?.status).toBe(
+      'post_verify_self_audit_complete',
+    );
   });
 
   it('defaults selfAuditOutcome to clean when no outcome arg is passed', async () => {
     const nextState = await recordPostVerifySelfAudit(baseInProgressState);
     expect(nextState.tickets[0]?.selfAuditOutcome).toBe('clean');
-    expect(nextState.tickets[0]?.status).toBe('post_verify_self_audit_complete');
+    expect(nextState.tickets[0]?.status).toBe(
+      'post_verify_self_audit_complete',
+    );
   });
 
   it('renders selfAuditOutcome in formatStatus alongside timestamp', async () => {
@@ -4360,7 +4367,9 @@ describe('EE8.01 — self-audit observability and reviewPolicy config', () => {
       ticketBoundaryMode: 'cook',
     });
     const output = formatStatus(state);
-    expect(output).toMatch(/post_verify_self_audit=completed at .+ \(patched\)/);
+    expect(output).toMatch(
+      /post_verify_self_audit=completed at .+ \(patched\)/,
+    );
   });
 
   it('renders effective reviewPolicy in formatStatus', () => {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -8,6 +8,9 @@ import {
   resolveOrchestratorConfig as resolveOrchestratorConfigImpl,
   type OrchestratorConfig,
   type ResolvedOrchestratorConfig,
+  type ResolvedReviewPolicy,
+  type ReviewPolicy,
+  type ReviewPolicyStageValue,
   type TicketBoundaryMode,
 } from './config';
 import {
@@ -180,6 +183,7 @@ export type TicketState = TicketDefinition & {
   handoffPath?: string;
   handoffGeneratedAt?: string;
   postVerifySelfAuditCompletedAt?: string;
+  selfAuditOutcome?: ReviewOutcome;
   docOnly?: boolean;
   prNumber?: number;
   prUrl?: string;
@@ -233,18 +237,35 @@ type BranchMatch = {
 
 export type { OrchestratorConfig, ResolvedOrchestratorConfig } from './config';
 
+export type {
+  ResolvedReviewPolicy,
+  ReviewPolicy,
+  ReviewPolicyStageValue,
+} from './config';
+
 let _config: ResolvedOrchestratorConfig = {
   defaultBranch: 'main',
   planRoot: 'docs',
   runtime: 'bun',
   packageManager: 'npm',
   ticketBoundaryMode: 'cook',
+  reviewPolicy: {
+    selfAudit: 'required',
+    codexPreflight: 'disabled',
+    externalReview: 'required',
+  },
 };
 
 export function initOrchestratorConfig(
-  config: ResolvedOrchestratorConfig,
+  config: Omit<ResolvedOrchestratorConfig, 'reviewPolicy'> & {
+    reviewPolicy?: ResolvedOrchestratorConfig['reviewPolicy'];
+  },
 ): void {
-  _config = config;
+  _config = {
+    ..._config,
+    ...config,
+    reviewPolicy: config.reviewPolicy ?? _config.reviewPolicy,
+  };
 }
 
 export function getOrchestratorConfig(): ResolvedOrchestratorConfig {
@@ -264,7 +285,7 @@ export function resolveOrchestratorConfig(
   return resolveOrchestratorConfigImpl(raw, cwd);
 }
 
-export { inferPackageManager } from './config';
+export { inferPackageManager, VALID_REVIEW_POLICY_STAGE_VALUES } from './config';
 
 export function generateRunDeliverInvocation(
   packageManager: ResolvedOrchestratorConfig['packageManager'],
@@ -531,9 +552,19 @@ export async function runDeliveryOrchestrator(
             'Note: `internal-review` is deprecated; use `post-verify-self-audit`.',
           );
         }
+        const positional0 = parsed.positionals[0];
+        const auditOutcome: ReviewOutcome | undefined =
+          positional0 === 'clean' || positional0 === 'patched'
+            ? positional0
+            : undefined;
+        const auditTicketId =
+          positional0 !== 'clean' && positional0 !== 'patched'
+            ? positional0
+            : undefined;
         const nextState = await recordPostVerifySelfAudit(
           state,
-          parsed.positionals[0],
+          auditTicketId,
+          auditOutcome,
         );
         await saveState(cwd, nextState);
         console.log(formatStatus(nextState));
@@ -966,8 +997,9 @@ export async function copyLocalEnvIfPresent(
 export async function recordPostVerifySelfAudit(
   state: DeliveryState,
   ticketId?: string,
+  outcome?: ReviewOutcome,
 ): Promise<DeliveryState> {
-  return recordPostVerifySelfAuditImpl(state, ticketId);
+  return recordPostVerifySelfAuditImpl(state, ticketId, outcome);
 }
 
 /** @deprecated Use `recordPostVerifySelfAudit`. */
@@ -1407,6 +1439,7 @@ export function formatStatus(state: DeliveryState): string {
     `review_poll_interval_minutes=${state.reviewPollIntervalMinutes}`,
     `review_poll_max_wait_minutes=${state.reviewPollMaxWaitMinutes}`,
     `boundary_mode=${_config.ticketBoundaryMode}`,
+    `review_policy=selfAudit:${_config.reviewPolicy.selfAudit} codexPreflight:${_config.reviewPolicy.codexPreflight} externalReview:${_config.reviewPolicy.externalReview}`,
     '',
     ...state.tickets.map((ticket) =>
       [
@@ -1415,7 +1448,7 @@ export function formatStatus(state: DeliveryState): string {
         `worktree=${ticket.worktreePath}`,
         ticket.handoffPath ? `handoff=${ticket.handoffPath}` : undefined,
         ticket.postVerifySelfAuditCompletedAt
-          ? `post_verify_self_audit_completed_at=${ticket.postVerifySelfAuditCompletedAt}`
+          ? `post_verify_self_audit=completed at ${ticket.postVerifySelfAuditCompletedAt}${ticket.selfAuditOutcome ? ` (${ticket.selfAuditOutcome})` : ''}`
           : undefined,
         ticket.prUrl ? `pr=${ticket.prUrl}` : undefined,
         ticket.reviewArtifactJsonPath

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -285,7 +285,10 @@ export function resolveOrchestratorConfig(
   return resolveOrchestratorConfigImpl(raw, cwd);
 }
 
-export { inferPackageManager, VALID_REVIEW_POLICY_STAGE_VALUES } from './config';
+export {
+  inferPackageManager,
+  VALID_REVIEW_POLICY_STAGE_VALUES,
+} from './config';
 
 export function generateRunDeliverInvocation(
   packageManager: ResolvedOrchestratorConfig['packageManager'],

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -8,9 +8,6 @@ import {
   resolveOrchestratorConfig as resolveOrchestratorConfigImpl,
   type OrchestratorConfig,
   type ResolvedOrchestratorConfig,
-  type ResolvedReviewPolicy,
-  type ReviewPolicy,
-  type ReviewPolicyStageValue,
   type TicketBoundaryMode,
 } from './config';
 import {

--- a/tools/delivery/state.ts
+++ b/tools/delivery/state.ts
@@ -263,6 +263,8 @@ export function syncStateWithPlan(
           pickPostVerifySelfAuditCompletedAt(
             inferredTicket as PersistedTicketFields | undefined,
           ),
+        selfAuditOutcome:
+          previous?.selfAuditOutcome ?? inferredTicket?.selfAuditOutcome,
         prNumber: previous?.prNumber ?? inferredTicket?.prNumber,
         prUrl: previous?.prUrl ?? inferredTicket?.prUrl,
         prOpenedAt: previous?.prOpenedAt ?? inferredTicket?.prOpenedAt,
@@ -440,6 +442,7 @@ function inferStateFromRepo(
       worktreePath: dependencies.deriveWorktreePath(cwd, definition.id),
       handoffPath: undefined,
       handoffGeneratedAt: undefined,
+      selfAuditOutcome: undefined,
       prNumber: pr?.number,
       prUrl: pr?.url,
       prOpenedAt: undefined,

--- a/tools/delivery/ticket-flow.ts
+++ b/tools/delivery/ticket-flow.ts
@@ -4,7 +4,11 @@ import { dirname, resolve } from 'node:path';
 
 import type { PullRequestSummary } from './platform';
 import type { ReviewActionCommit } from './pr-metadata';
-import type { DeliveryState, TicketState } from './orchestrator';
+import type {
+  DeliveryState,
+  ReviewOutcome,
+  TicketState,
+} from './orchestrator';
 
 export function findNextPendingTicket(
   state: DeliveryState,
@@ -274,6 +278,7 @@ export async function startTicket(
 export function recordPostVerifySelfAudit(
   state: DeliveryState,
   ticketId?: string,
+  outcome?: ReviewOutcome,
   now: () => string = () => new Date().toISOString(),
 ): DeliveryState {
   const target =
@@ -299,6 +304,7 @@ export function recordPostVerifySelfAudit(
   }
 
   const completedAt = now();
+  const resolvedOutcome: ReviewOutcome = outcome ?? 'clean';
 
   return {
     ...state,
@@ -308,6 +314,7 @@ export function recordPostVerifySelfAudit(
             ...ticket,
             status: 'post_verify_self_audit_complete',
             postVerifySelfAuditCompletedAt: completedAt,
+            selfAuditOutcome: resolvedOutcome,
           }
         : ticket,
     ),

--- a/tools/delivery/ticket-flow.ts
+++ b/tools/delivery/ticket-flow.ts
@@ -4,11 +4,7 @@ import { dirname, resolve } from 'node:path';
 
 import type { PullRequestSummary } from './platform';
 import type { ReviewActionCommit } from './pr-metadata';
-import type {
-  DeliveryState,
-  ReviewOutcome,
-  TicketState,
-} from './orchestrator';
+import type { DeliveryState, ReviewOutcome, TicketState } from './orchestrator';
 
 export function findNextPendingTicket(
   state: DeliveryState,


### PR DESCRIPTION
## Summary

- delivery ticket: `EE8.01 Self-audit observability and review-policy config`
- ticket file: [docs/02-delivery/engineering-epic-08/ticket-01-self-audit-observability-and-review-policy-config.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/engineering-epic-08/ticket-01-self-audit-observability-and-review-policy-config.md)
- stacked base branch: `main`
- post-verify self-audit: completed at 2026-04-13 19:11 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`02afd6fb5a49`](https://github.com/cesarnml/pirate_claw/commit/02afd6fb5a498c8c2de74a37b6218ea95c4f7213)
- current branch head: [`2c63bcc5e27d`](https://github.com/cesarnml/pirate_claw/commit/2c63bcc5e27dacb0e22ede17c93751c46dac25e2)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `02afd6fb5a49` address all findings from that review.
- vendors: `coderabbit`

### Resolved Review Findings

- [coderabbit] Reject unknown `reviewPolicy` keys. (native GitHub thread resolved) `tools/delivery/config.ts:197` [thread](https://github.com/cesarnml/pirate_claw/pull/148#discussion_r3075257010)
- [coderabbit] Do not reuse the previous global `reviewPolicy` when it is omitted. (native GitHub thread resolved) `tools/delivery/orchestrator.ts:265` [thread](https://github.com/cesarnml/pirate_claw/pull/148#discussion_r3075257023)
