### PR TITLE
feat: add onboarding tv target save [P17.02]

### DIFF
--- a/docs/02-delivery/phase-17/ticket-02-onboarding-tv-target.md
+++ b/docs/02-delivery/phase-17/ticket-02-onboarding-tv-target.md
@@ -51,3 +51,5 @@ An operator on the TV onboarding path can save TV defaults and at least one show
 ## Rationale
 
 TV target onboarding is separated because its preservation rule is easy to get wrong: the API accepts a full `tv.shows` array, so the onboarding implementation must carry forward the existing list explicitly.
+
+The onboarding route owns its save action instead of delegating through `/config` so the flow stays route-local and can sequence `PUT /api/config/tv/defaults` followed by `PUT /api/config` with the returned ETag. That keeps the default-save and show-append behavior incremental without clobbering existing TV targets.

--- a/docs/02-delivery/phase-17/ticket-02-onboarding-tv-target.md
+++ b/docs/02-delivery/phase-17/ticket-02-onboarding-tv-target.md
@@ -53,3 +53,5 @@ An operator on the TV onboarding path can save TV defaults and at least one show
 TV target onboarding is separated because its preservation rule is easy to get wrong: the API accepts a full `tv.shows` array, so the onboarding implementation must carry forward the existing list explicitly.
 
 The onboarding route owns its save action instead of delegating through `/config` so the flow stays route-local and can sequence `PUT /api/config/tv/defaults` followed by `PUT /api/config` with the returned ETag. That keeps the default-save and show-append behavior incremental without clobbering existing TV targets.
+
+The UI only presents the TV-specific target step when the loaded config already includes a TV feed. Movie-only partial setups stay on a neutral handoff message so this ticket does not pretend to support the movie-target path before `P17.03`.

--- a/web/src/routes/onboarding/+page.server.ts
+++ b/web/src/routes/onboarding/+page.server.ts
@@ -52,6 +52,20 @@ function parseExistingFeeds(raw: string | File | null): FeedConfig[] {
 	}
 }
 
+function parseExistingShows(raw: string | File | null): string[] {
+	if (raw === null) return [];
+	try {
+		const parsed = JSON.parse(String(raw));
+		if (!Array.isArray(parsed)) return [];
+		return parsed
+			.filter((entry): entry is string => typeof entry === 'string')
+			.map((entry) => entry.trim())
+			.filter(Boolean);
+	} catch {
+		return [];
+	}
+}
+
 export const actions: Actions = {
 	saveFeed: async ({ request }) => {
 		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
@@ -112,6 +126,91 @@ export const actions: Actions = {
 		} catch (error) {
 			console.error('[onboarding] saveFeed failed:', error);
 			return fail(500, { feedsMessage: 'Could not save feed.' });
+		}
+	},
+
+	saveTvTarget: async ({ request }) => {
+		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+		if (!writeToken) {
+			return fail(403, { tvTargetMessage: 'Config writes are disabled.' });
+		}
+
+		const formData = await request.formData();
+		const ifMatch = String(formData.get('ifMatch') ?? '').trim();
+		if (!ifMatch) {
+			return fail(400, { tvTargetMessage: 'Missing config revision. Reload and try again.' });
+		}
+
+		const showName = String(formData.get('showName') ?? '').trim();
+		if (!showName) {
+			return fail(400, { tvTargetMessage: 'A TV show name is required.' });
+		}
+
+		const existingShows = parseExistingShows(formData.get('existingShowsJson'));
+		const nextShows = existingShows.includes(showName)
+			? existingShows
+			: [...existingShows, showName];
+		const resolutions = formData.getAll('tvResolution').map(String);
+		const codecs = formData.getAll('tvCodec').map(String);
+
+		try {
+			const defaultsResponse = await apiRequest('/api/config/tv/defaults', {
+				method: 'PUT',
+				headers: {
+					'content-type': 'application/json',
+					authorization: `Bearer ${writeToken}`,
+					'if-match': ifMatch
+				},
+				body: JSON.stringify({ resolutions, codecs })
+			});
+
+			if (!defaultsResponse.ok) {
+				let tvTargetMessage = `Save failed (${defaultsResponse.status}).`;
+				try {
+					const body = (await defaultsResponse.json()) as { error?: string };
+					if (body.error) tvTargetMessage = body.error;
+				} catch {
+					// keep fallback message
+				}
+				return fail(defaultsResponse.status, {
+					tvTargetMessage,
+					tvTargetEtag: defaultsResponse.headers.get('etag')
+				});
+			}
+
+			const defaultsEtag = defaultsResponse.headers.get('etag') ?? ifMatch;
+			const showsResponse = await apiRequest('/api/config', {
+				method: 'PUT',
+				headers: {
+					'content-type': 'application/json',
+					authorization: `Bearer ${writeToken}`,
+					'if-match': defaultsEtag
+				},
+				body: JSON.stringify({ runtime: {}, tv: { shows: nextShows } })
+			});
+
+			if (!showsResponse.ok) {
+				let tvTargetMessage = `Save failed (${showsResponse.status}).`;
+				try {
+					const body = (await showsResponse.json()) as { error?: string };
+					if (body.error) tvTargetMessage = body.error;
+				} catch {
+					// keep fallback message
+				}
+				return fail(showsResponse.status, {
+					tvTargetMessage,
+					tvTargetEtag: showsResponse.headers.get('etag')
+				});
+			}
+
+			return {
+				tvTargetSuccess: true,
+				tvTargetMessage: 'TV target saved.',
+				tvTargetEtag: showsResponse.headers.get('etag')
+			};
+		} catch (error) {
+			console.error('[onboarding] saveTvTarget failed:', error);
+			return fail(500, { tvTargetMessage: 'Could not save TV target.' });
 		}
 	}
 };

--- a/web/src/routes/onboarding/+page.server.ts
+++ b/web/src/routes/onboarding/+page.server.ts
@@ -152,6 +152,7 @@ export const actions: Actions = {
 			: [...existingShows, showName];
 		const resolutions = formData.getAll('tvResolution').map(String);
 		const codecs = formData.getAll('tvCodec').map(String);
+		let tvTargetEtag = ifMatch;
 
 		try {
 			const defaultsResponse = await apiRequest('/api/config/tv/defaults', {
@@ -178,13 +179,13 @@ export const actions: Actions = {
 				});
 			}
 
-			const defaultsEtag = defaultsResponse.headers.get('etag') ?? ifMatch;
+			tvTargetEtag = defaultsResponse.headers.get('etag') ?? ifMatch;
 			const showsResponse = await apiRequest('/api/config', {
 				method: 'PUT',
 				headers: {
 					'content-type': 'application/json',
 					authorization: `Bearer ${writeToken}`,
-					'if-match': defaultsEtag
+					'if-match': tvTargetEtag
 				},
 				body: JSON.stringify({ runtime: {}, tv: { shows: nextShows } })
 			});
@@ -199,7 +200,7 @@ export const actions: Actions = {
 				}
 				return fail(showsResponse.status, {
 					tvTargetMessage,
-					tvTargetEtag: showsResponse.headers.get('etag')
+					tvTargetEtag: showsResponse.headers.get('etag') ?? tvTargetEtag
 				});
 			}
 
@@ -210,7 +211,10 @@ export const actions: Actions = {
 			};
 		} catch (error) {
 			console.error('[onboarding] saveTvTarget failed:', error);
-			return fail(500, { tvTargetMessage: 'Could not save TV target.' });
+			return fail(500, {
+				tvTargetMessage: 'Could not save TV target.',
+				tvTargetEtag
+			});
 		}
 	}
 };

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -4,19 +4,44 @@
 	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
 	import type { ActionData, PageData } from './$types';
 
+	const ALL_RESOLUTIONS = ['2160p', '1080p', '720p', '480p'];
+	const ALL_CODECS = ['x264', 'x265'];
 	const { data, form }: { data: PageData; form?: ActionData } = $props();
 
 	let selectedPath = $state<'tv' | 'movie' | 'both'>('tv');
 	let feedMediaType = $state<'tv' | 'movie'>('tv');
+	let tvResolutions = $state<string[]>([]);
+	let tvCodecs = $state<string[]>([]);
 
 	$effect(() => {
 		feedMediaType = selectedPath === 'movie' ? 'movie' : 'tv';
+	});
+
+	$effect(() => {
+		tvResolutions = [...(data.config?.tvDefaults?.resolutions ?? [])];
+		tvCodecs = [...(data.config?.tvDefaults?.codecs ?? [])];
 	});
 
 	function dismissOnboarding() {
 		if (!browser) return;
 		writeOnboardingDismissed(true);
 		window.location.href = '/';
+	}
+
+	function toggleResolution(resolution: string) {
+		if (tvResolutions.includes(resolution)) {
+			tvResolutions = tvResolutions.filter((entry) => entry !== resolution);
+			return;
+		}
+		tvResolutions = [...tvResolutions, resolution];
+	}
+
+	function toggleCodec(codec: string) {
+		if (tvCodecs.includes(codec)) {
+			tvCodecs = tvCodecs.filter((entry) => entry !== codec);
+			return;
+		}
+		tvCodecs = [...tvCodecs, codec];
 	}
 </script>
 
@@ -150,12 +175,103 @@
 					</div>
 				</form>
 			</div>
+		{:else if !(data.onboarding?.hasTvTargets ?? false) && !(data.onboarding?.hasMovieTargets ?? false)}
+			<Alert>
+				<AlertTitle>Step 3 — Add a TV target</AlertTitle>
+				<AlertDescription>
+					Your first feed is saved. Add a TV show and optional defaults without replacing any
+					existing shows already in config.
+				</AlertDescription>
+			</Alert>
+
+			<form method="POST" action="?/saveTvTarget" class="space-y-4">
+				<input type="hidden" name="ifMatch" value={form?.tvTargetEtag ?? data.etag ?? ''} />
+				<input
+					type="hidden"
+					name="existingShowsJson"
+					value={JSON.stringify(data.config?.tv.map((rule) => rule.name) ?? [])}
+				/>
+				{#each tvResolutions as resolution}
+					<input type="hidden" name="tvResolution" value={resolution} />
+				{/each}
+				{#each tvCodecs as codec}
+					<input type="hidden" name="tvCodec" value={codec} />
+				{/each}
+
+				<div class="space-y-1">
+					<label for="show-name" class="text-sm font-medium">TV show</label>
+					<input
+						id="show-name"
+						name="showName"
+						type="text"
+						placeholder="The Example Show"
+						class="border-input bg-background ring-offset-background h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+					/>
+				</div>
+
+				<div class="space-y-2">
+					<p class="text-sm font-medium">TV resolutions</p>
+					<div class="flex flex-wrap gap-2">
+						{#each ALL_RESOLUTIONS as resolution}
+							<button
+								type="button"
+								class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {tvResolutions.includes(
+									resolution
+								)
+									? 'bg-primary text-primary-foreground border-primary'
+									: 'border-border bg-card hover:bg-muted/50'}"
+								onclick={() => toggleResolution(resolution)}
+							>
+								{resolution}
+							</button>
+						{/each}
+					</div>
+				</div>
+
+				<div class="space-y-2">
+					<p class="text-sm font-medium">TV codecs</p>
+					<div class="flex flex-wrap gap-2">
+						{#each ALL_CODECS as codec}
+							<button
+								type="button"
+								class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {tvCodecs.includes(
+									codec
+								)
+									? 'bg-primary text-primary-foreground border-primary'
+									: 'border-border bg-card hover:bg-muted/50'}"
+								onclick={() => toggleCodec(codec)}
+							>
+								{codec}
+							</button>
+						{/each}
+					</div>
+				</div>
+
+				{#if form?.tvTargetMessage}
+					<p class:text-destructive={!(form?.tvTargetSuccess ?? false)} class="text-sm">
+						{form.tvTargetMessage}
+					</p>
+				{/if}
+
+				<div class="flex flex-wrap items-center gap-3">
+					<button
+						type="submit"
+						class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
+						disabled={!(form?.tvTargetEtag ?? data.etag)}
+					>
+						Save TV target
+					</button>
+					<a href="/config" class="text-muted-foreground text-sm hover:underline"
+						>Use Config page instead</a
+					>
+				</div>
+			</form>
 		{:else}
 			<Alert>
-				<AlertTitle>First feed already saved</AlertTitle>
+				<AlertTitle>TV target already saved</AlertTitle>
 				<AlertDescription>
-					Your feed is in place. The next onboarding tickets will add guided TV and movie target
-					setup. You can continue later from this route or work directly in the
+					Your feed and at least one target are already in place. Continue later from this route or
+					work directly in the
 					<a href="/config" class="text-primary font-medium hover:underline">Config page</a>.
 				</AlertDescription>
 			</Alert>

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -12,6 +12,7 @@
 	let feedMediaType = $state<'tv' | 'movie'>('tv');
 	let tvResolutions = $state<string[]>([]);
 	let tvCodecs = $state<string[]>([]);
+	const hasTvFeed = $derived((data.config?.feeds ?? []).some((feed) => feed.mediaType === 'tv'));
 
 	$effect(() => {
 		feedMediaType = selectedPath === 'movie' ? 'movie' : 'tv';
@@ -175,7 +176,7 @@
 					</div>
 				</form>
 			</div>
-		{:else if !(data.onboarding?.hasTvTargets ?? false) && !(data.onboarding?.hasMovieTargets ?? false)}
+		{:else if !(data.onboarding?.hasTvTargets ?? false) && !(data.onboarding?.hasMovieTargets ?? false) && hasTvFeed}
 			<Alert>
 				<AlertTitle>Step 3 — Add a TV target</AlertTitle>
 				<AlertDescription>
@@ -220,6 +221,8 @@
 								)
 									? 'bg-primary text-primary-foreground border-primary'
 									: 'border-border bg-card hover:bg-muted/50'}"
+								aria-label={`Toggle ${resolution}`}
+								aria-pressed={tvResolutions.includes(resolution)}
 								onclick={() => toggleResolution(resolution)}
 							>
 								{resolution}
@@ -239,6 +242,8 @@
 								)
 									? 'bg-primary text-primary-foreground border-primary'
 									: 'border-border bg-card hover:bg-muted/50'}"
+								aria-label={`Toggle ${codec}`}
+								aria-pressed={tvCodecs.includes(codec)}
 								onclick={() => toggleCodec(codec)}
 							>
 								{codec}
@@ -266,13 +271,31 @@
 					>
 				</div>
 			</form>
-		{:else}
+		{:else if !(data.onboarding?.hasTvTargets ?? false) && !(data.onboarding?.hasMovieTargets ?? false)}
+			<Alert>
+				<AlertTitle>Target setup depends on your feed path</AlertTitle>
+				<AlertDescription>
+					Your first feed is saved. Continue in the
+					<a href="/config" class="text-primary font-medium hover:underline">Config page</a>
+					to finish target setup for this feed type.
+				</AlertDescription>
+			</Alert>
+		{:else if data.onboarding?.hasTvTargets}
 			<Alert>
 				<AlertTitle>TV target already saved</AlertTitle>
 				<AlertDescription>
 					Your feed and at least one target are already in place. Continue later from this route or
 					work directly in the
 					<a href="/config" class="text-primary font-medium hover:underline">Config page</a>.
+				</AlertDescription>
+			</Alert>
+		{:else}
+			<Alert>
+				<AlertTitle>Movie target already saved</AlertTitle>
+				<AlertDescription>
+					Your feed and at least one target are already in place. Continue in the
+					<a href="/config" class="text-primary font-medium hover:underline">Config page</a>
+					for any additional target setup.
 				</AlertDescription>
 			</Alert>
 		{/if}

--- a/web/src/routes/onboarding/onboarding.test.ts
+++ b/web/src/routes/onboarding/onboarding.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from 'vitest';
+import { fireEvent } from '@testing-library/svelte';
 import { render, screen } from '@testing-library/svelte';
 import emptyConfig from '../../../../fixtures/api/config-empty.json';
 import feedOnlyConfig from '../../../../fixtures/api/config-feed-only.json';
+import configWithTvDefaults from '../../../../fixtures/api/config-with-tv-defaults.json';
 import type { AppConfig } from '$lib/types';
 import Page from './+page.svelte';
 
 const emptyConfigFixture = emptyConfig as AppConfig;
 const feedOnlyConfigFixture = feedOnlyConfig as AppConfig;
+const configWithTvDefaultsFixture = configWithTvDefaults as AppConfig;
 
 describe('/onboarding', () => {
 	it('renders blocked state when writes are disabled', () => {
@@ -75,5 +78,74 @@ describe('/onboarding', () => {
 
 		expect(screen.getByText('Resume onboarding')).toBeInTheDocument();
 		expect(screen.queryByText('Onboarding already complete')).not.toBeInTheDocument();
+	});
+
+	it('renders the TV target step for feed-only config', () => {
+		render(Page, {
+			data: {
+				config: feedOnlyConfigFixture,
+				etag: '"rev-2"',
+				canWrite: true,
+				onboarding: {
+					state: 'partial_setup',
+					hasFeeds: true,
+					hasTvTargets: false,
+					hasMovieTargets: false,
+					minimumComplete: false
+				},
+				error: null
+			},
+			form: undefined
+		});
+
+		expect(screen.getByText('Step 3 — Add a TV target')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Save TV target' })).toBeInTheDocument();
+	});
+
+	it('pre-populates tv defaults chips from config.tvDefaults', () => {
+		render(Page, {
+			data: {
+				config: configWithTvDefaultsFixture,
+				etag: '"rev-2"',
+				canWrite: true,
+				onboarding: {
+					state: 'partial_setup',
+					hasFeeds: true,
+					hasTvTargets: false,
+					hasMovieTargets: false,
+					minimumComplete: false
+				},
+				error: null
+			},
+			form: undefined
+		});
+
+		const resolutionButton = screen.getByRole('button', { name: '1080p' });
+		const codecButton = screen.getByRole('button', { name: 'x265' });
+		expect(resolutionButton.className).toContain('bg-primary');
+		expect(codecButton.className).toContain('bg-primary');
+	});
+
+	it('toggles tv defaults chips in the tv target step', async () => {
+		render(Page, {
+			data: {
+				config: feedOnlyConfigFixture,
+				etag: '"rev-2"',
+				canWrite: true,
+				onboarding: {
+					state: 'partial_setup',
+					hasFeeds: true,
+					hasTvTargets: false,
+					hasMovieTargets: false,
+					minimumComplete: false
+				},
+				error: null
+			},
+			form: undefined
+		});
+
+		const resolutionButton = screen.getByRole('button', { name: '1080p' });
+		await fireEvent.click(resolutionButton);
+		expect(resolutionButton.className).toContain('bg-primary');
 	});
 });

--- a/web/src/routes/onboarding/onboarding.test.ts
+++ b/web/src/routes/onboarding/onboarding.test.ts
@@ -120,10 +120,12 @@ describe('/onboarding', () => {
 			form: undefined
 		});
 
-		const resolutionButton = screen.getByRole('button', { name: '1080p' });
-		const codecButton = screen.getByRole('button', { name: 'x265' });
+		const resolutionButton = screen.getByRole('button', { name: 'Toggle 1080p' });
+		const codecButton = screen.getByRole('button', { name: 'Toggle x265' });
 		expect(resolutionButton.className).toContain('bg-primary');
 		expect(codecButton.className).toContain('bg-primary');
+		expect(resolutionButton).toHaveAttribute('aria-pressed', 'true');
+		expect(codecButton).toHaveAttribute('aria-pressed', 'true');
 	});
 
 	it('toggles tv defaults chips in the tv target step', async () => {
@@ -144,8 +146,59 @@ describe('/onboarding', () => {
 			form: undefined
 		});
 
-		const resolutionButton = screen.getByRole('button', { name: '1080p' });
+		const resolutionButton = screen.getByRole('button', { name: 'Toggle 1080p' });
 		await fireEvent.click(resolutionButton);
 		expect(resolutionButton.className).toContain('bg-primary');
+		expect(resolutionButton).toHaveAttribute('aria-pressed', 'true');
+	});
+
+	it('avoids the tv-specific step for movie-only feeds', () => {
+		render(Page, {
+			data: {
+				config: {
+					...feedOnlyConfigFixture,
+					feeds: feedOnlyConfigFixture.feeds.map((feed) => ({
+						...feed,
+						mediaType: 'movie' as const
+					}))
+				},
+				etag: '"rev-2"',
+				canWrite: true,
+				onboarding: {
+					state: 'partial_setup',
+					hasFeeds: true,
+					hasTvTargets: false,
+					hasMovieTargets: false,
+					minimumComplete: false
+				},
+				error: null
+			},
+			form: undefined
+		});
+
+		expect(screen.queryByText('Step 3 — Add a TV target')).not.toBeInTheDocument();
+		expect(screen.getByText('Target setup depends on your feed path')).toBeInTheDocument();
+	});
+
+	it('uses movie-specific copy when a movie target already exists', () => {
+		render(Page, {
+			data: {
+				config: feedOnlyConfigFixture,
+				etag: '"rev-2"',
+				canWrite: true,
+				onboarding: {
+					state: 'partial_setup',
+					hasFeeds: true,
+					hasTvTargets: false,
+					hasMovieTargets: true,
+					minimumComplete: true
+				},
+				error: null
+			},
+			form: undefined
+		});
+
+		expect(screen.getByText('Movie target already saved')).toBeInTheDocument();
+		expect(screen.queryByText('TV target already saved')).not.toBeInTheDocument();
 	});
 });

--- a/web/src/routes/onboarding/page.server.test.ts
+++ b/web/src/routes/onboarding/page.server.test.ts
@@ -159,4 +159,138 @@ describe('onboarding page server', () => {
 			);
 		});
 	});
+
+	describe('saveTvTarget', () => {
+		it('returns fail(400) when ifMatch is missing', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+
+			const body = new URLSearchParams();
+			body.set('showName', 'Show Alpha');
+
+			const result = await actions.saveTvTarget({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(400);
+			expect((result as { data?: { tvTargetMessage?: string } }).data?.tvTargetMessage).toContain(
+				'Missing config revision'
+			);
+			expect(apiRequestMock).not.toHaveBeenCalled();
+		});
+
+		it('appends a new show after saving tv defaults', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock
+				.mockResolvedValueOnce(new Response(null, { status: 200, headers: { etag: '"rev-2"' } }))
+				.mockResolvedValueOnce(new Response(null, { status: 200, headers: { etag: '"rev-3"' } }));
+
+			const body = new URLSearchParams();
+			body.set('ifMatch', '"rev-1"');
+			body.set('showName', 'Show Beta');
+			body.set('existingShowsJson', JSON.stringify(['Show Alpha']));
+			body.append('tvResolution', '1080p');
+			body.append('tvCodec', 'x265');
+
+			const result = await actions.saveTvTarget({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { tvTargetSuccess?: boolean }).tvTargetSuccess).toBe(true);
+			expect((result as { tvTargetEtag?: string }).tvTargetEtag).toBe('"rev-3"');
+			expect(apiRequestMock).toHaveBeenNthCalledWith(
+				1,
+				'/api/config/tv/defaults',
+				expect.objectContaining({
+					method: 'PUT',
+					body: JSON.stringify({ resolutions: ['1080p'], codecs: ['x265'] })
+				})
+			);
+			expect(apiRequestMock).toHaveBeenNthCalledWith(
+				2,
+				'/api/config',
+				expect.objectContaining({
+					method: 'PUT',
+					body: JSON.stringify({ runtime: {}, tv: { shows: ['Show Alpha', 'Show Beta'] } })
+				})
+			);
+		});
+
+		it('does not duplicate an existing show name', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock
+				.mockResolvedValueOnce(new Response(null, { status: 200, headers: { etag: '"rev-2"' } }))
+				.mockResolvedValueOnce(new Response(null, { status: 200, headers: { etag: '"rev-3"' } }));
+
+			const body = new URLSearchParams();
+			body.set('ifMatch', '"rev-1"');
+			body.set('showName', 'Show Alpha');
+			body.set('existingShowsJson', JSON.stringify(['Show Alpha']));
+
+			const result = await actions.saveTvTarget({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { tvTargetSuccess?: boolean }).tvTargetSuccess).toBe(true);
+			expect(apiRequestMock).toHaveBeenNthCalledWith(
+				2,
+				'/api/config',
+				expect.objectContaining({
+					method: 'PUT',
+					body: JSON.stringify({ runtime: {}, tv: { shows: ['Show Alpha'] } })
+				})
+			);
+		});
+
+		it('surfaces tv defaults save errors', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(JSON.stringify({ error: 'TV defaults failed.' }), {
+					status: 400,
+					headers: { etag: '"rev-2"' }
+				})
+			);
+
+			const body = new URLSearchParams();
+			body.set('ifMatch', '"rev-1"');
+			body.set('showName', 'Show Alpha');
+			body.set('existingShowsJson', JSON.stringify([]));
+
+			const result = await actions.saveTvTarget({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(400);
+			expect((result as { data?: { tvTargetMessage?: string } }).data?.tvTargetMessage).toContain(
+				'TV defaults failed'
+			);
+		});
+	});
 });

--- a/web/src/routes/onboarding/page.server.test.ts
+++ b/web/src/routes/onboarding/page.server.test.ts
@@ -262,6 +262,34 @@ describe('onboarding page server', () => {
 			);
 		});
 
+		it('returns the post-defaults etag when the show save fails', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock
+				.mockResolvedValueOnce(new Response(null, { status: 200, headers: { etag: '"rev-2"' } }))
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ error: 'stale revision' }), { status: 409 })
+				);
+
+			const body = new URLSearchParams();
+			body.set('ifMatch', '"rev-1"');
+			body.set('showName', 'Show Beta');
+			body.set('existingShowsJson', JSON.stringify(['Show Alpha']));
+
+			const result = await actions.saveTvTarget({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(409);
+			expect((result as { data?: { tvTargetEtag?: string } }).data?.tvTargetEtag).toBe('"rev-2"');
+		});
+
 		it('surfaces tv defaults save errors', async () => {
 			vi.doMock('$env/dynamic/private', () => ({
 				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }


### PR DESCRIPTION
## Summary

- delivery ticket: `P17.02 Onboarding TV Target Save`
- ticket file: [docs/02-delivery/phase-17/ticket-02-onboarding-tv-target.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-17/ticket-02-onboarding-tv-target.md)
- stacked base branch: `agents/p17-01-onboarding-shell-trigger-rules-and-first-feed-save`
- post-verify self-audit: completed at 2026-04-14 07:22 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`321864806d8e`](https://github.com/cesarnml/pirate_claw/commit/321864806d8edbe72f19753f971a48e976e981e1)
- current branch head: [`50466d4408ae`](https://github.com/cesarnml/pirate_claw/commit/50466d4408aedd8c4a77b32f3cc5bd67e1309e54)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `321864806d8e` address all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Return the post-defaults ETag on any later failure. (native GitHub thread resolved) `web/src/routes/onboarding/+page.server.ts:213` [thread](https://github.com/cesarnml/pirate_claw/pull/155#discussion_r3077824204)
- [coderabbit] Don’t force TV-specific onboarding onto movie-only feed setups. (native GitHub thread resolved) `web/src/routes/onboarding/+page.svelte:185` [thread](https://github.com/cesarnml/pirate_claw/pull/155#discussion_r3077824219)
- [coderabbit] Expose chip selection state semantically. (native GitHub thread resolved) `web/src/routes/onboarding/+page.svelte:226` [thread](https://github.com/cesarnml/pirate_claw/pull/155#discussion_r3077824221)
