### PR TITLE
docs: close Phase 17 delivery [P17.07]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pirate Claw is a local CLI for pulling media candidates from RSS feeds, matching them against your rules, and queueing approved downloads in Transmission.
 
-Phases **01–16** are implemented on `main`. **Phases 17–18** are defined in `docs/01-product/` and start after ticket decomposition and developer sign-off.
+Phases **01–17** are implemented on `main`. **Phase 18** remains in product-definition/planning mode under `docs/01-product/`.
 
 It currently supports:
 
@@ -42,6 +42,8 @@ It currently supports:
 ```
 
 Check state with `pirate-claw status`. Retry failed submissions with `pirate-claw retry-failed`. Reconcile tracked torrents from Transmission with `pirate-claw reconcile`.
+
+For the guided first-run path: start the daemon, open the dashboard, and use `/onboarding` to save your first feed and first target instead of editing the config by hand.
 
 ## Configuration
 
@@ -189,9 +191,9 @@ cd web && PIRATE_CLAW_API_URL=http://localhost:5555 PORT=5174 node build/index.j
 
 Pirate Claw is a local operator tool for a personal NAS. The roadmap through Phase 18 targets eliminating the need to SSH in for day-to-day operation.
 
-**Implemented (Phases 01–16):** RSS ingestion, policy matching, Transmission queuing, lifecycle reconciliation, TMDB enrichment, read dashboard, unified config editing from the UI, post-save daemon restart and Transmission ping controls, full feed and target management, and live Transmission activity views.
+**Implemented (Phases 01–17):** RSS ingestion, policy matching, Transmission queuing, lifecycle reconciliation, TMDB enrichment, read dashboard, unified config editing from the UI, post-save daemon restart and Transmission ping controls, full feed and target management, onboarding/resume flow, and explicit empty states across the dashboard and key routes.
 
-**Planned (Phases 17–18):** Onboarding wizard, v1.0.0 release, and schema versioning.
+**Planned (Phase 18):** v1.0.0 release and schema versioning.
 
 Not in scope through v1:
 

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -436,7 +436,7 @@ Goal:
 
 Current status:
 
-- product definition only; see [`docs/01-product/phase-17-onboarding-and-empty-state.md`](../01-product/phase-17-onboarding-and-empty-state.md)
+- implemented on `main` via `P17.01`-`P17.07` stacked delivery; see [`docs/02-delivery/phase-17/implementation-plan.md`](../02-delivery/phase-17/implementation-plan.md) and [`docs/01-product/phase-17-onboarding-and-empty-state.md`](../01-product/phase-17-onboarding-and-empty-state.md)
 
 ## Phase 18: v1.0.0 Release and Schema Versioning
 
@@ -467,8 +467,8 @@ The following items are **mapped** to numbered phases (no longer “unbounded”
 
 ## Current Planning Posture
 
-- product phases `01`–`16` are implemented on `main`; **Phase 16** is delivered via `P16.01`–`P16.09` stacked delivery
-- product phases `12`–`18` are defined in `docs/01-product/`; **Phases 17–18** remain product-definition-first until their tickets are approved and implemented
+- product phases `01`–`17` are implemented on `main`; **Phase 17** is delivered via `P17.01`–`P17.07` stacked delivery
+- product phases `12`–`18` are defined in `docs/01-product/`; **Phase 18** remains product-definition-first until its tickets are approved and implemented
 - engineering epic write-ups **`EE01`–`EE06`** live under `docs/03-engineering/` (orchestrator, PR hygiene, and delivery workflow tooling)
 - each new phase requires an explicit planning pass, approved ticket decomposition, and developer sign-off before implementation starts
 - smaller bounded changes can still proceed as standalone PR work without inventing a new phase
@@ -487,4 +487,4 @@ Working notes:
 - promote durable technical choices into ADRs
 - numbered phases are planning buckets, not a promise of strict implementation sequence when dependencies allow independent work
 
-Last verified against `README.md` and active delivery plans: 2026-04-13 (Phase 16 delivered).
+Last verified against `README.md` and active delivery plans: 2026-04-14 (Phase 17 delivered).

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -10,7 +10,7 @@ Its job is to answer three questions quickly:
 
 ## Current Repo State
 
-Pirate Claw is implemented through **Phase 16** on `main` (product phases 01–16; see [`roadmap.md`](./roadmap.md)). Delivery artifacts for Phases 12–16 live under [`docs/02-delivery/`](../02-delivery/). Product definitions for **Phases 17–18** live under [`docs/01-product/`](../01-product/) ahead of implementation; the Phase 16 product spec is the contract reference for the latest shipped scope. Phases **17–18** are **not yet implemented** in code.
+Pirate Claw is implemented through **Phase 17** on `main` (product phases 01–17; see [`roadmap.md`](./roadmap.md)). Delivery artifacts for Phases 12–17 live under [`docs/02-delivery/`](../02-delivery/). The product definition for **Phase 18** lives under [`docs/01-product/`](../01-product/) ahead of implementation; the Phase 17 product spec is the contract reference for the latest shipped scope. Phase **18** is **not yet implemented** in code.
 
 Current delivered surface:
 
@@ -32,6 +32,7 @@ Current delivered surface:
 - Phase 15 dashboard visibility: home overview (Transmission session strip, active downloads, recent outcomes, archive grid), TV and movie library views with live transfer stats where a `transmissionTorrentHash` joins to Transmission, skipped-no-match outcomes, and `/candidates/unmatched` — refresh on page reload only (no WebSocket/SSE push)
 - optional TMDB enrichment: `tmdb` config block and/or `PIRATE_CLAW_TMDB_API_KEY`, SQLite-backed cache, lazy enrichment on API reads, and an optional daemon background refresh cadence via `runtime.tmdbRefreshIntervalMinutes` (default 6 hours; set `0` to disable)
 - Phase 16 config editing: unified `/config` accordion cards, per-section toast feedback, post-save daemon restart affordance, Transmission ping, and read-only tooltips when write auth is absent
+- Phase 17 onboarding and empty states: `/onboarding` guided first-run flow, strict initial-empty auto-trigger plus dismissal suppression/resume, blocked onboarding when writes are disabled, and explicit empty-state guidance across `/`, `/config`, `/shows`, `/movies`, and `/candidates/unmatched`
 
 Current product boundary:
 
@@ -47,9 +48,8 @@ Current product boundary:
 - read-only daemon HTTP API (`/api/health`, `/api/status`, `/api/candidates`, `/api/shows`, `/api/movies`, `/api/feeds`, `/api/config`, plus Phase 15 `/api/transmission/session`, `/api/transmission/torrents`, `/api/outcomes`) when `runtime.apiPort` is configured
 - TMDB metadata is display-only and does not gate RSS intake
 
-Still deferred (Phases 17–18):
+Still deferred (Phase 18 and beyond):
 
-- onboarding wizard and per-section empty states (Phase 17)
 - v1.0.0 release and config/DB schema versioning (Phase 18)
 - remote feed capture
 - hosted persistence
@@ -57,13 +57,14 @@ Still deferred (Phases 17–18):
 - Synology archiving
 - ingestion redesign beyond the local SQLite model
 
-Last verified against `README.md` and CLI commands: 2026-04-13 (Phase 16 delivered).
+Last verified against `README.md` and CLI commands: 2026-04-14 (Phase 17 delivered).
 
 Current planning focus:
 
 - see [`roadmap.md`](./roadmap.md) for numbered phases and what is implemented on `main`
 - use the roadmap to confirm whether the request is a bounded standalone change or needs a new approved phase/epic planning pass
 - treat the current Phase 07 config surface and the current extracted delivery-orchestrator module boundaries as the baseline for future work
+- Phase 18 release/versioning work is the next numbered product phase after the shipped onboarding and empty-state surface
 
 ## Read These Docs By Task Type
 

--- a/docs/01-product/phase-17-onboarding-and-empty-state.md
+++ b/docs/01-product/phase-17-onboarding-and-empty-state.md
@@ -1,6 +1,6 @@
 # Phase 17: Onboarding and Empty State Experience
 
-**Delivery status:** Not started — product definition only; no `docs/02-delivery/phase-17/` implementation plan until tickets are approved.
+**Delivery status:** Delivered on `main` via `P17.01`-`P17.07`; see [`docs/02-delivery/phase-17/`](../02-delivery/phase-17/).
 
 Phase 17 covers two distinct surfaces: a first-time setup wizard for operators who just installed pirate-claw, and per-section empty states in the main UI for operators who have a running daemon but haven't added feeds or targets yet.
 

--- a/docs/02-delivery/phase-17/implementation-plan.md
+++ b/docs/02-delivery/phase-17/implementation-plan.md
@@ -94,4 +94,4 @@ Pause for review if:
 
 ## Delivery status
 
-Planning/decomposition only. Implementation has not started.
+Delivered on `main` via `P17.01`-`P17.07` stacked delivery.

--- a/docs/02-delivery/phase-17/ticket-07-docs-and-phase-exit.md
+++ b/docs/02-delivery/phase-17/ticket-07-docs-and-phase-exit.md
@@ -27,16 +27,16 @@ Update the onboarding/runbook docs, mark Phase 17 delivered across status docs, 
 
 ### Phase exit verification checklist
 
-- [ ] onboarding route exists and honors strict initial-empty auto-trigger only
-- [ ] dismissal suppression and explicit resume behavior implemented
-- [ ] write-disabled onboarding blocked state implemented
-- [ ] first feed save works via existing feeds write path
-- [ ] TV target onboarding appends without clobbering existing shows
-- [ ] movie target onboarding preserves existing movie policy when present
-- [ ] Done step enforces the minimum completion gate and renders a summary
-- [ ] route-level empty states aligned (`/shows`, `/movies`, `/candidates/unmatched`, `/config`)
-- [ ] dashboard empty states and `/` + `/config` onboarding affordances aligned
-- [ ] onboarding fixture snapshots committed and referenced by dependent tests
+- [x] onboarding route exists and honors strict initial-empty auto-trigger only
+- [x] dismissal suppression and explicit resume behavior implemented
+- [x] write-disabled onboarding blocked state implemented
+- [x] first feed save works via existing feeds write path
+- [x] TV target onboarding appends without clobbering existing shows
+- [x] movie target onboarding preserves existing movie policy when present
+- [x] Done step enforces the minimum completion gate and renders a summary
+- [x] route-level empty states aligned (`/shows`, `/movies`, `/candidates/unmatched`, `/config`)
+- [x] dashboard empty states and `/` + `/config` onboarding affordances aligned
+- [x] onboarding fixture snapshots committed and referenced by dependent tests
 
 ## Out of Scope
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ Phase-level product definitions.
 - `phase-14-feed-setup-and-target-management.md`: feed and target management via web UI — feeds, TV defaults, movie policy (implemented)
 - `phase-15-rich-visual-state-and-activity-views.md`: live Transmission progress, TV/movie enriched views, unmatched candidates (implemented)
 - `phase-16-config-editing-hot-reload-and-daemon-controls.md`: unified Config page, inline validation, post-save daemon restart (implemented)
-- `phase-17-onboarding-and-empty-state.md`: first-time setup wizard and per-section empty states (product definition)
+- `phase-17-onboarding-and-empty-state.md`: first-time setup wizard and per-section empty states (implemented)
 - `phase-18-v1-release-and-schema-versioning.md`: v1.0.0 release, config schemaVersion, SQLite PRAGMA user_version (product definition)
 
 ### `02-delivery`
@@ -74,6 +74,7 @@ Execution plans, issue conventions, and ticket breakdowns.
 - `phase-14/implementation-plan.md`: feed setup and target management delivery plan (tickets P14.01–P14.06)
 - `phase-15/implementation-plan.md`: rich visual state and activity views delivery plan (tickets P15.01–P15.07; delivered on `main`)
 - `phase-16/implementation-plan.md`: config editing, hot reload, and daemon controls delivery plan (tickets P16.01–P16.09; delivered on `main`)
+- `phase-17/implementation-plan.md`: onboarding and empty-state delivery plan (tickets P17.01–P17.07; delivered on `main`)
 
 ### `03-engineering`
 


### PR DESCRIPTION
## Summary

- delivery ticket: `P17.07 Docs and Phase Exit`
- ticket file: [docs/02-delivery/phase-17/ticket-07-docs-and-phase-exit.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-17/ticket-07-docs-and-phase-exit.md)
- stacked base branch: `agents/p17-06-dashboard-empty-states-and-onboarding-affordances`

## External AI Review

- outcome: `clean`
- current branch head: [`cd93204c96b8`](https://github.com/cesarnml/pirate_claw/commit/cd93204c96b8442c2b374f607e47a551f53d9046)
- no prudent follow-up changes were required.
