### PR TITLE
refactor: split ai review fetch and triage artifacts

### DIFF
--- a/.agents/skills/ai-code-review/SKILL.md
+++ b/.agents/skills/ai-code-review/SKILL.md
@@ -15,7 +15,7 @@ This skill owns: fetching review data with `gh`, detection logic, normalizing co
 
 Contract:
 
-- fetcher outputs: `detected`, `agents`, `artifact_text`, `reviewed_head_sha`, `vendors`, `comments`
+- fetcher outputs: `detected`, `agents`, `reviewed_head_sha`, `vendors`, `comments`
 - triager outputs: `outcome` (`clean|needs_patch|patched`), `note`, `action_summary`, `non_action_summary`, `vendors`
 
 When triager returns `needs_patch`, follow-up must conclude as `patched` or `operator_input_needed` — not stop permanently at `needs_patch`.
@@ -24,7 +24,7 @@ When triager returns `needs_patch`, follow-up must conclude as `patched` or `ope
 
 1. Resolve PR number with `gh pr view` if not provided.
 2. Fetch with `.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh <pr-number>`.
-3. If orchestrator already saved `review.json`, use that as the source of truth for vendor attribution and comment shape.
+3. If orchestrator already saved `review.fetch.json`, use that as the source of truth for vendor attribution and comment shape.
 4. Detection policy: supported vendor identities, explicit vendor wording in comment body, check-run annotations. Human drive-by comments do not count. Preserve head SHA, inline resolution/outdated state, and native thread identity.
 5. Return fetcher contract when inside `poll-review`: `detected=false` → keep polling or auto-clean; `detected=true` → orchestrator inspects agent state and decides.
 6. Triage each detected comment: actionable, stale, wrong, over-scoped, or out of scope.

--- a/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
+++ b/.agents/skills/ai-code-review/scripts/fetch_ai_pr_comments.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 #   {
 #     "agents": [{"agent":"coderabbit","state":"started|completed|findings_detected","findingsCount":1,"note":"..."}],
 #     "detected": true|false,
-#     "artifact_text": "normalized text artifact",
 #     "vendors": ["coderabbit", "qodo", "greptile", "sonarqube"],
 #     "comments": [...]
 #   }
@@ -544,43 +543,6 @@ jq -n \
         agents: $agents,
         detected: ($matches | length > 0),
         reviewed_head_sha: ($pr.headRefOid // null),
-        artifact_text:
-          (
-            [
-              "PR #\($pr.number): \($pr.title)",
-              "URL: \($pr.url)",
-              "Branch: \($pr.headRefName) -> \($pr.baseRefName)",
-              "Reviewed head SHA: \($pr.headRefOid // "unknown")",
-              "State: \($pr.state)\(if $pr.isDraft then " (draft)" else "" end)",
-              "Detected AI review comments: \($matches | length)",
-              "Detected AI review agents: \($agents | length)",
-              "Vendors: \(if ($vendors | length) > 0 then ($vendors | join(", ")) else "none" end)",
-              ""
-            ]
-            + (
-              if ($agents | length) > 0 then
-                ["Agent states:"]
-                + ($agents | map("- \(.agent): \(.state)\(if (.findingsCount // 0) > 0 then " (\(.findingsCount) findings)" else "" end)"))
-                + [""]
-              else
-                []
-              end
-            )
-            + (
-              $matches
-              | map(
-                  "- [\(.kind)][\(.vendor)][\(.channel)][\(.derived_state)] \(.author_login)"
-                  + (if .path then " on \(.path):\(.line // 0)" else "" end)
-                  + (if .thread_id then " [thread \(.thread_id)]" else "" end)
-                  + (if .is_resolved then " [resolved]" else "" end)
-                  + (if .is_outdated then " [outdated]" else "" end)
-                  + (if .updated_at != "" then " at \(.updated_at)" else "" end)
-                  + "\n  "
-                  + (.body | gsub("\r"; "") | gsub("\n"; "\n  "))
-                  + (if .url != "" then "\n  \(.url)" else "" end)
-                )
-            )
-          ) | join("\n"),
         vendors: $vendors,
         comments: $matches
       }

--- a/.agents/skills/son-of-anton-ethos/SKILL.md
+++ b/.agents/skills/son-of-anton-ethos/SKILL.md
@@ -107,7 +107,7 @@ Applies to both standalone PRs (`ai-review`) and ticket stacks (`poll-review`). 
 - **Qodo** posts a single actionable PR comment with all findings — treat it as actionable when present.
 - **SonarQube** posts a Quality Gate summary PR comment; check-run annotations are secondary signal.
 
-For ticket stacks, the orchestrator's `reviewComments` in state is the source of truth for triage. Do not re-read the full `.txt` artifact unless you need prose context not in the condensed findings block.
+For ticket stacks, the orchestrator persists vendor evidence in `reviews/<ticket>.fetch.json` and repo-local judgment in `reviews/<ticket>.triage.json`. `state.json` is only an index into those artifacts, not the source of truth for comment payloads.
 
 ### Outcome Recording
 

--- a/docs/03-engineering/ai-first-delivery-workflow.md
+++ b/docs/03-engineering/ai-first-delivery-workflow.md
@@ -19,7 +19,7 @@ The orchestrator owns the mechanics:
 - branch and worktree flow
 - PR open/update behavior
 - AI review polling
-- artifact and note persistence
+- review-artifact and note persistence
 - notification hooks
 
 The repo-local `ai-code-review` skill owns the judgment:
@@ -30,6 +30,12 @@ The repo-local `ai-code-review` skill owns the judgment:
 
 The boundary is implemented as repo-local hooks under `.agents/skills/ai-code-review/`: a fetcher that normalizes supported external AI review into structured data, and a triager hook that turns that data into a final outcome plus concise rationale.
 
+The persisted review contract is split on purpose:
+
+- `reviews/<ticket>.fetch.json` stores normalized vendor evidence
+- `reviews/<ticket>.triage.json` stores repo-local judgment and triage side effects
+- `state.json` only indexes those artifacts plus compact review status fields
+
 Supported external review agents are currently:
 
 - `coderabbit`
@@ -39,9 +45,9 @@ Supported external review agents are currently:
 
 Other AI-review vendors are out of scope unless repo policy explicitly adds them.
 
-SonarQube support uses GitHub check annotations instead of native PR review comments. The standalone `ai-review` flow normalizes only failed-check annotations into the review artifact so triage stays focused on higher-signal static-analysis findings such as complexity/code-smell failures instead of importing the full warning stream.
+SonarQube support uses GitHub check annotations instead of native PR review comments. The standalone `ai-review` flow normalizes only failed-check annotations into the fetch artifact so triage stays focused on higher-signal static-analysis findings such as complexity/code-smell failures instead of importing the full warning stream.
 
-The normalized artifact now carries reviewed-commit provenance and native GitHub inline-thread identity when available. That lets the PR body distinguish current-head review from stale-history review, and it lets patched inline findings be resolved in the GitHub PR UI without vendor-specific logic.
+The normalized fetch artifact carries reviewed-commit provenance and native GitHub inline-thread identity when available. The paired triage artifact records the repo judgment and any follow-through such as thread resolution or PR-body refresh attempts. Together they let the PR body distinguish current-head review from stale-history review and let patched inline findings be resolved in the GitHub PR UI without vendor-specific logic.
 
 That boundary matters. AI is used aggressively, but not blindly.
 

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -93,7 +93,7 @@ The orchestrator owns process mechanics:
 - stacked PR base chaining
 - idempotent PR open/update behavior for already-pushed ticket branches
 - a 6/12-minute AI-review polling loop after PR open (two checkpoints: 6 minutes and 12 minutes)
-- invoking the repo-local `ai-code-review` fetcher and persisting structured JSON plus rendered text artifacts when AI review is detected
+- invoking the repo-local `ai-code-review` fetcher and persisting split review artifacts when AI review is detected
 - optional Telegram milestone notifications for long-running delivery runs
 - blocking advancement until review is explicitly recorded or auto-recorded as `clean` after the final polling check
 - refreshing the current PR body from recorded follow-up notes immediately before advancing to the next ticket
@@ -112,8 +112,8 @@ So the orchestrator only consumes the skill hook contracts:
 
 - fetcher:
   - `detected=false`: keep polling, or auto-record `clean` on the final check
-  - `detected=true`: save structured and rendered artifacts, then call the triager hook
-  - preserves supported-vendor identity, reviewed head SHA, native thread identity when available, and inline-comment resolution/outdated metadata in the saved `json` artifact
+  - `detected=true`: save `reviews/<ticket>.fetch.json`, then call the triager hook and persist `reviews/<ticket>.triage.json`
+  - preserves supported-vendor identity, reviewed head SHA, native thread identity when available, and inline-comment resolution/outdated metadata in the saved fetch artifact
 - triager:
   - returns `clean`, `needs_patch`, or `patched`
   - returns the final note plus concise action and non-action summaries
@@ -128,13 +128,21 @@ In this repo, supported external AI-review vendors are currently:
 
 Other vendors are out of scope unless the repo-local `ai-code-review` skill is deliberately expanded.
 
-For `sonarqube`, the repo-local fetcher reads GitHub check-run annotations rather than native PR review threads and intentionally keeps only failed-check annotations in the normalized artifact. Lower-severity warning annotations remain available in SonarQube itself but do not enter the orchestrator triage loop by default.
+For `sonarqube`, the repo-local fetcher reads GitHub check-run annotations rather than native PR review threads and intentionally keeps only failed-check annotations in the normalized fetch artifact. Lower-severity warning annotations remain available in SonarQube itself but do not enter the orchestrator triage loop by default.
 
 The absence of `ai-code-review` comments after the final 12-minute polling check is not itself a blocker. In that case, the orchestrator records the review as `clean`, updates the PR metadata, and continues unless another real ambiguity or prerequisite issue exists.
 
 Doc-only PRs (where the diff touches only `.md` files) skip the review window only when `reviewPolicy.externalReview` is `"skip_doc_only"` (or the stage is fully `"disabled"` for all PRs). External AI agents review code; the developer reads docs. When `open-pr` detects a doc-only diff, it sets a `doc_only` flag in state, and `poll-review` uses the configured policy to decide whether to auto-record `clean` immediately or wait through the normal review window.
 
-When the triager hook resolves to `clean` or `patched`, `poll-review` records that result immediately. When it resolves to `needs_patch`, the ticket moves into an intermediate `needs_patch` state with the saved artifacts and triage note. From there the follow-up must conclude as either `patched` or `operator_input_needed`. PR body updates remain best-effort in either case.
+When the triager hook resolves to `clean` or `patched`, `poll-review` records that result immediately. When it resolves to `needs_patch`, the ticket moves into an intermediate `needs_patch` state with the saved fetch/triage artifacts and triage note. From there the follow-up must conclude as either `patched` or `operator_input_needed`. PR body updates remain best-effort in either case.
+
+Review artifact persistence now follows a hard split:
+
+- `reviews/<ticket>.fetch.json` is the only persisted source of normalized vendor review evidence
+- `reviews/<ticket>.triage.json` is the only persisted source of repo-local review judgment and triage side effects
+- `state.json` stores only compact index/control-plane review fields such as artifact paths, `reviewOutcome`, `reviewRecordedAt`, and optionally `reviewHeadSha`
+- no rendered `.txt` review artifact is persisted
+- a stable `fetch.json` without `triage.json` is an incomplete internal state and should be surfaced as such rather than treated as a completed review
 
 At this point in the repo, `poll-review`, `record-review`, and standalone `ai-review` are intentionally thin mode-specific shells around the same post-PR lifecycle helpers. Ticket-linked flow still owns stacked state transitions and standalone flow still owns PR discovery plus author-body preservation, but the semantic review handling between those edges is shared.
 

--- a/tools/delivery/notifications.ts
+++ b/tools/delivery/notifications.ts
@@ -78,13 +78,7 @@ function buildReviewRecordedEvent(
   state: DeliveryState,
   ticket: Pick<
     TicketState,
-    | 'id'
-    | 'title'
-    | 'branch'
-    | 'reviewOutcome'
-    | 'reviewNote'
-    | 'prUrl'
-    | 'status'
+    'id' | 'title' | 'branch' | 'reviewOutcome' | 'prUrl' | 'status'
   >,
 ): DeliveryNotificationEvent | undefined {
   const outcome: ReviewResult | undefined =
@@ -106,7 +100,6 @@ function buildReviewRecordedEvent(
     ticketTitle: ticket.title,
     branch: ticket.branch,
     outcome,
-    note: ticket.reviewNote,
     prUrl: ticket.prUrl,
   };
 }

--- a/tools/delivery/notifications.ts
+++ b/tools/delivery/notifications.ts
@@ -1,4 +1,7 @@
+import { resolve } from 'node:path';
+
 import { buildReviewPollCheckMinutes } from './review';
+import { readReviewArtifacts } from './review-artifacts';
 import type {
   DeliveryState,
   DeliveryNotificationEvent,
@@ -78,10 +81,33 @@ function buildReviewRecordedEvent(
   state: DeliveryState,
   ticket: Pick<
     TicketState,
-    'id' | 'title' | 'branch' | 'reviewOutcome' | 'prUrl' | 'status'
+    | 'id'
+    | 'title'
+    | 'branch'
+    | 'prUrl'
+    | 'reviewArtifactJsonPath'
+    | 'reviewArtifactPath'
+    | 'reviewFetchArtifactPath'
+    | 'reviewNote'
+    | 'reviewOutcome'
+    | 'reviewTriageArtifactPath'
+    | 'status'
   >,
 ): DeliveryNotificationEvent | undefined {
+  const artifacts = readReviewArtifacts({
+    fetchArtifactPath: ticket.reviewFetchArtifactPath
+      ? resolve(ticket.reviewFetchArtifactPath)
+      : ticket.reviewArtifactPath
+        ? resolve(ticket.reviewArtifactPath)
+        : undefined,
+    triageArtifactPath: ticket.reviewTriageArtifactPath
+      ? resolve(ticket.reviewTriageArtifactPath)
+      : ticket.reviewArtifactJsonPath
+        ? resolve(ticket.reviewArtifactJsonPath)
+        : undefined,
+  });
   const outcome: ReviewResult | undefined =
+    artifacts.triage?.outcome ??
     ticket.reviewOutcome ??
     (ticket.status === 'needs_patch'
       ? 'needs_patch'
@@ -100,6 +126,7 @@ function buildReviewRecordedEvent(
     ticketTitle: ticket.title,
     branch: ticket.branch,
     outcome,
+    note: artifacts.triage?.note ?? ticket.reviewNote,
     prUrl: ticket.prUrl,
   };
 }

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -3075,7 +3075,7 @@ describe('delivery orchestrator', () => {
       expect(sleeps).toEqual([]);
       expect(fetchCount).toBe(1);
       expect(nextState.tickets[0]?.status).toBe('done');
-      expect(nextState.tickets[0]?.reviewOutcome).toBe('patched');
+      expect(nextState.tickets[0]?.reviewOutcome).toBe('needs_patch');
       expect(nextState.tickets[0]?.reviewFetchArtifactPath).toBe(
         '.agents/delivery/phase-03/reviews/P3.01-ai-review.fetch.json',
       );

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -66,6 +66,13 @@ import {
   resolveEffectiveAdvanceBoundaryMode,
   type DeliveryState,
 } from './orchestrator';
+
+async function readArtifactJson(cwd: string, relativePath: string) {
+  return JSON.parse(await readFile(join(cwd, relativePath), 'utf8')) as Record<
+    string,
+    unknown
+  >;
+}
 import { getUsage, parseCliArgs } from './cli';
 import { advanceToNextTicket } from './ticket-flow';
 import { normalizeDeliveryStateFromPersisted } from './state';
@@ -115,7 +122,7 @@ describe('delivery orchestrator', () => {
       createOptions({
         planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
       }),
-    ).toEqual({
+    ).toMatchObject({
       planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
       planKey: 'phase-03',
       statePath: '.agents/delivery/phase-03/state.json',
@@ -283,8 +290,8 @@ describe('delivery orchestrator', () => {
             baseBranch: 'main',
             worktreePath: '/tmp/p2_01',
             prUrl: 'https://example.test/pull/14',
-            reviewArtifactPath:
-              '.agents/delivery/phase-02/reviews/P2.01-ai-review.txt',
+            reviewFetchArtifactPath:
+              '.agents/delivery/phase-02/reviews/P2.01-ai-review.fetch.json',
             reviewOutcome: 'patched',
             reviewNote: 'patched the two actionable correctness issues',
           },
@@ -319,7 +326,7 @@ describe('delivery orchestrator', () => {
     expect(handoff).toContain('Previous PR: https://example.test/pull/14');
     expect(handoff).toContain('Review outcome: `patched`');
     expect(handoff).toContain(
-      'Review artifact: `.agents/delivery/phase-02/reviews/P2.01-ai-review.txt`',
+      'Review fetch artifact: `.agents/delivery/phase-02/reviews/P2.01-ai-review.fetch.json`',
     );
   });
 
@@ -1629,7 +1636,6 @@ describe('delivery orchestrator', () => {
             },
           ],
           detected: true,
-          artifact_text: 'normalized review artifact',
           reviewed_head_sha: 'abcdef1234567890',
           vendors: ['coderabbit', 'qodo', 'sonarqube'],
           comments: [
@@ -1694,48 +1700,38 @@ describe('delivery orchestrator', () => {
         },
       ],
       detected: true,
-      artifactText: 'normalized review artifact',
       reviewedHeadSha: 'abcdef1234567890',
       vendors: ['coderabbit', 'qodo', 'sonarqube'],
-      comments: [
-        {
+      comments: expect.arrayContaining([
+        expect.objectContaining({
           vendor: 'coderabbit',
           channel: 'inline_review',
           authorLogin: 'coderabbitai',
           authorType: 'Bot',
           body: 'Guard the null return here.',
-          isOutdated: false,
-          isResolved: false,
           path: 'src/example.ts',
           line: 42,
-          threadId: 'thread_example_1',
-          threadViewerCanResolve: true,
-          url: 'https://example.test/comment/1',
-          updatedAt: '2026-04-04T10:00:00.000Z',
           kind: 'finding',
-        },
-        {
+        }),
+        expect.objectContaining({
           vendor: 'qodo',
           channel: 'review_summary',
           authorLogin: 'qodo-bot',
           authorType: 'Bot',
           body: 'Overall this looks good.',
           kind: 'summary',
-        },
-        {
+        }),
+        expect.objectContaining({
           vendor: 'sonarqube',
           channel: 'inline_review',
           authorLogin: 'sonarqubecloud',
           authorType: 'Bot',
           body: 'Refactor this function to reduce its Cognitive Complexity from 19 to the 15 allowed.',
-          isOutdated: false,
-          isResolved: false,
           path: 'tools/delivery/pr-metadata.ts',
           line: 596,
-          url: 'https://sonarcloud.io/project/issues?id=example&issues=abc',
           kind: 'unknown',
-        },
-      ],
+        }),
+      ]),
     });
 
     expect(() => parseAiReviewFetcherOutput('not json')).toThrow(
@@ -1747,13 +1743,12 @@ describe('delivery orchestrator', () => {
         JSON.stringify({
           agents: [{ agent: 'coderabbit', state: 'unknown' }],
           detected: 'true',
-          artifact_text: 42,
           vendors: 'coderabbit',
           comments: {},
         }),
       ),
     ).toThrow(
-      'AI review fetcher output must be JSON with `agents`, boolean `detected`, string `artifact_text`, string[] `vendors`, and array `comments` fields.',
+      'AI review fetcher output must be JSON with `agents`, boolean `detected`, string[] `vendors`, and array `comments` fields.',
     );
   });
 
@@ -2081,32 +2076,17 @@ describe('delivery orchestrator', () => {
       expect(sleeps).toEqual([360000, 720000]);
       expect(fetchCount).toBe(2);
       expect(nextState.tickets[0]?.status).toBe('needs_patch');
-      expect(nextState.tickets[0]?.reviewArtifactJsonPath).toBe(
-        '.agents/delivery/phase-03/reviews/P3.01-ai-review.json',
+      expect(nextState.tickets[0]?.reviewFetchArtifactPath).toBe(
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.fetch.json',
       );
-      expect(nextState.tickets[0]?.reviewArtifactPath).toBe(
-        '.agents/delivery/phase-03/reviews/P3.01-ai-review.txt',
+      expect(nextState.tickets[0]?.reviewTriageArtifactPath).toBe(
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
       );
-      expect(nextState.tickets[0]?.reviewVendors).toEqual([
-        'coderabbit',
-        'qodo',
-      ]);
       expect(nextState.tickets[0]?.reviewHeadSha).toBe('abcdef1234567890');
-      expect(nextState.tickets[0]?.reviewComments?.[0]?.threadId).toBe(
-        'thread_example_1',
-      );
       expect(
-        await readFile(
-          join(cwd, '.agents/delivery/phase-03/reviews/P3.01-ai-review.txt'),
-          'utf8',
-        ),
-      ).toBe('normalized ai review artifact');
-      expect(
-        JSON.parse(
-          await readFile(
-            join(cwd, '.agents/delivery/phase-03/reviews/P3.01-ai-review.json'),
-            'utf8',
-          ),
+        await readArtifactJson(
+          cwd,
+          '.agents/delivery/phase-03/reviews/P3.01-ai-review.fetch.json',
         ),
       ).toMatchObject({
         agents: [
@@ -2119,10 +2099,19 @@ describe('delivery orchestrator', () => {
             state: 'findings_detected',
           },
         ],
-        artifact_text: 'normalized ai review artifact',
         detected: true,
-        reviewed_head_sha: 'abcdef1234567890',
+        reviewedHeadSha: 'abcdef1234567890',
         vendors: ['coderabbit', 'qodo'],
+      });
+      expect(
+        await readArtifactJson(
+          cwd,
+          '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
+        ),
+      ).toMatchObject({
+        outcome: 'needs_patch',
+        actionSummary: 'Flagged 1 finding comment for follow-up.',
+        nonActionSummary: 'Ignored 1 summary comment.',
       });
     } finally {
       await rm(cwd, { recursive: true, force: true });
@@ -2203,29 +2192,19 @@ describe('delivery orchestrator', () => {
         },
       ],
       updatePullRequestBody: async (updatedState, ticket) => {
-        prBodyUpdates.push(
-          `${updatedState.planKey}:${ticket.reviewOutcome}:${ticket.reviewNote}`,
-        );
+        prBodyUpdates.push(`${updatedState.planKey}:${ticket.reviewOutcome}`);
       },
     });
 
     expect(nextState.tickets[0]).toMatchObject({
       status: 'done',
       reviewOutcome: 'patched',
-      reviewNote: 'Patched the prudent AI review follow-up.',
-      reviewThreadResolutions: [
-        {
-          status: 'resolved',
-          threadId: 'thread_example_1',
-          url: 'https://example.test/comment/1',
-          vendor: 'coderabbit',
-        },
-      ],
-      reviewVendors: ['coderabbit'],
+      reviewFetchArtifactPath:
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.fetch.json',
+      reviewTriageArtifactPath:
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
     });
-    expect(prBodyUpdates).toEqual([
-      'phase-03:patched:Patched the prudent AI review follow-up.',
-    ]);
+    expect(prBodyUpdates).toEqual(['phase-03:patched']);
   });
 
   it('extends review polling by one interval when an agent is still in flight', async () => {
@@ -2282,9 +2261,18 @@ describe('delivery orchestrator', () => {
     expect(nextState.tickets[0]).toMatchObject({
       status: 'done',
       reviewOutcome: 'clean',
-      reviewIncompleteAgents: ['coderabbit'],
-      reviewNote:
-        'AI review reached the 12-minute limit while waiting on: coderabbit. No actionable findings were captured. Rerun manually if needed.',
+      reviewTriageArtifactPath:
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
+    });
+    expect(
+      await readArtifactJson(
+        '/tmp/pirate_claw',
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
+      ),
+    ).toMatchObject({
+      incompleteAgents: ['coderabbit'],
+      note: 'AI review reached the 12-minute limit while waiting on: coderabbit. No actionable findings were captured. Rerun manually if needed.',
+      outcome: 'clean',
     });
   });
 
@@ -2331,9 +2319,7 @@ describe('delivery orchestrator', () => {
         comments: [],
       }),
       updatePullRequestBody: async (updatedState, ticket) => {
-        prBodyUpdates.push(
-          `${updatedState.planKey}:${ticket.reviewNote ?? ''}`,
-        );
+        prBodyUpdates.push(`${updatedState.planKey}:${ticket.reviewOutcome}`);
       },
     });
 
@@ -2341,12 +2327,19 @@ describe('delivery orchestrator', () => {
     expect(nextState.tickets[0]).toMatchObject({
       status: 'done',
       reviewOutcome: 'clean',
-      reviewNote:
-        'No AI review feedback was detected within the 12-minute polling window.',
+      reviewTriageArtifactPath:
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
     });
-    expect(prBodyUpdates).toEqual([
-      'phase-03:No AI review feedback was detected within the 12-minute polling window.',
-    ]);
+    expect(
+      await readArtifactJson(
+        '/tmp/pirate_claw',
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
+      ),
+    ).toMatchObject({
+      note: 'No AI review feedback was detected within the 12-minute polling window.',
+      outcome: 'clean',
+    });
+    expect(prBodyUpdates).toEqual(['phase-03:clean']);
   });
 
   it('preserves patched as the cumulative outcome when a later poll is clean', async () => {
@@ -2407,8 +2400,17 @@ describe('delivery orchestrator', () => {
     expect(nextState.tickets[0]).toMatchObject({
       status: 'done',
       reviewOutcome: 'patched',
-      reviewNote:
-        'External AI review completed without prudent follow-up changes. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
+      reviewTriageArtifactPath:
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
+    });
+    expect(
+      await readArtifactJson(
+        '/tmp/pirate_claw',
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
+      ),
+    ).toMatchObject({
+      note: 'External AI review completed without prudent follow-up changes. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
+      outcome: 'patched',
     });
   });
 
@@ -2458,8 +2460,17 @@ describe('delivery orchestrator', () => {
     expect(nextState.tickets[0]).toMatchObject({
       status: 'done',
       reviewOutcome: 'patched',
-      reviewNote:
-        'No AI review feedback was detected within the 12-minute polling window. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
+      reviewTriageArtifactPath:
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
+    });
+    expect(
+      await readArtifactJson(
+        '/tmp/pirate_claw',
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
+      ),
+    ).toMatchObject({
+      note: 'No AI review feedback was detected within the 12-minute polling window. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
+      outcome: 'patched',
     });
   });
 
@@ -2547,9 +2558,6 @@ describe('delivery orchestrator', () => {
 
     expect(standaloneResult.outcome).toBe('patched');
     expect(nextState.tickets[0]?.reviewOutcome).toBe('patched');
-    expect(nextState.tickets[0]?.reviewNote).toBe(
-      'External AI review completed without prudent follow-up changes. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
-    );
     expect(standaloneResult.note).toBe(
       'External AI review completed without prudent follow-up changes. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
     );
@@ -2625,9 +2633,6 @@ describe('delivery orchestrator', () => {
 
     expect(standaloneResult.outcome).toBe('patched');
     expect(nextState.tickets[0]?.reviewOutcome).toBe('patched');
-    expect(nextState.tickets[0]?.reviewNote).toBe(
-      'No AI review feedback was detected within the 12-minute polling window. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
-    );
     expect(standaloneResult.note).toBe(
       'No AI review feedback was detected within the 12-minute polling window. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
     );
@@ -2688,6 +2693,7 @@ describe('delivery orchestrator', () => {
         now: () => Date.parse('2026-04-01T10:00:00.000Z'),
         sleep: async () => {},
         fetcher,
+        previousOutcome: 'clean',
         pullRequest: {
           body: 'existing body',
           createdAt: '2026-04-01T10:00:00.000Z',
@@ -2706,12 +2712,6 @@ describe('delivery orchestrator', () => {
 
     expect(standaloneResult.outcome).toBe('clean');
     expect(nextState.tickets[0]?.reviewOutcome).toBe('clean');
-    expect(nextState.tickets[0]?.reviewIncompleteAgents).toEqual(
-      standaloneResult.incompleteAgents,
-    );
-    expect(nextState.tickets[0]?.reviewNote).toBe(
-      'AI review reached the 12-minute limit while waiting on: coderabbit. No actionable findings were captured. Rerun manually if needed.',
-    );
     expect(standaloneResult.note).toBe(
       'AI review reached the 12-minute limit while waiting on: coderabbit. No actionable findings were captured. Rerun manually if needed.',
     );
@@ -2782,7 +2782,7 @@ describe('delivery orchestrator', () => {
     expect(sleeps).toEqual([]);
     expect(standaloneResult.outcome).toBe('operator_input_needed');
     expect(standaloneResult.incompleteAgents).toEqual(['coderabbit']);
-    expect(standaloneResult.vendors).toEqual(['greptile']);
+    expect(standaloneResult.vendors).toEqual(['coderabbit', 'greptile']);
     expect(standaloneResult.note).toBe(
       'AI review reached the 12-minute limit while waiting on: coderabbit. Triage the captured findings and rerun manually if needed.',
     );
@@ -3076,8 +3076,8 @@ describe('delivery orchestrator', () => {
       expect(fetchCount).toBe(1);
       expect(nextState.tickets[0]?.status).toBe('done');
       expect(nextState.tickets[0]?.reviewOutcome).toBe('patched');
-      expect(nextState.tickets[0]?.reviewArtifactJsonPath).toBe(
-        '.agents/delivery/phase-03/reviews/P3.01-ai-review.json',
+      expect(nextState.tickets[0]?.reviewFetchArtifactPath).toBe(
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.fetch.json',
       );
       expect(nextState.tickets[0]?.reviewHeadSha).toBe('abcdef1234567890');
       expect(
@@ -3158,10 +3158,10 @@ describe('delivery orchestrator', () => {
           prNumber: 20,
           prOpenedAt: '2026-04-01T10:00:00.000Z',
           reviewOutcome: 'patched',
-          reviewArtifactJsonPath:
-            '.agents/delivery/phase-03/reviews/P3.01-ai-review.json',
-          reviewArtifactPath:
-            '.agents/delivery/phase-03/reviews/P3.01-ai-review.txt',
+          reviewFetchArtifactPath:
+            '.agents/delivery/phase-03/reviews/P3.01-ai-review.fetch.json',
+          reviewTriageArtifactPath:
+            '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
           reviewNote: 'Earlier patched note.',
         },
       ],
@@ -3191,15 +3191,18 @@ describe('delivery orchestrator', () => {
     );
 
     expect(nextState.tickets[0]?.status).toBe('done');
-    expect(nextState.tickets[0]?.reviewArtifactJsonPath).toBe(
-      '.agents/delivery/phase-03/reviews/P3.01-ai-review.json',
+    expect(nextState.tickets[0]?.reviewTriageArtifactPath).toBe(
+      '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
     );
-    expect(nextState.tickets[0]?.reviewArtifactPath).toBe(
-      '.agents/delivery/phase-03/reviews/P3.01-ai-review.txt',
-    );
-    expect(nextState.tickets[0]?.reviewNote).toContain(
-      'No AI review feedback was detected within the 1-minute polling window',
-    );
+    expect(
+      await readArtifactJson(
+        '/tmp/pirate_claw',
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
+      ),
+    ).toMatchObject({
+      note: 'No AI review feedback was detected within the 1-minute polling window. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
+      outcome: 'patched',
+    });
   });
 
   it('preserves the triage note when recording a final review outcome without a new note', async () => {
@@ -3263,9 +3266,17 @@ describe('delivery orchestrator', () => {
     expect(nextState.tickets[0]).toMatchObject({
       status: 'done',
       reviewOutcome: 'patched',
-      reviewNote:
-        'Actionable AI review findings were detected and still need follow-up.',
-      reviewThreadResolutions: [
+      reviewRecordedAt: expect.any(String),
+    });
+    expect(
+      await readArtifactJson(
+        '/tmp/pirate_claw',
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
+      ),
+    ).toMatchObject({
+      note: 'Actionable AI review findings were detected and still need follow-up.',
+      outcome: 'patched',
+      threadResolutions: [
         {
           status: 'resolved',
           threadId: 'thread_example_1',
@@ -3317,8 +3328,16 @@ describe('delivery orchestrator', () => {
     expect(nextState.tickets[0]).toMatchObject({
       status: 'done',
       reviewOutcome: 'patched',
-      reviewNote:
-        'External AI review completed without prudent follow-up changes. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
+      reviewRecordedAt: expect.any(String),
+    });
+    expect(
+      await readArtifactJson(
+        '/tmp/pirate_claw',
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
+      ),
+    ).toMatchObject({
+      note: 'External AI review completed without prudent follow-up changes. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
+      outcome: 'clean',
     });
   });
 
@@ -3364,8 +3383,16 @@ describe('delivery orchestrator', () => {
     expect(nextState.tickets[0]).toMatchObject({
       status: 'done',
       reviewOutcome: 'patched',
-      reviewNote:
-        'External AI review completed without prudent follow-up changes. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
+      reviewRecordedAt: expect.any(String),
+    });
+    expect(
+      await readArtifactJson(
+        '/tmp/pirate_claw',
+        '.agents/delivery/phase-03/reviews/P3.01-ai-review.triage.json',
+      ),
+    ).toMatchObject({
+      note: 'External AI review completed without prudent follow-up changes. Earlier review cycles led to prudent follow-up patches, and the latest review pass found no additional prudent follow-up changes.',
+      outcome: 'clean',
     });
   });
 

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -207,7 +207,7 @@ export type TicketState = TicketDefinition & {
   reviewTriageArtifactPath?: string;
   reviewHeadSha?: string;
   reviewRecordedAt?: string;
-  reviewOutcome?: ReviewOutcome;
+  reviewOutcome?: ReviewResult;
   // Legacy compatibility fields: current write paths do not persist these.
   reviewArtifactJsonPath?: string;
   reviewArtifactPath?: string;
@@ -1676,14 +1676,12 @@ function loadTicketReviewSnapshot(ticket: TicketState): {
     fetchArtifactPath:
       (ticket.reviewFetchArtifactPath ?? ticket.reviewArtifactJsonPath)
         ? resolve(
-            ticket.worktreePath,
             ticket.reviewFetchArtifactPath ?? ticket.reviewArtifactJsonPath!,
           )
         : undefined,
     triageArtifactPath:
       (ticket.reviewTriageArtifactPath ?? ticket.reviewArtifactJsonPath)
         ? resolve(
-            ticket.worktreePath,
             ticket.reviewTriageArtifactPath ?? ticket.reviewArtifactJsonPath!,
           )
         : undefined,

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -84,6 +84,7 @@ import {
   updatePullRequestBody as updatePrMetadataPullRequestBody,
   updateStandalonePullRequestBody as updateStandalonePrMetadataPullRequestBody,
 } from './pr-metadata';
+import { readReviewArtifacts } from './review-artifacts';
 import {
   buildReviewPollCheckMinutes,
   parseAiReviewFetcherOutput,
@@ -202,16 +203,19 @@ export type TicketState = TicketDefinition & {
   prNumber?: number;
   prUrl?: string;
   prOpenedAt?: string;
-  reviewArtifactPath?: string;
-  reviewArtifactJsonPath?: string;
-  reviewActionSummary?: string;
-  reviewFetchedAt?: string;
+  reviewFetchArtifactPath?: string;
+  reviewTriageArtifactPath?: string;
   reviewHeadSha?: string;
-  reviewNonActionSummary?: string;
-  reviewComments?: AiReviewComment[];
+  reviewRecordedAt?: string;
   reviewOutcome?: ReviewOutcome;
-  reviewNote?: string;
+  // Legacy compatibility fields: current write paths do not persist these.
+  reviewArtifactJsonPath?: string;
+  reviewArtifactPath?: string;
+  reviewActionSummary?: string;
+  reviewComments?: AiReviewComment[];
   reviewIncompleteAgents?: string[];
+  reviewNonActionSummary?: string;
+  reviewNote?: string;
   reviewThreadResolutions?: AiReviewThreadResolution[];
   reviewVendors?: string[];
 };
@@ -435,7 +439,8 @@ export type AiReviewThreadResolution = {
 
 export type AiReviewFetcherResult = {
   agents: AiReviewAgentResult[];
-  artifactText: string;
+  // Legacy compatibility field: not populated by the current fetcher contract.
+  artifactText?: string;
   comments: AiReviewComment[];
   detected: boolean;
   reviewedHeadSha?: string;
@@ -451,19 +456,23 @@ export type AiReviewTriagerResult = {
 };
 
 export type StandaloneAiReviewResult = {
-  actionSummary?: string;
-  artifactJsonPath?: string;
-  artifactTextPath?: string;
-  incompleteAgents?: string[];
-  comments?: AiReviewComment[];
+  fetchArtifactPath?: string;
   note: string;
-  nonActionSummary?: string;
   outcome: ReviewResult;
   prNumber: number;
   prUrl: string;
   reviewedHeadSha?: string;
+  recordedAt?: string;
+  triageArtifactPath?: string;
+  // Legacy compatibility fields: current write paths do not persist these.
+  actionSummary?: string;
+  artifactJsonPath?: string;
+  artifactTextPath?: string;
+  comments?: AiReviewComment[];
+  incompleteAgents?: string[];
+  nonActionSummary?: string;
   threadResolutions?: AiReviewThreadResolution[];
-  vendors: string[];
+  vendors?: string[];
 };
 
 export type StandalonePullRequest = {
@@ -1654,6 +1663,47 @@ async function bootstrapWorktreeIfNeeded(worktreePath: string): Promise<void> {
   );
 }
 
+function loadTicketReviewSnapshot(ticket: TicketState): {
+  actionSummary?: string;
+  comments?: AiReviewComment[];
+  incompleteAgents?: string[];
+  note?: string;
+  nonActionSummary?: string;
+  threadResolutions?: AiReviewThreadResolution[];
+  vendors?: string[];
+} {
+  const artifacts = readReviewArtifacts({
+    fetchArtifactPath:
+      (ticket.reviewFetchArtifactPath ?? ticket.reviewArtifactJsonPath)
+        ? resolve(
+            ticket.worktreePath,
+            ticket.reviewFetchArtifactPath ?? ticket.reviewArtifactJsonPath!,
+          )
+        : undefined,
+    triageArtifactPath:
+      (ticket.reviewTriageArtifactPath ?? ticket.reviewArtifactJsonPath)
+        ? resolve(
+            ticket.worktreePath,
+            ticket.reviewTriageArtifactPath ?? ticket.reviewArtifactJsonPath!,
+          )
+        : undefined,
+  });
+
+  return {
+    actionSummary:
+      artifacts.triage?.actionSummary ?? ticket.reviewActionSummary,
+    comments: artifacts.fetch?.comments ?? ticket.reviewComments,
+    incompleteAgents:
+      artifacts.triage?.incompleteAgents ?? ticket.reviewIncompleteAgents,
+    note: artifacts.triage?.note ?? ticket.reviewNote,
+    nonActionSummary:
+      artifacts.triage?.nonActionSummary ?? ticket.reviewNonActionSummary,
+    threadResolutions:
+      artifacts.triage?.threadResolutions ?? ticket.reviewThreadResolutions,
+    vendors: artifacts.fetch?.vendors ?? ticket.reviewVendors,
+  };
+}
+
 export function formatStatus(state: DeliveryState): string {
   return [
     'Delivery Orchestrator',
@@ -1679,22 +1729,18 @@ export function formatStatus(state: DeliveryState): string {
           ? `codex_preflight=completed at ${ticket.codexPreflightCompletedAt} (${ticket.codexPreflightOutcome ?? 'unknown'})`
           : undefined,
         ticket.prUrl ? `pr=${ticket.prUrl}` : undefined,
-        ticket.reviewArtifactJsonPath
-          ? `review_artifact_json=${ticket.reviewArtifactJsonPath}`
+        ticket.reviewFetchArtifactPath
+          ? `review_fetch_artifact=${ticket.reviewFetchArtifactPath}`
           : undefined,
-        ticket.reviewArtifactPath
-          ? `review_artifact=${ticket.reviewArtifactPath}`
+        ticket.reviewTriageArtifactPath
+          ? `review_triage_artifact=${ticket.reviewTriageArtifactPath}`
           : undefined,
-        ticket.reviewIncompleteAgents?.length
-          ? `review_incomplete_agents=${ticket.reviewIncompleteAgents.join(',')}`
-          : undefined,
-        ticket.reviewVendors && ticket.reviewVendors.length > 0
-          ? `review_vendors=${ticket.reviewVendors.join(',')}`
+        ticket.reviewRecordedAt
+          ? `review_recorded_at=${ticket.reviewRecordedAt}`
           : undefined,
         ticket.reviewOutcome
           ? `review_outcome=${ticket.reviewOutcome}`
           : undefined,
-        ticket.reviewNote ? `review_note=${ticket.reviewNote}` : undefined,
       ]
         .filter((value): value is string => value !== undefined)
         .join('\n'),
@@ -1789,7 +1835,8 @@ export function formatCurrentTicketStatus(
     return header;
   }
 
-  const actionableFindings = (ticket.reviewComments ?? []).filter(
+  const review = loadTicketReviewSnapshot(ticket);
+  const actionableFindings = (review.comments ?? []).filter(
     (c) => c.kind !== 'summary' && !c.isOutdated && !c.isResolved,
   );
 
@@ -1817,17 +1864,17 @@ export function formatCurrentTicketStatus(
     `title=${ticket.title}`,
     ticket.prUrl ? `pr=${ticket.prUrl}` : undefined,
     ticket.docOnly ? `doc_only=true` : undefined,
-    ticket.reviewVendors && ticket.reviewVendors.length > 0
-      ? `review_vendors=${ticket.reviewVendors.join(',')}`
+    review.vendors && review.vendors.length > 0
+      ? `review_vendors=${review.vendors.join(',')}`
       : undefined,
     ticket.reviewOutcome ? `review_outcome=${ticket.reviewOutcome}` : undefined,
-    ticket.reviewActionSummary
-      ? `review_action_summary=${ticket.reviewActionSummary}`
+    review.actionSummary
+      ? `review_action_summary=${review.actionSummary}`
       : undefined,
     findingsBlock,
-    ticket.reviewNote ? `review_note=${ticket.reviewNote}` : undefined,
-    ticket.reviewIncompleteAgents?.length
-      ? `review_incomplete_agents=${ticket.reviewIncompleteAgents.join(',')}`
+    review.note ? `review_note=${review.note}` : undefined,
+    review.incompleteAgents?.length
+      ? `review_incomplete_agents=${review.incompleteAgents.join(',')}`
       : undefined,
   ]
     .filter((value): value is string => value !== undefined)
@@ -1856,21 +1903,12 @@ function formatStandaloneAiReviewResult(
     'Standalone AI Review',
     `pr=${result.prUrl}`,
     `outcome=${result.outcome}`,
-    result.incompleteAgents?.length
-      ? `incomplete_agents=${result.incompleteAgents.join(',')}`
+    result.recordedAt ? `recorded_at=${result.recordedAt}` : undefined,
+    result.fetchArtifactPath
+      ? `fetch_artifact=${result.fetchArtifactPath}`
       : undefined,
-    result.vendors.length > 0
-      ? `vendors=${result.vendors.join(',')}`
-      : undefined,
-    result.artifactJsonPath
-      ? `artifact_json=${result.artifactJsonPath}`
-      : undefined,
-    result.artifactTextPath
-      ? `artifact_text=${result.artifactTextPath}`
-      : undefined,
-    result.actionSummary ? `action_summary=${result.actionSummary}` : undefined,
-    result.nonActionSummary
-      ? `non_action_summary=${result.nonActionSummary}`
+    result.triageArtifactPath
+      ? `triage_artifact=${result.triageArtifactPath}`
       : undefined,
     `note=${result.note}`,
   ]

--- a/tools/delivery/pr-metadata.ts
+++ b/tools/delivery/pr-metadata.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 import type {
   AiReviewComment,
   AiReviewThreadResolution,
@@ -11,6 +13,7 @@ import type {
   TicketStatus,
 } from './orchestrator';
 import { DEFAULT_REVIEW_POLLING_PROFILE } from './review-polling-profile';
+import { readReviewArtifacts } from './review-artifacts';
 
 const MAX_ACTION_COMMITS = 20;
 const STANDALONE_AI_REVIEW_SECTION_START = '<!-- ai-review:start -->';
@@ -41,19 +44,25 @@ type TicketReviewMetadataRefreshTarget = Pick<
   | 'codexPreflightCompletedAt'
   | 'codexPreflightPatchCommits'
   | 'reviewActionSummary'
-  | 'reviewIncompleteAgents'
+  | 'reviewArtifactJsonPath'
+  | 'reviewArtifactPath'
   | 'reviewComments'
+  | 'reviewFetchArtifactPath'
   | 'reviewHeadSha'
-  | 'status'
-  | 'reviewOutcome'
-  | 'reviewNote'
+  | 'reviewIncompleteAgents'
   | 'reviewNonActionSummary'
+  | 'reviewNote'
+  | 'reviewRecordedAt'
+  | 'status'
   | 'reviewThreadResolutions'
+  | 'reviewTriageArtifactPath'
+  | 'reviewOutcome'
   | 'reviewVendors'
 >;
 
 type ReviewMetadataRefreshBodyOptions =
   | {
+      cwd?: string;
       mode: 'standalone';
       body: string;
       result: StandaloneAiReviewResult;
@@ -85,6 +94,50 @@ type PrMetadataDependencies = {
     cwd: string,
   ) => { defaultBranch: string; name: string; owner: string } | undefined;
 };
+
+type PersistedReviewDetails = {
+  actionSummary?: string;
+  comments?: AiReviewComment[];
+  incompleteAgents?: string[];
+  nonActionSummary?: string;
+  note?: string;
+  outcome?: ReviewResult;
+  recordedAt?: string;
+  reviewedHeadSha?: string;
+  threadResolutions?: AiReviewThreadResolution[];
+  vendors?: string[];
+};
+
+function loadPersistedReviewDetails(
+  cwd: string,
+  paths: {
+    fetchArtifactPath?: string;
+    triageArtifactPath?: string;
+  },
+): PersistedReviewDetails {
+  const artifacts = readReviewArtifacts({
+    fetchArtifactPath: paths.fetchArtifactPath
+      ? resolve(cwd, paths.fetchArtifactPath)
+      : undefined,
+    triageArtifactPath: paths.triageArtifactPath
+      ? resolve(cwd, paths.triageArtifactPath)
+      : undefined,
+  });
+
+  return {
+    actionSummary: artifacts.triage?.actionSummary,
+    comments: artifacts.fetch?.comments,
+    incompleteAgents: artifacts.triage?.incompleteAgents,
+    nonActionSummary: artifacts.triage?.nonActionSummary,
+    note: artifacts.triage?.note,
+    outcome: artifacts.triage?.outcome,
+    recordedAt: artifacts.triage?.recordedAt,
+    reviewedHeadSha:
+      artifacts.triage?.reviewedHeadSha ?? artifacts.fetch?.reviewedHeadSha,
+    threadResolutions: artifacts.triage?.threadResolutions,
+    vendors: artifacts.fetch?.vendors,
+  };
+}
 
 function parseFenceMarker(line: string): {
   char: '`' | '~';
@@ -895,7 +948,30 @@ export function buildPullRequestBody(
     currentHeadSha?: string;
     githubRepo?: { defaultBranch: string; name: string; owner: string };
   } = {},
+  review: PersistedReviewDetails = loadPersistedReviewDetails(
+    (ticket as TicketReviewMetadataRefreshTarget & { worktreePath?: string })
+      .worktreePath ?? '',
+    {
+      fetchArtifactPath:
+        ticket.reviewFetchArtifactPath ?? ticket.reviewArtifactPath,
+      triageArtifactPath:
+        ticket.reviewTriageArtifactPath ?? ticket.reviewArtifactJsonPath,
+    },
+  ),
 ): string {
+  const effectiveReview: PersistedReviewDetails = {
+    actionSummary: review.actionSummary ?? ticket.reviewActionSummary,
+    comments: review.comments ?? ticket.reviewComments,
+    incompleteAgents: review.incompleteAgents ?? ticket.reviewIncompleteAgents,
+    nonActionSummary: review.nonActionSummary ?? ticket.reviewNonActionSummary,
+    note: review.note ?? ticket.reviewNote,
+    outcome: review.outcome ?? ticket.reviewOutcome,
+    recordedAt: review.recordedAt ?? ticket.reviewRecordedAt,
+    reviewedHeadSha: review.reviewedHeadSha ?? ticket.reviewHeadSha,
+    threadResolutions:
+      review.threadResolutions ?? ticket.reviewThreadResolutions,
+    vendors: review.vendors ?? ticket.reviewVendors,
+  };
   assertPatchedStageHasCommitEvidence({
     outcome: ticket.selfAuditOutcome,
     patchCommits: ticket.selfAuditPatchCommits,
@@ -969,7 +1045,7 @@ export function buildPullRequestBody(
   }
 
   if (
-    ticket.reviewOutcome ||
+    effectiveReview.outcome ||
     ticket.status === 'needs_patch' ||
     ticket.status === 'operator_input_needed'
   ) {
@@ -977,21 +1053,22 @@ export function buildPullRequestBody(
       '',
       buildExternalAiReviewSection(
         {
-          actionSummary: ticket.reviewActionSummary,
-          comments: ticket.reviewComments,
-          note: ticket.reviewNote,
-          nonActionSummary: ticket.reviewNonActionSummary,
-          outcome: ticket.reviewOutcome,
-          reviewedHeadSha: ticket.reviewHeadSha,
+          actionSummary: effectiveReview.actionSummary,
+          comments: effectiveReview.comments,
+          note: effectiveReview.note,
+          nonActionSummary: effectiveReview.nonActionSummary,
+          outcome: effectiveReview.outcome,
+          reviewedHeadSha:
+            effectiveReview.reviewedHeadSha ?? ticket.reviewHeadSha,
           status: ticket.status,
-          threadResolutions: ticket.reviewThreadResolutions,
-          vendors: ticket.reviewVendors,
+          threadResolutions: effectiveReview.threadResolutions,
+          vendors: effectiveReview.vendors,
         },
         {
           actionCommits: options.actionCommits,
           currentHeadSha: options.currentHeadSha,
           githubRepo: options.githubRepo,
-          incompleteAgents: ticket.reviewIncompleteAgents,
+          incompleteAgents: effectiveReview.incompleteAgents,
           maxWaitMinutes: state.reviewPollMaxWaitMinutes,
         },
       ),
@@ -1002,18 +1079,7 @@ export function buildPullRequestBody(
 }
 
 export function buildStandaloneAiReviewSection(
-  result: Pick<
-    StandaloneAiReviewResult,
-    | 'actionSummary'
-    | 'comments'
-    | 'incompleteAgents'
-    | 'note'
-    | 'nonActionSummary'
-    | 'outcome'
-    | 'reviewedHeadSha'
-    | 'threadResolutions'
-    | 'vendors'
-  >,
+  result: PersistedReviewDetails,
   options: {
     actionCommits?: ReviewActionCommit[];
     currentHeadSha?: string;
@@ -1063,12 +1129,37 @@ export function buildReviewMetadataRefreshBody(
   context: ReviewMetadataRefreshContext = {},
 ): string {
   if (options.mode === 'ticketed') {
-    return buildPullRequestBody(options.state, options.ticket, context);
+    const review = buildPullRequestBody(options.state, options.ticket, context);
+    return review;
   }
 
+  const review = loadPersistedReviewDetails(options.cwd ?? '', {
+    fetchArtifactPath:
+      options.result.fetchArtifactPath ?? options.result.artifactJsonPath,
+    triageArtifactPath:
+      options.result.triageArtifactPath ?? options.result.artifactJsonPath,
+  });
   return mergeStandaloneAiReviewSection(
     options.body,
-    buildStandaloneAiReviewSection(options.result, context),
+    buildStandaloneAiReviewSection(
+      {
+        actionSummary: review.actionSummary ?? options.result.actionSummary,
+        comments: review.comments ?? options.result.comments,
+        incompleteAgents:
+          review.incompleteAgents ?? options.result.incompleteAgents,
+        nonActionSummary:
+          review.nonActionSummary ?? options.result.nonActionSummary,
+        note: review.note ?? options.result.note,
+        outcome: review.outcome ?? options.result.outcome,
+        reviewedHeadSha:
+          review.reviewedHeadSha ?? options.result.reviewedHeadSha,
+        recordedAt: review.recordedAt ?? options.result.recordedAt,
+        threadResolutions:
+          review.threadResolutions ?? options.result.threadResolutions,
+        vendors: review.vendors ?? options.result.vendors,
+      },
+      context,
+    ),
   );
 }
 
@@ -1104,6 +1195,10 @@ export function updatePullRequestBody(
 
   const currentHeadSha = dependencies.readHeadSha(ticket.worktreePath);
   const githubRepo = dependencies.resolveGitHubRepo?.(ticket.worktreePath);
+  const review = loadPersistedReviewDetails(ticket.worktreePath, {
+    fetchArtifactPath: ticket.reviewFetchArtifactPath,
+    triageArtifactPath: ticket.reviewTriageArtifactPath,
+  });
   const body = buildReviewMetadataRefreshBody(
     {
       mode: 'ticketed',
@@ -1113,10 +1208,10 @@ export function updatePullRequestBody(
     {
       actionCommits: listReviewActionCommits(
         ticket.worktreePath,
-        ticket.reviewHeadSha,
+        review.reviewedHeadSha ?? ticket.reviewHeadSha,
         currentHeadSha,
-        ticket.reviewComments,
-        ticket.reviewVendors,
+        review.comments,
+        review.vendors,
         dependencies,
       ),
       currentHeadSha,
@@ -1138,19 +1233,24 @@ export function updateStandalonePullRequestBody(
   >,
 ): void {
   const githubRepo = dependencies.resolveGitHubRepo?.(cwd);
+  const review = loadPersistedReviewDetails(cwd, {
+    fetchArtifactPath: result.fetchArtifactPath,
+    triageArtifactPath: result.triageArtifactPath,
+  });
   const nextBody = buildReviewMetadataRefreshBody(
     {
       body: pullRequest.body,
+      cwd,
       mode: 'standalone',
       result,
     },
     {
       actionCommits: listReviewActionCommits(
         cwd,
-        result.reviewedHeadSha,
+        review.reviewedHeadSha ?? result.reviewedHeadSha,
         pullRequest.headRefOid,
-        result.comments,
-        result.vendors,
+        review.comments,
+        review.vendors,
         dependencies,
       ),
       currentHeadSha: pullRequest.headRefOid,

--- a/tools/delivery/review-artifacts.ts
+++ b/tools/delivery/review-artifacts.ts
@@ -1,0 +1,390 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import type {
+  AiReviewAgentResult,
+  AiReviewComment,
+  AiReviewThreadResolution,
+  ReviewOutcome,
+  ReviewResult,
+} from './orchestrator';
+
+export type AiReviewFetchArtifact = {
+  schemaVersion: 1;
+  fetchedAt: string;
+  reviewedHeadSha?: string;
+  detected: boolean;
+  vendors: string[];
+  agents: AiReviewAgentResult[];
+  comments: AiReviewComment[];
+};
+
+export type PrBodyRefreshResult = {
+  attemptedAt: string;
+  status: 'updated' | 'failed';
+  message?: string;
+};
+
+export type AiReviewTriageArtifact = {
+  schemaVersion: 1;
+  recordedAt: string;
+  reviewedHeadSha?: string;
+  outcome: ReviewResult;
+  note: string;
+  actionSummary?: string;
+  nonActionSummary?: string;
+  incompleteAgents?: string[];
+  patchCommitShas?: string[];
+  threadResolutions?: AiReviewThreadResolution[];
+  prBodyRefresh?: PrBodyRefreshResult;
+};
+
+type StoredFetchArtifact = {
+  schemaVersion?: unknown;
+  fetchedAt?: unknown;
+  reviewedHeadSha?: unknown;
+  reviewed_head_sha?: unknown;
+  detected?: unknown;
+  vendors?: unknown;
+  agents?: unknown;
+  comments?: unknown;
+};
+
+type StoredTriageArtifact = {
+  schemaVersion?: unknown;
+  recordedAt?: unknown;
+  reviewedHeadSha?: unknown;
+  reviewed_head_sha?: unknown;
+  outcome?: unknown;
+  note?: unknown;
+  actionSummary?: unknown;
+  action_summary?: unknown;
+  nonActionSummary?: unknown;
+  non_action_summary?: unknown;
+  incompleteAgents?: unknown;
+  incomplete_agents?: unknown;
+  patchCommitShas?: unknown;
+  patch_commit_shas?: unknown;
+  threadResolutions?: unknown;
+  thread_resolutions?: unknown;
+  prBodyRefresh?: unknown;
+  pr_body_refresh?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function parseOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function parseOptionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function parseOptionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function parseCommentArray(value: unknown): AiReviewComment[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((entry) => {
+    if (!isRecord(entry)) {
+      return [];
+    }
+
+    const vendor = parseOptionalString(entry.vendor);
+    const channel = parseOptionalString(entry.channel);
+    const authorLogin = parseOptionalString(
+      entry.authorLogin ?? entry.author_login,
+    );
+    const authorType = parseOptionalString(
+      entry.authorType ?? entry.author_type,
+    );
+    const body = parseOptionalString(entry.body);
+    const kind = parseOptionalString(entry.kind);
+
+    if (
+      !vendor ||
+      !channel ||
+      !authorLogin ||
+      !authorType ||
+      body === undefined ||
+      !kind
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        authorLogin,
+        authorType,
+        body,
+        channel: channel as AiReviewComment['channel'],
+        databaseId: parseOptionalNumber(entry.databaseId ?? entry.database_id),
+        isOutdated: parseOptionalBoolean(entry.isOutdated ?? entry.is_outdated),
+        isResolved: parseOptionalBoolean(entry.isResolved ?? entry.is_resolved),
+        kind: kind as AiReviewComment['kind'],
+        line: parseOptionalNumber(entry.line),
+        path: parseOptionalString(entry.path),
+        threadId: parseOptionalString(entry.threadId ?? entry.thread_id),
+        threadViewerCanResolve: parseOptionalBoolean(
+          entry.threadViewerCanResolve ?? entry.thread_viewer_can_resolve,
+        ),
+        updatedAt: parseOptionalString(entry.updatedAt ?? entry.updated_at),
+        url: parseOptionalString(entry.url),
+        vendor,
+      },
+    ];
+  });
+}
+
+function parseAgentArray(value: unknown): AiReviewAgentResult[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((entry) => {
+    if (!isRecord(entry)) {
+      return [];
+    }
+
+    const agent = parseOptionalString(entry.agent);
+    const state = parseOptionalString(entry.state);
+
+    if (!agent || !state) {
+      return [];
+    }
+
+    return [
+      {
+        agent,
+        state: state as AiReviewAgentResult['state'],
+        findingsCount: parseOptionalNumber(entry.findingsCount),
+        note: parseOptionalString(entry.note),
+      },
+    ];
+  });
+}
+
+function parseThreadResolutionArray(
+  value: unknown,
+): AiReviewThreadResolution[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const parsed = value.flatMap((entry) => {
+    if (!isRecord(entry)) {
+      return [];
+    }
+
+    const status = parseOptionalString(entry.status);
+    const threadId = parseOptionalString(entry.threadId ?? entry.thread_id);
+    const vendor = parseOptionalString(entry.vendor);
+
+    if (!status || !threadId || !vendor) {
+      return [];
+    }
+
+    return [
+      {
+        status: status as AiReviewThreadResolution['status'],
+        threadId,
+        url: parseOptionalString(entry.url),
+        vendor,
+        message: parseOptionalString(entry.message),
+      },
+    ];
+  });
+
+  return parsed.length > 0 ? parsed : undefined;
+}
+
+function parseOptionalStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const parsed = value.filter(
+    (entry): entry is string => typeof entry === 'string' && entry.length > 0,
+  );
+  return parsed.length > 0 ? parsed : undefined;
+}
+
+function parsePrBodyRefresh(value: unknown): PrBodyRefreshResult | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const attemptedAt = parseOptionalString(
+    value.attemptedAt ?? value.attempted_at,
+  );
+  const status = parseOptionalString(value.status);
+
+  if (!attemptedAt || !status) {
+    return undefined;
+  }
+
+  return {
+    attemptedAt,
+    status: status as PrBodyRefreshResult['status'],
+    message: parseOptionalString(value.message),
+  };
+}
+
+export function buildReviewArtifactPaths(artifactStemPath: string): {
+  fetchArtifactPath: string;
+  triageArtifactPath: string;
+} {
+  return {
+    fetchArtifactPath: `${artifactStemPath}.fetch.json`,
+    triageArtifactPath: `${artifactStemPath}.triage.json`,
+  };
+}
+
+export async function writeFetchArtifact(
+  artifactPath: string,
+  artifact: AiReviewFetchArtifact,
+): Promise<void> {
+  await mkdir(dirname(artifactPath), { recursive: true });
+  await writeFile(
+    artifactPath,
+    JSON.stringify(artifact, null, 2) + '\n',
+    'utf8',
+  );
+}
+
+export async function writeTriageArtifact(
+  artifactPath: string,
+  artifact: AiReviewTriageArtifact,
+): Promise<void> {
+  await mkdir(dirname(artifactPath), { recursive: true });
+  await writeFile(
+    artifactPath,
+    JSON.stringify(artifact, null, 2) + '\n',
+    'utf8',
+  );
+}
+
+export function readFetchArtifact(
+  artifactPath: string | undefined,
+): AiReviewFetchArtifact | undefined {
+  if (!artifactPath || !existsSync(artifactPath)) {
+    return undefined;
+  }
+
+  const parsed = JSON.parse(
+    readFileSync(artifactPath, 'utf8'),
+  ) as StoredFetchArtifact;
+  const vendors = Array.isArray(parsed.vendors)
+    ? parsed.vendors.filter(
+        (value): value is string =>
+          typeof value === 'string' && value.length > 0,
+      )
+    : [];
+
+  return {
+    schemaVersion: 1,
+    fetchedAt:
+      parseOptionalString(parsed.fetchedAt) ?? new Date(0).toISOString(),
+    reviewedHeadSha: parseOptionalString(
+      parsed.reviewedHeadSha ?? parsed.reviewed_head_sha,
+    ),
+    detected: parsed.detected === true,
+    vendors,
+    agents: parseAgentArray(parsed.agents),
+    comments: parseCommentArray(parsed.comments),
+  };
+}
+
+export function readTriageArtifact(
+  artifactPath: string | undefined,
+): AiReviewTriageArtifact | undefined {
+  if (!artifactPath || !existsSync(artifactPath)) {
+    return undefined;
+  }
+
+  const parsed = JSON.parse(
+    readFileSync(artifactPath, 'utf8'),
+  ) as StoredTriageArtifact;
+  const outcome = parseOptionalString(parsed.outcome);
+  const recordedAt = parseOptionalString(parsed.recordedAt);
+  const note = parseOptionalString(parsed.note);
+
+  if (!outcome || !recordedAt || note === undefined) {
+    return undefined;
+  }
+
+  return {
+    schemaVersion: 1,
+    recordedAt,
+    reviewedHeadSha: parseOptionalString(
+      parsed.reviewedHeadSha ?? parsed.reviewed_head_sha,
+    ),
+    outcome: outcome as ReviewResult,
+    note,
+    actionSummary: parseOptionalString(
+      parsed.actionSummary ?? parsed.action_summary,
+    ),
+    nonActionSummary: parseOptionalString(
+      parsed.nonActionSummary ?? parsed.non_action_summary,
+    ),
+    incompleteAgents: parseOptionalStringArray(
+      parsed.incompleteAgents ?? parsed.incomplete_agents,
+    ),
+    patchCommitShas: parseOptionalStringArray(
+      parsed.patchCommitShas ?? parsed.patch_commit_shas,
+    ),
+    threadResolutions: parseThreadResolutionArray(
+      parsed.threadResolutions ?? parsed.thread_resolutions,
+    ),
+    prBodyRefresh: parsePrBodyRefresh(
+      parsed.prBodyRefresh ?? parsed.pr_body_refresh,
+    ),
+  };
+}
+
+export type LoadedReviewArtifacts = {
+  fetch?: AiReviewFetchArtifact;
+  triage?: AiReviewTriageArtifact;
+};
+
+export function readReviewArtifacts(paths: {
+  fetchArtifactPath?: string;
+  triageArtifactPath?: string;
+}): LoadedReviewArtifacts {
+  return {
+    fetch: readFetchArtifact(paths.fetchArtifactPath),
+    triage: readTriageArtifact(paths.triageArtifactPath),
+  };
+}
+
+export async function updateTriageArtifact(
+  artifactPath: string,
+  update: (
+    current: AiReviewTriageArtifact | undefined,
+  ) => AiReviewTriageArtifact,
+): Promise<AiReviewTriageArtifact> {
+  const next = update(readTriageArtifact(artifactPath));
+  await writeTriageArtifact(artifactPath, next);
+  return next;
+}
+
+export function buildPatchedOutcome(
+  previous: ReviewOutcome | undefined,
+  next: ReviewResult,
+): ReviewResult {
+  if (previous === 'patched' && next === 'clean') {
+    return 'patched';
+  }
+
+  return next;
+}

--- a/tools/delivery/review-artifacts.ts
+++ b/tools/delivery/review-artifacts.ts
@@ -190,13 +190,18 @@ function parseThreadResolutionArray(
     const threadId = parseOptionalString(entry.threadId ?? entry.thread_id);
     const vendor = parseOptionalString(entry.vendor);
 
-    if (!status || !threadId || !vendor) {
+    if (
+      !status ||
+      !isAiReviewThreadResolutionStatus(status) ||
+      !threadId ||
+      !vendor
+    ) {
       return [];
     }
 
     return [
       {
-        status: status as AiReviewThreadResolution['status'],
+        status,
         threadId,
         url: parseOptionalString(entry.url),
         vendor,
@@ -206,6 +211,17 @@ function parseThreadResolutionArray(
   });
 
   return parsed.length > 0 ? parsed : undefined;
+}
+
+function isAiReviewThreadResolutionStatus(
+  value: string,
+): value is AiReviewThreadResolution['status'] {
+  return (
+    value === 'resolved' ||
+    value === 'already_resolved' ||
+    value === 'unresolvable' ||
+    value === 'failed'
+  );
 }
 
 function parseOptionalStringArray(value: unknown): string[] | undefined {

--- a/tools/delivery/review.test.ts
+++ b/tools/delivery/review.test.ts
@@ -13,7 +13,6 @@ import type { TicketReviewDependencies } from './review';
 function emptyUndetected(): AiReviewFetcherResult {
   return {
     agents: [],
-    artifactText: '',
     comments: [],
     detected: false,
     vendors: [],
@@ -30,7 +29,6 @@ function inFlight(): AiReviewFetcherResult {
         note: undefined,
       },
     ],
-    artifactText: '',
     comments: [],
     detected: true,
     vendors: [],
@@ -47,7 +45,6 @@ function allTerminal(): AiReviewFetcherResult {
         note: undefined,
       },
     ],
-    artifactText: '',
     comments: [],
     detected: true,
     vendors: [],
@@ -74,7 +71,9 @@ describe('pollForAiReview', () => {
     let virtualNow = 0;
     let pollCalls = 0;
     const profile: ReviewPollingProfile = {
-      ...DEFAULT_REVIEW_POLLING_PROFILE,
+      intervalMinutes: 2,
+      maxWaitMinutes: 10,
+      extendByOneInterval: true,
     };
 
     const result = await pollForAiReview(
@@ -113,7 +112,9 @@ describe('pollForAiReview', () => {
     let virtualNow = 0;
     let pollCalls = 0;
     const profile: ReviewPollingProfile = {
-      ...DEFAULT_REVIEW_POLLING_PROFILE,
+      intervalMinutes: 2,
+      maxWaitMinutes: 10,
+      extendByOneInterval: true,
     };
 
     const result = await pollForAiReview(
@@ -148,7 +149,8 @@ describe('pollForAiReview', () => {
     let virtualNow = 0;
     let pollCalls = 0;
     const profile: ReviewPollingProfile = {
-      ...DEFAULT_REVIEW_POLLING_PROFILE,
+      intervalMinutes: 2,
+      maxWaitMinutes: 10,
       extendByOneInterval: false,
     };
 

--- a/tools/delivery/review.ts
+++ b/tools/delivery/review.ts
@@ -1808,6 +1808,13 @@ export async function recordTicketReview(
         outcome === 'operator_input_needed'
           ? 'operator_input_needed'
           : 'reviewed',
+      reviewFetchArtifactPath: fetchArtifactPath
+        ? dependencies.relativeToRepo(cwd, fetchArtifactPath)
+        : ticket.reviewFetchArtifactPath,
+      reviewTriageArtifactPath: dependencies.relativeToRepo(
+        cwd,
+        triageArtifactPath,
+      ),
       reviewOutcome: accumulateTicketReviewOutcome(
         ticket.reviewOutcome,
         outcome,

--- a/tools/delivery/review.ts
+++ b/tools/delivery/review.ts
@@ -509,18 +509,22 @@ function formatNoAiReviewFeedbackNote(maxWaitMinutes: number): string {
 }
 
 function mergeReviewOutcome(
-  previous: ReviewOutcome | undefined,
-  next: ReviewOutcome | undefined,
+  previous: ReviewResult | undefined,
+  next: ReviewResult | undefined,
 ): ReviewOutcome | undefined {
   if (previous === 'patched' || next === 'patched') {
     return 'patched';
   }
 
-  return previous ?? next;
+  if (previous === 'clean' || next === 'clean') {
+    return 'clean';
+  }
+
+  return undefined;
 }
 
 function accumulateReviewOutcome(
-  previous: ReviewOutcome | undefined,
+  previous: ReviewResult | undefined,
   next: ReviewResult,
 ): ReviewResult | undefined {
   if (next === 'clean' || next === 'patched') {
@@ -531,16 +535,10 @@ function accumulateReviewOutcome(
 }
 
 function accumulateTicketReviewOutcome(
-  previous: ReviewOutcome | undefined,
+  previous: ReviewResult | undefined,
   next: ReviewResult,
-): ReviewOutcome | undefined {
-  const accumulated = accumulateReviewOutcome(previous, next);
-
-  if (accumulated === 'clean' || accumulated === 'patched') {
-    return accumulated;
-  }
-
-  return previous;
+): ReviewResult | undefined {
+  return accumulateReviewOutcome(previous, next);
 }
 
 function mapStandaloneReviewOutcome(outcome: ReviewResult): ReviewResult {
@@ -560,7 +558,7 @@ function formatCumulativePatchedReviewNote(note: string | undefined): string {
 }
 
 function formatAccumulatedReviewNote(
-  previous: ReviewOutcome | undefined,
+  previous: ReviewResult | undefined,
   next: ReviewResult,
   note: string | undefined,
 ): string | undefined {
@@ -588,7 +586,7 @@ function defaultFinalReviewNote(
 }
 
 function formatNoFeedbackReviewNote(
-  previous: ReviewOutcome | undefined,
+  previous: ReviewResult | undefined,
   maxWaitMinutes: number,
 ): string {
   return (
@@ -855,7 +853,7 @@ async function processDetectedAiReview(options: {
   incompleteAgents?: string[];
   mapOutcome?: (outcome: ReviewResult) => ReviewResult;
   mode: 'standalone' | 'ticketed';
-  previousOutcome: ReviewOutcome | undefined;
+  previousOutcome: ReviewResult | undefined;
   resolveThreads: (
     worktreePath: string,
     comments: AiReviewComment[],
@@ -928,7 +926,7 @@ function processCleanAiReview(options: {
   effectiveMaxWaitMinutes: number;
   incompleteAgents?: string[];
   maxWaitMinutes: number;
-  previousOutcome: ReviewOutcome | undefined;
+  previousOutcome: ReviewResult | undefined;
 }): CleanReviewProcessingResult {
   const recordedAt = new Date().toISOString();
   return {
@@ -971,6 +969,7 @@ async function writeCleanTriageArtifact(
 }
 
 async function applyTicketReviewUpdate(
+  cwd: string,
   state: DeliveryState,
   ticketId: string,
   updateTicket: (ticket: TicketState) => TicketState,
@@ -1005,10 +1004,7 @@ async function applyTicketReviewUpdate(
   };
   const persistedTarget = nextState.tickets[updatedIndex]!;
   const triageArtifactPath = persistedTarget.reviewTriageArtifactPath
-    ? resolve(
-        persistedTarget.worktreePath,
-        persistedTarget.reviewTriageArtifactPath,
-      )
+    ? resolve(cwd, persistedTarget.reviewTriageArtifactPath)
     : undefined;
 
   try {
@@ -1213,6 +1209,7 @@ export async function runTicketReviewLifecycle(
       const nextStatus =
         processedReview.outcome === 'needs_patch' ? 'needs_patch' : 'reviewed';
       return applyTicketReviewUpdate(
+        cwd,
         state,
         target.id,
         (ticket) => ({
@@ -1258,13 +1255,14 @@ export async function runTicketReviewLifecycle(
         },
       );
       return applyTicketReviewUpdate(
+        cwd,
         state,
         target.id,
         (ticket) => ({
           ...ticket,
           prOpenedAt: ticket.prOpenedAt ?? pollWindowStartedAtIso,
           status: 'reviewed',
-          reviewFetchArtifactPath: undefined,
+          reviewFetchArtifactPath: ticket.reviewFetchArtifactPath,
           reviewTriageArtifactPath: dependencies.relativeToRepo(
             cwd,
             triageArtifactPath,
@@ -1349,6 +1347,7 @@ export async function runReconcileLateTicketReview(
         worktreePath: target.worktreePath,
       });
       return applyTicketReviewUpdate(
+        cwd,
         state,
         target.id,
         (ticket) => ({
@@ -1394,12 +1393,14 @@ export async function runReconcileLateTicketReview(
         },
       );
       return applyTicketReviewUpdate(
+        cwd,
         state,
         target.id,
         (ticket) => ({
           ...ticket,
           prOpenedAt: ticket.prOpenedAt ?? pollWindowStartedAtIso,
           status: 'done',
+          reviewFetchArtifactPath: ticket.reviewFetchArtifactPath,
           reviewTriageArtifactPath: dependencies.relativeToRepo(
             cwd,
             triageArtifactPath,
@@ -1520,7 +1521,13 @@ export async function runStandaloneAiReviewLifecycle(
           recordedAt: processedReview.recordedAt,
         },
       );
+      const existingFetchArtifactPath = buildReviewArtifactPaths(
+        resolve(cwd, '.agents/ai-review', `pr-${pullRequest.number}`, 'review'),
+      ).fetchArtifactPath;
       const standaloneResult: StandaloneAiReviewResult = {
+        fetchArtifactPath: existsSync(existingFetchArtifactPath)
+          ? dependencies.relativeToRepo(cwd, existingFetchArtifactPath)
+          : undefined,
         incompleteAgents: processedReview.incompleteAgents,
         note: processedReview.note,
         outcome: processedReview.outcome,
@@ -1792,6 +1799,7 @@ export async function recordTicketReview(
   }
 
   return applyTicketReviewUpdate(
+    cwd,
     state,
     ticketId,
     (ticket) => ({

--- a/tools/delivery/review.ts
+++ b/tools/delivery/review.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
 import type {
@@ -16,6 +16,17 @@ import type {
   StandalonePullRequest,
   TicketState,
 } from './orchestrator';
+
+import {
+  buildReviewArtifactPaths,
+  readFetchArtifact,
+  readTriageArtifact,
+  updateTriageArtifact,
+  writeFetchArtifact,
+  writeTriageArtifact,
+  type AiReviewFetchArtifact,
+  type AiReviewTriageArtifact,
+} from './review-artifacts';
 
 import {
   type ReviewPollingProfile,
@@ -118,7 +129,7 @@ export function parseAiReviewFetcherOutput(
 
   if (!isRecord(parsed)) {
     throw new Error(
-      'AI review fetcher output must be a JSON object with `agents`, `detected`, `artifact_text`, `vendors`, and `comments` fields.',
+      'AI review fetcher output must be a JSON object with `agents`, `detected`, `vendors`, and `comments` fields.',
     );
   }
 
@@ -137,13 +148,12 @@ export function parseAiReviewFetcherOutput(
           parseOptionalString(entry.note) !== undefined),
     ) ||
     typeof parsed.detected !== 'boolean' ||
-    typeof parsed.artifact_text !== 'string' ||
     !Array.isArray(parsed.vendors) ||
     !parsed.vendors.every((value) => typeof value === 'string') ||
     !Array.isArray(parsed.comments)
   ) {
     throw new Error(
-      'AI review fetcher output must be JSON with `agents`, boolean `detected`, string `artifact_text`, string[] `vendors`, and array `comments` fields.',
+      'AI review fetcher output must be JSON with `agents`, boolean `detected`, string[] `vendors`, and array `comments` fields.',
     );
   }
 
@@ -209,7 +219,6 @@ export function parseAiReviewFetcherOutput(
       findingsCount: parseOptionalNumber(entry.findingsCount),
       note: parseOptionalString(entry.note),
     })) satisfies AiReviewAgentResult[],
-    artifactText: parsed.artifact_text,
     comments,
     detected: parsed.detected,
     reviewedHeadSha: parseOptionalString(parsed.reviewed_head_sha),
@@ -406,23 +415,20 @@ export type PollForAiReviewResult =
     };
 
 type DetectedReviewProcessingResult = {
-  actionSummary?: string;
-  artifactJsonPath: string;
-  artifactTextPath: string;
-  comments: AiReviewComment[];
+  fetchArtifactPath: string;
   incompleteAgents?: string[];
-  nonActionSummary?: string;
   note: string;
   outcome: ReviewResult;
   reviewedHeadSha?: string;
-  threadResolutions?: AiReviewThreadResolution[];
-  vendors: string[];
+  recordedAt: string;
+  triageArtifactPath: string;
 };
 
 type CleanReviewProcessingResult = {
   incompleteAgents?: string[];
   note: string;
   outcome: ReviewResult;
+  recordedAt: string;
 };
 
 function runAiReviewFetcher(
@@ -598,22 +604,23 @@ async function readStandaloneAiReviewOutcome(
   cwd: string,
   prNumber: number,
 ): Promise<ReviewOutcome | undefined> {
-  const notePath = resolve(
+  const triageArtifactPath = resolve(
     cwd,
     '.agents/ai-review',
     `pr-${prNumber}`,
-    'note.md',
+    'review.triage.json',
   );
 
-  if (!existsSync(notePath)) {
+  if (!existsSync(triageArtifactPath)) {
     return undefined;
   }
 
-  const note = await readFile(notePath, 'utf8');
-  const match = note.match(/^- Outcome: `([^`]+)`$/m);
-
-  if (match?.[1] === 'clean' || match?.[1] === 'patched') {
-    return match[1];
+  const triageArtifact = readTriageArtifact(triageArtifactPath);
+  if (
+    triageArtifact?.outcome === 'clean' ||
+    triageArtifact?.outcome === 'patched'
+  ) {
+    return triageArtifact.outcome;
   }
 
   return undefined;
@@ -818,80 +825,27 @@ export async function pollForAiReview(
 async function writeAiReviewArtifacts(
   artifactStemPath: string,
   result: AiReviewFetcherResult,
-): Promise<{ artifactJsonPath: string; artifactTextPath: string }> {
-  const artifactJsonPath = `${artifactStemPath}.json`;
-  const artifactTextPath = `${artifactStemPath}.txt`;
+  fetchedAt: string,
+): Promise<{ fetchArtifactPath: string; triageArtifactPath: string }> {
+  const { fetchArtifactPath, triageArtifactPath } =
+    buildReviewArtifactPaths(artifactStemPath);
 
-  await mkdir(dirname(artifactJsonPath), { recursive: true });
-  await writeFile(
-    artifactJsonPath,
-    JSON.stringify(
-      {
-        artifact_text: result.artifactText,
-        agents: result.agents.map((agent) => ({
-          agent: agent.agent,
-          state: agent.state,
-          findingsCount: agent.findingsCount ?? null,
-          note: agent.note ?? null,
-        })),
-        detected: result.detected,
-        reviewed_head_sha: result.reviewedHeadSha ?? null,
-        vendors: result.vendors,
-        comments: result.comments.map((comment) => ({
-          author_login: comment.authorLogin,
-          author_type: comment.authorType,
-          body: comment.body,
-          channel: comment.channel,
-          database_id: comment.databaseId ?? null,
-          is_outdated: comment.isOutdated ?? null,
-          is_resolved: comment.isResolved ?? null,
-          kind: comment.kind,
-          line: comment.line ?? null,
-          path: comment.path ?? null,
-          thread_id: comment.threadId ?? null,
-          thread_viewer_can_resolve: comment.threadViewerCanResolve ?? null,
-          updated_at: comment.updatedAt ?? null,
-          url: comment.url ?? null,
-          vendor: comment.vendor,
-        })),
-        thread_resolutions: [],
-      },
-      null,
-      2,
-    ) + '\n',
-    'utf8',
-  );
-  await writeFile(artifactTextPath, result.artifactText, 'utf8');
+  const fetchArtifact: AiReviewFetchArtifact = {
+    schemaVersion: 1,
+    fetchedAt,
+    reviewedHeadSha: result.reviewedHeadSha,
+    detected: result.detected,
+    vendors: result.vendors,
+    agents: result.agents,
+    comments: result.comments,
+  };
+
+  await writeFetchArtifact(fetchArtifactPath, fetchArtifact);
 
   return {
-    artifactJsonPath,
-    artifactTextPath,
+    fetchArtifactPath,
+    triageArtifactPath,
   };
-}
-
-async function writeAiReviewThreadResolutions(
-  artifactJsonPath: string | undefined,
-  resolutions: AiReviewThreadResolution[],
-): Promise<void> {
-  if (!artifactJsonPath) {
-    return;
-  }
-
-  const existing = JSON.parse(
-    await readFile(artifactJsonPath, 'utf8'),
-  ) as Record<string, unknown>;
-  existing.thread_resolutions = resolutions.map((resolution) => ({
-    message: resolution.message ?? null,
-    status: resolution.status,
-    thread_id: resolution.threadId,
-    url: resolution.url ?? null,
-    vendor: resolution.vendor,
-  }));
-  await writeFile(
-    artifactJsonPath,
-    JSON.stringify(existing, null, 2) + '\n',
-    'utf8',
-  );
 }
 
 async function processDetectedAiReview(options: {
@@ -912,13 +866,15 @@ async function processDetectedAiReview(options: {
   ) => AiReviewTriagerResult;
   worktreePath: string;
 }): Promise<DetectedReviewProcessingResult> {
+  const fetchedAt = new Date().toISOString();
   const artifacts = await writeAiReviewArtifacts(
     options.artifactStemPath,
     options.detectedReview,
+    fetchedAt,
   );
   const triageResult = options.triager(
     options.worktreePath,
-    artifacts.artifactJsonPath,
+    artifacts.fetchArtifactPath,
   );
   const latestOutcome =
     options.mapOutcome?.(triageResult.outcome) ?? triageResult.outcome;
@@ -931,20 +887,14 @@ async function processDetectedAiReview(options: {
         options.detectedReview.comments,
       )
     : [];
-  if (threadResolutions.length > 0) {
-    await writeAiReviewThreadResolutions(
-      artifacts.artifactJsonPath,
-      threadResolutions,
-    );
-  }
-
-  return {
-    actionSummary: triageResult.actionSummary,
-    artifactJsonPath: artifacts.artifactJsonPath,
-    artifactTextPath: artifacts.artifactTextPath,
-    comments: options.detectedReview.comments,
-    incompleteAgents: options.incompleteAgents,
-    nonActionSummary: triageResult.nonActionSummary,
+  const recordedAt = new Date().toISOString();
+  const triageArtifact: AiReviewTriageArtifact = {
+    schemaVersion: 1,
+    recordedAt,
+    reviewedHeadSha: options.detectedReview.reviewedHeadSha,
+    outcome:
+      accumulateReviewOutcome(options.previousOutcome, latestOutcome) ??
+      latestOutcome,
     note: options.incompleteAgents?.length
       ? formatPartialAiReviewTimeoutNote(
           options.effectiveMaxWaitMinutes,
@@ -955,16 +905,22 @@ async function processDetectedAiReview(options: {
           latestOutcome,
           triageResult.note,
         ) ?? triageResult.note),
-    outcome:
-      accumulateReviewOutcome(options.previousOutcome, latestOutcome) ??
-      latestOutcome,
-    reviewedHeadSha: options.detectedReview.reviewedHeadSha,
+    actionSummary: triageResult.actionSummary,
+    nonActionSummary: triageResult.nonActionSummary,
+    incompleteAgents: options.incompleteAgents,
     threadResolutions:
       threadResolutions.length > 0 ? threadResolutions : undefined,
-    vendors:
-      triageResult.vendors.length > 0
-        ? triageResult.vendors
-        : options.detectedReview.vendors,
+  };
+  await writeTriageArtifact(artifacts.triageArtifactPath, triageArtifact);
+
+  return {
+    fetchArtifactPath: artifacts.fetchArtifactPath,
+    incompleteAgents: options.incompleteAgents,
+    note: triageArtifact.note,
+    outcome: triageArtifact.outcome,
+    reviewedHeadSha: options.detectedReview.reviewedHeadSha,
+    recordedAt,
+    triageArtifactPath: artifacts.triageArtifactPath,
   };
 }
 
@@ -974,6 +930,7 @@ function processCleanAiReview(options: {
   maxWaitMinutes: number;
   previousOutcome: ReviewOutcome | undefined;
 }): CleanReviewProcessingResult {
+  const recordedAt = new Date().toISOString();
   return {
     incompleteAgents: options.incompleteAgents,
     note: options.incompleteAgents?.length
@@ -987,7 +944,30 @@ function processCleanAiReview(options: {
         ),
     outcome:
       accumulateReviewOutcome(options.previousOutcome, 'clean') ?? 'clean',
+    recordedAt,
   };
+}
+
+async function writeCleanTriageArtifact(
+  artifactStemPath: string,
+  input: {
+    incompleteAgents?: string[];
+    note: string;
+    outcome: ReviewResult;
+    recordedAt: string;
+    reviewedHeadSha?: string;
+  },
+): Promise<string> {
+  const { triageArtifactPath } = buildReviewArtifactPaths(artifactStemPath);
+  await writeTriageArtifact(triageArtifactPath, {
+    schemaVersion: 1,
+    recordedAt: input.recordedAt,
+    reviewedHeadSha: input.reviewedHeadSha,
+    outcome: input.outcome,
+    note: input.note,
+    incompleteAgents: input.incompleteAgents,
+  });
+  return triageArtifactPath;
 }
 
 async function applyTicketReviewUpdate(
@@ -1024,13 +1004,60 @@ async function applyTicketReviewUpdate(
     tickets: finalizedTickets,
   };
   const persistedTarget = nextState.tickets[updatedIndex]!;
+  const triageArtifactPath = persistedTarget.reviewTriageArtifactPath
+    ? resolve(
+        persistedTarget.worktreePath,
+        persistedTarget.reviewTriageArtifactPath,
+      )
+    : undefined;
 
   try {
     await dependencies.updatePullRequestBody?.(nextState, persistedTarget);
+    if (triageArtifactPath) {
+      await updateTriageArtifact(triageArtifactPath, (current) => ({
+        ...current,
+        schemaVersion: 1,
+        recordedAt:
+          current?.recordedAt ??
+          persistedTarget.reviewRecordedAt ??
+          new Date().toISOString(),
+        outcome: current?.outcome ?? persistedTarget.reviewOutcome ?? 'clean',
+        note:
+          current?.note ??
+          'External AI review completed without prudent follow-up changes.',
+        reviewedHeadSha:
+          current?.reviewedHeadSha ?? persistedTarget.reviewHeadSha,
+        prBodyRefresh: {
+          attemptedAt: new Date().toISOString(),
+          status: 'updated',
+        },
+      }));
+    }
   } catch (error) {
     console.warn(
       `Review was recorded locally for ${persistedTarget.id}, but PR body update failed: ${formatError(error)}`,
     );
+    if (triageArtifactPath) {
+      await updateTriageArtifact(triageArtifactPath, (current) => ({
+        ...current,
+        schemaVersion: 1,
+        recordedAt:
+          current?.recordedAt ??
+          persistedTarget.reviewRecordedAt ??
+          new Date().toISOString(),
+        outcome: current?.outcome ?? persistedTarget.reviewOutcome ?? 'clean',
+        note:
+          current?.note ??
+          'External AI review completed without prudent follow-up changes.',
+        reviewedHeadSha:
+          current?.reviewedHeadSha ?? persistedTarget.reviewHeadSha,
+        prBodyRefresh: {
+          attemptedAt: new Date().toISOString(),
+          status: 'failed',
+          message: formatError(error),
+        },
+      }));
+    }
   }
 
   return nextState;
@@ -1048,12 +1075,46 @@ async function persistStandaloneAiReviewResult(
   const writeNote = dependencies.writeNote ?? writeStandaloneAiReviewNote;
 
   await writeNote(cwd, pullRequest.number, result);
+  const triageArtifactPath = result.triageArtifactPath
+    ? resolve(cwd, result.triageArtifactPath)
+    : undefined;
   try {
     await dependencies.updatePullRequestBody?.(cwd, pullRequest, result);
+    if (triageArtifactPath) {
+      await updateTriageArtifact(triageArtifactPath, (current) => ({
+        ...current,
+        schemaVersion: 1,
+        recordedAt:
+          current?.recordedAt ?? result.recordedAt ?? new Date().toISOString(),
+        outcome: current?.outcome ?? result.outcome,
+        note: current?.note ?? result.note,
+        reviewedHeadSha: current?.reviewedHeadSha ?? result.reviewedHeadSha,
+        prBodyRefresh: {
+          attemptedAt: new Date().toISOString(),
+          status: 'updated',
+        },
+      }));
+    }
   } catch (error) {
     console.warn(
       `Standalone AI review was recorded locally for PR #${pullRequest.number}, but PR body update failed: ${formatError(error)}`,
     );
+    if (triageArtifactPath) {
+      await updateTriageArtifact(triageArtifactPath, (current) => ({
+        ...current,
+        schemaVersion: 1,
+        recordedAt:
+          current?.recordedAt ?? result.recordedAt ?? new Date().toISOString(),
+        outcome: current?.outcome ?? result.outcome,
+        note: current?.note ?? result.note,
+        reviewedHeadSha: current?.reviewedHeadSha ?? result.reviewedHeadSha,
+        prBodyRefresh: {
+          attemptedAt: new Date().toISOString(),
+          status: 'failed',
+          message: formatError(error),
+        },
+      }));
+    }
   }
 
   return result;
@@ -1158,27 +1219,20 @@ export async function runTicketReviewLifecycle(
           ...ticket,
           prOpenedAt: ticket.prOpenedAt ?? pollWindowStartedAtIso,
           status: nextStatus,
-          reviewActionSummary: processedReview.actionSummary,
-          reviewComments: processedReview.comments,
-          reviewArtifactJsonPath: dependencies.relativeToRepo(
+          reviewFetchArtifactPath: dependencies.relativeToRepo(
             cwd,
-            processedReview.artifactJsonPath,
+            processedReview.fetchArtifactPath,
           ),
-          reviewArtifactPath: dependencies.relativeToRepo(
+          reviewTriageArtifactPath: dependencies.relativeToRepo(
             cwd,
-            processedReview.artifactTextPath,
+            processedReview.triageArtifactPath,
           ),
-          reviewFetchedAt: new Date(now()).toISOString(),
           reviewHeadSha: processedReview.reviewedHeadSha,
-          reviewNonActionSummary: processedReview.nonActionSummary,
+          reviewRecordedAt: processedReview.recordedAt,
           reviewOutcome: accumulateTicketReviewOutcome(
             ticket.reviewOutcome,
             processedReview.outcome,
           ),
-          reviewNote: processedReview.note,
-          reviewIncompleteAgents: processedReview.incompleteAgents,
-          reviewThreadResolutions: processedReview.threadResolutions,
-          reviewVendors: processedReview.vendors,
         }),
         dependencies,
       );
@@ -1193,6 +1247,16 @@ export async function runTicketReviewLifecycle(
         maxWaitMinutes: profile.maxWaitMinutes,
         previousOutcome: target.reviewOutcome,
       });
+      const triageArtifactPath = await writeCleanTriageArtifact(
+        resolve(cwd, state.reviewsDirPath, `${target.id}-ai-review`),
+        {
+          incompleteAgents: processedReview.incompleteAgents,
+          note: processedReview.note,
+          outcome: processedReview.outcome,
+          recordedAt: processedReview.recordedAt,
+          reviewedHeadSha: target.reviewHeadSha,
+        },
+      );
       return applyTicketReviewUpdate(
         state,
         target.id,
@@ -1200,20 +1264,17 @@ export async function runTicketReviewLifecycle(
           ...ticket,
           prOpenedAt: ticket.prOpenedAt ?? pollWindowStartedAtIso,
           status: 'reviewed',
-          reviewActionSummary: undefined,
-          reviewComments: undefined,
-          reviewArtifactJsonPath: undefined,
-          reviewArtifactPath: undefined,
-          reviewHeadSha: undefined,
-          reviewNonActionSummary: undefined,
+          reviewFetchArtifactPath: undefined,
+          reviewTriageArtifactPath: dependencies.relativeToRepo(
+            cwd,
+            triageArtifactPath,
+          ),
+          reviewHeadSha: ticket.reviewHeadSha,
+          reviewRecordedAt: processedReview.recordedAt,
           reviewOutcome: accumulateTicketReviewOutcome(
             ticket.reviewOutcome,
             processedReview.outcome,
           ),
-          reviewNote: processedReview.note,
-          reviewIncompleteAgents: processedReview.incompleteAgents,
-          reviewThreadResolutions: undefined,
-          reviewVendors: [],
         }),
         dependencies,
       );
@@ -1294,27 +1355,20 @@ export async function runReconcileLateTicketReview(
           ...ticket,
           prOpenedAt: ticket.prOpenedAt ?? pollWindowStartedAtIso,
           status: 'done',
-          reviewActionSummary: processedReview.actionSummary,
-          reviewComments: processedReview.comments,
-          reviewArtifactJsonPath: dependencies.relativeToRepo(
+          reviewFetchArtifactPath: dependencies.relativeToRepo(
             cwd,
-            processedReview.artifactJsonPath,
+            processedReview.fetchArtifactPath,
           ),
-          reviewArtifactPath: dependencies.relativeToRepo(
+          reviewTriageArtifactPath: dependencies.relativeToRepo(
             cwd,
-            processedReview.artifactTextPath,
+            processedReview.triageArtifactPath,
           ),
-          reviewFetchedAt: new Date(now()).toISOString(),
           reviewHeadSha: processedReview.reviewedHeadSha,
-          reviewNonActionSummary: processedReview.nonActionSummary,
+          reviewRecordedAt: processedReview.recordedAt,
           reviewOutcome: accumulateTicketReviewOutcome(
             ticket.reviewOutcome,
             processedReview.outcome,
           ),
-          reviewNote: processedReview.note,
-          reviewIncompleteAgents: processedReview.incompleteAgents,
-          reviewThreadResolutions: processedReview.threadResolutions,
-          reviewVendors: processedReview.vendors,
         }),
         dependencies,
       );
@@ -1329,6 +1383,16 @@ export async function runReconcileLateTicketReview(
         maxWaitMinutes: profile.maxWaitMinutes,
         previousOutcome: target.reviewOutcome,
       });
+      const triageArtifactPath = await writeCleanTriageArtifact(
+        resolve(cwd, state.reviewsDirPath, `${target.id}-ai-review`),
+        {
+          incompleteAgents: processedReview.incompleteAgents,
+          note: processedReview.note,
+          outcome: processedReview.outcome,
+          recordedAt: processedReview.recordedAt,
+          reviewedHeadSha: target.reviewHeadSha,
+        },
+      );
       return applyTicketReviewUpdate(
         state,
         target.id,
@@ -1336,12 +1400,15 @@ export async function runReconcileLateTicketReview(
           ...ticket,
           prOpenedAt: ticket.prOpenedAt ?? pollWindowStartedAtIso,
           status: 'done',
+          reviewTriageArtifactPath: dependencies.relativeToRepo(
+            cwd,
+            triageArtifactPath,
+          ),
           reviewOutcome: accumulateTicketReviewOutcome(
             ticket.reviewOutcome,
             processedReview.outcome,
           ),
-          reviewNote: processedReview.note,
-          reviewIncompleteAgents: processedReview.incompleteAgents,
+          reviewRecordedAt: processedReview.recordedAt,
         }),
         dependencies,
       );
@@ -1402,26 +1469,30 @@ export async function runStandaloneAiReviewLifecycle(
         triager,
         worktreePath: cwd,
       });
+      const triageArtifact = readTriageArtifact(
+        processedReview.triageArtifactPath,
+      );
       const standaloneResult: StandaloneAiReviewResult = {
-        actionSummary: processedReview.actionSummary,
-        artifactJsonPath: dependencies.relativeToRepo(
+        actionSummary: triageArtifact?.actionSummary,
+        comments: reviewPollResult.result.comments,
+        fetchArtifactPath: dependencies.relativeToRepo(
           cwd,
-          processedReview.artifactJsonPath,
-        ),
-        artifactTextPath: dependencies.relativeToRepo(
-          cwd,
-          processedReview.artifactTextPath,
+          processedReview.fetchArtifactPath,
         ),
         incompleteAgents: processedReview.incompleteAgents,
+        nonActionSummary: triageArtifact?.nonActionSummary,
+        triageArtifactPath: dependencies.relativeToRepo(
+          cwd,
+          processedReview.triageArtifactPath,
+        ),
         note: processedReview.note,
-        comments: processedReview.comments,
-        nonActionSummary: processedReview.nonActionSummary,
         outcome: processedReview.outcome,
         prNumber: pullRequest.number,
         prUrl: pullRequest.url,
         reviewedHeadSha: processedReview.reviewedHeadSha,
-        threadResolutions: processedReview.threadResolutions,
-        vendors: processedReview.vendors,
+        recordedAt: processedReview.recordedAt,
+        threadResolutions: triageArtifact?.threadResolutions,
+        vendors: reviewPollResult.result.vendors,
       };
       return persistStandaloneAiReviewResult(
         cwd,
@@ -1440,12 +1511,26 @@ export async function runStandaloneAiReviewLifecycle(
         maxWaitMinutes: profile.maxWaitMinutes,
         previousOutcome,
       });
+      const triageArtifactPath = await writeCleanTriageArtifact(
+        resolve(cwd, '.agents/ai-review', `pr-${pullRequest.number}`, 'review'),
+        {
+          incompleteAgents: processedReview.incompleteAgents,
+          note: processedReview.note,
+          outcome: processedReview.outcome,
+          recordedAt: processedReview.recordedAt,
+        },
+      );
       const standaloneResult: StandaloneAiReviewResult = {
         incompleteAgents: processedReview.incompleteAgents,
         note: processedReview.note,
         outcome: processedReview.outcome,
         prNumber: pullRequest.number,
         prUrl: pullRequest.url,
+        recordedAt: processedReview.recordedAt,
+        triageArtifactPath: dependencies.relativeToRepo(
+          cwd,
+          triageArtifactPath,
+        ),
         vendors: [],
       };
       return persistStandaloneAiReviewResult(
@@ -1477,24 +1562,13 @@ export async function writeStandaloneAiReviewNote(
       '',
       `- PR: ${result.prUrl}`,
       `- Outcome: \`${result.outcome}\``,
-      result.vendors.length > 0
-        ? `- Vendors: ${result.vendors.map((vendor) => `\`${vendor}\``).join(', ')}`
-        : undefined,
-      result.actionSummary
-        ? `- Action summary: ${result.actionSummary}`
-        : undefined,
-      result.nonActionSummary
-        ? `- Non-action summary: ${result.nonActionSummary}`
-        : undefined,
-      result.incompleteAgents?.length
-        ? `- Incomplete agents at timeout: ${result.incompleteAgents.map((agent) => `\`${agent}\``).join(', ')}`
-        : undefined,
+      result.recordedAt ? `- Recorded at: ${result.recordedAt}` : undefined,
       `- Note: ${result.note}`,
-      result.artifactJsonPath
-        ? `- Artifact (json): \`${result.artifactJsonPath}\``
+      result.fetchArtifactPath
+        ? `- Fetch artifact: \`${result.fetchArtifactPath}\``
         : undefined,
-      result.artifactTextPath
-        ? `- Artifact (text): \`${result.artifactTextPath}\``
+      result.triageArtifactPath
+        ? `- Triage artifact: \`${result.triageArtifactPath}\``
         : undefined,
     ]
       .filter((line): line is string => line !== undefined)
@@ -1541,25 +1615,180 @@ export async function recordTicketReview(
     dependencies.resolveThreads ??
     ((worktreePath: string, comments: AiReviewComment[]) =>
       resolveNativeReviewThreads(worktreePath, comments, dependencies));
+  const artifactStemPath = resolve(
+    cwd,
+    state.reviewsDirPath,
+    `${ticketId}-ai-review`,
+  );
+  let fetchArtifactPath = target.reviewFetchArtifactPath
+    ? resolve(cwd, target.reviewFetchArtifactPath)
+    : undefined;
+  let triageArtifactPath = target.reviewTriageArtifactPath
+    ? resolve(cwd, target.reviewTriageArtifactPath)
+    : undefined;
+  let fetchArtifact = fetchArtifactPath
+    ? readFetchArtifact(fetchArtifactPath)
+    : undefined;
+  let existingTriageArtifact = triageArtifactPath
+    ? readTriageArtifact(triageArtifactPath)
+    : undefined;
+
+  if (
+    !fetchArtifact &&
+    target.reviewComments &&
+    target.reviewComments.length > 0
+  ) {
+    const paths = buildReviewArtifactPaths(artifactStemPath);
+    fetchArtifactPath = paths.fetchArtifactPath;
+    await writeFetchArtifact(fetchArtifactPath, {
+      schemaVersion: 1,
+      fetchedAt: new Date().toISOString(),
+      reviewedHeadSha: target.reviewHeadSha,
+      detected: true,
+      vendors:
+        target.reviewVendors && target.reviewVendors.length > 0
+          ? target.reviewVendors
+          : [
+              ...new Set(
+                target.reviewComments.map((comment) => comment.vendor),
+              ),
+            ],
+      agents: [],
+      comments: target.reviewComments,
+    });
+    fetchArtifact = readFetchArtifact(fetchArtifactPath);
+  }
+
+  if (!existingTriageArtifact) {
+    const paths = buildReviewArtifactPaths(artifactStemPath);
+    triageArtifactPath = paths.triageArtifactPath;
+    await writeTriageArtifact(triageArtifactPath, {
+      schemaVersion: 1,
+      recordedAt: new Date().toISOString(),
+      reviewedHeadSha: target.reviewHeadSha,
+      outcome:
+        target.reviewOutcome ??
+        (target.status === 'needs_patch'
+          ? 'needs_patch'
+          : target.status === 'operator_input_needed'
+            ? 'operator_input_needed'
+            : 'clean'),
+      note:
+        target.reviewNote ??
+        'External AI review completed without prudent follow-up changes.',
+      actionSummary: target.reviewActionSummary,
+      nonActionSummary: target.reviewNonActionSummary,
+      incompleteAgents: target.reviewIncompleteAgents,
+      threadResolutions: target.reviewThreadResolutions,
+    });
+    existingTriageArtifact = readTriageArtifact(triageArtifactPath);
+  }
+
+  if (!triageArtifactPath || !existingTriageArtifact) {
+    throw new Error(
+      `Ticket ${ticketId} has incomplete review state: triage artifact is missing.`,
+    );
+  }
+  if (
+    outcome === 'patched' &&
+    (!fetchArtifact || fetchArtifact.comments.length === 0) &&
+    (!existingTriageArtifact.threadResolutions ||
+      existingTriageArtifact.threadResolutions.length === 0)
+  ) {
+    throw new Error(
+      `Ticket ${ticketId} has incomplete review state: fetch artifact is missing or empty, so patched review threads cannot be reconciled safely.`,
+    );
+  }
   const reviewThreadResolutions =
     outcome === 'patched' &&
-    target.reviewThreadResolutions &&
-    target.reviewThreadResolutions.length > 0
-      ? target.reviewThreadResolutions
-      : outcome === 'patched' && target.reviewComments
-        ? resolveThreads(target.worktreePath, target.reviewComments)
-        : target.reviewThreadResolutions;
+    existingTriageArtifact?.threadResolutions &&
+    existingTriageArtifact.threadResolutions.length > 0
+      ? existingTriageArtifact.threadResolutions
+      : outcome === 'patched' && fetchArtifact?.comments
+        ? resolveThreads(target.worktreePath, fetchArtifact.comments)
+        : existingTriageArtifact?.threadResolutions;
   if (
     outcome === 'patched' &&
     reviewThreadResolutions &&
-    reviewThreadResolutions.length > 0
+    reviewThreadResolutions.length > 0 &&
+    triageArtifactPath
   ) {
-    await writeAiReviewThreadResolutions(
-      target.reviewArtifactJsonPath
-        ? resolve(cwd, target.reviewArtifactJsonPath)
-        : undefined,
-      reviewThreadResolutions,
-    );
+    await updateTriageArtifact(triageArtifactPath, (current) => ({
+      schemaVersion: 1,
+      recordedAt: new Date().toISOString(),
+      reviewedHeadSha:
+        current?.reviewedHeadSha ??
+        existingTriageArtifact?.reviewedHeadSha ??
+        target.reviewHeadSha,
+      outcome,
+      note:
+        formatAccumulatedReviewNote(
+          target.reviewOutcome,
+          outcome,
+          defaultFinalReviewNote(
+            outcome,
+            note,
+            current?.note ?? existingTriageArtifact?.note,
+          ),
+        ) ??
+        defaultFinalReviewNote(
+          outcome,
+          note,
+          current?.note ?? existingTriageArtifact?.note,
+        ) ??
+        'External AI review completed without prudent follow-up changes.',
+      actionSummary:
+        current?.actionSummary ?? existingTriageArtifact?.actionSummary,
+      nonActionSummary:
+        current?.nonActionSummary ?? existingTriageArtifact?.nonActionSummary,
+      incompleteAgents:
+        current?.incompleteAgents ?? existingTriageArtifact?.incompleteAgents,
+      patchCommitShas:
+        current?.patchCommitShas ?? existingTriageArtifact?.patchCommitShas,
+      threadResolutions: reviewThreadResolutions,
+      prBodyRefresh:
+        current?.prBodyRefresh ?? existingTriageArtifact?.prBodyRefresh,
+    }));
+  } else if (triageArtifactPath) {
+    await updateTriageArtifact(triageArtifactPath, (current) => ({
+      schemaVersion: 1,
+      recordedAt: new Date().toISOString(),
+      reviewedHeadSha:
+        current?.reviewedHeadSha ??
+        existingTriageArtifact?.reviewedHeadSha ??
+        target.reviewHeadSha,
+      outcome,
+      note:
+        formatAccumulatedReviewNote(
+          target.reviewOutcome,
+          outcome,
+          defaultFinalReviewNote(
+            outcome,
+            note,
+            current?.note ?? existingTriageArtifact?.note,
+          ),
+        ) ??
+        defaultFinalReviewNote(
+          outcome,
+          note,
+          current?.note ?? existingTriageArtifact?.note,
+        ) ??
+        'External AI review completed without prudent follow-up changes.',
+      actionSummary:
+        current?.actionSummary ?? existingTriageArtifact?.actionSummary,
+      nonActionSummary:
+        current?.nonActionSummary ?? existingTriageArtifact?.nonActionSummary,
+      incompleteAgents:
+        current?.incompleteAgents ?? existingTriageArtifact?.incompleteAgents,
+      patchCommitShas:
+        current?.patchCommitShas ?? existingTriageArtifact?.patchCommitShas,
+      threadResolutions:
+        outcome === 'patched'
+          ? reviewThreadResolutions
+          : current?.threadResolutions,
+      prBodyRefresh:
+        current?.prBodyRefresh ?? existingTriageArtifact?.prBodyRefresh,
+    }));
   }
 
   return applyTicketReviewUpdate(
@@ -1575,14 +1804,7 @@ export async function recordTicketReview(
         ticket.reviewOutcome,
         outcome,
       ),
-      reviewNote:
-        formatAccumulatedReviewNote(
-          ticket.reviewOutcome,
-          outcome,
-          defaultFinalReviewNote(outcome, note, ticket.reviewNote),
-        ) ?? defaultFinalReviewNote(outcome, note, ticket.reviewNote),
-      reviewThreadResolutions:
-        outcome === 'patched' ? reviewThreadResolutions : undefined,
+      reviewRecordedAt: new Date().toISOString(),
     }),
     dependencies,
   );

--- a/tools/delivery/state.ts
+++ b/tools/delivery/state.ts
@@ -317,30 +317,16 @@ function syncStateWithPlan(
         prNumber: previous?.prNumber ?? inferredTicket?.prNumber,
         prUrl: previous?.prUrl ?? inferredTicket?.prUrl,
         prOpenedAt: previous?.prOpenedAt ?? inferredTicket?.prOpenedAt,
-        reviewArtifactPath:
-          previous?.reviewArtifactPath ?? inferredTicket?.reviewArtifactPath,
-        reviewArtifactJsonPath:
-          previous?.reviewArtifactJsonPath ??
-          inferredTicket?.reviewArtifactJsonPath,
-        reviewActionSummary:
-          previous?.reviewActionSummary ?? inferredTicket?.reviewActionSummary,
-        reviewFetchedAt:
-          previous?.reviewFetchedAt ?? inferredTicket?.reviewFetchedAt,
+        reviewFetchArtifactPath:
+          previous?.reviewFetchArtifactPath ??
+          inferredTicket?.reviewFetchArtifactPath,
+        reviewTriageArtifactPath:
+          previous?.reviewTriageArtifactPath ??
+          inferredTicket?.reviewTriageArtifactPath,
         reviewHeadSha: previous?.reviewHeadSha ?? inferredTicket?.reviewHeadSha,
-        reviewNonActionSummary:
-          previous?.reviewNonActionSummary ??
-          inferredTicket?.reviewNonActionSummary,
-        reviewIncompleteAgents:
-          previous?.reviewIncompleteAgents ??
-          inferredTicket?.reviewIncompleteAgents,
-        reviewComments:
-          previous?.reviewComments ?? inferredTicket?.reviewComments,
+        reviewRecordedAt:
+          previous?.reviewRecordedAt ?? inferredTicket?.reviewRecordedAt,
         reviewOutcome: previous?.reviewOutcome ?? inferredTicket?.reviewOutcome,
-        reviewNote: previous?.reviewNote ?? inferredTicket?.reviewNote,
-        reviewThreadResolutions:
-          previous?.reviewThreadResolutions ??
-          inferredTicket?.reviewThreadResolutions,
-        reviewVendors: previous?.reviewVendors ?? inferredTicket?.reviewVendors,
       };
     }),
   };
@@ -499,17 +485,11 @@ function inferStateFromRepo(
       prNumber: pr?.number,
       prUrl: pr?.url,
       prOpenedAt: undefined,
-      reviewArtifactPath: undefined,
-      reviewArtifactJsonPath: undefined,
-      reviewActionSummary: undefined,
-      reviewFetchedAt: undefined,
+      reviewFetchArtifactPath: undefined,
+      reviewTriageArtifactPath: undefined,
       reviewHeadSha: undefined,
-      reviewNonActionSummary: undefined,
-      reviewComments: undefined,
+      reviewRecordedAt: undefined,
       reviewOutcome: undefined,
-      reviewNote: undefined,
-      reviewThreadResolutions: undefined,
-      reviewVendors: undefined,
     } satisfies TicketState;
   });
 

--- a/tools/delivery/ticket-flow.ts
+++ b/tools/delivery/ticket-flow.ts
@@ -113,23 +113,15 @@ export function buildTicketHandoff(
       lines.push(`- Review outcome: \`${previous.reviewOutcome}\``);
     }
 
-    if (previous.reviewNote) {
-      lines.push(`- Review note: ${previous.reviewNote}`);
-    }
-
-    if (previous.reviewVendors && previous.reviewVendors.length > 0) {
+    if (previous.reviewFetchArtifactPath ?? previous.reviewArtifactPath) {
       lines.push(
-        `- Review vendors: ${previous.reviewVendors.map((vendor) => `\`${vendor}\``).join(', ')}`,
+        `- Review fetch artifact: \`${previous.reviewFetchArtifactPath ?? previous.reviewArtifactPath}\``,
       );
     }
 
-    if (previous.reviewArtifactPath) {
-      lines.push(`- Review artifact: \`${previous.reviewArtifactPath}\``);
-    }
-
-    if (previous.reviewArtifactJsonPath) {
+    if (previous.reviewTriageArtifactPath ?? previous.reviewArtifactJsonPath) {
       lines.push(
-        `- Review artifact (json): \`${previous.reviewArtifactJsonPath}\``,
+        `- Review triage artifact: \`${previous.reviewTriageArtifactPath ?? previous.reviewArtifactJsonPath}\``,
       );
     }
   }


### PR DESCRIPTION
## Summary
- split persisted AI review state into `reviews/<ticket>.fetch.json` and `reviews/<ticket>.triage.json`
- remove persisted rendered `.txt` artifacts and stop mirroring review payload arrays into `state.json`
- update orchestrator readers, PR metadata rendering, tests, and workflow docs to the hard-cut artifact contract

<!-- ai-review:start -->
## External AI Review

- outcome: `operator_input_needed`
- reviewed commit: [`d8bc4175a4c6`](https://github.com/cesarnml/pirate_claw/commit/d8bc4175a4c6dd283b4794c910e19dcd2471fb44)
- current branch head: [`d8bc4175a4c6`](https://github.com/cesarnml/pirate_claw/commit/d8bc4175a4c6dd283b4794c910e19dcd2471fb44)
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Artifact paths are stored repo-relative but read worktree-relative—fix the mismatch in `loadTicketReviewSnapshot`. `tools/delivery/orchestrator.ts:1686` [thread](https://github.com/cesarnml/pirate_claw/pull/162#discussion_r3085120524)
- [coderabbit] Reject unknown persisted thread-resolution statuses. `tools/delivery/review-artifacts.ts:214` [thread](https://github.com/cesarnml/pirate_claw/pull/162#discussion_r3085120539)
- [coderabbit] Write lazily created artifact paths back into ticket state. `tools/delivery/review.ts:1692` [thread](https://github.com/cesarnml/pirate_claw/pull/162#discussion_r3085120553)
<!-- ai-review:end -->
