### PR TITLE
docs(delivery): align docs and workflow guidance with EE8 [EE8.03]

### DIFF
--- a/.agents/skills/son-of-anton-ethos/SKILL.md
+++ b/.agents/skills/son-of-anton-ethos/SKILL.md
@@ -11,7 +11,7 @@ Execution ethos for approved multi-ticket phase/epic work and standalone (non-ti
 
 1. **Entrypoint.** Use `bun run deliver`. Read `docs/03-engineering/delivery-orchestrator.md` for command surface — not ad hoc substitutes.
 2. **When to use.** Smaller bounded changes ship as standalone PRs without a new phase/epic. Use `bun run deliver ai-review [--pr <number>]` — not the ticketed stacked flow (`--plan …`, `poll-review`, `advance`, etc.).
-3. **Before external review.** Complete implement → verify (`bun run verify` + scoped tests) in build mode, then self-audit mode (re-read diff, second-pass risky areas). For ticket stacks run `post-verify-self-audit` CLI. If the active ticket workflow includes Codex preflight, complete that gate before `open-pr`. Standalone PRs have no self-audit CLI equivalent, but the same mode switch applies.
+3. **Before external review.** Complete implement → verify (`bun run verify` + scoped tests) in build mode, then self-audit mode (re-read diff, second-pass risky areas). For ticket stacks run `post-verify-self-audit [clean|patched]` CLI (defaults to `clean` when arg omitted). If `reviewPolicy.codexPreflight` is `"required"`, run the `codex:rescue` skill, apply prudent findings, then record with `codex-preflight [clean|patched]` before `open-pr`. Standalone PRs have no self-audit CLI equivalent, but the same mode switch applies.
 4. **Running `ai-review`.** Uses real wall-clock polling. Surface that before starting; do not hide the time cost.
 5. **Commits.** Follow AGENTS Pre-Commit (Prettier for touched files; spellcheck when docs or user-facing copy changed).
 6. **Product-scope gates** apply to new phase/epic work — not to standalone PRs already allowed outside a new phase.
@@ -37,7 +37,7 @@ Commit the delivery plan and all ticket docs to the default branch before creati
 1. Re-read required repo docs and handoff artifacts at each ticket boundary.
 2. Use the supported orchestrator path, not ad hoc manual substitutes.
 3. Move one ticket at a time in order.
-4. For each ticket: implement → verify → update ticket rationale → open/refresh PR → run AI-review polling → patch prudent findings → advance.
+4. For each ticket: implement → verify → update ticket rationale → self-audit (`post-verify-self-audit [clean|patched]`) → (if `codexPreflight: "required"`) Codex preflight (`codex-preflight [clean|patched]`) → open/refresh PR → run AI-review polling → patch prudent findings → advance.
 5. During the external review wait, do nothing.
 6. Do not write ahead across ticket boundaries.
 7. After `advance`, follow the active boundary mode and keep going without asking for permission unless a real blocker exists.
@@ -75,7 +75,27 @@ Record `clean` only when no actionable feedback found. Record `patched` when act
 
 ### Docs-Only PRs
 
-Skip the external review window. Record `clean` immediately and advance.
+Skip the external review window. Record `clean` immediately and advance. Codex preflight is also auto-skipped for doc-only tickets — the orchestrator records `skipped` without requiring an outcome arg.
+
+## Codex Preflight
+
+**Role split:**
+
+- **Claude** executes and patches (build mode and self-audit).
+- **Codex** reviews internally via the `codex:rescue` skill — a second AI opinion before the PR is published.
+- **External AI vendors** (CodeRabbit, Qodo, Greptile, SonarQube) review post-publication via `poll-review`.
+
+**When `codexPreflight` is `"required"`** in `orchestrator.config.json`:
+
+1. Run the `codex:rescue` skill.
+2. Apply prudent findings.
+3. Record the outcome: `bun run deliver --plan <plan> codex-preflight [clean|patched]`
+
+The CLI is a state recorder only — never invoke Codex from within the CLI.
+
+**When `codexPreflight` is `"disabled"`** (the default): skip the step entirely. `open-pr` does not require `codex_preflight_complete` status.
+
+If `codex-plugin-cc` is unavailable, set `codexPreflight: "disabled"` in `orchestrator.config.json` to bypass the gate.
 
 ## Stop Conditions
 

--- a/.agents/skills/son-of-anton-ethos/SKILL.md
+++ b/.agents/skills/son-of-anton-ethos/SKILL.md
@@ -37,7 +37,7 @@ Commit the delivery plan and all ticket docs to the default branch before creati
 1. Re-read required repo docs and handoff artifacts at each ticket boundary.
 2. Use the supported orchestrator path, not ad hoc manual substitutes.
 3. Move one ticket at a time in order.
-4. For each ticket: implement → verify → update ticket rationale → self-audit (`post-verify-self-audit [clean|patched]`) → (if `codexPreflight: "required"`) Codex preflight (`codex-preflight [clean|patched]`) → open/refresh PR → run AI-review polling → patch prudent findings → advance.
+4. For each ticket: implement → verify → update ticket rationale → self-audit (`post-verify-self-audit [clean|patched]`) → (if `codexPreflight: "required"`) Codex preflight (`codex-preflight [clean|patched]`) → open/refresh PR → run AI-review polling → patch prudent findings → record-review → advance.
 5. During the external review wait, do nothing.
 6. Do not write ahead across ticket boundaries.
 7. After `advance`, follow the active boundary mode and keep going without asking for permission unless a real blocker exists.

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -46,7 +46,13 @@ All fields are optional. When the file is absent, the orchestrator infers sensib
 - `reviewPolicy.codexPreflight`: `"disabled"` — Codex preflight is off by default; set to `"required"` after a successful trial run
 - `reviewPolicy.externalReview`: `"required"`
 
-Valid `reviewPolicy` stage values are `"required"`, `"skip_doc_only"`, and `"disabled"`. Invalid values and unknown keys are rejected at config load with a clear error.
+Valid `reviewPolicy` stage values are:
+
+- `"required"` — the stage must complete before the workflow can proceed.
+- `"skip_doc_only"` — the stage is required for code PRs but automatically skipped for doc-only PRs (PRs whose changed files are all `.md`).
+- `"disabled"` — the stage is never run, regardless of PR content.
+
+Invalid values and unknown keys are rejected at config load with a clear error.
 
 Supported `ticketBoundaryMode` values are:
 

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -17,8 +17,8 @@ This keeps the product boundary honest. `src/` remains the Pirate Claw applicati
 ## Configurable Core
 
 The orchestrator core now reads `orchestrator.config.json` at the repo root so
-branch, plan-root, runtime-internal, bootstrap defaults, and ticket-boundary
-behavior are not hardcoded:
+branch, plan-root, runtime-internal, bootstrap defaults, ticket-boundary
+behavior, and review policy are not hardcoded:
 
 ```json
 {
@@ -26,7 +26,12 @@ behavior are not hardcoded:
   "planRoot": "docs",
   "runtime": "bun",
   "packageManager": "bun",
-  "ticketBoundaryMode": "cook"
+  "ticketBoundaryMode": "cook",
+  "reviewPolicy": {
+    "selfAudit": "required",
+    "codexPreflight": "disabled",
+    "externalReview": "required"
+  }
 }
 ```
 
@@ -37,6 +42,11 @@ All fields are optional. When the file is absent, the orchestrator infers sensib
 - `runtime`: `"bun"` (`"bun"` uses `Bun.spawnSync`, `"node"` uses `child_process.spawnSync` inside the orchestrator implementation)
 - `packageManager`: inferred from lockfile (`bun.lock` → `"bun"`, `pnpm-lock.yaml` → `"pnpm"`, `yarn.lock` → `"yarn"`, `package-lock.json` → `"npm"`, fallback `"npm"`) for worktree bootstrap behavior
 - `ticketBoundaryMode`: `"cook"`
+- `reviewPolicy.selfAudit`: `"required"`
+- `reviewPolicy.codexPreflight`: `"disabled"` — Codex preflight is off by default; set to `"required"` after a successful trial run
+- `reviewPolicy.externalReview`: `"required"`
+
+Valid `reviewPolicy` stage values are `"required"`, `"skip_doc_only"`, and `"disabled"`. Invalid values and unknown keys are rejected at config load with a clear error.
 
 Supported `ticketBoundaryMode` values are:
 
@@ -198,7 +208,17 @@ That inference is intentionally conservative. It reconstructs enough state to re
 
 After **build mode** (implementation and automated verification, for example `bun run verify:quiet` and any scoped tests the ticket implies), the agent switches to **self-audit mode**: a deliberate pass over the diff and ticket acceptance before publishing the branch for external AI code review. Stay in the same implementation session—this is a mode switch, not a handoff.
 
-The `post-verify-self-audit` command **records** that self-audit mode completed (ticket status and timestamp in local delivery state). It does **not** run checks or read the diff; the agent performs verification in build mode and the diff review in self-audit mode, then invokes this command.
+The `post-verify-self-audit` command **records** that self-audit mode completed (ticket status, outcome, and timestamp in local delivery state). It does **not** run checks or read the diff; the agent performs verification in build mode and the diff review in self-audit mode, then invokes this command.
+
+The command accepts an optional outcome argument:
+
+```bash
+bun run deliver --plan <plan> post-verify-self-audit          # defaults to "clean"
+bun run deliver --plan <plan> post-verify-self-audit clean    # no changes during self-audit
+bun run deliver --plan <plan> post-verify-self-audit patched  # self-audit found and fixed issues
+```
+
+When omitted, outcome defaults to `clean`. The `status` command renders the outcome alongside the completion timestamp.
 
 **Before `post-verify-self-audit`, confirm at least:**
 
@@ -207,7 +227,36 @@ The `post-verify-self-audit` command **records** that self-audit mode completed 
 - Higher-risk areas changed in the diff (data shape, migrations, auth, API contracts) got a second read in self-audit mode.
 - The delivery ticket doc has an updated **Rationale** when behavior or trade-offs changed (repo policy).
 
-Then run `post-verify-self-audit`, then `open-pr`. The deprecated alias `internal-review` still works and prints a notice.
+Then run `post-verify-self-audit`, then (if Codex preflight is enabled) `codex-preflight`, then `open-pr`. The deprecated alias `internal-review` still works and prints a notice.
+
+## Codex preflight (ticket stacks)
+
+When `reviewPolicy.codexPreflight` is `"required"`, the agent must record a Codex preflight outcome before `open-pr` is allowed for code tickets.
+
+**Role split:**
+
+- **Claude** executes and patches during build and self-audit mode.
+- **Codex** reviews the implementation internally via the `codex:rescue` skill — a second AI opinion before the PR is published.
+- **External AI vendors** (CodeRabbit, Qodo, Greptile, SonarQube) review post-publication during `poll-review`.
+
+**Running Codex preflight:**
+
+1. Run the Codex review step by invoking the `codex:rescue` skill.
+2. Apply any prudent findings.
+3. Record the outcome:
+
+```bash
+bun run deliver --plan <plan> codex-preflight clean    # Codex found nothing worth patching
+bun run deliver --plan <plan> codex-preflight patched  # Codex findings were applied
+```
+
+The CLI is a state recorder only — it does not invoke Codex. The agent runs the Codex skill, then calls this command.
+
+**Doc-only tickets** auto-skip Codex preflight. The orchestrator detects doc-only by inspecting the local git diff at `codex-preflight` time (all changed files are `.md`) and records `skipped` without requiring an outcome arg. A clear message is printed: "Doc-only ticket — Codex preflight auto-skipped."
+
+When `reviewPolicy.codexPreflight` is `"disabled"` (the default), `open-pr` does not require `codex_preflight_complete` status and tickets at `post_verify_self_audit_complete` may proceed directly to `open-pr`.
+
+If `codex-plugin-cc` is unavailable, set `codexPreflight: "disabled"` in `orchestrator.config.json` to bypass the gate.
 
 ## Commands
 
@@ -224,7 +273,8 @@ Available commands:
 - `repair-state`
 - `ai-review [--pr <number>]`
 - `start [ticket-id]`
-- `post-verify-self-audit [ticket-id]` (alias: `internal-review`, deprecated)
+- `post-verify-self-audit [clean|patched]` (alias: `internal-review`, deprecated)
+- `codex-preflight [clean|patched]`
 - `open-pr [ticket-id]`
 - `poll-review [ticket-id]`
 - `reconcile-late-review <ticket-id>`
@@ -238,15 +288,27 @@ Separate post-delivery closeout command:
 
 ## Typical Flow
 
-Default `cook` flow:
+Default `cook` flow (with Codex preflight disabled — the default):
 
 ```bash
 bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md start
-bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md post-verify-self-audit
+bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md post-verify-self-audit [clean|patched]
 bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md open-pr
 bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md poll-review
 # if the triager hook leaves the ticket in needs_patch, follow up and then record the final outcome
 bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md record-review P2.02 patched "patched the two actionable correctness issues"
+bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md advance
+```
+
+With `codexPreflight: "required"` in `orchestrator.config.json`, add the Codex preflight step after self-audit:
+
+```bash
+bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md start
+bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md post-verify-self-audit [clean|patched]
+# run codex:rescue skill, apply prudent findings, then record:
+bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md codex-preflight [clean|patched]
+bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md open-pr
+bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md poll-review
 bun run deliver --plan docs/02-delivery/phase-02/implementation-plan.md advance
 ```
 
@@ -276,7 +338,7 @@ bun run deliver ai-review
 
 At each ticket boundary, read the generated handoff artifact before continuing implementation.
 
-After implementation and verification in build mode, use `bun run verify:quiet` rather than `bun run verify` to suppress passing output and show only failures. Complete **self-audit mode** (see above), then record it with `post-verify-self-audit` before opening a substantial ticket-linked PR. After `open-pr`, the orchestrator surfaces the ai-review polling cadence and check timestamps. `poll-review` checks at 6 and 12 minutes after PR open; doc-only PRs (diff touches only `.md` files) skip the window and auto-record `clean`. At the 6-minute check, the orchestrator advances immediately if all detected external review agents have finished their run (including agents that report clean). Otherwise it waits for the 12-minute final check. Do nothing during the review window — no file reads, no ticket prep. The wait is free. `poll-review` writes `json` and `txt` artifacts and runs the triager hook. When findings are detected, `poll-review` output includes a condensed findings block — `[vendor] path:line — title` per actionable finding — so the implementing agent can triage and patch without reading the full `.txt` artifact. `poll-review` otherwise auto-records `clean` at the final check. After `advance`, follow the selected boundary mode: continue directly in `cook`, or reset and resume with the canonical prompt in `gated` / `glide` fallback.
+After implementation and verification in build mode, use `bun run verify:quiet` rather than `bun run verify` to suppress passing output and show only failures. Complete **self-audit mode** (see above), then record it with `post-verify-self-audit [clean|patched]` before moving on. When `reviewPolicy.codexPreflight` is `"required"`, run the `codex:rescue` skill, apply prudent findings, then record with `codex-preflight [clean|patched]`. After that (or directly after `post-verify-self-audit` when Codex preflight is disabled), run `open-pr`. After `open-pr`, the orchestrator surfaces the ai-review polling cadence and check timestamps. `poll-review` checks at 6 and 12 minutes after PR open; doc-only PRs (diff touches only `.md` files) skip the window and auto-record `clean`. At the 6-minute check, the orchestrator advances immediately if all detected external review agents have finished their run (including agents that report clean). Otherwise it waits for the 12-minute final check. Do nothing during the review window — no file reads, no ticket prep. The wait is free. `poll-review` writes `json` and `txt` artifacts and runs the triager hook. When findings are detected, `poll-review` output includes a condensed findings block — `[vendor] path:line — title` per actionable finding — so the implementing agent can triage and patch without reading the full `.txt` artifact. `poll-review` otherwise auto-records `clean` at the final check. After `advance`, follow the selected boundary mode: continue directly in `cook`, or reset and resume with the canonical prompt in `gated` / `glide` fallback.
 
 If a parent ticket was squash-merged onto `main`, run:
 

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -586,7 +586,33 @@ export async function runDeliveryOrchestrator(
           preflightPositional === 'clean' || preflightPositional === 'patched'
             ? preflightPositional
             : undefined;
-        const nextState = recordCodexPreflight(state, preflightOutcome);
+        const preflightTarget = state.tickets.find(
+          (t) => t.status === 'post_verify_self_audit_complete',
+        );
+        let isDocOnly = !!preflightTarget?.docOnly;
+        if (preflightTarget && !isDocOnly) {
+          const diffResult = runPlatformProcessResult(
+            preflightTarget.worktreePath,
+            [
+              'git',
+              'diff',
+              `origin/${preflightTarget.baseBranch}...HEAD`,
+              '--name-only',
+            ],
+            _config.runtime,
+          );
+          if (diffResult.exitCode === 0) {
+            const changedFiles = diffResult.stdout.split('\n').filter(Boolean);
+            isDocOnly =
+              changedFiles.length > 0 &&
+              changedFiles.every((f) => f.endsWith('.md'));
+          }
+        }
+        const nextState = recordCodexPreflight(
+          state,
+          preflightOutcome,
+          isDocOnly,
+        );
         const justRecordedPreflight = nextState.tickets.find(
           (t) =>
             t.status === 'codex_preflight_complete' &&
@@ -1043,8 +1069,9 @@ export async function recordInternalReview(
 export function recordCodexPreflight(
   state: DeliveryState,
   outcome?: 'clean' | 'patched',
+  isDocOnly?: boolean,
 ): DeliveryState {
-  return recordCodexPreflightImpl(state, outcome);
+  return recordCodexPreflightImpl(state, outcome, isDocOnly);
 }
 
 export async function openPullRequest(

--- a/tools/delivery/state.ts
+++ b/tools/delivery/state.ts
@@ -137,16 +137,16 @@ export async function repairState(
 }> {
   const { absoluteStatePath, inferred, ticketDefinitions } =
     await loadPlanContext(cwd, options, dependencies);
-  const repairedState = syncStateWithPlan(
-    undefined,
-    ticketDefinitions,
-    options,
-    inferred,
-    dependencies,
-  );
   const hadExistingState = existsSync(absoluteStatePath);
 
   if (!hadExistingState) {
+    const repairedState = syncStateWithPlan(
+      undefined,
+      ticketDefinitions,
+      options,
+      inferred,
+      dependencies,
+    );
     await saveState(cwd, repairedState);
 
     return {
@@ -160,6 +160,13 @@ export async function repairState(
 
   const existing = normalizeDeliveryStateFromPersisted(
     JSON.parse(await readFile(absoluteStatePath, 'utf8')),
+  );
+  const repairedState = syncStateWithPlan(
+    existing,
+    ticketDefinitions,
+    options,
+    inferred,
+    dependencies,
   );
   const changes = summarizeStateDifferences(existing, repairedState);
   let backupPath: string | undefined;

--- a/tools/delivery/state.ts
+++ b/tools/delivery/state.ts
@@ -265,6 +265,7 @@ export function syncStateWithPlan(
           ),
         selfAuditOutcome:
           previous?.selfAuditOutcome ?? inferredTicket?.selfAuditOutcome,
+        docOnly: (previous?.docOnly ?? inferredTicket?.docOnly) || undefined,
         codexPreflightOutcome:
           previous?.codexPreflightOutcome ??
           inferredTicket?.codexPreflightOutcome,

--- a/tools/delivery/ticket-flow.ts
+++ b/tools/delivery/ticket-flow.ts
@@ -329,6 +329,7 @@ export const recordInternalReview = recordPostVerifySelfAudit;
 export function recordCodexPreflight(
   state: DeliveryState,
   outcome?: 'clean' | 'patched',
+  isDocOnly?: boolean,
   now: () => string = () => new Date().toISOString(),
 ): DeliveryState {
   const target = state.tickets.find(
@@ -341,10 +342,10 @@ export function recordCodexPreflight(
     );
   }
 
-  const isDocOnly = !!target.docOnly;
+  const docOnly = isDocOnly ?? !!target.docOnly;
   let resolvedOutcome: CodexPreflightOutcome;
 
-  if (isDocOnly) {
+  if (docOnly) {
     resolvedOutcome = 'skipped';
   } else if (outcome === 'clean' || outcome === 'patched') {
     resolvedOutcome = outcome;
@@ -448,7 +449,7 @@ export function openPullRequest(
     dependencies.codexPreflightPolicy === 'required'
   ) {
     throw new Error(
-      `Ticket ${target.id} requires Codex preflight before opening a PR. Run \`bun run deliver codex-preflight [clean|patched]\` after completing the Codex review step. If codex-plugin-cc is unavailable, set codexPreflight to "disabled" in orchestrator.config.json to bypass.`,
+      `Ticket ${target.id} requires Codex preflight before opening a PR. Run \`bun run deliver codex-preflight <clean|patched>\` after completing the Codex review step. If codex-plugin-cc is unavailable, set codexPreflight to "disabled" in orchestrator.config.json to bypass.`,
     );
   }
 


### PR DESCRIPTION
## Summary

- delivery ticket: `EE8.03 Docs and workflow guidance`
- ticket file: [docs/02-delivery/engineering-epic-08/ticket-03-docs-and-workflow-guidance.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/engineering-epic-08/ticket-03-docs-and-workflow-guidance.md)
- stacked base branch: `agents/ee8-02-codex-preflight-command-status-and-gate`
- post-verify self-audit: completed at 2026-04-13 19:42 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`deb65dbe8214`](https://github.com/cesarnml/pirate_claw/commit/deb65dbe8214e4bd3e1e6906e374b93be0977ed7)
- current branch head: [`e3b5095c250a`](https://github.com/cesarnml/pirate_claw/commit/e3b5095c250a9d8e438d8db1046145347bec52e6)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `deb65dbe8214` address all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Add the missing `record-review` step before `advance`. (native GitHub thread resolved) `.agents/skills/son-of-anton-ethos/SKILL.md:43` [thread](https://github.com/cesarnml/pirate_claw/pull/150#discussion_r3075447156)
- [coderabbit] Define `skip_doc_only` instead of just listing it. (native GitHub thread resolved) `docs/03-engineering/delivery-orchestrator.md:50` [thread](https://github.com/cesarnml/pirate_claw/pull/150#discussion_r3075447167)
- [coderabbit] `repair-state` still clears `docOnly` for already-open docs-only tickets. (native GitHub thread resolved) `tools/delivery/state.ts:268` [thread](https://github.com/cesarnml/pirate_claw/pull/150#discussion_r3075447174)
