### PR TITLE
feat(delivery): add codex-preflight command, status, and open-pr gate [EE8.02]

### DIFF
--- a/tools/delivery/cli.ts
+++ b/tools/delivery/cli.ts
@@ -26,6 +26,7 @@ export function getUsage(runDeliverInvocation: string): string {
     '  start [ticket-id]',
     '  post-verify-self-audit [clean|patched]',
     '    (alias: internal-review — deprecated)',
+    '  codex-preflight [clean|patched]',
     '  open-pr [ticket-id]',
     '  poll-review [ticket-id]',
     '  reconcile-late-review <ticket-id>',

--- a/tools/delivery/config.ts
+++ b/tools/delivery/config.ts
@@ -168,12 +168,17 @@ function parseReviewPolicy(raw: unknown): ReviewPolicy {
 
   const obj = raw as Record<string, unknown>;
   const result: ReviewPolicy = {};
+  const KNOWN_KEYS = ['selfAudit', 'codexPreflight', 'externalReview'] as const;
 
-  for (const key of [
-    'selfAudit',
-    'codexPreflight',
-    'externalReview',
-  ] as const) {
+  for (const unknownKey of Object.keys(obj)) {
+    if (!KNOWN_KEYS.includes(unknownKey as (typeof KNOWN_KEYS)[number])) {
+      throw new Error(
+        `Unknown reviewPolicy key "${unknownKey}" in orchestrator.config.json. Expected keys: ${KNOWN_KEYS.join(', ')}`,
+      );
+    }
+  }
+
+  for (const key of KNOWN_KEYS) {
     const value = obj[key];
 
     if (value === undefined) {

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -32,7 +32,9 @@ import {
   inferPackageManager,
   initOrchestratorConfig,
   VALID_REVIEW_POLICY_STAGE_VALUES,
+  recordCodexPreflight,
   loadOrchestratorConfig,
+  type CodexPreflightOutcome,
   mergeStandaloneAiReviewSection,
   notifyBestEffort,
   openPullRequest,
@@ -4449,5 +4451,233 @@ describe('EE8.01 — self-audit observability and reviewPolicy config', () => {
       'skip_doc_only',
       'disabled',
     ]);
+  });
+});
+
+describe('EE8.02 — codex preflight command, status, and gate', () => {
+  const basePostAuditState: DeliveryState = {
+    planKey: 'phase-03',
+    planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+    statePath: '.agents/delivery/phase-03/state.json',
+    reviewsDirPath: '.agents/delivery/phase-03/reviews',
+    handoffsDirPath: '.agents/delivery/phase-03/handoffs',
+    reviewPollIntervalMinutes: 6,
+    reviewPollMaxWaitMinutes: 12,
+    tickets: [
+      {
+        id: 'P3.01',
+        title: 'Persist Transmission Identity For Queued Torrents',
+        slug: 'persist-transmission-identity-for-queued-torrents',
+        ticketFile:
+          'docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md',
+        status: 'post_verify_self_audit_complete',
+        branch:
+          'agents/p3-01-persist-transmission-identity-for-queued-torrents',
+        baseBranch: 'main',
+        worktreePath: '/tmp/p3_01',
+        postVerifySelfAuditCompletedAt: '2026-04-14T00:00:00.000Z',
+      },
+    ],
+  };
+
+  it('records codexPreflightOutcome: clean and transitions to codex_preflight_complete', () => {
+    const nextState = recordCodexPreflight(basePostAuditState, 'clean');
+    expect(nextState.tickets[0]?.codexPreflightOutcome).toBe('clean');
+    expect(nextState.tickets[0]?.status).toBe('codex_preflight_complete');
+    expect(nextState.tickets[0]?.codexPreflightCompletedAt).toBeTruthy();
+  });
+
+  it('records codexPreflightOutcome: patched and transitions to codex_preflight_complete', () => {
+    const nextState = recordCodexPreflight(basePostAuditState, 'patched');
+    expect(nextState.tickets[0]?.codexPreflightOutcome).toBe('patched');
+    expect(nextState.tickets[0]?.status).toBe('codex_preflight_complete');
+  });
+
+  it('records codexPreflightOutcome: skipped for doc-only tickets', () => {
+    const docOnlyState: DeliveryState = {
+      ...basePostAuditState,
+      tickets: basePostAuditState.tickets.map((t) => ({
+        ...t,
+        docOnly: true,
+      })),
+    };
+    const nextState = recordCodexPreflight(docOnlyState);
+    expect(nextState.tickets[0]?.codexPreflightOutcome).toBe('skipped');
+    expect(nextState.tickets[0]?.status).toBe('codex_preflight_complete');
+  });
+
+  it('rejects codex-preflight when ticket is not at post_verify_self_audit_complete', () => {
+    const inProgressState: DeliveryState = {
+      ...basePostAuditState,
+      tickets: basePostAuditState.tickets.map((t) => ({
+        ...t,
+        status: 'in_progress' as const,
+      })),
+    };
+    expect(() => recordCodexPreflight(inProgressState, 'clean')).toThrow(
+      /No ticket at post_verify_self_audit_complete status/,
+    );
+  });
+
+  it('rejects codex-preflight on a code ticket with no outcome arg', () => {
+    expect(() => recordCodexPreflight(basePostAuditState)).toThrow(
+      /requires a Codex preflight outcome/,
+    );
+  });
+
+  it('statusRank orders: post_verify_self_audit_complete < codex_preflight_complete < in_review', () => {
+    // Verify via syncStateWithPlan status selection: higher rank wins
+    const options = createOptions({
+      planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+    });
+    const existing: DeliveryState = {
+      ...options,
+      planKey: options.planKey,
+      tickets: [
+        {
+          id: 'P3.01',
+          title: 'Persist Transmission Identity For Queued Torrents',
+          slug: 'persist-transmission-identity-for-queued-torrents',
+          ticketFile:
+            'docs/02-delivery/phase-03/ticket-01-persist-transmission-identity-for-queued-torrents.md',
+          status: 'codex_preflight_complete',
+          branch:
+            'agents/p3-01-persist-transmission-identity-for-queued-torrents',
+          baseBranch: 'main',
+          worktreePath: '/tmp/p3_01',
+        },
+      ],
+    };
+    // inferred state has lower rank (post_verify_self_audit_complete) — existing wins
+    const inferred: DeliveryState = {
+      ...existing,
+      tickets: existing.tickets.map((t) => ({
+        ...t,
+        status: 'post_verify_self_audit_complete' as const,
+      })),
+    };
+    const synced = syncStateWithPlan(
+      existing,
+      existing.tickets,
+      '/tmp',
+      options,
+      inferred,
+    );
+    expect(synced.tickets[0]?.status).toBe('codex_preflight_complete');
+  });
+
+  it('open-pr rejects code ticket at post_verify_self_audit_complete when policy is required', async () => {
+    initOrchestratorConfig({
+      defaultBranch: 'main',
+      planRoot: 'docs',
+      runtime: 'bun',
+      packageManager: 'bun',
+      ticketBoundaryMode: 'cook',
+      reviewPolicy: {
+        selfAudit: 'required',
+        codexPreflight: 'required',
+        externalReview: 'required',
+      },
+    });
+    try {
+      await expect(
+        openPullRequest(basePostAuditState, '/tmp/pirate_claw', 'P3.01'),
+      ).rejects.toThrow(/requires Codex preflight before opening a PR/);
+    } finally {
+      initOrchestratorConfig({
+        defaultBranch: 'main',
+        planRoot: 'docs',
+        runtime: 'bun',
+        packageManager: 'bun',
+        ticketBoundaryMode: 'cook',
+        reviewPolicy: {
+          selfAudit: 'required',
+          codexPreflight: 'disabled',
+          externalReview: 'required',
+        },
+      });
+    }
+  });
+
+  it('open-pr error message includes codex-plugin-cc and config escape hatch', async () => {
+    initOrchestratorConfig({
+      defaultBranch: 'main',
+      planRoot: 'docs',
+      runtime: 'bun',
+      packageManager: 'bun',
+      ticketBoundaryMode: 'cook',
+      reviewPolicy: {
+        selfAudit: 'required',
+        codexPreflight: 'required',
+        externalReview: 'required',
+      },
+    });
+    try {
+      await expect(
+        openPullRequest(basePostAuditState, '/tmp/pirate_claw', 'P3.01'),
+      ).rejects.toThrow(/codex-plugin-cc/);
+      await expect(
+        openPullRequest(basePostAuditState, '/tmp/pirate_claw', 'P3.01'),
+      ).rejects.toThrow(/codexPreflight.*disabled.*orchestrator\.config\.json/);
+    } finally {
+      initOrchestratorConfig({
+        defaultBranch: 'main',
+        planRoot: 'docs',
+        runtime: 'bun',
+        packageManager: 'bun',
+        ticketBoundaryMode: 'cook',
+        reviewPolicy: {
+          selfAudit: 'required',
+          codexPreflight: 'disabled',
+          externalReview: 'required',
+        },
+      });
+    }
+  });
+
+  it('formats codex_preflight outcome in formatStatus', () => {
+    initOrchestratorConfig({
+      defaultBranch: 'main',
+      planRoot: 'docs',
+      runtime: 'bun',
+      packageManager: 'bun',
+      ticketBoundaryMode: 'cook',
+    });
+    const state: DeliveryState = {
+      ...basePostAuditState,
+      tickets: basePostAuditState.tickets.map((t) => ({
+        ...t,
+        status: 'codex_preflight_complete' as const,
+        codexPreflightOutcome: 'clean' as CodexPreflightOutcome,
+        codexPreflightCompletedAt: '2026-04-14T10:00:00.000Z',
+      })),
+    };
+    const output = formatStatus(state);
+    expect(output).toContain(
+      'codex_preflight=completed at 2026-04-14T10:00:00.000Z (clean)',
+    );
+  });
+
+  it('formats skipped codex_preflight outcome in formatStatus', () => {
+    initOrchestratorConfig({
+      defaultBranch: 'main',
+      planRoot: 'docs',
+      runtime: 'bun',
+      packageManager: 'bun',
+      ticketBoundaryMode: 'cook',
+    });
+    const state: DeliveryState = {
+      ...basePostAuditState,
+      tickets: basePostAuditState.tickets.map((t) => ({
+        ...t,
+        status: 'codex_preflight_complete' as const,
+        codexPreflightOutcome: 'skipped' as CodexPreflightOutcome,
+        codexPreflightCompletedAt: '2026-04-14T10:00:00.000Z',
+      })),
+    };
+    const output = formatStatus(state);
+    expect(output).toContain(
+      'codex_preflight=completed at 2026-04-14T10:00:00.000Z (skipped)',
+    );
   });
 });

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -261,7 +261,11 @@ export function initOrchestratorConfig(
   _config = {
     ..._config,
     ...config,
-    reviewPolicy: config.reviewPolicy ?? _config.reviewPolicy,
+    reviewPolicy: config.reviewPolicy ?? {
+      selfAudit: 'required',
+      codexPreflight: 'disabled',
+      externalReview: 'required',
+    },
   };
 }
 

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -100,6 +100,7 @@ import {
   findNextPendingTicket,
   findTicketByBranch,
   openPullRequest as openPullRequestImpl,
+  recordCodexPreflight as recordCodexPreflightImpl,
   recordPostVerifySelfAudit as recordPostVerifySelfAuditImpl,
   restackTicket as restackTicketImpl,
   startTicket as startTicketImpl,
@@ -153,6 +154,7 @@ export type TicketStatus =
   | 'pending'
   | 'in_progress'
   | 'post_verify_self_audit_complete'
+  | 'codex_preflight_complete'
   | 'in_review'
   | 'needs_patch'
   | 'operator_input_needed'
@@ -164,6 +166,8 @@ export type ReviewResult =
   | ReviewOutcome
   | 'needs_patch'
   | 'operator_input_needed';
+
+export type CodexPreflightOutcome = 'clean' | 'patched' | 'skipped';
 
 export type TicketDefinition = {
   id: string;
@@ -181,6 +185,8 @@ export type TicketState = TicketDefinition & {
   handoffGeneratedAt?: string;
   postVerifySelfAuditCompletedAt?: string;
   selfAuditOutcome?: ReviewOutcome;
+  codexPreflightOutcome?: CodexPreflightOutcome;
+  codexPreflightCompletedAt?: string;
   docOnly?: boolean;
   prNumber?: number;
   prUrl?: string;
@@ -570,6 +576,26 @@ export async function runDeliveryOrchestrator(
           auditTicketId,
           auditOutcome,
         );
+        await saveState(cwd, nextState);
+        console.log(formatStatus(nextState));
+        return 0;
+      }
+      case 'codex-preflight': {
+        const preflightPositional = parsed.positionals[0];
+        const preflightOutcome =
+          preflightPositional === 'clean' || preflightPositional === 'patched'
+            ? preflightPositional
+            : undefined;
+        const nextState = recordCodexPreflight(state, preflightOutcome);
+        const justRecordedPreflight = nextState.tickets.find(
+          (t) =>
+            t.status === 'codex_preflight_complete' &&
+            state.tickets.find((prev) => prev.id === t.id)?.status ===
+              'post_verify_self_audit_complete',
+        );
+        if (justRecordedPreflight?.codexPreflightOutcome === 'skipped') {
+          console.log('Doc-only ticket — Codex preflight auto-skipped.');
+        }
         await saveState(cwd, nextState);
         console.log(formatStatus(nextState));
         return 0;
@@ -1014,6 +1040,13 @@ export async function recordInternalReview(
   return recordPostVerifySelfAuditImpl(state, ticketId);
 }
 
+export function recordCodexPreflight(
+  state: DeliveryState,
+  outcome?: 'clean' | 'patched',
+): DeliveryState {
+  return recordCodexPreflightImpl(state, outcome);
+}
+
 export async function openPullRequest(
   state: DeliveryState,
   cwd: string,
@@ -1023,6 +1056,7 @@ export async function openPullRequest(
     assertReviewerFacingMarkdown,
     buildPullRequestBody,
     buildPullRequestTitle,
+    codexPreflightPolicy: _config.reviewPolicy.codexPreflight,
     createPullRequest,
     editPullRequest,
     ensureBranchPushed,
@@ -1453,6 +1487,9 @@ export function formatStatus(state: DeliveryState): string {
         ticket.handoffPath ? `handoff=${ticket.handoffPath}` : undefined,
         ticket.postVerifySelfAuditCompletedAt
           ? `post_verify_self_audit=completed at ${ticket.postVerifySelfAuditCompletedAt}${ticket.selfAuditOutcome ? ` (${ticket.selfAuditOutcome})` : ''}`
+          : undefined,
+        ticket.codexPreflightCompletedAt
+          ? `codex_preflight=completed at ${ticket.codexPreflightCompletedAt} (${ticket.codexPreflightOutcome ?? 'unknown'})`
           : undefined,
         ticket.prUrl ? `pr=${ticket.prUrl}` : undefined,
         ticket.reviewArtifactJsonPath

--- a/tools/delivery/state.ts
+++ b/tools/delivery/state.ts
@@ -265,6 +265,12 @@ export function syncStateWithPlan(
           ),
         selfAuditOutcome:
           previous?.selfAuditOutcome ?? inferredTicket?.selfAuditOutcome,
+        codexPreflightOutcome:
+          previous?.codexPreflightOutcome ??
+          inferredTicket?.codexPreflightOutcome,
+        codexPreflightCompletedAt:
+          previous?.codexPreflightCompletedAt ??
+          inferredTicket?.codexPreflightCompletedAt,
         prNumber: previous?.prNumber ?? inferredTicket?.prNumber,
         prUrl: previous?.prUrl ?? inferredTicket?.prUrl,
         prOpenedAt: previous?.prOpenedAt ?? inferredTicket?.prOpenedAt,
@@ -443,6 +449,8 @@ function inferStateFromRepo(
       handoffPath: undefined,
       handoffGeneratedAt: undefined,
       selfAuditOutcome: undefined,
+      codexPreflightOutcome: undefined,
+      codexPreflightCompletedAt: undefined,
       prNumber: pr?.number,
       prUrl: pr?.url,
       prOpenedAt: undefined,
@@ -531,16 +539,18 @@ function statusRank(status: TicketStatus): number {
       return 1;
     case 'post_verify_self_audit_complete':
       return 2;
-    case 'in_review':
+    case 'codex_preflight_complete':
       return 3;
-    case 'needs_patch':
+    case 'in_review':
       return 4;
-    case 'operator_input_needed':
+    case 'needs_patch':
       return 5;
-    case 'reviewed':
+    case 'operator_input_needed':
       return 6;
-    case 'done':
+    case 'reviewed':
       return 7;
+    case 'done':
+      return 8;
   }
 }
 

--- a/tools/delivery/ticket-flow.ts
+++ b/tools/delivery/ticket-flow.ts
@@ -4,7 +4,13 @@ import { dirname, resolve } from 'node:path';
 
 import type { PullRequestSummary } from './platform';
 import type { ReviewActionCommit } from './pr-metadata';
-import type { DeliveryState, ReviewOutcome, TicketState } from './orchestrator';
+import type {
+  CodexPreflightOutcome,
+  DeliveryState,
+  ReviewOutcome,
+  ReviewPolicyStageValue,
+  TicketState,
+} from './orchestrator';
 
 export function findNextPendingTicket(
   state: DeliveryState,
@@ -320,6 +326,51 @@ export function recordPostVerifySelfAudit(
 /** @deprecated Use `recordPostVerifySelfAudit`. */
 export const recordInternalReview = recordPostVerifySelfAudit;
 
+export function recordCodexPreflight(
+  state: DeliveryState,
+  outcome?: 'clean' | 'patched',
+  now: () => string = () => new Date().toISOString(),
+): DeliveryState {
+  const target = state.tickets.find(
+    (ticket) => ticket.status === 'post_verify_self_audit_complete',
+  );
+
+  if (!target) {
+    throw new Error(
+      'No ticket at post_verify_self_audit_complete status found to record Codex preflight.',
+    );
+  }
+
+  const isDocOnly = !!target.docOnly;
+  let resolvedOutcome: CodexPreflightOutcome;
+
+  if (isDocOnly) {
+    resolvedOutcome = 'skipped';
+  } else if (outcome === 'clean' || outcome === 'patched') {
+    resolvedOutcome = outcome;
+  } else {
+    throw new Error(
+      `Ticket ${target.id} requires a Codex preflight outcome. Pass \`clean\` or \`patched\`.`,
+    );
+  }
+
+  const completedAt = now();
+
+  return {
+    ...state,
+    tickets: state.tickets.map((ticket) =>
+      ticket.id === target.id
+        ? {
+            ...ticket,
+            status: 'codex_preflight_complete',
+            codexPreflightOutcome: resolvedOutcome,
+            codexPreflightCompletedAt: completedAt,
+          }
+        : ticket,
+    ),
+  };
+}
+
 export function openPullRequest(
   state: DeliveryState,
   cwd: string,
@@ -339,6 +390,7 @@ export function openPullRequest(
       ticket: Pick<TicketState, 'id' | 'title'>,
       commitSubject?: string,
     ) => string;
+    codexPreflightPolicy?: ReviewPolicyStageValue;
     createPullRequest: (
       cwd: string,
       options: {
@@ -373,14 +425,16 @@ export function openPullRequest(
     (ticketId
       ? state.tickets.find((ticket) => ticket.id === ticketId)
       : (state.tickets.find(
+          (ticket) => ticket.status === 'codex_preflight_complete',
+        ) ??
+        state.tickets.find(
           (ticket) => ticket.status === 'post_verify_self_audit_complete',
-        ) ?? state.tickets.find((ticket) => ticket.status === 'in_review'))) ??
+        ) ??
+        state.tickets.find((ticket) => ticket.status === 'in_review'))) ??
     undefined;
 
   if (!target) {
-    throw new Error(
-      'No ticket in post-verify self-audit complete state found to open as a PR.',
-    );
+    throw new Error('No ticket in a PR-openable state found to open as a PR.');
   }
 
   if (target.status === 'in_progress') {
@@ -390,7 +444,17 @@ export function openPullRequest(
   }
 
   if (
+    target.status === 'post_verify_self_audit_complete' &&
+    dependencies.codexPreflightPolicy === 'required'
+  ) {
+    throw new Error(
+      `Ticket ${target.id} requires Codex preflight before opening a PR. Run \`bun run deliver codex-preflight [clean|patched]\` after completing the Codex review step. If codex-plugin-cc is unavailable, set codexPreflight to "disabled" in orchestrator.config.json to bypass.`,
+    );
+  }
+
+  if (
     target.status !== 'post_verify_self_audit_complete' &&
+    target.status !== 'codex_preflight_complete' &&
     target.status !== 'in_review'
   ) {
     throw new Error(


### PR DESCRIPTION
## Summary

- delivery ticket: `EE8.02 Codex preflight command, status, and gate`
- ticket file: [docs/02-delivery/engineering-epic-08/ticket-02-codex-preflight-command-status-and-gate.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/engineering-epic-08/ticket-02-codex-preflight-command-status-and-gate.md)
- stacked base branch: `agents/ee8-01-self-audit-observability-and-review-policy-config`
- post-verify self-audit: completed at 2026-04-13 19:24 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`136b6d093a89`](https://github.com/cesarnml/pirate_claw/commit/136b6d093a899646db939db48b445db55b834c0e)
- current branch head: [`adc9d7289f88`](https://github.com/cesarnml/pirate_claw/commit/adc9d7289f88ba439c0cdaad3551334370e156d7)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `136b6d093a89` address all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Carry `docOnly` through state sync as well. (native GitHub thread resolved) `tools/delivery/state.ts:273` [thread](https://github.com/cesarnml/pirate_claw/pull/149#discussion_r3075339680)
- [coderabbit] Docs-only Codex auto-skip is unreachable in the normal flow. (native GitHub thread resolved) `tools/delivery/ticket-flow.ts:355` [thread](https://github.com/cesarnml/pirate_claw/pull/149#discussion_r3075339684)
- [coderabbit] Don’t print an unblock command here that the CLI itself rejects. (native GitHub thread resolved) `tools/delivery/ticket-flow.ts:452` [thread](https://github.com/cesarnml/pirate_claw/pull/149#discussion_r3075339691)
