### PR TITLE
feat: add onboarding movie target flow [P17.03]

### DIFF
--- a/docs/02-delivery/phase-17/ticket-03-onboarding-movie-target-and-both-flow.md
+++ b/docs/02-delivery/phase-17/ticket-03-onboarding-movie-target-and-both-flow.md
@@ -55,3 +55,5 @@ An operator can complete the movie onboarding path, and the `Both` branch can gu
 ## Rationale
 
 Movie onboarding is separated from TV onboarding because the backend write semantics are different: movie writes replace the full movies section, so preservation behavior must be tested and reviewed on its own.
+
+The onboarding route keeps the chosen path (`tv`, `movie`, or `both`) in route-local form state across post-backs instead of introducing a second onboarding state machine. That keeps the `Both` flow explicit while still letting movie-only partial setups land directly on the movie step and preserving existing movie policy whenever it is already populated.

--- a/web/src/routes/onboarding/+page.server.ts
+++ b/web/src/routes/onboarding/+page.server.ts
@@ -2,7 +2,7 @@ import { env } from '$env/dynamic/private';
 import { fail } from '@sveltejs/kit';
 import { deriveOnboardingStatus } from '$lib/onboarding';
 import { apiRequest } from '$lib/server/api';
-import type { AppConfig, FeedConfig } from '$lib/types';
+import type { AppConfig, FeedConfig, MoviePolicy } from '$lib/types';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
@@ -66,6 +66,19 @@ function parseExistingShows(raw: string | File | null): string[] {
 	}
 }
 
+function parseExistingYears(raw: string | File | null): number[] {
+	if (raw === null) return [];
+	try {
+		const parsed = JSON.parse(String(raw));
+		if (!Array.isArray(parsed)) return [];
+		return parsed
+			.map((entry) => Number(entry))
+			.filter((entry) => Number.isInteger(entry) && entry >= 1900 && entry <= 2100);
+	} catch {
+		return [];
+	}
+}
+
 export const actions: Actions = {
 	saveFeed: async ({ request }) => {
 		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
@@ -83,6 +96,7 @@ export const actions: Actions = {
 		const name = String(formData.get('feedName') ?? '').trim();
 		const url = String(formData.get('feedUrl') ?? '').trim();
 		const mediaType = String(formData.get('feedMediaType') ?? 'tv').trim();
+		const onboardingPath = String(formData.get('onboardingPath') ?? 'tv').trim();
 
 		if (!name || !url) {
 			return fail(400, { feedsMessage: 'Feed name and URL are required.' });
@@ -121,7 +135,8 @@ export const actions: Actions = {
 			return {
 				feedsSuccess: true,
 				feedsMessage: 'Feed saved.',
-				feedsEtag: response.headers.get('etag')
+				feedsEtag: response.headers.get('etag'),
+				onboardingPath
 			};
 		} catch (error) {
 			console.error('[onboarding] saveFeed failed:', error);
@@ -145,6 +160,7 @@ export const actions: Actions = {
 		if (!showName) {
 			return fail(400, { tvTargetMessage: 'A TV show name is required.' });
 		}
+		const onboardingPath = String(formData.get('onboardingPath') ?? 'tv').trim();
 
 		const existingShows = parseExistingShows(formData.get('existingShowsJson'));
 		const nextShows = existingShows.includes(showName)
@@ -207,7 +223,8 @@ export const actions: Actions = {
 			return {
 				tvTargetSuccess: true,
 				tvTargetMessage: 'TV target saved.',
-				tvTargetEtag: showsResponse.headers.get('etag')
+				tvTargetEtag: showsResponse.headers.get('etag'),
+				onboardingPath
 			};
 		} catch (error) {
 			console.error('[onboarding] saveTvTarget failed:', error);
@@ -215,6 +232,90 @@ export const actions: Actions = {
 				tvTargetMessage: 'Could not save TV target.',
 				tvTargetEtag
 			});
+		}
+	},
+
+	saveMovieTarget: async ({ request }) => {
+		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+		if (!writeToken) {
+			return fail(403, { movieTargetMessage: 'Config writes are disabled.' });
+		}
+
+		const formData = await request.formData();
+		const ifMatch = String(formData.get('ifMatch') ?? '').trim();
+		if (!ifMatch) {
+			return fail(400, { movieTargetMessage: 'Missing config revision. Reload and try again.' });
+		}
+
+		const rawYear = String(formData.get('movieYear') ?? '').trim();
+		const movieYear = Number(rawYear);
+		if (!Number.isInteger(movieYear) || movieYear < 1900 || movieYear > 2100) {
+			return fail(400, {
+				movieTargetMessage: 'Movie year must be a whole number between 1900 and 2100.'
+			});
+		}
+
+		const movieCodecPolicy = String(formData.get('movieCodecPolicy') ?? '').trim();
+		if (movieCodecPolicy !== 'prefer' && movieCodecPolicy !== 'require') {
+			return fail(400, {
+				movieTargetMessage: 'Codec policy must be "prefer" or "require".'
+			});
+		}
+
+		const onboardingPath = String(formData.get('onboardingPath') ?? 'movie').trim();
+		const movieResolutions = formData.getAll('movieResolution').map(String);
+		const movieCodecs = formData.getAll('movieCodec').map(String);
+		const existingYears = parseExistingYears(formData.get('existingMovieYearsJson'));
+		const existingResolutions = parseExistingShows(formData.get('existingMovieResolutionsJson'));
+		const existingCodecs = parseExistingShows(formData.get('existingMovieCodecsJson'));
+		const existingCodecPolicy = String(formData.get('existingMovieCodecPolicy') ?? 'prefer').trim();
+		const nextYears = [...new Set([...existingYears, movieYear])].sort((a, b) => a - b);
+		const hasExistingMoviePolicy = existingResolutions.length > 0 || existingCodecs.length > 0;
+		const payload: MoviePolicy = {
+			years: nextYears,
+			resolutions: hasExistingMoviePolicy ? existingResolutions : movieResolutions,
+			codecs: hasExistingMoviePolicy ? existingCodecs : movieCodecs,
+			codecPolicy:
+				hasExistingMoviePolicy &&
+				(existingCodecPolicy === 'prefer' || existingCodecPolicy === 'require')
+					? existingCodecPolicy
+					: movieCodecPolicy
+		};
+
+		try {
+			const response = await apiRequest('/api/config/movies', {
+				method: 'PUT',
+				headers: {
+					'content-type': 'application/json',
+					authorization: `Bearer ${writeToken}`,
+					'if-match': ifMatch
+				},
+				body: JSON.stringify(payload)
+			});
+
+			if (!response.ok) {
+				let movieTargetMessage = `Save failed (${response.status}).`;
+				try {
+					const body = (await response.json()) as { error?: string };
+					if (body.error) movieTargetMessage = body.error;
+				} catch {
+					// keep fallback message
+				}
+				return fail(response.status, {
+					movieTargetMessage,
+					movieTargetEtag: response.headers.get('etag')
+				});
+			}
+
+			return {
+				movieTargetSuccess: true,
+				movieTargetMessage: 'Movie target saved.',
+				movieTargetEtag: response.headers.get('etag'),
+				onboardingPath
+			};
+		} catch (error) {
+			console.error('[onboarding] saveMovieTarget failed:', error);
+			return fail(500, { movieTargetMessage: 'Could not save movie target.' });
 		}
 	}
 };

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -12,7 +12,46 @@
 	let feedMediaType = $state<'tv' | 'movie'>('tv');
 	let tvResolutions = $state<string[]>([]);
 	let tvCodecs = $state<string[]>([]);
+	let movieResolutions = $state<string[]>([]);
+	let movieCodecs = $state<string[]>([]);
+	let movieCodecPolicy = $state<'prefer' | 'require'>('prefer');
 	const hasTvFeed = $derived((data.config?.feeds ?? []).some((feed) => feed.mediaType === 'tv'));
+	const hasMovieFeed = $derived(
+		(data.config?.feeds ?? []).some((feed) => feed.mediaType === 'movie')
+	);
+	const onboardingPath = $derived.by<'tv' | 'movie' | 'both'>(() => {
+		if (
+			form?.onboardingPath === 'tv' ||
+			form?.onboardingPath === 'movie' ||
+			form?.onboardingPath === 'both'
+		) {
+			return form.onboardingPath;
+		}
+		if (hasTvFeed && hasMovieFeed) return 'both';
+		if (hasMovieFeed) return 'movie';
+		return 'tv';
+	});
+	const showTvTargetStep = $derived(
+		(data.onboarding?.hasFeeds ?? false) &&
+			!(data.onboarding?.hasTvTargets ?? false) &&
+			!(data.onboarding?.hasMovieTargets ?? false) &&
+			onboardingPath !== 'movie'
+	);
+	const showMovieTargetStep = $derived(
+		(data.onboarding?.hasFeeds ?? false) &&
+			!(data.onboarding?.hasMovieTargets ?? false) &&
+			(onboardingPath === 'movie' || onboardingPath === 'both') &&
+			(onboardingPath !== 'both' ||
+				(data.onboarding?.hasTvTargets ?? false) ||
+				!!form?.tvTargetSuccess)
+	);
+	const hasExistingMoviePolicy = $derived(
+		(data.config?.movies.resolutions.length ?? 0) > 0 ||
+			(data.config?.movies.codecs.length ?? 0) > 0
+	);
+	const movieStepTitle = $derived(
+		onboardingPath === 'both' ? 'Step 4 — Add a movie target' : 'Step 3 — Add a movie target'
+	);
 
 	$effect(() => {
 		feedMediaType = selectedPath === 'movie' ? 'movie' : 'tv';
@@ -21,6 +60,9 @@
 	$effect(() => {
 		tvResolutions = [...(data.config?.tvDefaults?.resolutions ?? [])];
 		tvCodecs = [...(data.config?.tvDefaults?.codecs ?? [])];
+		movieResolutions = [...(data.config?.movies.resolutions ?? [])];
+		movieCodecs = [...(data.config?.movies.codecs ?? [])];
+		movieCodecPolicy = data.config?.movies.codecPolicy ?? 'prefer';
 	});
 
 	function dismissOnboarding() {
@@ -44,6 +86,22 @@
 		}
 		tvCodecs = [...tvCodecs, codec];
 	}
+
+	function toggleMovieResolution(resolution: string) {
+		if (movieResolutions.includes(resolution)) {
+			movieResolutions = movieResolutions.filter((entry) => entry !== resolution);
+			return;
+		}
+		movieResolutions = [...movieResolutions, resolution];
+	}
+
+	function toggleMovieCodec(codec: string) {
+		if (movieCodecs.includes(codec)) {
+			movieCodecs = movieCodecs.filter((entry) => entry !== codec);
+			return;
+		}
+		movieCodecs = [...movieCodecs, codec];
+	}
 </script>
 
 <h1 class="text-3xl font-bold tracking-tight">Onboarding</h1>
@@ -60,7 +118,7 @@
 			Enable config writes before using onboarding. You can still review the existing dashboard.
 		</AlertDescription>
 	</Alert>
-{:else if data.onboarding?.state === 'ready'}
+{:else if data.onboarding?.state === 'ready' && !showMovieTargetStep}
 	<Alert class="mt-6">
 		<AlertTitle>Onboarding already complete</AlertTitle>
 		<AlertDescription>
@@ -105,7 +163,7 @@
 				</div>
 				<p class="text-muted-foreground text-sm">
 					{selectedPath === 'both'
-						? 'Both is supported. This first ticket saves one feed and leaves target setup for the next steps.'
+						? 'Both is supported. Save one feed first, then onboarding will guide TV and movie targets in order.'
 						: `Your first feed will default to ${feedMediaType.toUpperCase()}.`}
 				</p>
 			</div>
@@ -114,6 +172,7 @@
 				<h2 class="text-lg font-semibold tracking-tight">Step 2 — Add your first feed</h2>
 				<form method="POST" action="?/saveFeed" class="space-y-4">
 					<input type="hidden" name="ifMatch" value={form?.feedsEtag ?? data.etag ?? ''} />
+					<input type="hidden" name="onboardingPath" value={selectedPath} />
 					<input
 						type="hidden"
 						name="existingFeedsJson"
@@ -176,7 +235,7 @@
 					</div>
 				</form>
 			</div>
-		{:else if !(data.onboarding?.hasTvTargets ?? false) && !(data.onboarding?.hasMovieTargets ?? false) && hasTvFeed}
+		{:else if showTvTargetStep}
 			<Alert>
 				<AlertTitle>Step 3 — Add a TV target</AlertTitle>
 				<AlertDescription>
@@ -187,6 +246,7 @@
 
 			<form method="POST" action="?/saveTvTarget" class="space-y-4">
 				<input type="hidden" name="ifMatch" value={form?.tvTargetEtag ?? data.etag ?? ''} />
+				<input type="hidden" name="onboardingPath" value={onboardingPath} />
 				<input
 					type="hidden"
 					name="existingShowsJson"
@@ -265,6 +325,161 @@
 						disabled={!(form?.tvTargetEtag ?? data.etag)}
 					>
 						Save TV target
+					</button>
+					<a href="/config" class="text-muted-foreground text-sm hover:underline"
+						>Use Config page instead</a
+					>
+				</div>
+			</form>
+		{:else if showMovieTargetStep}
+			<Alert>
+				<AlertTitle>{movieStepTitle}</AlertTitle>
+				<AlertDescription>
+					{#if onboardingPath === 'both'}
+						Your TV target is saved. Finish the guided flow by adding the first movie year target.
+					{:else}
+						Your feed is saved. Add a movie year target and policy defaults.
+					{/if}
+				</AlertDescription>
+			</Alert>
+
+			<form method="POST" action="?/saveMovieTarget" class="space-y-4">
+				<input
+					type="hidden"
+					name="ifMatch"
+					value={form?.movieTargetEtag ?? form?.tvTargetEtag ?? data.etag ?? ''}
+				/>
+				<input type="hidden" name="onboardingPath" value={onboardingPath} />
+				<input
+					type="hidden"
+					name="existingMovieYearsJson"
+					value={JSON.stringify(data.config?.movies.years ?? [])}
+				/>
+				<input
+					type="hidden"
+					name="existingMovieResolutionsJson"
+					value={JSON.stringify(data.config?.movies.resolutions ?? [])}
+				/>
+				<input
+					type="hidden"
+					name="existingMovieCodecsJson"
+					value={JSON.stringify(data.config?.movies.codecs ?? [])}
+				/>
+				<input
+					type="hidden"
+					name="existingMovieCodecPolicy"
+					value={data.config?.movies.codecPolicy ?? 'prefer'}
+				/>
+				{#each movieResolutions as resolution}
+					<input type="hidden" name="movieResolution" value={resolution} />
+				{/each}
+				{#each movieCodecs as codec}
+					<input type="hidden" name="movieCodec" value={codec} />
+				{/each}
+
+				<div class="space-y-1">
+					<label for="movie-year" class="text-sm font-medium">Movie year</label>
+					<input
+						id="movie-year"
+						name="movieYear"
+						type="number"
+						min="1900"
+						max="2100"
+						placeholder="2024"
+						class="border-input bg-background ring-offset-background h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+					/>
+				</div>
+
+				<div class="space-y-2">
+					<p class="text-sm font-medium">Movie resolutions</p>
+					<div class="flex flex-wrap gap-2">
+						{#each ALL_RESOLUTIONS as resolution}
+							<button
+								type="button"
+								class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {movieResolutions.includes(
+									resolution
+								)
+									? 'bg-primary text-primary-foreground border-primary'
+									: 'border-border bg-card hover:bg-muted/50'}"
+								aria-label={`Toggle ${resolution}`}
+								aria-pressed={movieResolutions.includes(resolution)}
+								onclick={() => toggleMovieResolution(resolution)}
+							>
+								{resolution}
+							</button>
+						{/each}
+					</div>
+				</div>
+
+				<div class="space-y-2">
+					<p class="text-sm font-medium">Movie codecs</p>
+					<div class="flex flex-wrap gap-2">
+						{#each ALL_CODECS as codec}
+							<button
+								type="button"
+								class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {movieCodecs.includes(
+									codec
+								)
+									? 'bg-primary text-primary-foreground border-primary'
+									: 'border-border bg-card hover:bg-muted/50'}"
+								aria-label={`Toggle ${codec}`}
+								aria-pressed={movieCodecs.includes(codec)}
+								onclick={() => toggleMovieCodec(codec)}
+							>
+								{codec}
+							</button>
+						{/each}
+					</div>
+				</div>
+
+				<div class="space-y-2">
+					<p class="text-sm font-medium">Codec policy</p>
+					<div class="flex flex-wrap gap-3">
+						<label
+							class="border-border flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+						>
+							<input
+								type="radio"
+								name="movieCodecPolicy"
+								value="prefer"
+								bind:group={movieCodecPolicy}
+							/>
+							<span>Prefer</span>
+						</label>
+						<label
+							class="border-border flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+						>
+							<input
+								type="radio"
+								name="movieCodecPolicy"
+								value="require"
+								bind:group={movieCodecPolicy}
+							/>
+							<span>Require</span>
+						</label>
+					</div>
+				</div>
+
+				{#if hasExistingMoviePolicy}
+					<p class="text-muted-foreground text-sm">
+						Existing movie policy is already configured. Onboarding will preserve it and only add
+						the new year target.
+					</p>
+				{/if}
+
+				{#if form?.movieTargetMessage}
+					<p class:text-destructive={!(form?.movieTargetSuccess ?? false)} class="text-sm">
+						{form.movieTargetMessage}
+					</p>
+				{/if}
+
+				<div class="flex flex-wrap items-center gap-3">
+					<button
+						type="submit"
+						class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
+						disabled={!(form?.movieTargetEtag ?? form?.tvTargetEtag ?? data.etag)}
+					>
+						Save movie target
 					</button>
 					<a href="/config" class="text-muted-foreground text-sm hover:underline"
 						>Use Config page instead</a

--- a/web/src/routes/onboarding/onboarding.test.ts
+++ b/web/src/routes/onboarding/onboarding.test.ts
@@ -3,12 +3,14 @@ import { fireEvent } from '@testing-library/svelte';
 import { render, screen } from '@testing-library/svelte';
 import emptyConfig from '../../../../fixtures/api/config-empty.json';
 import feedOnlyConfig from '../../../../fixtures/api/config-feed-only.json';
+import configWithMovies from '../../../../fixtures/api/config-with-movies.json';
 import configWithTvDefaults from '../../../../fixtures/api/config-with-tv-defaults.json';
 import type { AppConfig } from '$lib/types';
 import Page from './+page.svelte';
 
 const emptyConfigFixture = emptyConfig as AppConfig;
 const feedOnlyConfigFixture = feedOnlyConfig as AppConfig;
+const configWithMoviesFixture = configWithMovies as AppConfig;
 const configWithTvDefaultsFixture = configWithTvDefaults as AppConfig;
 
 describe('/onboarding', () => {
@@ -152,7 +154,7 @@ describe('/onboarding', () => {
 		expect(resolutionButton).toHaveAttribute('aria-pressed', 'true');
 	});
 
-	it('avoids the tv-specific step for movie-only feeds', () => {
+	it('renders the movie target step for movie-only feeds', () => {
 		render(Page, {
 			data: {
 				config: {
@@ -177,7 +179,8 @@ describe('/onboarding', () => {
 		});
 
 		expect(screen.queryByText('Step 3 — Add a TV target')).not.toBeInTheDocument();
-		expect(screen.getByText('Target setup depends on your feed path')).toBeInTheDocument();
+		expect(screen.getByText('Step 3 — Add a movie target')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Save movie target' })).toBeInTheDocument();
 	});
 
 	it('uses movie-specific copy when a movie target already exists', () => {
@@ -200,5 +203,64 @@ describe('/onboarding', () => {
 
 		expect(screen.getByText('Movie target already saved')).toBeInTheDocument();
 		expect(screen.queryByText('TV target already saved')).not.toBeInTheDocument();
+	});
+
+	it('shows the movie step after tv save in the both flow', () => {
+		render(Page, {
+			data: {
+				config: {
+					...configWithMoviesFixture,
+					movies: { years: [], resolutions: [], codecs: [], codecPolicy: 'prefer' }
+				},
+				etag: '"rev-3"',
+				canWrite: true,
+				onboarding: {
+					state: 'ready',
+					hasFeeds: true,
+					hasTvTargets: true,
+					hasMovieTargets: false,
+					minimumComplete: true
+				},
+				error: null
+			},
+			form: {
+				tvTargetSuccess: true,
+				tvTargetMessage: 'TV target saved.',
+				tvTargetEtag: '"rev-3"',
+				onboardingPath: 'both'
+			}
+		});
+
+		expect(screen.getByText('Step 4 — Add a movie target')).toBeInTheDocument();
+		expect(screen.queryByText('Onboarding already complete')).not.toBeInTheDocument();
+	});
+
+	it('preserves existing movie policy copy when present', () => {
+		render(Page, {
+			data: {
+				config: {
+					...configWithMoviesFixture,
+					movies: { years: [], resolutions: ['1080p'], codecs: ['x265'], codecPolicy: 'require' }
+				},
+				etag: '"rev-3"',
+				canWrite: true,
+				onboarding: {
+					state: 'partial_setup',
+					hasFeeds: true,
+					hasTvTargets: true,
+					hasMovieTargets: false,
+					minimumComplete: true
+				},
+				error: null
+			},
+			form: {
+				movieTargetSuccess: false,
+				movieTargetMessage: '',
+				movieTargetEtag: '"rev-3"',
+				onboardingPath: 'both'
+			}
+		});
+
+		expect(screen.getByText(/Existing movie policy is already configured/)).toBeInTheDocument();
 	});
 });

--- a/web/src/routes/onboarding/page.server.test.ts
+++ b/web/src/routes/onboarding/page.server.test.ts
@@ -321,4 +321,144 @@ describe('onboarding page server', () => {
 			);
 		});
 	});
+
+	describe('saveMovieTarget', () => {
+		it('validates movie year bounds', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+
+			const body = new URLSearchParams();
+			body.set('ifMatch', '"rev-1"');
+			body.set('movieYear', '1899');
+			body.set('movieCodecPolicy', 'prefer');
+
+			const result = await actions.saveMovieTarget({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(400);
+			expect(
+				(result as { data?: { movieTargetMessage?: string } }).data?.movieTargetMessage
+			).toContain('between 1900 and 2100');
+			expect(apiRequestMock).not.toHaveBeenCalled();
+		});
+
+		it('validates codec policy', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+
+			const body = new URLSearchParams();
+			body.set('ifMatch', '"rev-1"');
+			body.set('movieYear', '2024');
+			body.set('movieCodecPolicy', 'sometimes');
+
+			const result = await actions.saveMovieTarget({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(400);
+			expect(
+				(result as { data?: { movieTargetMessage?: string } }).data?.movieTargetMessage
+			).toContain('Codec policy');
+			expect(apiRequestMock).not.toHaveBeenCalled();
+		});
+
+		it('preserves existing movie policy during resumed onboarding', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(null, { status: 200, headers: { etag: '"rev-2"' } })
+			);
+
+			const body = new URLSearchParams();
+			body.set('ifMatch', '"rev-1"');
+			body.set('movieYear', '2024');
+			body.set('movieCodecPolicy', 'prefer');
+			body.set('existingMovieYearsJson', JSON.stringify([2023]));
+			body.set('existingMovieResolutionsJson', JSON.stringify(['1080p']));
+			body.set('existingMovieCodecsJson', JSON.stringify(['x265']));
+			body.set('existingMovieCodecPolicy', 'require');
+			body.append('movieResolution', '720p');
+			body.append('movieCodec', 'x264');
+
+			const result = await actions.saveMovieTarget({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { movieTargetSuccess?: boolean }).movieTargetSuccess).toBe(true);
+			expect(apiRequestMock).toHaveBeenCalledWith(
+				'/api/config/movies',
+				expect.objectContaining({
+					method: 'PUT',
+					body: JSON.stringify({
+						years: [2023, 2024],
+						resolutions: ['1080p'],
+						codecs: ['x265'],
+						codecPolicy: 'require'
+					})
+				})
+			);
+		});
+
+		it('seeds an empty movie policy from onboarding inputs', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(null, { status: 200, headers: { etag: '"rev-2"' } })
+			);
+
+			const body = new URLSearchParams();
+			body.set('ifMatch', '"rev-1"');
+			body.set('movieYear', '2024');
+			body.set('movieCodecPolicy', 'prefer');
+			body.set('existingMovieYearsJson', JSON.stringify([]));
+			body.set('existingMovieResolutionsJson', JSON.stringify([]));
+			body.set('existingMovieCodecsJson', JSON.stringify([]));
+			body.set('existingMovieCodecPolicy', 'prefer');
+			body.append('movieResolution', '1080p');
+			body.append('movieCodec', 'x265');
+
+			const result = await actions.saveMovieTarget({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { movieTargetSuccess?: boolean }).movieTargetSuccess).toBe(true);
+			expect(apiRequestMock).toHaveBeenCalledWith(
+				'/api/config/movies',
+				expect.objectContaining({
+					method: 'PUT',
+					body: JSON.stringify({
+						years: [2024],
+						resolutions: ['1080p'],
+						codecs: ['x265'],
+						codecPolicy: 'prefer'
+					})
+				})
+			);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

- delivery ticket: `P17.03 Onboarding Movie Target Save and Both Flow`
- ticket file: [docs/02-delivery/phase-17/ticket-03-onboarding-movie-target-and-both-flow.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-17/ticket-03-onboarding-movie-target-and-both-flow.md)
- stacked base branch: `agents/p17-02-onboarding-tv-target-save`
- post-verify self-audit: completed at 2026-04-14 07:44 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`f3a09e9530e0`](https://github.com/cesarnml/pirate_claw/commit/f3a09e9530e064c1e524803008b6deff311dad7b)
- current branch head: [`f3a09e9530e0`](https://github.com/cesarnml/pirate_claw/commit/f3a09e9530e064c1e524803008b6deff311dad7b)
- vendors: `coderabbit`, `sonarqube`
