### PR TITLE
feat(web): add dashboard empty states and onboarding affordances [P17.06]

### DIFF
--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -133,6 +133,7 @@
 		data.onboarding?.state === 'partial_setup' ||
 			(data.onboarding?.state === 'initial_empty' && onboardingDismissed)
 	);
+	const showOnboardingLink = $derived(data.onboarding?.state !== 'writes_disabled');
 </script>
 
 <h1 class="text-3xl font-bold tracking-tight">Dashboard</h1>
@@ -145,16 +146,21 @@
 		<AlertDescription class="flex flex-wrap items-center gap-3">
 			<span>
 				{#if data.onboarding.state === 'writes_disabled'}
-					Enable config writes before using onboarding.
+					Config writes are disabled, so guided setup is unavailable until write access is enabled.
 				{:else if showResumeCopy}
-					Continue the guided setup flow from where you left off.
+					Continue the guided setup flow from where you left off, or keep configuring manually.
 				{:else}
-					Start with your first feed, then continue into guided setup.
+					Start onboarding to save your first feed and finish the rest of setup without editing
+					JSON.
 				{/if}
 			</span>
-			<a href="/onboarding" class="text-primary text-sm font-medium hover:underline">
-				{showResumeCopy ? 'Resume onboarding' : 'Start onboarding'}
-			</a>
+			{#if showOnboardingLink}
+				<a href="/onboarding" class="text-primary text-sm font-medium hover:underline">
+					{showResumeCopy ? 'Resume onboarding' : 'Start onboarding'}
+				</a>
+			{:else}
+				<a href="/config" class="text-primary text-sm font-medium hover:underline"> Open config </a>
+			{/if}
 			{#if data.onboarding.state === 'initial_empty' && !onboardingDismissed}
 				<button
 					type="button"
@@ -268,22 +274,26 @@
 		</div>
 
 		<!-- Active Downloads -->
-		{#if activeDownloads.length > 0}
-			<Card>
-				<CardHeader class="pb-3">
-					<div class="flex items-center justify-between">
-						<h2 class="text-lg font-semibold tracking-tight">Active Downloads</h2>
-						<a href="/candidates" class="text-primary text-sm hover:underline">View all</a>
-					</div>
-				</CardHeader>
-				<CardContent>
+		<Card>
+			<CardHeader class="pb-3">
+				<div class="flex items-center justify-between">
+					<h2 class="text-lg font-semibold tracking-tight">Active Downloads</h2>
+					<a href="/candidates" class="text-primary text-sm hover:underline">View all</a>
+				</div>
+			</CardHeader>
+			<CardContent>
+				{#if activeDownloads.length === 0}
+					<p class="text-muted-foreground text-sm">
+						No active downloads yet. Queued torrents will appear here while Transmission is pulling
+						them down.
+					</p>
+				{:else}
 					<ul class="space-y-4">
 						{#each activeDownloads as { torrent, candidate }}
 							{@const title = candidate?.normalizedTitle ?? torrent.name}
 							{@const posterUrl =
 								candidate?.tmdb && 'posterUrl' in candidate.tmdb ? candidate.tmdb.posterUrl : null}
 							<li class="flex items-center gap-3">
-								<!-- Poster / initial box -->
 								{#if posterUrl}
 									<img src={posterUrl} alt={title} class="h-12 w-8 shrink-0 rounded object-cover" />
 								{:else}
@@ -293,7 +303,6 @@
 										{initialBox(title)}
 									</div>
 								{/if}
-								<!-- Info -->
 								<div class="min-w-0 flex-1">
 									<p class="truncate text-sm font-medium">{title}</p>
 									<div class="mt-1 flex items-center gap-3 text-xs">
@@ -308,7 +317,6 @@
 										>
 									</div>
 								</div>
-								<!-- Speed + ETA -->
 								<div class="text-muted-foreground shrink-0 text-right text-xs">
 									<p>{formatSpeed(torrent.rateDownload)}</p>
 									<p>{formatEta(torrent.eta)}</p>
@@ -316,9 +324,9 @@
 							</li>
 						{/each}
 					</ul>
-				</CardContent>
-			</Card>
-		{/if}
+				{/if}
+			</CardContent>
+		</Card>
 
 		<!-- Event Log -->
 		<Card>
@@ -327,7 +335,10 @@
 			</CardHeader>
 			<CardContent>
 				{#if recentCandidates.length === 0}
-					<p class="text-muted-foreground text-sm">No candidates yet.</p>
+					<p class="text-muted-foreground text-sm">
+						No activity yet. Recent queue, skip, and completion events will show up here after the
+						first successful cycles run.
+					</p>
 				{:else}
 					<div class="border-border rounded-md border">
 						<Table>
@@ -366,9 +377,14 @@
 		</Card>
 
 		<!-- Archive Commit grid -->
-		{#if archiveItems.length > 0}
-			<section data-testid="archive-grid">
-				<h2 class="mb-4 text-lg font-semibold tracking-tight">Recently Completed</h2>
+		<section data-testid="archive-grid">
+			<h2 class="mb-4 text-lg font-semibold tracking-tight">Recently Completed</h2>
+			{#if archiveItems.length === 0}
+				<p class="text-muted-foreground text-sm">
+					Nothing has finished downloading yet. Completed items will collect here once Pirate Claw
+					starts finding matches.
+				</p>
+			{:else}
 				<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
 					{#each archiveItems as item}
 						{@const posterUrl = item.tmdb && 'posterUrl' in item.tmdb ? item.tmdb.posterUrl : null}
@@ -395,8 +411,8 @@
 						</div>
 					{/each}
 				</div>
-			</section>
-		{/if}
+			{/if}
+		</section>
 	</section>
 {:else}
 	<!-- Defensive: load currently returns either health or error, not both null -->

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -158,11 +158,13 @@
 		<AlertDescription class="flex flex-wrap items-center gap-3">
 			<span>
 				{#if data.onboarding.state === 'writes_disabled'}
-					Enable config writes before using onboarding.
+					Config writes are disabled, so guided onboarding is unavailable until write access is
+					enabled.
 				{:else if data.onboarding.state === 'partial_setup'}
-					Your setup is still incomplete. Resume the guided flow or keep configuring manually here.
+					Your setup is still incomplete. Resume onboarding or keep editing the config directly
+					here.
 				{:else}
-					No setup has been completed yet. Start onboarding for the guided path.
+					If you want the guided setup path, start onboarding here instead of editing JSON by hand.
 				{/if}
 			</span>
 			{#if data.onboarding.state !== 'writes_disabled'}

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -167,6 +167,33 @@ describe('/config', () => {
 		);
 	});
 
+	it('renders start onboarding banner for initial-empty setup', () => {
+		render(Page, {
+			data: {
+				config: { ...mockConfig, feeds: [], tv: [], movies: { ...mockConfig.movies, years: [] } },
+				error: null,
+				etag: '"rev-1"',
+				canWrite: true,
+				transmissionSession: null,
+				onboarding: {
+					state: 'initial_empty',
+					hasFeeds: false,
+					hasTvTargets: false,
+					hasMovieTargets: false,
+					minimumComplete: false
+				}
+			},
+			form: undefined
+		});
+		expect(screen.getByRole('link', { name: 'Start onboarding' })).toHaveAttribute(
+			'href',
+			'/onboarding'
+		);
+		expect(
+			screen.getByText(/If you want the guided setup path, start onboarding here/)
+		).toBeInTheDocument();
+	});
+
 	it('renders all accordion items open on load', () => {
 		render(Page, {
 			data: {

--- a/web/src/routes/dashboard.test.ts
+++ b/web/src/routes/dashboard.test.ts
@@ -109,6 +109,23 @@ describe('/', () => {
 		);
 	});
 
+	it('links writes-disabled onboarding banner back to config', () => {
+		render(Page, {
+			data: {
+				...baseData,
+				onboarding: {
+					state: 'writes_disabled',
+					hasFeeds: false,
+					hasTvTargets: false,
+					hasMovieTargets: false,
+					minimumComplete: false
+				}
+			}
+		});
+		expect(screen.getByRole('link', { name: 'Open config' })).toHaveAttribute('href', '/config');
+		expect(screen.queryByRole('link', { name: /onboarding/i })).not.toBeInTheDocument();
+	});
+
 	it('respects dismissal suppression by switching to resume onboarding copy', () => {
 		writeOnboardingDismissed(true);
 		render(Page, {
@@ -146,9 +163,12 @@ describe('/', () => {
 		expect(screen.queryByRole('link', { name: /onboarding/i })).not.toBeInTheDocument();
 	});
 
-	it('Active Downloads hidden when transmissionTorrents is empty', () => {
+	it('renders explicit Active Downloads empty state when transmissionTorrents is empty', () => {
 		render(Page, { data: { ...baseData, transmissionTorrents: [] } });
-		expect(screen.queryByRole('heading', { name: 'Active Downloads' })).not.toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Active Downloads' })).toBeInTheDocument();
+		expect(
+			screen.getByText(/No active downloads yet\. Queued torrents will appear here/)
+		).toBeInTheDocument();
 	});
 
 	it('Active Downloads renders max 5 rows and View all link', () => {
@@ -202,11 +222,13 @@ describe('/', () => {
 		expect(screen.getByText('Failed').parentElement).toHaveTextContent('1');
 	});
 
-	it('Archive Commit grid renders top 6 completed, hidden when none', () => {
-		const { unmount } = render(Page, { data: baseData });
-		expect(screen.queryByText('Recently Completed')).not.toBeInTheDocument();
-		unmount();
+	it('renders explicit Recently Completed empty state when there is no archive data', () => {
+		render(Page, { data: baseData });
+		expect(screen.getByText('Recently Completed')).toBeInTheDocument();
+		expect(screen.getByText(/Nothing has finished downloading yet\./)).toBeInTheDocument();
+	});
 
+	it('Archive Commit grid renders top 6 completed items', () => {
 		const completed = Array.from({ length: 8 }, (_, i) =>
 			mockCandidate({
 				identityKey: `done${i}`,


### PR DESCRIPTION
## Summary

- delivery ticket: `P17.06 Dashboard Empty States and Onboarding Affordances`
- ticket file: [docs/02-delivery/phase-17/ticket-06-dashboard-empty-states-and-affordances.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-17/ticket-06-dashboard-empty-states-and-affordances.md)
- stacked base branch: `agents/p17-05-route-level-empty-state-alignment`
- post-verify self-audit: completed at 2026-04-14 09:31 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`f3b0c0b94b57`](https://github.com/cesarnml/pirate_claw/commit/f3b0c0b94b5720db0d0525b4f94f14e5e24333b1)
- current branch head: [`f3b0c0b94b57`](https://github.com/cesarnml/pirate_claw/commit/f3b0c0b94b5720db0d0525b4f94f14e5e24333b1)
- vendors: `coderabbit`, `sonarqube`
