### PR TITLE
refactor: clarify state sync entrypoints [EE9.02]

### DIFF
--- a/docs/02-delivery/engineering-epic-09/ticket-02-syncstatewithplan-call-site-clarity.md
+++ b/docs/02-delivery/engineering-epic-09/ticket-02-syncstatewithplan-call-site-clarity.md
@@ -70,6 +70,10 @@ like `syncStateWithPlan(undefined, plan, now)` is compact but hides intent in a
 sentinel argument. Thin wrappers keep the implementation centralized while
 making the two modes explicit to reviewers and future maintainers.
 
+The shipped change keeps `syncStateWithPlan` private inside `state.ts` and
+routes both repo call sites plus the test surface through explicit
+`syncStateFromScratch` and `syncStateFromExisting` names.
+
 ## Notes
 
 - Keep this ticket behavior-neutral. Do not combine it with review-policy

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -55,7 +55,8 @@ import {
   resolveReviewTriager,
   runStandaloneAiReview,
   summarizeStateDifferences,
-  syncStateWithPlan,
+  syncStateFromExisting,
+  syncStateFromScratch,
   runProcessResult,
   formatCurrentTicketStatus,
   formatAdvanceBoundaryGuidance,
@@ -228,7 +229,7 @@ describe('delivery orchestrator', () => {
       ],
     };
 
-    const synced = syncStateWithPlan(
+    const synced = syncStateFromExisting(
       existing,
       [
         {
@@ -3649,7 +3650,7 @@ describe('delivery orchestrator', () => {
       }
     });
 
-    it('syncStateWithPlan uses configured defaultBranch for first ticket baseBranch', () => {
+    it('syncStateFromScratch uses configured defaultBranch for first ticket baseBranch', () => {
       initOrchestratorConfig({
         defaultBranch: 'develop',
         planRoot: 'docs',
@@ -3663,8 +3664,7 @@ describe('delivery orchestrator', () => {
           planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
         });
 
-        const synced = syncStateWithPlan(
-          undefined,
+        const synced = syncStateFromScratch(
           [
             {
               id: 'P3.01',
@@ -4526,7 +4526,7 @@ describe('EE8.02 — codex preflight command, status, and gate', () => {
   });
 
   it('statusRank orders: post_verify_self_audit_complete < codex_preflight_complete < in_review', () => {
-    // Verify via syncStateWithPlan status selection: higher rank wins
+    // Verify via syncStateFromExisting status selection: higher rank wins
     const options = createOptions({
       planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
     });
@@ -4556,7 +4556,7 @@ describe('EE8.02 — codex preflight command, status, and gate', () => {
         status: 'post_verify_self_audit_complete' as const,
       })),
     };
-    const synced = syncStateWithPlan(
+    const synced = syncStateFromExisting(
       existing,
       existing.tickets,
       '/tmp',

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -50,7 +50,8 @@ import {
   repairState as repairStateImpl,
   saveState as saveStateImpl,
   summarizeStateDifferences as summarizeStateDifferencesImpl,
-  syncStateWithPlan as syncStateWithPlanImpl,
+  syncStateFromExisting as syncStateFromExistingImpl,
+  syncStateFromScratch as syncStateFromScratchImpl,
 } from './state';
 import {
   buildRunBlockedEvent,
@@ -865,19 +866,39 @@ export function parsePlan(
   return parsePlanImpl(markdown, planPath);
 }
 
-export function syncStateWithPlan(
-  existing: DeliveryState | undefined,
+export function syncStateFromScratch(
   ticketDefinitions: TicketDefinition[],
   cwd: string,
   options: OrchestratorOptions,
   inferred?: DeliveryState,
 ): DeliveryState {
-  return syncStateWithPlanImpl(existing, ticketDefinitions, options, inferred, {
+  return syncStateFromScratchImpl(ticketDefinitions, options, inferred, {
     cwd,
     defaultBranch: _config.defaultBranch,
     deriveBranchName,
     deriveWorktreePath,
   });
+}
+
+export function syncStateFromExisting(
+  existing: DeliveryState,
+  ticketDefinitions: TicketDefinition[],
+  cwd: string,
+  options: OrchestratorOptions,
+  inferred?: DeliveryState,
+): DeliveryState {
+  return syncStateFromExistingImpl(
+    existing,
+    ticketDefinitions,
+    options,
+    inferred,
+    {
+      cwd,
+      defaultBranch: _config.defaultBranch,
+      deriveBranchName,
+      deriveWorktreePath,
+    },
+  );
 }
 
 export function deriveBranchName(

--- a/tools/delivery/state.ts
+++ b/tools/delivery/state.ts
@@ -103,8 +103,7 @@ export async function loadState(
     await loadPlanContext(cwd, options, dependencies);
 
   if (!existsSync(absoluteStatePath)) {
-    return syncStateWithPlan(
-      undefined,
+    return syncStateFromScratch(
       ticketDefinitions,
       options,
       inferred,
@@ -116,7 +115,7 @@ export async function loadState(
     JSON.parse(await readFile(absoluteStatePath, 'utf8')),
   );
 
-  return syncStateWithPlan(
+  return syncStateFromExisting(
     existing,
     ticketDefinitions,
     options,
@@ -140,8 +139,7 @@ export async function repairState(
   const hadExistingState = existsSync(absoluteStatePath);
 
   if (!hadExistingState) {
-    const repairedState = syncStateWithPlan(
-      undefined,
+    const repairedState = syncStateFromScratch(
       ticketDefinitions,
       options,
       inferred,
@@ -161,7 +159,7 @@ export async function repairState(
   const existing = normalizeDeliveryStateFromPersisted(
     JSON.parse(await readFile(absoluteStatePath, 'utf8')),
   );
-  const repairedState = syncStateWithPlan(
+  const repairedState = syncStateFromExisting(
     existing,
     ticketDefinitions,
     options,
@@ -203,7 +201,38 @@ export async function saveState(
   );
 }
 
-export function syncStateWithPlan(
+export function syncStateFromScratch(
+  ticketDefinitions: TicketDefinition[],
+  options: OrchestratorOptions,
+  inferred: DeliveryState | undefined,
+  dependencies: SyncStateDependencies,
+): DeliveryState {
+  return syncStateWithPlan(
+    undefined,
+    ticketDefinitions,
+    options,
+    inferred,
+    dependencies,
+  );
+}
+
+export function syncStateFromExisting(
+  existing: DeliveryState,
+  ticketDefinitions: TicketDefinition[],
+  options: OrchestratorOptions,
+  inferred: DeliveryState | undefined,
+  dependencies: SyncStateDependencies,
+): DeliveryState {
+  return syncStateWithPlan(
+    existing,
+    ticketDefinitions,
+    options,
+    inferred,
+    dependencies,
+  );
+}
+
+function syncStateWithPlan(
   existing: DeliveryState | undefined,
   ticketDefinitions: TicketDefinition[],
   options: OrchestratorOptions,


### PR DESCRIPTION
## Summary

- delivery ticket: `EE9.02 syncStateWithPlan call-site clarity`
- ticket file: [docs/02-delivery/engineering-epic-09/ticket-02-syncstatewithplan-call-site-clarity.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/engineering-epic-09/ticket-02-syncstatewithplan-call-site-clarity.md)
- stacked base branch: `agents/ee9-01-doc-only-detection-consolidation`
- post-verify self-audit: completed at 2026-04-13 22:00 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`26e1b734a45f`](https://github.com/cesarnml/pirate_claw/commit/26e1b734a45faee77df67d25cca94a7dabdfc777)
- current branch head: [`26e1b734a45f`](https://github.com/cesarnml/pirate_claw/commit/26e1b734a45faee77df67d25cca94a7dabdfc777)
- vendors: `coderabbit`
