### PR TITLE
feat: add onboarding done summary [P17.04]

### DIFF
--- a/docs/02-delivery/phase-17/ticket-04-onboarding-done-summary-resume.md
+++ b/docs/02-delivery/phase-17/ticket-04-onboarding-done-summary-resume.md
@@ -55,3 +55,5 @@ The onboarding flow has a coherent end state: it knows when minimum setup is sat
 ## Rationale
 
 This ticket owns the cross-step state machine rather than burying it in one of the target tickets. That keeps the movie and TV target tickets focused on their write semantics and makes the completion rules easy to review.
+
+The done state is implemented as a read-only summary on `/onboarding` instead of an automatic redirect so operators can see what the guided flow actually configured before leaving. Resume behavior stays lightweight: the dashboard and config page surface links back into onboarding, while the strict auto-trigger remains limited to the initial-empty case.

--- a/web/src/lib/onboarding.ts
+++ b/web/src/lib/onboarding.ts
@@ -1,7 +1,9 @@
 import type { AppConfig, OnboardingStatus } from '$lib/types';
 
 export const ONBOARDING_DISMISSED_KEY = 'pirate-claw:onboarding-dismissed';
+export const ONBOARDING_PATH_KEY = 'pirate-claw:onboarding-path';
 let onboardingDismissedFallback = false;
+let onboardingPathFallback: 'tv' | 'movie' | 'both' = 'tv';
 
 export function deriveOnboardingStatus(config: AppConfig, canWrite: boolean): OnboardingStatus {
 	const hasFeeds = config.feeds.length > 0;
@@ -67,4 +69,18 @@ export function writeOnboardingDismissed(value: boolean): void {
 	const storage = getStorage();
 	if (!storage) return;
 	storage.setItem(ONBOARDING_DISMISSED_KEY, value ? 'true' : 'false');
+}
+
+export function readOnboardingPath(): 'tv' | 'movie' | 'both' {
+	const storage = getStorage();
+	const raw = storage ? storage.getItem(ONBOARDING_PATH_KEY) : onboardingPathFallback;
+	if (raw === 'movie' || raw === 'both') return raw;
+	return 'tv';
+}
+
+export function writeOnboardingPath(value: 'tv' | 'movie' | 'both'): void {
+	onboardingPathFallback = value;
+	const storage = getStorage();
+	if (!storage) return;
+	storage.setItem(ONBOARDING_PATH_KEY, value);
 }

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -1,7 +1,8 @@
 import { env } from '$env/dynamic/private';
 import { fail } from '@sveltejs/kit';
+import { deriveOnboardingStatus } from '$lib/onboarding';
 import { apiRequest } from '$lib/server/api';
-import type { AppConfig } from '$lib/types';
+import type { AppConfig, OnboardingStatus } from '$lib/types';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
@@ -16,10 +17,12 @@ export const load: PageServerLoad = async () => {
 	let etag: string | null = null;
 	let error: string | null = null;
 	let transmissionSession: { version: string } | null = null;
+	let onboarding: OnboardingStatus | null = null;
 
 	if (configResult.status === 'fulfilled' && configResult.value.ok) {
 		config = (await configResult.value.json()) as AppConfig;
 		etag = configResult.value.headers.get('etag');
+		onboarding = deriveOnboardingStatus(config, canWrite);
 	} else {
 		console.error('[config] failed to load config');
 		error = 'Could not reach the API.';
@@ -30,7 +33,7 @@ export const load: PageServerLoad = async () => {
 		transmissionSession = { version: sessionData.version };
 	}
 
-	return { config, etag, canWrite, error, transmissionSession };
+	return { config, etag, canWrite, error, transmissionSession, onboarding };
 };
 
 function parseOptionalInt(input: unknown): number | undefined {

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -150,6 +150,30 @@
 	Effective configuration from the API (secrets redacted).
 </p>
 
+{#if data.onboarding && data.onboarding.state !== 'ready'}
+	<Alert class="mt-6">
+		<AlertTitle>
+			{data.onboarding.state === 'partial_setup' ? 'Resume onboarding' : 'Start onboarding'}
+		</AlertTitle>
+		<AlertDescription class="flex flex-wrap items-center gap-3">
+			<span>
+				{#if data.onboarding.state === 'writes_disabled'}
+					Enable config writes before using onboarding.
+				{:else if data.onboarding.state === 'partial_setup'}
+					Your setup is still incomplete. Resume the guided flow or keep configuring manually here.
+				{:else}
+					No setup has been completed yet. Start onboarding for the guided path.
+				{/if}
+			</span>
+			{#if data.onboarding.state !== 'writes_disabled'}
+				<a href="/onboarding" class="text-primary text-sm font-medium hover:underline">
+					{data.onboarding.state === 'partial_setup' ? 'Resume onboarding' : 'Start onboarding'}
+				</a>
+			{/if}
+		</AlertDescription>
+	</Alert>
+{/if}
+
 {#if data.error}
 	<Alert variant="destructive" class="mt-6">
 		<AlertTitle>API unavailable</AlertTitle>

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -55,7 +55,8 @@ describe('/config', () => {
 				error: null,
 				etag: '"rev-1"',
 				canWrite: true,
-				transmissionSession: null
+				transmissionSession: null,
+				onboarding: null
 			},
 			form: undefined
 		});
@@ -78,7 +79,8 @@ describe('/config', () => {
 				error: 'Could not reach the API.',
 				etag: null,
 				canWrite: false,
-				transmissionSession: null
+				transmissionSession: null,
+				onboarding: null
 			},
 			form: undefined
 		});
@@ -92,7 +94,8 @@ describe('/config', () => {
 				error: null,
 				etag: '"rev-1"',
 				canWrite: true,
-				transmissionSession: null
+				transmissionSession: null,
+				onboarding: null
 			},
 			form: undefined
 		});
@@ -110,7 +113,8 @@ describe('/config', () => {
 				error: null,
 				etag: '"rev-1"',
 				canWrite: true,
-				transmissionSession: null
+				transmissionSession: null,
+				onboarding: null
 			},
 			form: undefined
 		});
@@ -130,11 +134,37 @@ describe('/config', () => {
 				error: null,
 				etag: '"rev-1"',
 				canWrite: true,
-				transmissionSession: null
+				transmissionSession: null,
+				onboarding: null
 			},
 			form: undefined
 		});
 		expect(screen.queryByRole('button', { name: /restart daemon/i })).not.toBeInTheDocument();
+	});
+
+	it('renders resume onboarding banner for partial setup', () => {
+		render(Page, {
+			data: {
+				config: mockConfig,
+				error: null,
+				etag: '"rev-1"',
+				canWrite: true,
+				transmissionSession: null,
+				onboarding: {
+					state: 'partial_setup',
+					hasFeeds: true,
+					hasTvTargets: false,
+					hasMovieTargets: false,
+					minimumComplete: false
+				}
+			},
+			form: undefined
+		});
+		expect(screen.getAllByText('Resume onboarding')).toHaveLength(2);
+		expect(screen.getByRole('link', { name: 'Resume onboarding' })).toHaveAttribute(
+			'href',
+			'/onboarding'
+		);
 	});
 
 	it('renders all accordion items open on load', () => {
@@ -144,7 +174,8 @@ describe('/config', () => {
 				error: null,
 				etag: '"rev-1"',
 				canWrite: true,
-				transmissionSession: null
+				transmissionSession: null,
+				onboarding: null
 			},
 			form: undefined
 		});
@@ -182,7 +213,8 @@ describe('/config', () => {
 				error: null,
 				etag: '"rev-1"',
 				canWrite: false,
-				transmissionSession: null
+				transmissionSession: null,
+				onboarding: null
 			},
 			form: undefined
 		});

--- a/web/src/routes/config/page.server.test.ts
+++ b/web/src/routes/config/page.server.test.ts
@@ -12,6 +12,38 @@ describe('config page server actions', () => {
 	});
 
 	describe('load', () => {
+		it('returns onboarding status for partial setup config', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { load } = await import('./+page.server');
+
+			apiRequestMock
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							feeds: [{ name: 'TV Feed', url: 'https://example.com/tv.rss', mediaType: 'tv' }],
+							tv: [],
+							movies: { years: [], resolutions: [], codecs: [], codecPolicy: 'prefer' },
+							transmission: { url: 'http://localhost:9091', username: '', password: '' },
+							runtime: {
+								runIntervalMinutes: 60,
+								reconcileIntervalMinutes: 60,
+								artifactDir: '/tmp',
+								artifactRetentionDays: 7
+							}
+						}),
+						{ status: 200 }
+					)
+				)
+				.mockRejectedValueOnce(new Error('network error'));
+
+			const result = await load({} as never);
+			expect((result as { onboarding: { state: string } | null }).onboarding?.state).toBe(
+				'partial_setup'
+			);
+		});
+
 		it('returns transmissionSession: null when session fetch fails', async () => {
 			vi.doMock('$env/dynamic/private', () => ({
 				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
-	import { writeOnboardingDismissed } from '$lib/onboarding';
+	import {
+		readOnboardingPath,
+		writeOnboardingDismissed,
+		writeOnboardingPath
+	} from '$lib/onboarding';
 	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
 	import type { ActionData, PageData } from './$types';
 
@@ -8,7 +12,7 @@
 	const ALL_CODECS = ['x264', 'x265'];
 	const { data, form }: { data: PageData; form?: ActionData } = $props();
 
-	let selectedPath = $state<'tv' | 'movie' | 'both'>('tv');
+	let selectedPath = $state<'tv' | 'movie' | 'both'>(browser ? readOnboardingPath() : 'tv');
 	let feedMediaType = $state<'tv' | 'movie'>('tv');
 	let tvResolutions = $state<string[]>([]);
 	let tvCodecs = $state<string[]>([]);
@@ -19,6 +23,7 @@
 	const hasMovieFeed = $derived(
 		(data.config?.feeds ?? []).some((feed) => feed.mediaType === 'movie')
 	);
+	const persistedPath = $derived(browser ? readOnboardingPath() : 'tv');
 	const onboardingPath = $derived.by<'tv' | 'movie' | 'both'>(() => {
 		if (
 			form?.onboardingPath === 'tv' ||
@@ -27,6 +32,7 @@
 		) {
 			return form.onboardingPath;
 		}
+		if (persistedPath === 'movie' || persistedPath === 'both') return persistedPath;
 		if (hasTvFeed && hasMovieFeed) return 'both';
 		if (hasMovieFeed) return 'movie';
 		return 'tv';
@@ -73,6 +79,11 @@
 
 	$effect(() => {
 		feedMediaType = selectedPath === 'movie' ? 'movie' : 'tv';
+	});
+
+	$effect(() => {
+		if (!browser) return;
+		writeOnboardingPath(selectedPath);
 	});
 
 	$effect(() => {
@@ -138,19 +149,21 @@
 	</Alert>
 {:else}
 	<section class="mt-8 space-y-6">
-		<Alert>
-			<AlertTitle>
-				{data.onboarding?.state === 'partial_setup' ? 'Resume onboarding' : 'First-time setup'}
-			</AlertTitle>
-			<AlertDescription>
-				{#if data.onboarding?.state === 'partial_setup'}
-					You already saved part of your config. Continue onboarding here or return to the
-					<a href="/config" class="text-primary font-medium hover:underline">Config page</a>.
-				{:else}
-					Start by choosing your feed path and saving your first RSS feed.
-				{/if}
-			</AlertDescription>
-		</Alert>
+		{#if !showDoneStep}
+			<Alert>
+				<AlertTitle>
+					{data.onboarding?.state === 'partial_setup' ? 'Resume onboarding' : 'First-time setup'}
+				</AlertTitle>
+				<AlertDescription>
+					{#if data.onboarding?.state === 'partial_setup'}
+						You already saved part of your config. Continue onboarding here or return to the
+						<a href="/config" class="text-primary font-medium hover:underline">Config page</a>.
+					{:else}
+						Start by choosing your feed path and saving your first RSS feed.
+					{/if}
+				</AlertDescription>
+			</Alert>
+		{/if}
 
 		{#if !(data.onboarding?.hasFeeds ?? false)}
 			<div class="space-y-3">

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -52,6 +52,24 @@
 	const movieStepTitle = $derived(
 		onboardingPath === 'both' ? 'Step 4 — Add a movie target' : 'Step 3 — Add a movie target'
 	);
+	const minimumComplete = $derived(
+		(data.onboarding?.minimumComplete ?? false) ||
+			!!form?.tvTargetSuccess ||
+			!!form?.movieTargetSuccess
+	);
+	const showDoneStep = $derived(minimumComplete && !showMovieTargetStep);
+	const configuredFeedCount = $derived(data.config?.feeds.length ?? 0);
+	const firstFeedLabel = $derived(
+		configuredFeedCount > 0
+			? `${data.config?.feeds[0]?.name} (${data.config?.feeds[0]?.mediaType})`
+			: null
+	);
+	const hasTvSummary = $derived(
+		(data.onboarding?.hasTvTargets ?? false) || !!form?.tvTargetSuccess
+	);
+	const hasMovieSummary = $derived(
+		(data.onboarding?.hasMovieTargets ?? false) || !!form?.movieTargetSuccess
+	);
 
 	$effect(() => {
 		feedMediaType = selectedPath === 'movie' ? 'movie' : 'tv';
@@ -116,16 +134,6 @@
 		<AlertTitle>Config writes are disabled</AlertTitle>
 		<AlertDescription>
 			Enable config writes before using onboarding. You can still review the existing dashboard.
-		</AlertDescription>
-	</Alert>
-{:else if data.onboarding?.state === 'ready' && !showMovieTargetStep}
-	<Alert class="mt-6">
-		<AlertTitle>Onboarding already complete</AlertTitle>
-		<AlertDescription>
-			Your config already has at least one feed and one target. Continue in the
-			<a href="/config" class="text-primary font-medium hover:underline">Config page</a>
-			or return to the
-			<a href="/" class="text-primary font-medium hover:underline">Dashboard</a>.
 		</AlertDescription>
 	</Alert>
 {:else}
@@ -486,6 +494,47 @@
 					>
 				</div>
 			</form>
+		{:else if showDoneStep}
+			<Alert>
+				<AlertTitle>Done</AlertTitle>
+				<AlertDescription>
+					Your minimum setup is complete. Review the summary, then continue in the dashboard.
+				</AlertDescription>
+			</Alert>
+
+			<div class="border-border bg-card space-y-4 rounded-lg border p-4">
+				<h2 class="text-lg font-semibold tracking-tight">Setup summary</h2>
+				<dl class="grid gap-3 text-sm sm:grid-cols-2">
+					<div class="space-y-1">
+						<dt class="text-muted-foreground">Feeds configured</dt>
+						<dd class="font-medium">{configuredFeedCount}</dd>
+					</div>
+					<div class="space-y-1">
+						<dt class="text-muted-foreground">First feed</dt>
+						<dd class="font-medium">{firstFeedLabel ?? 'None yet'}</dd>
+					</div>
+					<div class="space-y-1">
+						<dt class="text-muted-foreground">TV target</dt>
+						<dd class="font-medium">{hasTvSummary ? 'Added' : 'Not added'}</dd>
+					</div>
+					<div class="space-y-1">
+						<dt class="text-muted-foreground">Movie target</dt>
+						<dd class="font-medium">{hasMovieSummary ? 'Added' : 'Not added'}</dd>
+					</div>
+				</dl>
+
+				<div class="flex flex-wrap items-center gap-3">
+					<a
+						href="/"
+						class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium"
+					>
+						Go to Dashboard
+					</a>
+					<a href="/config" class="text-muted-foreground text-sm hover:underline">
+						Review Config
+					</a>
+				</div>
+			</div>
 		{:else if !(data.onboarding?.hasTvTargets ?? false) && !(data.onboarding?.hasMovieTargets ?? false)}
 			<Alert>
 				<AlertTitle>Target setup depends on your feed path</AlertTitle>
@@ -493,24 +542,6 @@
 					Your first feed is saved. Continue in the
 					<a href="/config" class="text-primary font-medium hover:underline">Config page</a>
 					to finish target setup for this feed type.
-				</AlertDescription>
-			</Alert>
-		{:else if data.onboarding?.hasTvTargets}
-			<Alert>
-				<AlertTitle>TV target already saved</AlertTitle>
-				<AlertDescription>
-					Your feed and at least one target are already in place. Continue later from this route or
-					work directly in the
-					<a href="/config" class="text-primary font-medium hover:underline">Config page</a>.
-				</AlertDescription>
-			</Alert>
-		{:else}
-			<Alert>
-				<AlertTitle>Movie target already saved</AlertTitle>
-				<AlertDescription>
-					Your feed and at least one target are already in place. Continue in the
-					<a href="/config" class="text-primary font-medium hover:underline">Config page</a>
-					for any additional target setup.
 				</AlertDescription>
 			</Alert>
 		{/if}

--- a/web/src/routes/onboarding/onboarding.test.ts
+++ b/web/src/routes/onboarding/onboarding.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { fireEvent } from '@testing-library/svelte';
 import { render, screen } from '@testing-library/svelte';
+import { writeOnboardingPath } from '$lib/onboarding';
 import emptyConfig from '../../../../fixtures/api/config-empty.json';
 import feedOnlyConfig from '../../../../fixtures/api/config-feed-only.json';
 import configWithMovies from '../../../../fixtures/api/config-with-movies.json';
@@ -14,6 +15,32 @@ const configWithMoviesFixture = configWithMovies as AppConfig;
 const configWithTvDefaultsFixture = configWithTvDefaults as AppConfig;
 
 describe('/onboarding', () => {
+	it('suppresses the intro alert once the done summary is active', () => {
+		render(Page, {
+			data: {
+				config: {
+					...configWithMoviesFixture,
+					tv: []
+				},
+				etag: '"rev-3"',
+				canWrite: true,
+				onboarding: {
+					state: 'ready',
+					hasFeeds: true,
+					hasTvTargets: false,
+					hasMovieTargets: true,
+					minimumComplete: true
+				},
+				error: null
+			},
+			form: undefined
+		});
+
+		expect(screen.getByText('Done')).toBeInTheDocument();
+		expect(screen.queryByText('First-time setup')).not.toBeInTheDocument();
+		expect(screen.queryByText('Resume onboarding')).not.toBeInTheDocument();
+	});
+
 	it('renders blocked state when writes are disabled', () => {
 		render(Page, {
 			data: {
@@ -233,6 +260,33 @@ describe('/onboarding', () => {
 
 		expect(screen.getByText('Step 4 — Add a movie target')).toBeInTheDocument();
 		expect(screen.queryByText('Done')).not.toBeInTheDocument();
+	});
+
+	it('keeps the movie step pending after reload for the both flow', () => {
+		writeOnboardingPath('both');
+		render(Page, {
+			data: {
+				config: {
+					...configWithMoviesFixture,
+					movies: { years: [], resolutions: [], codecs: [], codecPolicy: 'prefer' }
+				},
+				etag: '"rev-3"',
+				canWrite: true,
+				onboarding: {
+					state: 'ready',
+					hasFeeds: true,
+					hasTvTargets: true,
+					hasMovieTargets: false,
+					minimumComplete: true
+				},
+				error: null
+			},
+			form: undefined
+		});
+
+		expect(screen.getByText('Step 4 — Add a movie target')).toBeInTheDocument();
+		expect(screen.queryByText('Done')).not.toBeInTheDocument();
+		writeOnboardingPath('tv');
 	});
 
 	it('preserves existing movie policy copy when present', () => {

--- a/web/src/routes/onboarding/onboarding.test.ts
+++ b/web/src/routes/onboarding/onboarding.test.ts
@@ -79,7 +79,7 @@ describe('/onboarding', () => {
 		});
 
 		expect(screen.getByText('Resume onboarding')).toBeInTheDocument();
-		expect(screen.queryByText('Onboarding already complete')).not.toBeInTheDocument();
+		expect(screen.queryByText('Done')).not.toBeInTheDocument();
 	});
 
 	it('renders the TV target step for feed-only config', () => {
@@ -201,8 +201,8 @@ describe('/onboarding', () => {
 			form: undefined
 		});
 
-		expect(screen.getByText('Movie target already saved')).toBeInTheDocument();
-		expect(screen.queryByText('TV target already saved')).not.toBeInTheDocument();
+		expect(screen.getByText('Done')).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'Go to Dashboard' })).toHaveAttribute('href', '/');
 	});
 
 	it('shows the movie step after tv save in the both flow', () => {
@@ -232,7 +232,7 @@ describe('/onboarding', () => {
 		});
 
 		expect(screen.getByText('Step 4 — Add a movie target')).toBeInTheDocument();
-		expect(screen.queryByText('Onboarding already complete')).not.toBeInTheDocument();
+		expect(screen.queryByText('Done')).not.toBeInTheDocument();
 	});
 
 	it('preserves existing movie policy copy when present', () => {
@@ -262,5 +262,59 @@ describe('/onboarding', () => {
 		});
 
 		expect(screen.getByText(/Existing movie policy is already configured/)).toBeInTheDocument();
+	});
+
+	it('shows the done summary after feed and tv target are present', () => {
+		render(Page, {
+			data: {
+				config: {
+					...configWithMoviesFixture,
+					feeds: [{ name: 'TV Feed', url: 'https://example.com/tv.rss', mediaType: 'tv' }],
+					movies: { years: [], resolutions: [], codecs: [], codecPolicy: 'prefer' }
+				},
+				etag: '"rev-3"',
+				canWrite: true,
+				onboarding: {
+					state: 'ready',
+					hasFeeds: true,
+					hasTvTargets: true,
+					hasMovieTargets: false,
+					minimumComplete: true
+				},
+				error: null
+			},
+			form: undefined
+		});
+
+		expect(screen.getByText('Done')).toBeInTheDocument();
+		expect(screen.getByText('Setup summary')).toBeInTheDocument();
+		expect(screen.getByText('Added')).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'Go to Dashboard' })).toHaveAttribute('href', '/');
+	});
+
+	it('shows the done summary after feed and movie target are present', () => {
+		render(Page, {
+			data: {
+				config: {
+					...configWithMoviesFixture,
+					tv: []
+				},
+				etag: '"rev-3"',
+				canWrite: true,
+				onboarding: {
+					state: 'ready',
+					hasFeeds: true,
+					hasTvTargets: false,
+					hasMovieTargets: true,
+					minimumComplete: true
+				},
+				error: null
+			},
+			form: undefined
+		});
+
+		expect(screen.getByText('Done')).toBeInTheDocument();
+		expect(screen.getByText('Movie target')).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'Go to Dashboard' })).toHaveAttribute('href', '/');
 	});
 });


### PR DESCRIPTION
## Summary

- delivery ticket: `P17.04 Onboarding Done Step, Completion Gate, and Resume Polish`
- ticket file: [docs/02-delivery/phase-17/ticket-04-onboarding-done-summary-resume.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-17/ticket-04-onboarding-done-summary-resume.md)
- stacked base branch: `agents/p17-03-onboarding-movie-target-save-and-both-flow`
- post-verify self-audit: completed at 2026-04-14 08:33 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`3e10bc05f3a9`](https://github.com/cesarnml/pirate_claw/commit/3e10bc05f3a9dd5779ddb6bc01c6fac8964e2182)
- current branch head: [`f2b8547e9a79`](https://github.com/cesarnml/pirate_claw/commit/f2b8547e9a793ffc10706efbd3b284a04bf07661)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commit `f2b8547e9a79` addresses all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Persist the `both` onboarding path across resumes so the pending movie step survives reloads. `web/src/routes/onboarding/+page.svelte:23` [thread](https://github.com/cesarnml/pirate_claw/pull/157#discussion_r3078199945)
- [coderabbit] Suppress the intro alert when the done summary is active and cover that state in tests. `web/src/routes/onboarding/+page.svelte:149` [thread](https://github.com/cesarnml/pirate_claw/pull/157#discussion_r3078199952)
