### PR TITLE
refactor: consolidate doc-only detection [EE9.01]

### DIFF
--- a/docs/02-delivery/engineering-epic-09/ticket-01-doc-only-detection-consolidation.md
+++ b/docs/02-delivery/engineering-epic-09/ticket-01-doc-only-detection-consolidation.md
@@ -73,6 +73,10 @@ has no network dependency, and cannot silently return `false` due to auth failur
 Using the local diff for both callers eliminates the divergence risk with no
 behavioral change.
 
+Implemented as a shared `platform.ts` helper so `codex-preflight` and `open-pr`
+now exercise the same safe-fail logic instead of carrying parallel doc-only
+checks in different modules.
+
 ## Notes
 
 - `EE9.03` depends on this ticket. `post-verify-self-audit` auto-skip (when

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -22,7 +22,7 @@ import {
   findOpenPullRequest as findPlatformOpenPullRequest,
   findPrimaryWorktreePath as findPlatformPrimaryWorktreePath,
   hasMergedPullRequestForBranch as hasPlatformMergedPullRequestForBranch,
-  isPrDocOnly as isPlatformPrDocOnly,
+  isLocalBranchDocOnly as isPlatformLocalBranchDocOnly,
   listCommitSubjectsBetween as listPlatformCommitSubjectsBetween,
   readCurrentBranch as readPlatformCurrentBranch,
   readHeadSha as readPlatformHeadSha,
@@ -589,25 +589,13 @@ export async function runDeliveryOrchestrator(
         const preflightTarget = state.tickets.find(
           (t) => t.status === 'post_verify_self_audit_complete',
         );
-        let isDocOnly = !!preflightTarget?.docOnly;
-        if (preflightTarget && !isDocOnly) {
-          const diffResult = runPlatformProcessResult(
-            preflightTarget.worktreePath,
-            [
-              'git',
-              'diff',
-              `origin/${preflightTarget.baseBranch}...HEAD`,
-              '--name-only',
-            ],
-            _config.runtime,
-          );
-          if (diffResult.exitCode === 0) {
-            const changedFiles = diffResult.stdout.split('\n').filter(Boolean);
-            isDocOnly =
-              changedFiles.length > 0 &&
-              changedFiles.every((f) => f.endsWith('.md'));
-          }
-        }
+        const isDocOnly = preflightTarget
+          ? isPlatformLocalBranchDocOnly(
+              preflightTarget.worktreePath,
+              preflightTarget.baseBranch,
+              _config.runtime,
+            )
+          : false;
         const nextState = recordCodexPreflight(
           state,
           preflightOutcome,
@@ -1101,10 +1089,10 @@ export async function openPullRequest(
       ? nextState.tickets.find((t) => t.id === ticketId)
       : nextState.tickets.find((t) => t.status === 'in_review')) ?? undefined;
 
-  if (reviewTicket?.prNumber) {
-    const docOnly = isPlatformPrDocOnly(
+  if (reviewTicket) {
+    const docOnly = isPlatformLocalBranchDocOnly(
       reviewTicket.worktreePath,
-      reviewTicket.prNumber,
+      reviewTicket.baseBranch,
       _config.runtime,
     );
 

--- a/tools/delivery/platform.ts
+++ b/tools/delivery/platform.ts
@@ -648,19 +648,15 @@ export function fetchOrigin(cwd: string, runtime: Runtime): void {
   runProcess(cwd, ['git', 'fetch', 'origin'], runtime);
 }
 
-/**
- * Returns true when every file touched by the PR is a Markdown file (.md).
- * Doc-only PRs skip the external AI review window.
- */
-export function isPrDocOnly(
+export function isLocalBranchDocOnly(
   cwd: string,
-  prNumber: number,
+  baseBranch: string,
   runtime: Runtime,
 ): boolean {
   try {
     const stdout = runProcess(
       cwd,
-      ['gh', 'pr', 'diff', String(prNumber), '--name-only'],
+      ['git', 'diff', `origin/${baseBranch}...HEAD`, '--name-only'],
       runtime,
     );
     const files = stdout


### PR DESCRIPTION
## Summary

- delivery ticket: `EE9.01 Doc-only detection consolidation`
- ticket file: [docs/02-delivery/engineering-epic-09/ticket-01-doc-only-detection-consolidation.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/engineering-epic-09/ticket-01-doc-only-detection-consolidation.md)
- stacked base branch: `main`
- post-verify self-audit: completed at 2026-04-13 21:50 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`14d6f17dc286`](https://github.com/cesarnml/pirate_claw/commit/14d6f17dc28685d1a4ed20f2e16812dcc216cf18)
- current branch head: [`14d6f17dc286`](https://github.com/cesarnml/pirate_claw/commit/14d6f17dc28685d1a4ed20f2e16812dcc216cf18)
- vendors: `coderabbit`
