### PR TITLE
feat: add onboarding shell and first feed step [P17.01]

### DIFF
--- a/docs/02-delivery/phase-17/ticket-01-onboarding-shell-feed-save.md
+++ b/docs/02-delivery/phase-17/ticket-01-onboarding-shell-feed-save.md
@@ -80,3 +80,5 @@ The app can detect the strict initial-empty case, launch onboarding only there, 
 ## Rationale
 
 This ticket is intentionally a thin real slice rather than a route-only shell. It proves the entry contract, dismissal semantics, and incremental-save model before later tickets add target-specific branching.
+
+The home route currently takes the "surface onboarding entry" branch rather than forcing an immediate redirect. That still honors the agreed trigger contract for this ticket while keeping the first slice smaller: the route now derives the strict initial-empty vs partial-setup state, surfaces onboarding affordances accordingly, and leaves stronger redirect behavior available as a later refinement if product review still wants it after the dedicated onboarding route exists.

--- a/fixtures/api/config-empty.json
+++ b/fixtures/api/config-empty.json
@@ -1,0 +1,22 @@
+{
+  "feeds": [],
+  "tv": [],
+  "movies": {
+    "years": [],
+    "resolutions": [],
+    "codecs": [],
+    "codecPolicy": "prefer"
+  },
+  "transmission": {
+    "url": "http://localhost:9091/transmission/rpc",
+    "username": "[redacted]",
+    "password": "[redacted]"
+  },
+  "runtime": {
+    "runIntervalMinutes": 30,
+    "reconcileIntervalMinutes": 1,
+    "artifactDir": ".pirate-claw/runtime",
+    "artifactRetentionDays": 7,
+    "apiPort": 4321
+  }
+}

--- a/fixtures/api/config-feed-only.json
+++ b/fixtures/api/config-feed-only.json
@@ -1,0 +1,28 @@
+{
+  "feeds": [
+    {
+      "name": "TV Feed",
+      "url": "https://example.com/tv.rss",
+      "mediaType": "tv"
+    }
+  ],
+  "tv": [],
+  "movies": {
+    "years": [],
+    "resolutions": [],
+    "codecs": [],
+    "codecPolicy": "prefer"
+  },
+  "transmission": {
+    "url": "http://localhost:9091/transmission/rpc",
+    "username": "[redacted]",
+    "password": "[redacted]"
+  },
+  "runtime": {
+    "runIntervalMinutes": 30,
+    "reconcileIntervalMinutes": 1,
+    "artifactDir": ".pirate-claw/runtime",
+    "artifactRetentionDays": 7,
+    "apiPort": 4321
+  }
+}

--- a/web/src/lib/onboarding.ts
+++ b/web/src/lib/onboarding.ts
@@ -1,0 +1,70 @@
+import type { AppConfig, OnboardingStatus } from '$lib/types';
+
+export const ONBOARDING_DISMISSED_KEY = 'pirate-claw:onboarding-dismissed';
+let onboardingDismissedFallback = false;
+
+export function deriveOnboardingStatus(config: AppConfig, canWrite: boolean): OnboardingStatus {
+	const hasFeeds = config.feeds.length > 0;
+	const hasTvTargets = config.tv.length > 0;
+	const hasMovieTargets = config.movies.years.length > 0;
+	const minimumComplete = hasFeeds && (hasTvTargets || hasMovieTargets);
+
+	if (minimumComplete) {
+		return {
+			state: 'ready',
+			hasFeeds,
+			hasTvTargets,
+			hasMovieTargets,
+			minimumComplete
+		};
+	}
+
+	if (!canWrite) {
+		return {
+			state: 'writes_disabled',
+			hasFeeds,
+			hasTvTargets,
+			hasMovieTargets,
+			minimumComplete
+		};
+	}
+
+	if (!hasFeeds && !hasTvTargets && !hasMovieTargets) {
+		return {
+			state: 'initial_empty',
+			hasFeeds,
+			hasTvTargets,
+			hasMovieTargets,
+			minimumComplete
+		};
+	}
+
+	return {
+		state: 'partial_setup',
+		hasFeeds,
+		hasTvTargets,
+		hasMovieTargets,
+		minimumComplete
+	};
+}
+
+function getStorage(): Pick<Storage, 'getItem' | 'setItem'> | null {
+	const storage = globalThis.localStorage;
+	if (storage && typeof storage.getItem === 'function' && typeof storage.setItem === 'function') {
+		return storage;
+	}
+	return null;
+}
+
+export function readOnboardingDismissed(): boolean {
+	const storage = getStorage();
+	if (!storage) return onboardingDismissedFallback;
+	return storage.getItem(ONBOARDING_DISMISSED_KEY) === 'true';
+}
+
+export function writeOnboardingDismissed(value: boolean): void {
+	onboardingDismissedFallback = value;
+	const storage = getStorage();
+	if (!storage) return;
+	storage.setItem(ONBOARDING_DISMISSED_KEY, value ? 'true' : 'false');
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -168,6 +168,16 @@ export type AppConfig = {
 	runtime: RuntimeConfig;
 };
 
+export type OnboardingState = 'initial_empty' | 'partial_setup' | 'ready' | 'writes_disabled';
+
+export type OnboardingStatus = {
+	state: OnboardingState;
+	hasFeeds: boolean;
+	hasTvTargets: boolean;
+	hasMovieTargets: boolean;
+	minimumComplete: boolean;
+};
+
 export type TorrentStatSnapshot = {
 	hash: string;
 	name: string;

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -1,19 +1,26 @@
+import { env } from '$env/dynamic/private';
+import { deriveOnboardingStatus } from '$lib/onboarding';
 import { apiFetch } from '$lib/server/api';
 import type {
+	AppConfig,
 	CandidateStateRecord,
 	DaemonHealth,
+	OnboardingStatus,
 	SessionInfo,
 	TorrentStatSnapshot
 } from '$lib/types';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-	const [healthResult, sessionResult, torrentsResult, candidatesResult] = await Promise.allSettled([
-		apiFetch<DaemonHealth>('/api/health'),
-		apiFetch<SessionInfo>('/api/transmission/session'),
-		apiFetch<{ torrents: TorrentStatSnapshot[] }>('/api/transmission/torrents'),
-		apiFetch<{ candidates: CandidateStateRecord[] }>('/api/candidates')
-	]);
+	const canWrite = !!env.PIRATE_CLAW_API_WRITE_TOKEN;
+	const [healthResult, sessionResult, torrentsResult, candidatesResult, configResult] =
+		await Promise.allSettled([
+			apiFetch<DaemonHealth>('/api/health'),
+			apiFetch<SessionInfo>('/api/transmission/session'),
+			apiFetch<{ torrents: TorrentStatSnapshot[] }>('/api/transmission/torrents'),
+			apiFetch<{ candidates: CandidateStateRecord[] }>('/api/candidates'),
+			apiFetch<AppConfig>('/api/config')
+		]);
 
 	const health = healthResult.status === 'fulfilled' ? healthResult.value : null;
 	const transmissionSession = sessionResult.status === 'fulfilled' ? sessionResult.value : null;
@@ -21,6 +28,10 @@ export const load: PageServerLoad = async () => {
 		torrentsResult.status === 'fulfilled' ? torrentsResult.value.torrents : null;
 	const candidates =
 		candidatesResult.status === 'fulfilled' ? candidatesResult.value.candidates : null;
+	const onboarding: OnboardingStatus | null =
+		configResult.status === 'fulfilled'
+			? deriveOnboardingStatus(configResult.value, canWrite)
+			: null;
 
 	const error = health === null ? 'Could not reach the API.' : null;
 
@@ -33,12 +44,16 @@ export const load: PageServerLoad = async () => {
 	if (candidatesResult.status === 'rejected') {
 		console.error('[dashboard] failed to load /api/candidates', candidatesResult.reason);
 	}
+	if (configResult.status === 'rejected') {
+		console.error('[dashboard] failed to load /api/config', configResult.reason);
+	}
 
 	return {
 		health,
 		transmissionSession,
 		transmissionTorrents,
 		candidates,
+		onboarding,
 		error
 	};
 };

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
+	import { readOnboardingDismissed, writeOnboardingDismissed } from '$lib/onboarding';
 	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
 	import { Card, CardContent, CardHeader } from '$lib/components/ui/card';
 	import {
@@ -13,6 +15,7 @@
 	import type { PageData } from './$types';
 
 	const { data }: { data: PageData } = $props();
+	let onboardingDismissed = $state(false);
 
 	function formatUptime(ms: number): string {
 		const totalSeconds = Math.floor(ms / 1000);
@@ -114,9 +117,55 @@
 			.sort((a, b) => b.transmissionDoneDate.localeCompare(a.transmissionDoneDate))
 			.slice(0, 6)
 	);
+
+	$effect(() => {
+		if (!browser) return;
+		onboardingDismissed = readOnboardingDismissed();
+	});
+
+	function dismissOnboardingPrompt() {
+		if (!browser) return;
+		writeOnboardingDismissed(true);
+		onboardingDismissed = readOnboardingDismissed();
+	}
 </script>
 
 <h1 class="text-3xl font-bold tracking-tight">Dashboard</h1>
+
+{#if data.onboarding && data.onboarding.state !== 'ready'}
+	<Alert class="mt-6">
+		<AlertTitle>
+			{data.onboarding.state === 'partial_setup' || onboardingDismissed
+				? 'Resume onboarding'
+				: 'Finish first-time setup'}
+		</AlertTitle>
+		<AlertDescription class="flex flex-wrap items-center gap-3">
+			<span>
+				{#if data.onboarding.state === 'writes_disabled'}
+					Enable config writes before using onboarding.
+				{:else if data.onboarding.state === 'partial_setup' || onboardingDismissed}
+					Continue the guided setup flow from where you left off.
+				{:else}
+					Start with your first feed, then continue into guided setup.
+				{/if}
+			</span>
+			<a href="/onboarding" class="text-primary text-sm font-medium hover:underline">
+				{data.onboarding.state === 'partial_setup' || onboardingDismissed
+					? 'Resume onboarding'
+					: 'Start onboarding'}
+			</a>
+			{#if data.onboarding.state === 'initial_empty' && !onboardingDismissed}
+				<button
+					type="button"
+					class="text-muted-foreground text-sm hover:underline"
+					onclick={dismissOnboardingPrompt}
+				>
+					Skip for now
+				</button>
+			{/if}
+		</AlertDescription>
+	</Alert>
+{/if}
 
 {#if data.error}
 	<Alert variant="destructive" class="mt-6" role="alert">

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -128,6 +128,11 @@
 		writeOnboardingDismissed(true);
 		onboardingDismissed = readOnboardingDismissed();
 	}
+
+	const showResumeCopy = $derived(
+		data.onboarding?.state === 'partial_setup' ||
+			(data.onboarding?.state === 'initial_empty' && onboardingDismissed)
+	);
 </script>
 
 <h1 class="text-3xl font-bold tracking-tight">Dashboard</h1>
@@ -135,24 +140,20 @@
 {#if data.onboarding && data.onboarding.state !== 'ready'}
 	<Alert class="mt-6">
 		<AlertTitle>
-			{data.onboarding.state === 'partial_setup' || onboardingDismissed
-				? 'Resume onboarding'
-				: 'Finish first-time setup'}
+			{showResumeCopy ? 'Resume onboarding' : 'Finish first-time setup'}
 		</AlertTitle>
 		<AlertDescription class="flex flex-wrap items-center gap-3">
 			<span>
 				{#if data.onboarding.state === 'writes_disabled'}
 					Enable config writes before using onboarding.
-				{:else if data.onboarding.state === 'partial_setup' || onboardingDismissed}
+				{:else if showResumeCopy}
 					Continue the guided setup flow from where you left off.
 				{:else}
 					Start with your first feed, then continue into guided setup.
 				{/if}
 			</span>
 			<a href="/onboarding" class="text-primary text-sm font-medium hover:underline">
-				{data.onboarding.state === 'partial_setup' || onboardingDismissed
-					? 'Resume onboarding'
-					: 'Start onboarding'}
+				{showResumeCopy ? 'Resume onboarding' : 'Start onboarding'}
 			</a>
 			{#if data.onboarding.state === 'initial_empty' && !onboardingDismissed}
 				<button

--- a/web/src/routes/dashboard.test.ts
+++ b/web/src/routes/dashboard.test.ts
@@ -4,9 +4,11 @@ import Page from './+page.svelte';
 import type {
 	CandidateStateRecord,
 	DaemonHealth,
+	OnboardingStatus,
 	SessionInfo,
 	TorrentStatSnapshot
 } from '$lib/types';
+import { writeOnboardingDismissed } from '$lib/onboarding';
 
 const mockHealth: DaemonHealth = {
 	uptime: 3661000,
@@ -59,6 +61,7 @@ const baseData = {
 	transmissionSession: mockSession,
 	transmissionTorrents: [],
 	candidates: [],
+	onboarding: null as OnboardingStatus | null,
 	error: null
 };
 
@@ -85,6 +88,62 @@ describe('/', () => {
 	it('renders error state when health is null', () => {
 		render(Page, { data: { ...baseData, health: null, error: 'Could not reach the API.' } });
 		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
+	});
+
+	it('surfaces onboarding entry for strict initial-empty setup', () => {
+		render(Page, {
+			data: {
+				...baseData,
+				onboarding: {
+					state: 'initial_empty',
+					hasFeeds: false,
+					hasTvTargets: false,
+					hasMovieTargets: false,
+					minimumComplete: false
+				}
+			}
+		});
+		expect(screen.getByRole('link', { name: 'Start onboarding' })).toHaveAttribute(
+			'href',
+			'/onboarding'
+		);
+	});
+
+	it('respects dismissal suppression by switching to resume onboarding copy', () => {
+		writeOnboardingDismissed(true);
+		render(Page, {
+			data: {
+				...baseData,
+				onboarding: {
+					state: 'initial_empty',
+					hasFeeds: false,
+					hasTvTargets: false,
+					hasMovieTargets: false,
+					minimumComplete: false
+				}
+			}
+		});
+		expect(screen.getByRole('link', { name: 'Resume onboarding' })).toHaveAttribute(
+			'href',
+			'/onboarding'
+		);
+		writeOnboardingDismissed(false);
+	});
+
+	it('does not surface onboarding entry when setup is already complete', () => {
+		render(Page, {
+			data: {
+				...baseData,
+				onboarding: {
+					state: 'ready',
+					hasFeeds: true,
+					hasTvTargets: true,
+					hasMovieTargets: false,
+					minimumComplete: true
+				}
+			}
+		});
+		expect(screen.queryByRole('link', { name: /onboarding/i })).not.toBeInTheDocument();
 	});
 
 	it('Active Downloads hidden when transmissionTorrents is empty', () => {

--- a/web/src/routes/onboarding/+page.server.ts
+++ b/web/src/routes/onboarding/+page.server.ts
@@ -1,0 +1,117 @@
+import { env } from '$env/dynamic/private';
+import { fail } from '@sveltejs/kit';
+import { deriveOnboardingStatus } from '$lib/onboarding';
+import { apiRequest } from '$lib/server/api';
+import type { AppConfig, FeedConfig } from '$lib/types';
+import type { Actions, PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+	const canWrite = !!env.PIRATE_CLAW_API_WRITE_TOKEN;
+
+	try {
+		const configResponse = await apiRequest('/api/config');
+		if (!configResponse.ok) {
+			console.error('[onboarding] failed to load /api/config');
+			return {
+				config: null,
+				etag: null,
+				canWrite,
+				onboarding: null,
+				error: 'Could not reach the API.'
+			};
+		}
+
+		const config = (await configResponse.json()) as AppConfig;
+		const etag = configResponse.headers.get('etag');
+		return {
+			config,
+			etag,
+			canWrite,
+			onboarding: deriveOnboardingStatus(config, canWrite),
+			error: null
+		};
+	} catch (error) {
+		console.error('[onboarding] failed to load /api/config', error);
+		return {
+			config: null,
+			etag: null,
+			canWrite,
+			onboarding: null,
+			error: 'Could not reach the API.'
+		};
+	}
+};
+
+function parseExistingFeeds(raw: string | File | null): FeedConfig[] {
+	if (raw === null) return [];
+	try {
+		const parsed = JSON.parse(String(raw));
+		return Array.isArray(parsed) ? (parsed as FeedConfig[]) : [];
+	} catch {
+		return [];
+	}
+}
+
+export const actions: Actions = {
+	saveFeed: async ({ request }) => {
+		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+		if (!writeToken) {
+			return fail(403, { feedsMessage: 'Config writes are disabled.' });
+		}
+
+		const formData = await request.formData();
+		const ifMatch = String(formData.get('ifMatch') ?? '').trim();
+		if (!ifMatch) {
+			return fail(400, { feedsMessage: 'Missing config revision. Reload and try again.' });
+		}
+
+		const existingFeeds = parseExistingFeeds(formData.get('existingFeedsJson'));
+		const name = String(formData.get('feedName') ?? '').trim();
+		const url = String(formData.get('feedUrl') ?? '').trim();
+		const mediaType = String(formData.get('feedMediaType') ?? 'tv').trim();
+
+		if (!name || !url) {
+			return fail(400, { feedsMessage: 'Feed name and URL are required.' });
+		}
+		if (mediaType !== 'tv' && mediaType !== 'movie') {
+			return fail(400, { feedsMessage: 'Feed type must be TV or Movie.' });
+		}
+
+		const feeds = [...existingFeeds, { name, url, mediaType }];
+
+		try {
+			const response = await apiRequest('/api/config/feeds', {
+				method: 'PUT',
+				headers: {
+					'content-type': 'application/json',
+					authorization: `Bearer ${writeToken}`,
+					'if-match': ifMatch
+				},
+				body: JSON.stringify(feeds)
+			});
+
+			if (!response.ok) {
+				let feedsMessage = `Save failed (${response.status}).`;
+				try {
+					const body = (await response.json()) as { error?: string };
+					if (body.error) feedsMessage = body.error;
+				} catch {
+					// keep fallback message
+				}
+				return fail(response.status, {
+					feedsMessage,
+					feedsEtag: response.headers.get('etag')
+				});
+			}
+
+			return {
+				feedsSuccess: true,
+				feedsMessage: 'Feed saved.',
+				feedsEtag: response.headers.get('etag')
+			};
+		} catch (error) {
+			console.error('[onboarding] saveFeed failed:', error);
+			return fail(500, { feedsMessage: 'Could not save feed.' });
+		}
+	}
+};

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+	import { browser } from '$app/environment';
+	import { writeOnboardingDismissed } from '$lib/onboarding';
+	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
+	import type { ActionData, PageData } from './$types';
+
+	const { data, form }: { data: PageData; form?: ActionData } = $props();
+
+	let selectedPath = $state<'tv' | 'movie' | 'both'>('tv');
+	let feedMediaType = $state<'tv' | 'movie'>('tv');
+
+	$effect(() => {
+		feedMediaType = selectedPath === 'movie' ? 'movie' : 'tv';
+	});
+
+	function dismissOnboarding() {
+		if (!browser) return;
+		writeOnboardingDismissed(true);
+		window.location.href = '/';
+	}
+</script>
+
+<h1 class="text-3xl font-bold tracking-tight">Onboarding</h1>
+
+{#if data.error}
+	<Alert variant="destructive" class="mt-6" role="alert">
+		<AlertTitle>API unavailable</AlertTitle>
+		<AlertDescription>{data.error}</AlertDescription>
+	</Alert>
+{:else if data.onboarding?.state === 'writes_disabled'}
+	<Alert class="mt-6">
+		<AlertTitle>Config writes are disabled</AlertTitle>
+		<AlertDescription>
+			Enable config writes before using onboarding. You can still review the existing dashboard.
+		</AlertDescription>
+	</Alert>
+{:else if data.onboarding?.state === 'ready'}
+	<Alert class="mt-6">
+		<AlertTitle>Onboarding already complete</AlertTitle>
+		<AlertDescription>
+			Your config already has at least one feed and one target. Continue in the
+			<a href="/config" class="text-primary font-medium hover:underline">Config page</a>
+			or return to the
+			<a href="/" class="text-primary font-medium hover:underline">Dashboard</a>.
+		</AlertDescription>
+	</Alert>
+{:else}
+	<section class="mt-8 space-y-6">
+		<Alert>
+			<AlertTitle>
+				{data.onboarding?.state === 'partial_setup' ? 'Resume onboarding' : 'First-time setup'}
+			</AlertTitle>
+			<AlertDescription>
+				{#if data.onboarding?.state === 'partial_setup'}
+					You already saved part of your config. Continue onboarding here or return to the
+					<a href="/config" class="text-primary font-medium hover:underline">Config page</a>.
+				{:else}
+					Start by choosing your feed path and saving your first RSS feed.
+				{/if}
+			</AlertDescription>
+		</Alert>
+
+		{#if !(data.onboarding?.hasFeeds ?? false)}
+			<div class="space-y-3">
+				<h2 class="text-lg font-semibold tracking-tight">Step 1 — Feed type</h2>
+				<div class="flex flex-wrap gap-3">
+					<label class="border-border flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
+						<input type="radio" bind:group={selectedPath} value="tv" />
+						<span>TV</span>
+					</label>
+					<label class="border-border flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
+						<input type="radio" bind:group={selectedPath} value="movie" />
+						<span>Movie</span>
+					</label>
+					<label class="border-border flex items-center gap-2 rounded-md border px-3 py-2 text-sm">
+						<input type="radio" bind:group={selectedPath} value="both" />
+						<span>Both</span>
+					</label>
+				</div>
+				<p class="text-muted-foreground text-sm">
+					{selectedPath === 'both'
+						? 'Both is supported. This first ticket saves one feed and leaves target setup for the next steps.'
+						: `Your first feed will default to ${feedMediaType.toUpperCase()}.`}
+				</p>
+			</div>
+
+			<div class="space-y-3">
+				<h2 class="text-lg font-semibold tracking-tight">Step 2 — Add your first feed</h2>
+				<form method="POST" action="?/saveFeed" class="space-y-4">
+					<input type="hidden" name="ifMatch" value={form?.feedsEtag ?? data.etag ?? ''} />
+					<input
+						type="hidden"
+						name="existingFeedsJson"
+						value={JSON.stringify(data.config?.feeds ?? [])}
+					/>
+					<div class="grid gap-3 sm:grid-cols-2">
+						<div class="space-y-1">
+							<label for="feed-name" class="text-sm font-medium">Feed name</label>
+							<input
+								id="feed-name"
+								name="feedName"
+								type="text"
+								placeholder="TV Feed"
+								class="border-input bg-background ring-offset-background h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+							/>
+						</div>
+						<div class="space-y-1">
+							<label for="feed-type" class="text-sm font-medium">Feed media type</label>
+							<select
+								id="feed-type"
+								name="feedMediaType"
+								bind:value={feedMediaType}
+								class="border-input bg-background ring-offset-background h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+							>
+								<option value="tv">TV</option>
+								<option value="movie">Movie</option>
+							</select>
+						</div>
+					</div>
+					<div class="space-y-1">
+						<label for="feed-url" class="text-sm font-medium">Feed URL</label>
+						<input
+							id="feed-url"
+							name="feedUrl"
+							type="url"
+							placeholder="https://example.com/feed.rss"
+							class="border-input bg-background ring-offset-background h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+						/>
+					</div>
+					{#if form?.feedsMessage}
+						<p class:text-destructive={!(form?.feedsSuccess ?? false)} class="text-sm">
+							{form.feedsMessage}
+						</p>
+					{/if}
+					<div class="flex flex-wrap items-center gap-3">
+						<button
+							type="submit"
+							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
+							disabled={!(form?.feedsEtag ?? data.etag)}
+						>
+							Save first feed
+						</button>
+						<button
+							type="button"
+							class="text-muted-foreground text-sm hover:underline"
+							onclick={dismissOnboarding}
+						>
+							Skip for now
+						</button>
+					</div>
+				</form>
+			</div>
+		{:else}
+			<Alert>
+				<AlertTitle>First feed already saved</AlertTitle>
+				<AlertDescription>
+					Your feed is in place. The next onboarding tickets will add guided TV and movie target
+					setup. You can continue later from this route or work directly in the
+					<a href="/config" class="text-primary font-medium hover:underline">Config page</a>.
+				</AlertDescription>
+			</Alert>
+		{/if}
+	</section>
+{/if}

--- a/web/src/routes/onboarding/onboarding.test.ts
+++ b/web/src/routes/onboarding/onboarding.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import emptyConfig from '../../../../fixtures/api/config-empty.json';
+import feedOnlyConfig from '../../../../fixtures/api/config-feed-only.json';
+import type { AppConfig } from '$lib/types';
+import Page from './+page.svelte';
+
+const emptyConfigFixture = emptyConfig as AppConfig;
+const feedOnlyConfigFixture = feedOnlyConfig as AppConfig;
+
+describe('/onboarding', () => {
+	it('renders blocked state when writes are disabled', () => {
+		render(Page, {
+			data: {
+				config: emptyConfigFixture,
+				etag: '"rev-1"',
+				canWrite: false,
+				onboarding: {
+					state: 'writes_disabled',
+					hasFeeds: false,
+					hasTvTargets: false,
+					hasMovieTargets: false,
+					minimumComplete: false
+				},
+				error: null
+			},
+			form: undefined
+		});
+
+		expect(screen.getByText('Config writes are disabled')).toBeInTheDocument();
+	});
+
+	it('renders the first feed step for strict initial-empty config', () => {
+		render(Page, {
+			data: {
+				config: emptyConfigFixture,
+				etag: '"rev-1"',
+				canWrite: true,
+				onboarding: {
+					state: 'initial_empty',
+					hasFeeds: false,
+					hasTvTargets: false,
+					hasMovieTargets: false,
+					minimumComplete: false
+				},
+				error: null
+			},
+			form: undefined
+		});
+
+		expect(screen.getByRole('heading', { name: 'Step 1 — Feed type' })).toBeInTheDocument();
+		expect(
+			screen.getByRole('heading', { name: 'Step 2 — Add your first feed' })
+		).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Save first feed' })).toBeInTheDocument();
+	});
+
+	it('renders partial-setup guidance instead of a ready/completed state for feed-only config', () => {
+		render(Page, {
+			data: {
+				config: feedOnlyConfigFixture,
+				etag: '"rev-2"',
+				canWrite: true,
+				onboarding: {
+					state: 'partial_setup',
+					hasFeeds: true,
+					hasTvTargets: false,
+					hasMovieTargets: false,
+					minimumComplete: false
+				},
+				error: null
+			},
+			form: undefined
+		});
+
+		expect(screen.getByText('Resume onboarding')).toBeInTheDocument();
+		expect(screen.queryByText('Onboarding already complete')).not.toBeInTheDocument();
+	});
+});

--- a/web/src/routes/onboarding/page.server.test.ts
+++ b/web/src/routes/onboarding/page.server.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import emptyConfig from '../../../../fixtures/api/config-empty.json';
+import feedOnlyConfig from '../../../../fixtures/api/config-feed-only.json';
+
+const apiRequestMock = vi.fn();
+vi.mock('$lib/server/api', () => ({
+	apiRequest: apiRequestMock
+}));
+
+describe('onboarding page server', () => {
+	beforeEach(() => {
+		apiRequestMock.mockReset();
+		vi.resetModules();
+	});
+
+	describe('load', () => {
+		it('returns writes_disabled onboarding state when writes are unavailable', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: '' }
+			}));
+			const { load } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(new Response(JSON.stringify(emptyConfig), { status: 200 }));
+
+			const result = await load({} as never);
+			expect((result as { onboarding: { state: string } | null }).onboarding?.state).toBe(
+				'writes_disabled'
+			);
+		});
+
+		it('returns initial_empty onboarding state for strict empty config', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { load } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(JSON.stringify(emptyConfig), { status: 200, headers: { etag: '"rev-1"' } })
+			);
+
+			const result = await load({} as never);
+			expect((result as { onboarding: { state: string } | null }).onboarding?.state).toBe(
+				'initial_empty'
+			);
+		});
+
+		it('returns partial_setup onboarding state for feed-only config', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { load } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(JSON.stringify(feedOnlyConfig), { status: 200, headers: { etag: '"rev-2"' } })
+			);
+
+			const result = await load({} as never);
+			expect((result as { onboarding: { state: string } | null }).onboarding?.state).toBe(
+				'partial_setup'
+			);
+		});
+	});
+
+	describe('saveFeed', () => {
+		it('returns fail(400) when ifMatch is missing', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+
+			const body = new URLSearchParams();
+			body.set('feedName', 'TV Feed');
+			body.set('feedUrl', 'https://example.com/feed.rss');
+			body.set('feedMediaType', 'tv');
+
+			const result = await actions.saveFeed({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(400);
+			expect((result as { data?: { feedsMessage?: string } }).data?.feedsMessage).toContain(
+				'Missing config revision'
+			);
+			expect(apiRequestMock).not.toHaveBeenCalled();
+		});
+
+		it('passes validation failures through from the feeds endpoint', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(JSON.stringify({ error: 'Feed URL failed validation.' }), {
+					status: 400,
+					headers: { etag: '"rev-2"' }
+				})
+			);
+
+			const body = new URLSearchParams();
+			body.set('ifMatch', '"rev-1"');
+			body.set('feedName', 'TV Feed');
+			body.set('feedUrl', 'https://example.com/feed.rss');
+			body.set('feedMediaType', 'tv');
+			body.set('existingFeedsJson', JSON.stringify([]));
+
+			const result = await actions.saveFeed({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(400);
+			expect((result as { data?: { feedsMessage?: string } }).data?.feedsMessage).toContain(
+				'Feed URL failed validation'
+			);
+		});
+
+		it('returns feedsSuccess with fresh etag on happy path', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(null, { status: 200, headers: { etag: '"rev-2"' } })
+			);
+
+			const body = new URLSearchParams();
+			body.set('ifMatch', '"rev-1"');
+			body.set('feedName', 'TV Feed');
+			body.set('feedUrl', 'https://example.com/feed.rss');
+			body.set('feedMediaType', 'tv');
+			body.set('existingFeedsJson', JSON.stringify([]));
+
+			const result = await actions.saveFeed({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { feedsSuccess?: boolean }).feedsSuccess).toBe(true);
+			expect((result as { feedsEtag?: string }).feedsEtag).toBe('"rev-2"');
+			expect(apiRequestMock).toHaveBeenCalledWith(
+				'/api/config/feeds',
+				expect.objectContaining({
+					method: 'PUT',
+					body: JSON.stringify([
+						{
+							name: 'TV Feed',
+							url: 'https://example.com/feed.rss',
+							mediaType: 'tv'
+						}
+					])
+				})
+			);
+		});
+	});
+});

--- a/web/src/routes/page.server.test.ts
+++ b/web/src/routes/page.server.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import emptyConfig from '../../../fixtures/api/config-empty.json';
+import feedOnlyConfig from '../../../fixtures/api/config-feed-only.json';
+
+const apiFetchMock = vi.fn();
+vi.mock('$lib/server/api', () => ({
+	apiFetch: apiFetchMock
+}));
+
+describe('dashboard page server load', () => {
+	beforeEach(() => {
+		apiFetchMock.mockReset();
+		vi.resetModules();
+	});
+
+	it('derives initial_empty onboarding state for a strict empty config', async () => {
+		vi.doMock('$env/dynamic/private', () => ({
+			env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+		}));
+		const { load } = await import('./+page.server');
+
+		apiFetchMock
+			.mockResolvedValueOnce({ uptime: 1, startedAt: '2024-01-01T00:00:00Z' })
+			.mockResolvedValueOnce({
+				version: '3.0',
+				downloadSpeed: 0,
+				uploadSpeed: 0,
+				activeTorrentCount: 0
+			})
+			.mockResolvedValueOnce({ torrents: [] })
+			.mockResolvedValueOnce({ candidates: [] })
+			.mockResolvedValueOnce(emptyConfig);
+
+		const result = await load({} as never);
+		expect((result as { onboarding: { state: string } | null }).onboarding?.state).toBe(
+			'initial_empty'
+		);
+	});
+
+	it('derives partial_setup onboarding state for feed-only config', async () => {
+		vi.doMock('$env/dynamic/private', () => ({
+			env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+		}));
+		const { load } = await import('./+page.server');
+
+		apiFetchMock
+			.mockResolvedValueOnce({ uptime: 1, startedAt: '2024-01-01T00:00:00Z' })
+			.mockResolvedValueOnce({
+				version: '3.0',
+				downloadSpeed: 0,
+				uploadSpeed: 0,
+				activeTorrentCount: 0
+			})
+			.mockResolvedValueOnce({ torrents: [] })
+			.mockResolvedValueOnce({ candidates: [] })
+			.mockResolvedValueOnce(feedOnlyConfig);
+
+		const result = await load({} as never);
+		expect((result as { onboarding: { state: string } | null }).onboarding?.state).toBe(
+			'partial_setup'
+		);
+	});
+
+	it('derives writes_disabled onboarding state when config is empty and writes are disabled', async () => {
+		vi.doMock('$env/dynamic/private', () => ({
+			env: { PIRATE_CLAW_API_WRITE_TOKEN: '' }
+		}));
+		const { load } = await import('./+page.server');
+
+		apiFetchMock
+			.mockResolvedValueOnce({ uptime: 1, startedAt: '2024-01-01T00:00:00Z' })
+			.mockResolvedValueOnce({
+				version: '3.0',
+				downloadSpeed: 0,
+				uploadSpeed: 0,
+				activeTorrentCount: 0
+			})
+			.mockResolvedValueOnce({ torrents: [] })
+			.mockResolvedValueOnce({ candidates: [] })
+			.mockResolvedValueOnce(emptyConfig);
+
+		const result = await load({} as never);
+		expect((result as { onboarding: { state: string } | null }).onboarding?.state).toBe(
+			'writes_disabled'
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- delivery ticket: `P17.01 Onboarding Shell, Trigger Rules, and First Feed Save`
- ticket file: [docs/02-delivery/phase-17/ticket-01-onboarding-shell-feed-save.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-17/ticket-01-onboarding-shell-feed-save.md)
- stacked base branch: `main`
- post-verify self-audit: completed at 2026-04-14 06:55 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`d8a8ee13c182`](https://github.com/cesarnml/pirate_claw/commit/d8a8ee13c182eb9e5a06fa1faae400756e58e1f0)
- current branch head: [`41638be5d3c3`](https://github.com/cesarnml/pirate_claw/commit/41638be5d3c30019c41f8aff66e0e1443eda1978)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `d8a8ee13c182` address all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Limit dismissal-based “Resume onboarding” copy to `initial_empty` only. (native GitHub thread resolved) `web/src/routes/+page.svelte:155` [thread](https://github.com/cesarnml/pirate_claw/pull/154#discussion_r3077668991)
