### PR TITLE
feat: add Plex foundation and refresh skeleton [P18.01]

### DIFF
--- a/docs/03-engineering/sqlite-schema.mmd
+++ b/docs/03-engineering/sqlite-schema.mmd
@@ -61,6 +61,64 @@ erDiagram
     TEXT created_at
   }
 
+  TMDB_MOVIE_CACHE {
+    TEXT match_key PK
+    INTEGER tmdb_id
+    INTEGER is_negative
+    TEXT expires_at
+    TEXT title
+    TEXT overview
+    TEXT poster_path
+    TEXT backdrop_path
+    REAL vote_average
+    INTEGER vote_count
+    TEXT genre_ids_json
+    TEXT release_date
+  }
+
+  TMDB_TV_CACHE {
+    TEXT match_key PK
+    INTEGER tmdb_id
+    INTEGER is_negative
+    TEXT expires_at
+    TEXT name
+    TEXT overview
+    TEXT poster_path
+    TEXT backdrop_path
+    REAL vote_average
+    INTEGER vote_count
+    TEXT genre_ids_json
+    TEXT first_air_date
+    INTEGER number_of_seasons
+    TEXT seasons_json
+  }
+
+  TMDB_TV_SEASON_CACHE {
+    TEXT show_match_key PK
+    INTEGER season_number PK
+    TEXT expires_at
+    TEXT episodes_json
+  }
+
+  PLEX_MOVIE_CACHE {
+    TEXT title PK
+    INTEGER year PK
+    TEXT plex_rating_key
+    INTEGER in_library
+    INTEGER watch_count
+    TEXT last_watched_at
+    TEXT cached_at
+  }
+
+  PLEX_TV_CACHE {
+    TEXT normalized_title PK
+    TEXT plex_rating_key
+    INTEGER in_library
+    INTEGER watch_count
+    TEXT last_watched_at
+    TEXT cached_at
+  }
+
   RUNS ||--o{ FEED_ITEMS : records
   RUNS ||--o{ FEED_ITEM_OUTCOMES : records
   RUNS ||--o{ CANDIDATE_STATE : first_seen_in

--- a/src/api.ts
+++ b/src/api.ts
@@ -745,7 +745,13 @@ export function buildShowBreakdowns(
       seasons.push({ season, episodes });
     }
     seasons.sort((a, b) => a.season - b.season);
-    shows.push({ normalizedTitle: title, seasons });
+    shows.push({
+      normalizedTitle: title,
+      seasons,
+      plexStatus: 'unknown',
+      watchCount: null,
+      lastWatchedAt: null,
+    });
   }
 
   return shows.sort((a, b) =>
@@ -771,6 +777,9 @@ export function buildMovieBreakdowns(
       queuedAt: c.queuedAt,
       transmissionPercentDone: c.transmissionPercentDone,
       transmissionTorrentHash: c.transmissionTorrentHash,
+      plexStatus: 'unknown' as const,
+      watchCount: null,
+      lastWatchedAt: null,
     }))
     .sort((a, b) => a.normalizedTitle.localeCompare(b.normalizedTitle));
 }
@@ -827,6 +836,10 @@ export function redactConfig(config: AppConfig): AppConfig {
 
   if (next.tmdb?.apiKey) {
     next.tmdb = { ...next.tmdb, apiKey: '[redacted]' };
+  }
+
+  if (next.plex?.token) {
+    next.plex = { ...next.plex, token: '[redacted]' };
   }
 
   return next;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,6 +17,7 @@ import {
   retryFailedCandidates,
   runPipeline,
 } from './pipeline';
+import { runPlexBackgroundRefresh } from './plex/background-refresh';
 import {
   filterDueFeeds,
   loadPollState,
@@ -200,6 +201,9 @@ export async function runCli(argv: string[]): Promise<number> {
           config.runtime.tmdbRefreshIntervalMinutes!;
         const scheduleTmdbRefresh =
           (tmdbMovies || tmdbShows) && tmdbRefreshIntervalMinutes > 0;
+        const plexRefreshIntervalMinutes =
+          config.plex?.refreshIntervalMinutes ?? 0;
+        const schedulePlexRefresh = plexRefreshIntervalMinutes > 0;
 
         const configHolder = { current: config };
 
@@ -251,7 +255,17 @@ export async function runCli(argv: string[]): Promise<number> {
                 });
               }
             : undefined,
-          options: daemonOptionsFromConfig(config.runtime),
+          plexRefreshCycle: schedulePlexRefresh
+            ? async () => {
+                await runPlexBackgroundRefresh({
+                  log,
+                });
+              }
+            : undefined,
+          options: daemonOptionsFromConfig(
+            config.runtime,
+            config.plex?.refreshIntervalMinutes,
+          ),
           signal: controller.signal,
           log,
           onCycleResult: (result) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,14 @@ export type TmdbConfig = {
   negativeCacheTtlDays?: number;
 };
 
+/** Optional Plex enrichment (Phase 18). Token may be supplied via env instead. */
+export type PlexConfig = {
+  url: string;
+  token: string;
+  /** Zero disables the background pass for local development. */
+  refreshIntervalMinutes: number;
+};
+
 export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   runIntervalMinutes: 30,
   reconcileIntervalMinutes: 1,
@@ -83,12 +91,15 @@ export type AppConfig = {
   transmission: TransmissionConfig;
   runtime: RuntimeConfig;
   tmdb?: TmdbConfig;
+  plex?: PlexConfig;
 };
 
 const DEFAULT_CONFIG_PATH = 'pirate-claw.config.json';
 const TRANSMISSION_USERNAME_ENV = 'PIRATE_CLAW_TRANSMISSION_USERNAME';
 const TRANSMISSION_PASSWORD_ENV = 'PIRATE_CLAW_TRANSMISSION_PASSWORD';
 const API_WRITE_TOKEN_ENV = 'PIRATE_CLAW_API_WRITE_TOKEN';
+const PLEX_TOKEN_ENV = 'PIRATE_CLAW_PLEX_TOKEN';
+const DEFAULT_PLEX_REFRESH_INTERVAL_MINUTES = 30;
 
 export class ConfigError extends Error {
   constructor(message: string) {
@@ -142,6 +153,7 @@ export function validateConfig(
     transmission: validateTransmission(transmission, path, env),
     runtime: validateRuntime(input.runtime, path, env),
     tmdb: validateOptionalTmdb(input.tmdb, path),
+    plex: validateOptionalPlex(input.plex, path, env),
   };
 }
 
@@ -675,6 +687,42 @@ function validateOptionalTmdbDayCount(
   return input;
 }
 
+function validateOptionalPlex(
+  input: unknown,
+  path: string,
+  env: Record<string, string | undefined>,
+): PlexConfig | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  const plex = expectRecord(input, `${path} plex`);
+  const inlineToken =
+    plex.token === undefined
+      ? undefined
+      : typeof plex.token === 'string'
+        ? plex.token
+        : (() => {
+            throw new ConfigError(
+              `Config file "${path} plex token" must be a string.`,
+            );
+          })();
+
+  return {
+    url: expectString(plex.url, `${path} plex url`),
+    token: resolveSecretFromInlineOrEnv(
+      inlineToken,
+      env[PLEX_TOKEN_ENV],
+      `${path} plex token`,
+    ),
+    refreshIntervalMinutes:
+      validateOptionalTmdbRefreshInterval(
+        plex.refreshIntervalMinutes,
+        `${path} plex refreshIntervalMinutes`,
+      ) ?? DEFAULT_PLEX_REFRESH_INTERVAL_MINUTES,
+  };
+}
+
 function validateRuntime(
   input: unknown,
   path: string,
@@ -741,6 +789,22 @@ function resolveApiWriteToken(
 
   // Empty string in config intentionally disables write auth.
   return inlineValue.length > 0 ? inlineValue : undefined;
+}
+
+function resolveSecretFromInlineOrEnv(
+  inlineValue: string | undefined,
+  envValue: string | undefined,
+  path: string,
+): string {
+  if (typeof inlineValue === 'string' && inlineValue.length > 0) {
+    return inlineValue;
+  }
+
+  if (typeof envValue === 'string' && envValue.length > 0) {
+    return envValue;
+  }
+
+  throw new ConfigError(`Config file "${path}" must be a non-empty string.`);
 }
 
 const MAX_INTERVAL_MINUTES = 44_640;

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -7,9 +7,14 @@ export type DaemonOptions = {
   apiPort?: number;
   /** When set (TMDB configured + interval > 0), daemon schedules background refreshes. */
   tmdbRefreshIntervalMs?: number;
+  /** When set (Plex configured + interval > 0), daemon schedules background refreshes. */
+  plexRefreshIntervalMs?: number;
 };
 
-export function daemonOptionsFromConfig(runtime: RuntimeConfig): DaemonOptions {
+export function daemonOptionsFromConfig(
+  runtime: RuntimeConfig,
+  plexRefreshIntervalMinutes?: number,
+): DaemonOptions {
   const tmdbMin = runtime.tmdbRefreshIntervalMinutes;
   return {
     runIntervalMs: runtime.runIntervalMinutes * 60 * 1000,
@@ -17,6 +22,10 @@ export function daemonOptionsFromConfig(runtime: RuntimeConfig): DaemonOptions {
     apiPort: runtime.apiPort,
     tmdbRefreshIntervalMs:
       tmdbMin != null && tmdbMin > 0 ? tmdbMin * 60 * 1000 : undefined,
+    plexRefreshIntervalMs:
+      plexRefreshIntervalMinutes != null && plexRefreshIntervalMinutes > 0
+        ? plexRefreshIntervalMinutes * 60 * 1000
+        : undefined,
   };
 }
 
@@ -25,6 +34,8 @@ export async function runDaemonLoop(input: {
   reconcileCycle: () => Promise<void>;
   /** Optional TMDB cache refresh; does not share the RSS `busy` lock. */
   tmdbRefreshCycle?: () => Promise<void>;
+  /** Optional Plex cache refresh; does not share the RSS `busy` lock. */
+  plexRefreshCycle?: () => Promise<void>;
   options: DaemonOptions;
   signal: AbortSignal;
   log?: (message: string) => void;
@@ -76,6 +87,8 @@ export async function runDaemonLoop(input: {
   let inFlight: Promise<void> | undefined;
   let tmdbInFlight: Promise<void> | undefined;
   let tmdbBusy = false;
+  let plexInFlight: Promise<void> | undefined;
+  let plexBusy = false;
 
   async function guardedCycle(
     type: string,
@@ -139,6 +152,38 @@ export async function runDaemonLoop(input: {
     }
   }
 
+  async function runPlexRefresh(): Promise<void> {
+    if (!input.plexRefreshCycle) {
+      return;
+    }
+    if (plexBusy) {
+      log('plex_refresh cycle skipped: already_running');
+      emitCycleResult({
+        type: 'plex_refresh',
+        status: 'skipped',
+        startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+        durationMs: 0,
+        skipReason: 'already_running',
+      });
+      return;
+    }
+    plexBusy = true;
+    const promise = executeCycle(
+      'plex_refresh',
+      input.plexRefreshCycle,
+      log,
+      emitCycleResult,
+    );
+    plexInFlight = promise;
+    try {
+      await promise;
+    } finally {
+      plexBusy = false;
+      plexInFlight = undefined;
+    }
+  }
+
   log('daemon started');
 
   await guardedCycle('run', runCycle);
@@ -171,6 +216,17 @@ export async function runDaemonLoop(input: {
     }, options.tmdbRefreshIntervalMs);
   }
 
+  let plexTimer: ReturnType<typeof setInterval> | undefined;
+  if (
+    options.plexRefreshIntervalMs != null &&
+    options.plexRefreshIntervalMs > 0 &&
+    input.plexRefreshCycle
+  ) {
+    plexTimer = setInterval(() => {
+      void runPlexRefresh();
+    }, options.plexRefreshIntervalMs);
+  }
+
   await new Promise<void>((resolve) => {
     if (signal.aborted) {
       resolve();
@@ -185,6 +241,9 @@ export async function runDaemonLoop(input: {
   if (tmdbTimer) {
     clearInterval(tmdbTimer);
   }
+  if (plexTimer) {
+    clearInterval(plexTimer);
+  }
 
   if (server) {
     server.stop();
@@ -197,6 +256,9 @@ export async function runDaemonLoop(input: {
 
   if (tmdbInFlight) {
     await tmdbInFlight;
+  }
+  if (plexInFlight) {
+    await plexInFlight;
   }
 
   log('daemon stopped');

--- a/src/movie-api-types.ts
+++ b/src/movie-api-types.ts
@@ -1,3 +1,5 @@
+export type PlexStatus = 'in_library' | 'missing' | 'unknown';
+
 /** TMDB fields exposed on movie API responses (dashboard + JSON). */
 export type TmdbMoviePublic = {
   tmdbId?: number;
@@ -20,5 +22,8 @@ export type MovieBreakdown = {
   queuedAt?: string;
   transmissionPercentDone?: number;
   transmissionTorrentHash?: string;
+  plexStatus: PlexStatus;
+  watchCount: number | null;
+  lastWatchedAt: string | null;
   tmdb?: TmdbMoviePublic;
 };

--- a/src/plex/background-refresh.ts
+++ b/src/plex/background-refresh.ts
@@ -1,0 +1,9 @@
+/**
+ * Phase 18 foundation ticket: reserve the daemon hook and prove scheduling
+ * works without introducing Plex matching behavior yet.
+ */
+export async function runPlexBackgroundRefresh(input: {
+  log: (message: string) => void;
+}): Promise<void> {
+  input.log('[plex] background refresh noop');
+}

--- a/src/plex/client.ts
+++ b/src/plex/client.ts
@@ -1,0 +1,126 @@
+import { XMLParser } from 'fast-xml-parser';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export type PlexLibrarySection = {
+  key: string;
+  type?: string;
+  title?: string;
+};
+
+export type PlexSearchResult = {
+  ratingKey?: string;
+  title?: string;
+  type?: string;
+  year?: number;
+  viewCount?: number;
+  lastViewedAt?: number;
+};
+
+type PlexMediaContainer = {
+  MediaContainer?: {
+    Directory?: Array<Record<string, unknown>> | Record<string, unknown>;
+    Video?: Array<Record<string, unknown>> | Record<string, unknown>;
+  };
+};
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '',
+});
+
+export class PlexHttpClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly token: string,
+    private readonly log: (message: string) => void,
+    private readonly timeoutMs = DEFAULT_TIMEOUT_MS,
+  ) {}
+
+  async listLibrarySections(): Promise<PlexLibrarySection[]> {
+    const container = await this.getXml('/library/sections');
+    const directories = asArray(container?.MediaContainer?.Directory);
+    return directories.map((entry) => ({
+      key: stringField(entry.key),
+      type: optionalStringField(entry.type),
+      title: optionalStringField(entry.title),
+    }));
+  }
+
+  async searchLibrary(
+    sectionKey: string,
+    title: string,
+  ): Promise<PlexSearchResult[]> {
+    const query = encodeURIComponent(title);
+    const container = await this.getXml(
+      `/library/sections/${encodeURIComponent(sectionKey)}/search?query=${query}`,
+    );
+    const videos = asArray(container?.MediaContainer?.Video);
+    return videos.map((entry) => ({
+      ratingKey: optionalStringField(entry.ratingKey),
+      title: optionalStringField(entry.title),
+      type: optionalStringField(entry.type),
+      year: optionalNumberField(entry.year),
+      viewCount: optionalNumberField(entry.viewCount),
+      lastViewedAt: optionalNumberField(entry.lastViewedAt),
+    }));
+  }
+
+  private async getXml(path: string): Promise<PlexMediaContainer | null> {
+    const url = new URL(path, this.baseUrl).toString();
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        headers: {
+          Accept: 'application/xml',
+          'X-Plex-Token': this.token,
+        },
+        signal: AbortSignal.timeout(this.timeoutMs),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.log(`plex request failed: ${path} (${message})`);
+      return null;
+    }
+
+    if (!response.ok) {
+      this.log(`plex HTTP ${response.status} for ${path}`);
+      return null;
+    }
+
+    try {
+      return parser.parse(await response.text()) as PlexMediaContainer;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.log(`plex response parse failed: ${path} (${message})`);
+      return null;
+    }
+  }
+}
+
+function asArray<T>(input: T | T[] | undefined): T[] {
+  if (input === undefined) {
+    return [];
+  }
+  return Array.isArray(input) ? input : [input];
+}
+
+function stringField(input: unknown): string {
+  return typeof input === 'string' ? input : String(input ?? '');
+}
+
+function optionalStringField(input: unknown): string | undefined {
+  return typeof input === 'string' && input.length > 0 ? input : undefined;
+}
+
+function optionalNumberField(input: unknown): number | undefined {
+  if (typeof input === 'number' && Number.isFinite(input)) {
+    return input;
+  }
+  if (typeof input === 'string' && input.length > 0) {
+    const parsed = Number(input);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}

--- a/src/plex/schema.ts
+++ b/src/plex/schema.ts
@@ -1,0 +1,28 @@
+import type { Database } from 'bun:sqlite';
+
+export function ensurePlexSchema(database: Database): void {
+  database.transaction(() => {
+    database.run(`
+      CREATE TABLE IF NOT EXISTS plex_movie_cache (
+        title TEXT NOT NULL,
+        year INTEGER NOT NULL,
+        plex_rating_key TEXT,
+        in_library INTEGER NOT NULL DEFAULT 0,
+        watch_count INTEGER,
+        last_watched_at TEXT,
+        cached_at TEXT NOT NULL,
+        PRIMARY KEY (title, year)
+      );
+    `);
+    database.run(`
+      CREATE TABLE IF NOT EXISTS plex_tv_cache (
+        normalized_title TEXT PRIMARY KEY NOT NULL,
+        plex_rating_key TEXT,
+        in_library INTEGER NOT NULL DEFAULT 0,
+        watch_count INTEGER,
+        last_watched_at TEXT,
+        cached_at TEXT NOT NULL
+      );
+    `);
+  })();
+}

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,5 +1,6 @@
 import { Database } from 'bun:sqlite';
 
+import { ensurePlexSchema } from './plex/schema';
 import type { TmdbMoviePublic } from './movie-api-types';
 import { ensureTmdbSchema } from './tmdb/schema';
 import type { TmdbTvShowMeta } from './tv-api-types';
@@ -257,6 +258,7 @@ export function ensureSchema(database: Database): void {
   ensureCandidateStateColumn(database, 'transmission_download_dir', 'TEXT');
 
   ensureTmdbSchema(database);
+  ensurePlexSchema(database);
 }
 
 export function hasStatusSchema(database: Database): boolean {

--- a/src/tmdb/tv-enrichment.ts
+++ b/src/tmdb/tv-enrichment.ts
@@ -260,7 +260,7 @@ export async function enrichShowBreakdowns(
       );
 
       return {
-        normalizedTitle: show.normalizedTitle,
+        ...show,
         seasons,
         tmdb: showMeta,
       };

--- a/src/tv-api-types.ts
+++ b/src/tv-api-types.ts
@@ -1,3 +1,5 @@
+import type { PlexStatus } from './movie-api-types';
+
 /** TMDB metadata attached to a TV show breakdown (API + dashboard). */
 export type TmdbTvShowMeta = {
   tmdbId?: number;
@@ -37,5 +39,8 @@ export type ShowSeason = {
 export type ShowBreakdown = {
   normalizedTitle: string;
   seasons: ShowSeason[];
+  plexStatus: PlexStatus;
+  watchCount: number | null;
+  lastWatchedAt: string | null;
   tmdb?: TmdbTvShowMeta;
 };

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -2267,4 +2267,80 @@ describe('redactConfig', () => {
     expect(redacted.tmdb?.apiKey).toBe('[redacted]');
     expect(config.tmdb?.apiKey).toBe('secret-tmdb');
   });
+
+  it('redacts plex token when present', () => {
+    const config: AppConfig = {
+      ...stubConfig(),
+      plex: {
+        url: 'http://plex.local:32400',
+        token: 'secret-plex',
+        refreshIntervalMinutes: 30,
+      },
+    };
+    const redacted = redactConfig(config);
+
+    expect(redacted.plex?.token).toBe('[redacted]');
+    expect(config.plex?.token).toBe('secret-plex');
+  });
+});
+
+describe('build Plex defaults', () => {
+  it('sets unknown Plex fields on movie breakdowns', () => {
+    const movies = buildMovieBreakdowns([
+      {
+        identityKey: 'movie:example movie|2024',
+        mediaType: 'movie',
+        status: 'queued',
+        ruleName: 'Example Movie',
+        score: 100,
+        reasons: ['matched'],
+        rawTitle: 'Example Movie 2024 1080p x265',
+        normalizedTitle: 'Example Movie',
+        year: 2024,
+        feedName: 'Movie Feed',
+        guidOrLink: 'https://example.test/movie',
+        publishedAt: '2026-01-01T00:00:00Z',
+        downloadUrl: 'https://example.test/movie.torrent',
+        firstSeenRunId: 1,
+        lastSeenRunId: 1,
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ]);
+
+    expect(movies[0]).toMatchObject({
+      plexStatus: 'unknown',
+      watchCount: null,
+      lastWatchedAt: null,
+    });
+  });
+
+  it('sets unknown Plex fields on show breakdowns', () => {
+    const shows = buildShowBreakdowns([
+      {
+        identityKey: 'tv:example show|1|1',
+        mediaType: 'tv',
+        status: 'queued',
+        ruleName: 'Example Show',
+        score: 100,
+        reasons: ['matched'],
+        rawTitle: 'Example.Show.S01E01.1080p.x265',
+        normalizedTitle: 'Example Show',
+        season: 1,
+        episode: 1,
+        feedName: 'TV Feed',
+        guidOrLink: 'https://example.test/show',
+        publishedAt: '2026-01-01T00:00:00Z',
+        downloadUrl: 'https://example.test/show.torrent',
+        firstSeenRunId: 1,
+        lastSeenRunId: 1,
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ]);
+
+    expect(shows[0]).toMatchObject({
+      plexStatus: 'unknown',
+      watchCount: null,
+      lastWatchedAt: null,
+    });
+  });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -866,6 +866,58 @@ describe('validateConfig', () => {
       }),
     ).toThrow(ConfigError);
   });
+
+  it('accepts optional plex block and defaults the refresh interval', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      plex: {
+        url: 'http://plex.local:32400',
+        token: 'plex-token',
+      },
+    });
+
+    expect(config.plex).toEqual({
+      url: 'http://plex.local:32400',
+      token: 'plex-token',
+      refreshIntervalMinutes: 30,
+    });
+  });
+
+  it('fills missing plex token from env values', () => {
+    const config = validateConfig(
+      {
+        ...createMinimalConfig(),
+        plex: {
+          url: 'http://plex.local:32400',
+        },
+      },
+      'config',
+      {
+        PIRATE_CLAW_PLEX_TOKEN: 'env-plex-token',
+      },
+    );
+
+    expect(config.plex).toEqual({
+      url: 'http://plex.local:32400',
+      token: 'env-plex-token',
+      refreshIntervalMinutes: 30,
+    });
+  });
+
+  it('fails when plex block is present without any token source', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        plex: {
+          url: 'http://plex.local:32400',
+        },
+      }),
+    ).toThrow(
+      new ConfigError(
+        'Config file "config plex token" must be a non-empty string.',
+      ),
+    );
+  });
 });
 
 function createMinimalConfig() {

--- a/test/daemon.test.ts
+++ b/test/daemon.test.ts
@@ -326,6 +326,44 @@ describe('daemon', () => {
     expect(options.apiPort).toBe(8080);
   });
 
+  it('passes plex refresh interval through daemonOptionsFromConfig', () => {
+    const options = daemonOptionsFromConfig(
+      {
+        runIntervalMinutes: 15,
+        reconcileIntervalMinutes: 2,
+        artifactDir: '.pirate-claw/runtime',
+        artifactRetentionDays: 7,
+      },
+      30,
+    );
+
+    expect(options.plexRefreshIntervalMs).toBe(30 * 60 * 1000);
+  });
+
+  it('schedules recurring plex refresh cycles', async () => {
+    const controller = new AbortController();
+    let plexRefreshCount = 0;
+
+    await runDaemonLoop({
+      runCycle: async () => {},
+      reconcileCycle: async () => {},
+      plexRefreshCycle: async () => {
+        plexRefreshCount += 1;
+        if (plexRefreshCount >= 2) {
+          controller.abort();
+        }
+      },
+      options: {
+        runIntervalMs: 600_000,
+        reconcileIntervalMs: 600_000,
+        plexRefreshIntervalMs: 10,
+      },
+      signal: controller.signal,
+    });
+
+    expect(plexRefreshCount).toBeGreaterThanOrEqual(2);
+  });
+
   it('wraps EADDRINUSE with an actionable error mentioning runtime.apiPort', async () => {
     const first = Bun.serve({
       port: 0,

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -260,6 +260,28 @@ describe('SQLite repository', () => {
     });
   });
 
+  it('creates Plex cache tables during schema initialization', async () => {
+    const path = await createDatabasePath();
+    const database = openDatabase(path);
+
+    openDatabases.push(database);
+    ensureSchema(database);
+
+    const movieTable = database
+      .query(
+        `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'plex_movie_cache'`,
+      )
+      .get() as { name: string } | null;
+    const tvTable = database
+      .query(
+        `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'plex_tv_cache'`,
+      )
+      .get() as { name: string } | null;
+
+    expect(movieTable?.name).toBe('plex_movie_cache');
+    expect(tvTable?.name).toBe('plex_tv_cache');
+  });
+
   it('persists reconciled lifecycle state and raw Transmission fields', async () => {
     const repository = createTestRepository(await createDatabasePath());
     const run = repository.startRun('2026-03-30T00:00:00.000Z');


### PR DESCRIPTION
## Summary

- delivery ticket: `P18.01 Foundation: plex config, HTTP client, SQLite cache, scheduler skeleton, graceful no-op`
- ticket file: [docs/02-delivery/phase-18/ticket-01-foundation-plex-client-cache.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-18/ticket-01-foundation-plex-client-cache.md)
- stacked base branch: `main`
- self-audit: outcome `clean` completed at 2026-04-16 13:30 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`10ba9c0c0a31`](https://github.com/cesarnml/pirate_claw/commit/10ba9c0c0a3183a5b82e27d9e28c7dc56053d404)
- current branch head: [`10ba9c0c0a31`](https://github.com/cesarnml/pirate_claw/commit/10ba9c0c0a3183a5b82e27d9e28c7dc56053d404)
- vendors: `coderabbit`, `sonarqube`
