### PR TITLE
feat: enrich movies with Plex cache [P18.02]

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -36,6 +36,8 @@ import type { MovieEnrichDeps } from './tmdb/movie-enrichment';
 import { enrichMovieBreakdowns } from './tmdb/movie-enrichment';
 import type { TvEnrichDeps } from './tmdb/tv-enrichment';
 import { enrichShowBreakdowns } from './tmdb/tv-enrichment';
+import type { PlexMovieEnrichDeps } from './plex/movies';
+import { enrichMovieBreakdownsFromPlexCache } from './plex/movies';
 
 export type CycleSnapshot = {
   status: CycleResult['status'];
@@ -90,6 +92,8 @@ export type ApiFetchDeps = {
   loadPollState: (path: string) => PollState;
   /** When set (TMDB configured), GET /api/movies lazily enriches from cache + TMDB. */
   tmdbMovies?: MovieEnrichDeps;
+  /** When set (Plex configured), GET /api/movies merges Plex cache status only. */
+  plexMovies?: PlexMovieEnrichDeps;
   /** When set (TMDB configured), GET /api/shows lazily enriches from cache + TMDB. */
   tmdbShows?: TvEnrichDeps;
   /**
@@ -142,6 +146,7 @@ export function createApiFetch(
     pollStatePath,
     loadPollState,
     tmdbMovies,
+    plexMovies,
     tmdbShows,
     tmdbCache,
     onCandidateTmdbCacheError,
@@ -198,9 +203,12 @@ export function createApiFetch(
       try {
         const candidates = repository.listCandidateStates();
         const base = buildMovieBreakdowns(candidates);
-        const movies = tmdbMovies
-          ? await enrichMovieBreakdowns(base, tmdbMovies)
+        const withPlex = plexMovies
+          ? enrichMovieBreakdownsFromPlexCache(base, plexMovies)
           : base;
+        const movies = tmdbMovies
+          ? await enrichMovieBreakdowns(withPlex, tmdbMovies)
+          : withPlex;
         return Response.json({ movies });
       } catch {
         return json500();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,9 @@ import {
   runPipeline,
 } from './pipeline';
 import { runPlexBackgroundRefresh } from './plex/background-refresh';
+import { PlexCache } from './plex/cache';
+import { PlexHttpClient } from './plex/client';
+import type { PlexMovieEnrichDeps } from './plex/movies';
 import {
   filterDueFeeds,
   loadPollState,
@@ -43,6 +46,27 @@ import type { MovieEnrichDeps } from './tmdb/movie-enrichment';
 import type { TvEnrichDeps } from './tmdb/tv-enrichment';
 import { resolveTmdbSettings } from './tmdb/settings';
 import { createTransmissionDownloader } from './transmission';
+
+function plexMovieEnrichDeps(
+  database: Database,
+  config: AppConfig,
+  log: (message: string) => void,
+): PlexMovieEnrichDeps | undefined {
+  if (!config.plex) {
+    return undefined;
+  }
+
+  return {
+    cache: new PlexCache(database),
+    client: new PlexHttpClient(
+      config.plex.url,
+      config.plex.token,
+      (m: string) => log(`[plex] ${m}`),
+    ),
+    refreshIntervalMinutes: config.plex.refreshIntervalMinutes,
+    log: (m: string) => log(`[plex] ${m}`),
+  };
+}
 
 function tmdbMovieEnrichDeps(
   database: Database,
@@ -197,6 +221,7 @@ export async function runCli(argv: string[]): Promise<number> {
 
         const tmdbMovies = tmdbMovieEnrichDeps(database, config, log);
         const tmdbShows = tmdbShowsEnrichDeps(database, config, log);
+        const plexMovies = plexMovieEnrichDeps(database, config, log);
         const tmdbRefreshIntervalMinutes =
           config.runtime.tmdbRefreshIntervalMinutes!;
         const scheduleTmdbRefresh =
@@ -258,6 +283,8 @@ export async function runCli(argv: string[]): Promise<number> {
           plexRefreshCycle: schedulePlexRefresh
             ? async () => {
                 await runPlexBackgroundRefresh({
+                  repository,
+                  plexMovies,
                   log,
                 });
               }
@@ -285,6 +312,7 @@ export async function runCli(argv: string[]): Promise<number> {
                   loadPollState,
                   tmdbMovies,
                   tmdbShows,
+                  plexMovies,
                   tmdbCache: tmdbMovies?.cache ?? tmdbShows?.cache,
                   onCandidateTmdbCacheError: (err, c) =>
                     log(

--- a/src/plex/background-refresh.ts
+++ b/src/plex/background-refresh.ts
@@ -1,9 +1,23 @@
+import { buildMovieBreakdowns } from '../api';
+import type { Repository } from '../repository';
+import type { PlexMovieEnrichDeps } from './movies';
+import { refreshMovieLibraryCache } from './movies';
+
 /**
- * Phase 18 foundation ticket: reserve the daemon hook and prove scheduling
- * works without introducing Plex matching behavior yet.
+ * Warm or refresh Plex cache for tracked media without blocking RSS intake.
  */
 export async function runPlexBackgroundRefresh(input: {
+  repository: Repository;
+  plexMovies?: PlexMovieEnrichDeps;
   log: (message: string) => void;
 }): Promise<void> {
-  input.log('[plex] background refresh noop');
+  const { repository, plexMovies, log } = input;
+  if (!plexMovies) {
+    return;
+  }
+
+  const candidates = repository.listCandidateStates();
+  const movies = buildMovieBreakdowns(candidates);
+  await refreshMovieLibraryCache(movies, plexMovies);
+  log('[plex] background refresh completed');
 }

--- a/src/plex/cache.ts
+++ b/src/plex/cache.ts
@@ -1,0 +1,73 @@
+import type { Database } from 'bun:sqlite';
+
+export type PlexMovieCacheRow = {
+  title: string;
+  year: number;
+  plexRatingKey: string | null;
+  inLibrary: boolean;
+  watchCount: number | null;
+  lastWatchedAt: string | null;
+  cachedAt: string;
+};
+
+export class PlexCache {
+  constructor(private readonly db: Database) {}
+
+  getMovie(title: string, year: number): PlexMovieCacheRow | undefined {
+    const row = this.db
+      .query(
+        `SELECT
+          title,
+          year,
+          plex_rating_key AS plexRatingKey,
+          in_library AS inLibrary,
+          watch_count AS watchCount,
+          last_watched_at AS lastWatchedAt,
+          cached_at AS cachedAt
+        FROM plex_movie_cache
+        WHERE title = ?1 AND year = ?2`,
+      )
+      .get(title, year) as
+      | (Omit<PlexMovieCacheRow, 'inLibrary'> & { inLibrary: number })
+      | null
+      | undefined;
+
+    if (!row) {
+      return undefined;
+    }
+
+    return {
+      ...row,
+      inLibrary: row.inLibrary === 1,
+    };
+  }
+
+  upsertMovie(row: PlexMovieCacheRow): void {
+    this.db.run(
+      `INSERT INTO plex_movie_cache (
+        title,
+        year,
+        plex_rating_key,
+        in_library,
+        watch_count,
+        last_watched_at,
+        cached_at
+      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+      ON CONFLICT(title, year) DO UPDATE SET
+        plex_rating_key = excluded.plex_rating_key,
+        in_library = excluded.in_library,
+        watch_count = excluded.watch_count,
+        last_watched_at = excluded.last_watched_at,
+        cached_at = excluded.cached_at`,
+      [
+        row.title,
+        row.year,
+        row.plexRatingKey,
+        row.inLibrary ? 1 : 0,
+        row.watchCount,
+        row.lastWatchedAt,
+        row.cachedAt,
+      ],
+    );
+  }
+}

--- a/src/plex/client.ts
+++ b/src/plex/client.ts
@@ -39,11 +39,33 @@ export class PlexHttpClient {
 
   async listLibrarySections(): Promise<PlexLibrarySection[]> {
     const container = await this.getXml('/library/sections');
+    if (!container) {
+      return [];
+    }
     const directories = asArray(container?.MediaContainer?.Directory);
     return directories.map((entry) => ({
       key: stringField(entry.key),
       type: optionalStringField(entry.type),
       title: optionalStringField(entry.title),
+    }));
+  }
+
+  async searchMovies(title: string): Promise<PlexSearchResult[] | null> {
+    const query = encodeURIComponent(title);
+    const container = await this.getXml(
+      `/library/search?query=${query}&type=1`,
+    );
+    if (!container) {
+      return null;
+    }
+    const videos = asArray(container?.MediaContainer?.Video);
+    return videos.map((entry) => ({
+      ratingKey: optionalStringField(entry.ratingKey),
+      title: optionalStringField(entry.title),
+      type: optionalStringField(entry.type),
+      year: optionalNumberField(entry.year),
+      viewCount: optionalNumberField(entry.viewCount),
+      lastViewedAt: optionalNumberField(entry.lastViewedAt),
     }));
   }
 
@@ -55,6 +77,9 @@ export class PlexHttpClient {
     const container = await this.getXml(
       `/library/sections/${encodeURIComponent(sectionKey)}/search?query=${query}`,
     );
+    if (!container) {
+      return [];
+    }
     const videos = asArray(container?.MediaContainer?.Video);
     return videos.map((entry) => ({
       ratingKey: optionalStringField(entry.ratingKey),

--- a/src/plex/movies.ts
+++ b/src/plex/movies.ts
@@ -1,0 +1,195 @@
+import type { MovieBreakdown } from '../movie-api-types';
+import type { PlexHttpClient, PlexSearchResult } from './client';
+import type { PlexCache } from './cache';
+
+const PLEX_MOVIE_MATCH_THRESHOLD = 0.72;
+
+export type PlexMovieEnrichDeps = {
+  cache: PlexCache;
+  client: PlexHttpClient;
+  refreshIntervalMinutes: number;
+  log: (message: string) => void;
+};
+
+export function enrichMovieBreakdownsFromPlexCache(
+  movies: MovieBreakdown[],
+  deps: Pick<PlexMovieEnrichDeps, 'cache' | 'refreshIntervalMinutes'>,
+): MovieBreakdown[] {
+  return movies.map((movie) => {
+    if (movie.year == null) {
+      return movie;
+    }
+
+    const row = deps.cache.getMovie(movie.normalizedTitle, movie.year);
+    if (!row || isPlexCacheExpired(row.cachedAt, deps.refreshIntervalMinutes)) {
+      return movie;
+    }
+
+    return {
+      ...movie,
+      plexStatus: row.inLibrary ? 'in_library' : 'missing',
+      watchCount: row.watchCount ?? 0,
+      lastWatchedAt: row.lastWatchedAt,
+    };
+  });
+}
+
+export async function refreshMovieLibraryCache(
+  movies: MovieBreakdown[],
+  deps: PlexMovieEnrichDeps,
+): Promise<void> {
+  const uniqueMovies = dedupeMovies(movies);
+
+  for (const movie of uniqueMovies) {
+    if (movie.year == null) {
+      continue;
+    }
+
+    const searchResults = await deps.client.searchMovies(movie.normalizedTitle);
+    if (searchResults === null) {
+      deps.log(
+        `plex movie refresh skipped for ${movie.normalizedTitle} (${String(movie.year)}): search unavailable`,
+      );
+      continue;
+    }
+
+    const best = selectBestMovieMatch(movie, searchResults);
+    const cachedAt = new Date().toISOString();
+
+    if (!best) {
+      deps.cache.upsertMovie({
+        title: movie.normalizedTitle,
+        year: movie.year,
+        plexRatingKey: null,
+        inLibrary: false,
+        watchCount: 0,
+        lastWatchedAt: null,
+        cachedAt,
+      });
+      continue;
+    }
+
+    deps.cache.upsertMovie({
+      title: movie.normalizedTitle,
+      year: movie.year,
+      plexRatingKey: best.ratingKey ?? null,
+      inLibrary: true,
+      watchCount: best.viewCount ?? 0,
+      lastWatchedAt:
+        best.lastViewedAt != null
+          ? new Date(best.lastViewedAt * 1000).toISOString()
+          : null,
+      cachedAt,
+    });
+  }
+}
+
+export function isPlexCacheExpired(
+  cachedAt: string,
+  refreshIntervalMinutes: number,
+): boolean {
+  const parsed = Date.parse(cachedAt);
+  if (Number.isNaN(parsed)) {
+    return true;
+  }
+
+  return parsed + refreshIntervalMinutes * 2 * 60_000 <= Date.now();
+}
+
+function dedupeMovies(movies: MovieBreakdown[]): MovieBreakdown[] {
+  const seen = new Set<string>();
+  const unique: MovieBreakdown[] = [];
+
+  for (const movie of movies) {
+    const key = `${movie.normalizedTitle.toLowerCase()}|${movie.year ?? '_'}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    unique.push(movie);
+  }
+
+  return unique;
+}
+
+function selectBestMovieMatch(
+  movie: MovieBreakdown,
+  candidates: PlexSearchResult[],
+): PlexSearchResult | undefined {
+  let best: { score: number; result: PlexSearchResult } | undefined;
+
+  for (const candidate of candidates) {
+    const score = movieMatchScore(movie, candidate);
+    if (score < PLEX_MOVIE_MATCH_THRESHOLD) {
+      continue;
+    }
+    if (!best || score > best.score) {
+      best = { score, result: candidate };
+    }
+  }
+
+  return best?.result;
+}
+
+function movieMatchScore(
+  movie: MovieBreakdown,
+  candidate: PlexSearchResult,
+): number {
+  const title = normalizeForMatch(movie.normalizedTitle);
+  const candidateTitle = normalizeForMatch(candidate.title ?? '');
+  if (!candidateTitle) {
+    return 0;
+  }
+
+  let score = diceCoefficient(title, candidateTitle);
+
+  if (movie.year != null && candidate.year != null) {
+    if (movie.year === candidate.year) {
+      score += 0.2;
+    } else {
+      score -= Math.min(Math.abs(movie.year - candidate.year) * 0.2, 0.6);
+    }
+  }
+
+  if (candidate.type && candidate.type !== 'movie') {
+    score -= 0.2;
+  }
+
+  return score;
+}
+
+function normalizeForMatch(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function diceCoefficient(left: string, right: string): number {
+  if (left === right) {
+    return 1;
+  }
+  if (left.length < 2 || right.length < 2) {
+    return 0;
+  }
+
+  const leftPairs = pairCounts(left);
+  const rightPairs = pairCounts(right);
+  let overlap = 0;
+
+  for (const [pair, leftCount] of leftPairs) {
+    const rightCount = rightPairs.get(pair) ?? 0;
+    overlap += Math.min(leftCount, rightCount);
+  }
+
+  return (2 * overlap) / (left.length - 1 + (right.length - 1));
+}
+
+function pairCounts(input: string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (let index = 0; index < input.length - 1; index += 1) {
+    const pair = input.slice(index, index + 2);
+    counts.set(pair, (counts.get(pair) ?? 0) + 1);
+  }
+  return counts;
+}

--- a/test/plex-movies.test.ts
+++ b/test/plex-movies.test.ts
@@ -1,0 +1,235 @@
+import { Database } from 'bun:sqlite';
+import { describe, expect, it } from 'bun:test';
+
+import { createApiFetch, createHealthState } from '../src/api';
+import { PlexCache } from '../src/plex/cache';
+import {
+  enrichMovieBreakdownsFromPlexCache,
+  isPlexCacheExpired,
+  refreshMovieLibraryCache,
+} from '../src/plex/movies';
+import { ensurePlexSchema } from '../src/plex/schema';
+import type { Repository } from '../src/repository';
+
+function stubRepository(): Repository {
+  return {
+    startRun: () => ({ id: 1, startedAt: '', status: 'running' }),
+    getRun: () => undefined,
+    completeRun: () => ({ id: 1, startedAt: '', status: 'completed' }),
+    failRun: () => ({ id: 1, startedAt: '', status: 'failed' }),
+    recordFeedItem: () => ({}) as never,
+    getCandidateState: () => undefined,
+    isCandidateQueued: () => false,
+    recordCandidateOutcome: () => ({}) as never,
+    recordCandidateReconciliation: () => ({}) as never,
+    recordFeedItemOutcome: () => ({}) as never,
+    listFeedItemOutcomes: () => [],
+    listRecentRunSummaries: () => [],
+    listCandidateStates: () => [],
+    listReconcilableCandidates: () => [],
+    listRetryableCandidates: () => [],
+    listSkippedNoMatchOutcomes: () => [],
+  };
+}
+
+describe('plex movie enrichment', () => {
+  it('writes an in-library movie cache row when Plex returns a strong match', async () => {
+    const db = new Database(':memory:');
+    ensurePlexSchema(db);
+    const cache = new PlexCache(db);
+
+    await refreshMovieLibraryCache(
+      [
+        {
+          normalizedTitle: 'Example Film',
+          year: 2024,
+          identityKey: 'movie:example film|2024',
+          status: 'queued',
+          plexStatus: 'unknown',
+          watchCount: null,
+          lastWatchedAt: null,
+        },
+      ],
+      {
+        cache,
+        client: {
+          searchMovies: async () => [
+            {
+              ratingKey: '123',
+              title: 'Example Film',
+              type: 'movie',
+              year: 2024,
+              viewCount: 4,
+              lastViewedAt: 1_712_793_600,
+            },
+          ],
+        } as never,
+        refreshIntervalMinutes: 30,
+        log: () => {},
+      },
+    );
+
+    expect(cache.getMovie('Example Film', 2024)).toMatchObject({
+      inLibrary: true,
+      plexRatingKey: '123',
+      watchCount: 4,
+      lastWatchedAt: '2024-04-11T00:00:00.000Z',
+    });
+  });
+
+  it('writes a missing cache row when Plex returns no usable match', async () => {
+    const db = new Database(':memory:');
+    ensurePlexSchema(db);
+    const cache = new PlexCache(db);
+
+    await refreshMovieLibraryCache(
+      [
+        {
+          normalizedTitle: 'Missing Film',
+          year: 2024,
+          identityKey: 'movie:missing film|2024',
+          status: 'queued',
+          plexStatus: 'unknown',
+          watchCount: null,
+          lastWatchedAt: null,
+        },
+      ],
+      {
+        cache,
+        client: {
+          searchMovies: async () => [],
+        } as never,
+        refreshIntervalMinutes: 30,
+        log: () => {},
+      },
+    );
+
+    expect(cache.getMovie('Missing Film', 2024)).toMatchObject({
+      inLibrary: false,
+      watchCount: 0,
+      lastWatchedAt: null,
+    });
+  });
+
+  it('treats stale Plex cache rows as unknown on API enrichment', () => {
+    const db = new Database(':memory:');
+    ensurePlexSchema(db);
+    const cache = new PlexCache(db);
+    cache.upsertMovie({
+      title: 'Stale Film',
+      year: 2024,
+      plexRatingKey: '123',
+      inLibrary: true,
+      watchCount: 2,
+      lastWatchedAt: '2026-04-01T00:00:00.000Z',
+      cachedAt: '2026-04-01T00:00:00.000Z',
+    });
+
+    const movies = enrichMovieBreakdownsFromPlexCache(
+      [
+        {
+          normalizedTitle: 'Stale Film',
+          year: 2024,
+          identityKey: 'movie:stale film|2024',
+          status: 'queued',
+          plexStatus: 'unknown',
+          watchCount: null,
+          lastWatchedAt: null,
+        },
+      ],
+      {
+        cache,
+        refreshIntervalMinutes: 30,
+      },
+    );
+
+    expect(movies[0]).toMatchObject({
+      plexStatus: 'unknown',
+      watchCount: null,
+      lastWatchedAt: null,
+    });
+    expect(isPlexCacheExpired('2026-04-01T00:00:00.000Z', 30)).toBe(true);
+  });
+
+  it('surfaces Plex cache fields in GET /api/movies', async () => {
+    const db = new Database(':memory:');
+    ensurePlexSchema(db);
+    const cache = new PlexCache(db);
+    cache.upsertMovie({
+      title: 'Example Film',
+      year: 2024,
+      plexRatingKey: '123',
+      inLibrary: true,
+      watchCount: 5,
+      lastWatchedAt: '2026-04-15T00:00:00.000Z',
+      cachedAt: new Date().toISOString(),
+    });
+
+    const handler = createApiFetch({
+      repository: {
+        ...stubRepository(),
+        listCandidateStates: () =>
+          [
+            {
+              identityKey: 'movie:example film|2024',
+              mediaType: 'movie',
+              status: 'queued',
+              ruleName: 'Example Film',
+              score: 100,
+              reasons: ['matched'],
+              rawTitle: 'Example Film 2024 1080p',
+              normalizedTitle: 'Example Film',
+              year: 2024,
+              feedName: 'Movie Feed',
+              guidOrLink: 'https://example.test/movie',
+              publishedAt: '2026-01-01T00:00:00Z',
+              downloadUrl: 'https://example.test/movie.torrent',
+              firstSeenRunId: 1,
+              lastSeenRunId: 1,
+              updatedAt: '2026-01-01T00:00:00Z',
+            },
+          ] as never,
+      },
+      health: createHealthState(),
+      config: {
+        feeds: [],
+        tv: [],
+        movies: {
+          years: [2024],
+          resolutions: ['1080p'],
+          codecs: ['x265'],
+          codecPolicy: 'prefer',
+        },
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+        },
+        runtime: {
+          runIntervalMinutes: 30,
+          reconcileIntervalMinutes: 1,
+          artifactDir: '.pirate-claw/runtime',
+          artifactRetentionDays: 7,
+        },
+      },
+      configPath: '/nonexistent/pirate-claw.config.json',
+      pollStatePath: '/nonexistent/poll-state.json',
+      loadPollState: () => ({ feeds: {} }),
+      plexMovies: {
+        cache,
+        client: {} as never,
+        refreshIntervalMinutes: 30,
+        log: () => {},
+      },
+    });
+
+    const response = await handler(new Request('http://localhost/api/movies'));
+    const body = await response.json();
+
+    expect(body.movies[0]).toMatchObject({
+      plexStatus: 'in_library',
+      watchCount: 5,
+      lastWatchedAt: '2026-04-15T00:00:00.000Z',
+    });
+  });
+});

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -64,6 +64,8 @@ export type TmdbTvShowMeta = {
 	numberOfSeasons?: number;
 };
 
+export type PlexStatus = 'in_library' | 'missing' | 'unknown';
+
 export type ShowEpisode = {
 	episode: number;
 	identityKey: string;
@@ -83,6 +85,9 @@ export type ShowSeason = {
 export type ShowBreakdown = {
 	normalizedTitle: string;
 	seasons: ShowSeason[];
+	plexStatus: PlexStatus;
+	watchCount: number | null;
+	lastWatchedAt: string | null;
 	tmdb?: TmdbTvShowMeta;
 };
 
@@ -107,6 +112,9 @@ export type MovieBreakdown = {
 	queuedAt?: string;
 	transmissionPercentDone?: number;
 	transmissionTorrentHash?: string;
+	plexStatus: PlexStatus;
+	watchCount: number | null;
+	lastWatchedAt: string | null;
 	tmdb?: TmdbMoviePublic;
 };
 

--- a/web/src/routes/movies/+page.svelte
+++ b/web/src/routes/movies/+page.svelte
@@ -61,6 +61,35 @@
 		}
 	}
 
+	function plexChipClass(status: MovieBreakdown['plexStatus']): string {
+		switch (status) {
+			case 'in_library':
+				return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200';
+			case 'missing':
+				return 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200';
+			default:
+				return 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300';
+		}
+	}
+
+	function plexStatusLabel(status: MovieBreakdown['plexStatus']): string {
+		switch (status) {
+			case 'in_library':
+				return 'In library';
+			case 'missing':
+				return 'Missing';
+			default:
+				return 'Unknown';
+		}
+	}
+
+	function formatLastWatched(value: string | null): string {
+		if (!value) return '—';
+		const date = new Date(value);
+		if (Number.isNaN(date.getTime())) return '—';
+		return date.toLocaleDateString();
+	}
+
 	/** Unified downloading predicate used in tab counts, filtering, and row rendering. */
 	function isMovieDownloading(m: MovieBreakdown): boolean {
 		return m.status === 'downloading' || m.lifecycleStatus === 'active';
@@ -276,6 +305,22 @@
 											<dd class="text-foreground inline">{movie.codec}</dd>
 										</div>
 									{/if}
+									<div>
+										<dt class="inline">Plex:</dt>
+										<dd class="inline">
+											<Badge variant="secondary" class={plexChipClass(movie.plexStatus)}>
+												{plexStatusLabel(movie.plexStatus)}
+											</Badge>
+										</dd>
+									</div>
+									<div>
+										<dt class="inline">Watches:</dt>
+										<dd class="text-foreground inline">{movie.watchCount ?? '—'}</dd>
+									</div>
+									<div>
+										<dt class="inline">Last watched:</dt>
+										<dd class="text-foreground inline">{formatLastWatched(movie.lastWatchedAt)}</dd>
+									</div>
 								</dl>
 								<!-- Progress bar -->
 								{#if showProgress}

--- a/web/src/routes/movies/movies.test.ts
+++ b/web/src/routes/movies/movies.test.ts
@@ -10,6 +10,9 @@ const mockMovie = (overrides: Partial<MovieBreakdown> = {}): MovieBreakdown => (
 	year: 2020,
 	resolution: '1080p',
 	codec: 'h264',
+	plexStatus: 'unknown',
+	watchCount: null,
+	lastWatchedAt: null,
 	tmdb: {
 		title: 'Example Film',
 		posterUrl: 'https://example.com/poster.jpg',
@@ -39,6 +42,28 @@ describe('/movies', () => {
 		expect(screen.getByText('A test overview.')).toBeInTheDocument();
 		expect(screen.getByLabelText(/TMDB vote average/)).toHaveTextContent('★ 7.2');
 		expect(screen.getByText('1080p')).toBeInTheDocument();
+	});
+
+	it('renders Plex status, watch count, and last watched date', () => {
+		render(Page, {
+			data: {
+				movies: [
+					mockMovie({
+						plexStatus: 'in_library',
+						watchCount: 3,
+						lastWatchedAt: '2026-04-15T00:00:00.000Z'
+					})
+				],
+				torrents: null,
+				error: null
+			}
+		});
+
+		expect(screen.getByText('In library')).toBeInTheDocument();
+		expect(screen.getByText('3')).toBeInTheDocument();
+		expect(
+			screen.getByText(new Date('2026-04-15T00:00:00.000Z').toLocaleDateString())
+		).toBeInTheDocument();
 	});
 
 	it('filter tabs render correct counts', () => {

--- a/web/src/routes/shows/[slug]/shows.test.ts
+++ b/web/src/routes/shows/[slug]/shows.test.ts
@@ -5,6 +5,9 @@ import type { ShowBreakdown, TorrentStatSnapshot } from '$lib/types';
 
 const mockShow: ShowBreakdown = {
 	normalizedTitle: 'The Show',
+	plexStatus: 'unknown',
+	watchCount: null,
+	lastWatchedAt: null,
 	seasons: [
 		{
 			season: 1,

--- a/web/src/routes/shows/shows.test.ts
+++ b/web/src/routes/shows/shows.test.ts
@@ -5,6 +5,9 @@ import type { ShowBreakdown } from '$lib/types';
 
 const mockShow: ShowBreakdown = {
 	normalizedTitle: 'The Example Show',
+	plexStatus: 'unknown',
+	watchCount: null,
+	lastWatchedAt: null,
 	seasons: [
 		{
 			season: 1,
@@ -35,6 +38,9 @@ const mockShow: ShowBreakdown = {
 
 const mockShow2: ShowBreakdown = {
 	normalizedTitle: 'Another Show',
+	plexStatus: 'unknown',
+	watchCount: null,
+	lastWatchedAt: null,
 	seasons: [
 		{
 			season: 1,


### PR DESCRIPTION
## Summary

- delivery ticket: `P18.02 Movies vertical slice: Plex match, cache enrichment, /api/movies fields, movie UI`
- ticket file: [docs/02-delivery/phase-18/ticket-02-movies-vertical-slice.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-18/ticket-02-movies-vertical-slice.md)
- stacked base branch: `agents/p18-01-foundation-plex-config-http-client-sqlite-cache-scheduler-skeleton-graceful-no-op`
- self-audit: outcome `clean` completed at 2026-04-16 13:43 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`82f45a9c1980`](https://github.com/cesarnml/pirate_claw/commit/82f45a9c1980a1708e51d27530def64e4ba8ac55)
- current branch head: [`82f45a9c1980`](https://github.com/cesarnml/pirate_claw/commit/82f45a9c1980a1708e51d27530def64e4ba8ac55)
- vendors: `coderabbit`
