### PR TITLE
feat: enrich shows with Plex cache [P18.03]

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -38,6 +38,8 @@ import type { TvEnrichDeps } from './tmdb/tv-enrichment';
 import { enrichShowBreakdowns } from './tmdb/tv-enrichment';
 import type { PlexMovieEnrichDeps } from './plex/movies';
 import { enrichMovieBreakdownsFromPlexCache } from './plex/movies';
+import type { PlexShowEnrichDeps } from './plex/shows';
+import { enrichShowBreakdownsFromPlexCache } from './plex/shows';
 
 export type CycleSnapshot = {
   status: CycleResult['status'];
@@ -94,6 +96,8 @@ export type ApiFetchDeps = {
   tmdbMovies?: MovieEnrichDeps;
   /** When set (Plex configured), GET /api/movies merges Plex cache status only. */
   plexMovies?: PlexMovieEnrichDeps;
+  /** When set (Plex configured), GET /api/shows merges Plex cache status only. */
+  plexShows?: PlexShowEnrichDeps;
   /** When set (TMDB configured), GET /api/shows lazily enriches from cache + TMDB. */
   tmdbShows?: TvEnrichDeps;
   /**
@@ -147,6 +151,7 @@ export function createApiFetch(
     loadPollState,
     tmdbMovies,
     plexMovies,
+    plexShows,
     tmdbShows,
     tmdbCache,
     onCandidateTmdbCacheError,
@@ -190,9 +195,12 @@ export function createApiFetch(
       try {
         const candidates = repository.listCandidateStates();
         const base = buildShowBreakdowns(candidates);
-        const shows = tmdbShows
-          ? await enrichShowBreakdowns(base, tmdbShows)
+        const withPlex = plexShows
+          ? enrichShowBreakdownsFromPlexCache(base, plexShows)
           : base;
+        const shows = tmdbShows
+          ? await enrichShowBreakdowns(withPlex, tmdbShows)
+          : withPlex;
         return Response.json({ shows });
       } catch {
         return json500();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ import { runPlexBackgroundRefresh } from './plex/background-refresh';
 import { PlexCache } from './plex/cache';
 import { PlexHttpClient } from './plex/client';
 import type { PlexMovieEnrichDeps } from './plex/movies';
+import type { PlexShowEnrichDeps } from './plex/shows';
 import {
   filterDueFeeds,
   loadPollState,
@@ -52,6 +53,27 @@ function plexMovieEnrichDeps(
   config: AppConfig,
   log: (message: string) => void,
 ): PlexMovieEnrichDeps | undefined {
+  if (!config.plex) {
+    return undefined;
+  }
+
+  return {
+    cache: new PlexCache(database),
+    client: new PlexHttpClient(
+      config.plex.url,
+      config.plex.token,
+      (m: string) => log(`[plex] ${m}`),
+    ),
+    refreshIntervalMinutes: config.plex.refreshIntervalMinutes,
+    log: (m: string) => log(`[plex] ${m}`),
+  };
+}
+
+function plexShowEnrichDeps(
+  database: Database,
+  config: AppConfig,
+  log: (message: string) => void,
+): PlexShowEnrichDeps | undefined {
   if (!config.plex) {
     return undefined;
   }
@@ -222,6 +244,7 @@ export async function runCli(argv: string[]): Promise<number> {
         const tmdbMovies = tmdbMovieEnrichDeps(database, config, log);
         const tmdbShows = tmdbShowsEnrichDeps(database, config, log);
         const plexMovies = plexMovieEnrichDeps(database, config, log);
+        const plexShows = plexShowEnrichDeps(database, config, log);
         const tmdbRefreshIntervalMinutes =
           config.runtime.tmdbRefreshIntervalMinutes!;
         const scheduleTmdbRefresh =
@@ -285,6 +308,7 @@ export async function runCli(argv: string[]): Promise<number> {
                 await runPlexBackgroundRefresh({
                   repository,
                   plexMovies,
+                  plexShows,
                   log,
                 });
               }
@@ -311,6 +335,7 @@ export async function runCli(argv: string[]): Promise<number> {
                   pollStatePath,
                   loadPollState,
                   tmdbMovies,
+                  plexShows,
                   tmdbShows,
                   plexMovies,
                   tmdbCache: tmdbMovies?.cache ?? tmdbShows?.cache,

--- a/src/plex/background-refresh.ts
+++ b/src/plex/background-refresh.ts
@@ -22,12 +22,22 @@ export async function runPlexBackgroundRefresh(input: {
 
   const candidates = repository.listCandidateStates();
   if (plexMovies) {
-    const movies = buildMovieBreakdowns(candidates);
-    await refreshMovieLibraryCache(movies, plexMovies);
+    try {
+      const movies = buildMovieBreakdowns(candidates);
+      await refreshMovieLibraryCache(movies, plexMovies);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log(`[plex] movie refresh failed: ${message}`);
+    }
   }
   if (plexShows) {
-    const shows = buildShowBreakdowns(candidates);
-    await refreshShowLibraryCache(shows, plexShows);
+    try {
+      const shows = buildShowBreakdowns(candidates);
+      await refreshShowLibraryCache(shows, plexShows);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log(`[plex] show refresh failed: ${message}`);
+    }
   }
   log('[plex] background refresh completed');
 }

--- a/src/plex/background-refresh.ts
+++ b/src/plex/background-refresh.ts
@@ -1,7 +1,10 @@
 import { buildMovieBreakdowns } from '../api';
+import { buildShowBreakdowns } from '../api';
 import type { Repository } from '../repository';
 import type { PlexMovieEnrichDeps } from './movies';
 import { refreshMovieLibraryCache } from './movies';
+import type { PlexShowEnrichDeps } from './shows';
+import { refreshShowLibraryCache } from './shows';
 
 /**
  * Warm or refresh Plex cache for tracked media without blocking RSS intake.
@@ -9,15 +12,22 @@ import { refreshMovieLibraryCache } from './movies';
 export async function runPlexBackgroundRefresh(input: {
   repository: Repository;
   plexMovies?: PlexMovieEnrichDeps;
+  plexShows?: PlexShowEnrichDeps;
   log: (message: string) => void;
 }): Promise<void> {
-  const { repository, plexMovies, log } = input;
-  if (!plexMovies) {
+  const { repository, plexMovies, plexShows, log } = input;
+  if (!plexMovies && !plexShows) {
     return;
   }
 
   const candidates = repository.listCandidateStates();
-  const movies = buildMovieBreakdowns(candidates);
-  await refreshMovieLibraryCache(movies, plexMovies);
+  if (plexMovies) {
+    const movies = buildMovieBreakdowns(candidates);
+    await refreshMovieLibraryCache(movies, plexMovies);
+  }
+  if (plexShows) {
+    const shows = buildShowBreakdowns(candidates);
+    await refreshShowLibraryCache(shows, plexShows);
+  }
   log('[plex] background refresh completed');
 }

--- a/src/plex/cache.ts
+++ b/src/plex/cache.ts
@@ -70,4 +70,68 @@ export class PlexCache {
       ],
     );
   }
+
+  getTv(normalizedTitle: string): PlexTvCacheRow | undefined {
+    const row = this.db
+      .query(
+        `SELECT
+          normalized_title AS normalizedTitle,
+          plex_rating_key AS plexRatingKey,
+          in_library AS inLibrary,
+          watch_count AS watchCount,
+          last_watched_at AS lastWatchedAt,
+          cached_at AS cachedAt
+        FROM plex_tv_cache
+        WHERE normalized_title = ?1`,
+      )
+      .get(normalizedTitle) as
+      | (Omit<PlexTvCacheRow, 'inLibrary'> & { inLibrary: number })
+      | null
+      | undefined;
+
+    if (!row) {
+      return undefined;
+    }
+
+    return {
+      ...row,
+      inLibrary: row.inLibrary === 1,
+    };
+  }
+
+  upsertTv(row: PlexTvCacheRow): void {
+    this.db.run(
+      `INSERT INTO plex_tv_cache (
+        normalized_title,
+        plex_rating_key,
+        in_library,
+        watch_count,
+        last_watched_at,
+        cached_at
+      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+      ON CONFLICT(normalized_title) DO UPDATE SET
+        plex_rating_key = excluded.plex_rating_key,
+        in_library = excluded.in_library,
+        watch_count = excluded.watch_count,
+        last_watched_at = excluded.last_watched_at,
+        cached_at = excluded.cached_at`,
+      [
+        row.normalizedTitle,
+        row.plexRatingKey,
+        row.inLibrary ? 1 : 0,
+        row.watchCount,
+        row.lastWatchedAt,
+        row.cachedAt,
+      ],
+    );
+  }
 }
+
+export type PlexTvCacheRow = {
+  normalizedTitle: string;
+  plexRatingKey: string | null;
+  inLibrary: boolean;
+  watchCount: number | null;
+  lastWatchedAt: string | null;
+  cachedAt: string;
+};

--- a/src/plex/client.ts
+++ b/src/plex/client.ts
@@ -69,6 +69,25 @@ export class PlexHttpClient {
     }));
   }
 
+  async searchShows(title: string): Promise<PlexSearchResult[] | null> {
+    const query = encodeURIComponent(title);
+    const container = await this.getXml(
+      `/library/search?query=${query}&type=2`,
+    );
+    if (!container) {
+      return null;
+    }
+    const videos = asArray(container?.MediaContainer?.Directory);
+    return videos.map((entry) => ({
+      ratingKey: optionalStringField(entry.ratingKey),
+      title: optionalStringField(entry.title),
+      type: optionalStringField(entry.type),
+      year: optionalNumberField(entry.year),
+      viewCount: optionalNumberField(entry.viewCount),
+      lastViewedAt: optionalNumberField(entry.lastViewedAt),
+    }));
+  }
+
   async searchLibrary(
     sectionKey: string,
     title: string,

--- a/src/plex/shows.ts
+++ b/src/plex/shows.ts
@@ -40,40 +40,47 @@ export async function refreshShowLibraryCache(
   const uniqueShows = dedupeShows(shows);
 
   for (const show of uniqueShows) {
-    const searchResults = await deps.client.searchShows(show.normalizedTitle);
-    if (searchResults === null) {
-      deps.log(
-        `plex show refresh skipped for ${show.normalizedTitle}: search unavailable`,
-      );
-      continue;
-    }
+    try {
+      const searchResults = await deps.client.searchShows(show.normalizedTitle);
+      if (searchResults === null) {
+        deps.log(
+          `plex show refresh skipped for ${show.normalizedTitle}: search unavailable`,
+        );
+        continue;
+      }
 
-    const best = selectBestShowMatch(show, searchResults);
-    const cachedAt = new Date().toISOString();
+      const best = selectBestShowMatch(show, searchResults);
+      const cachedAt = new Date().toISOString();
 
-    if (!best) {
+      if (!best) {
+        deps.cache.upsertTv({
+          normalizedTitle: show.normalizedTitle,
+          plexRatingKey: null,
+          inLibrary: false,
+          watchCount: 0,
+          lastWatchedAt: null,
+          cachedAt,
+        });
+        continue;
+      }
+
       deps.cache.upsertTv({
         normalizedTitle: show.normalizedTitle,
-        plexRatingKey: null,
-        inLibrary: false,
-        watchCount: 0,
-        lastWatchedAt: null,
+        plexRatingKey: best.ratingKey ?? null,
+        inLibrary: true,
+        watchCount: best.viewCount ?? 0,
+        lastWatchedAt:
+          best.lastViewedAt != null
+            ? new Date(best.lastViewedAt * 1000).toISOString()
+            : null,
         cachedAt,
       });
-      continue;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      deps.log(
+        `plex show refresh failed for ${show.normalizedTitle}: ${message}`,
+      );
     }
-
-    deps.cache.upsertTv({
-      normalizedTitle: show.normalizedTitle,
-      plexRatingKey: best.ratingKey ?? null,
-      inLibrary: true,
-      watchCount: best.viewCount ?? 0,
-      lastWatchedAt:
-        best.lastViewedAt != null
-          ? new Date(best.lastViewedAt * 1000).toISOString()
-          : null,
-      cachedAt,
-    });
   }
 }
 

--- a/src/plex/shows.ts
+++ b/src/plex/shows.ts
@@ -1,0 +1,179 @@
+import type { ShowBreakdown } from '../tv-api-types';
+import type { PlexHttpClient, PlexSearchResult } from './client';
+import type { PlexCache } from './cache';
+
+const PLEX_SHOW_MATCH_THRESHOLD = 0.72;
+
+export type PlexShowEnrichDeps = {
+  cache: PlexCache;
+  client: PlexHttpClient;
+  refreshIntervalMinutes: number;
+  log: (message: string) => void;
+};
+
+export function enrichShowBreakdownsFromPlexCache(
+  shows: ShowBreakdown[],
+  deps: Pick<PlexShowEnrichDeps, 'cache' | 'refreshIntervalMinutes'>,
+): ShowBreakdown[] {
+  return shows.map((show) => {
+    const row = deps.cache.getTv(show.normalizedTitle);
+    if (
+      !row ||
+      isPlexShowCacheExpired(row.cachedAt, deps.refreshIntervalMinutes)
+    ) {
+      return show;
+    }
+
+    return {
+      ...show,
+      plexStatus: row.inLibrary ? 'in_library' : 'missing',
+      watchCount: row.watchCount ?? 0,
+      lastWatchedAt: row.lastWatchedAt,
+    };
+  });
+}
+
+export async function refreshShowLibraryCache(
+  shows: ShowBreakdown[],
+  deps: PlexShowEnrichDeps,
+): Promise<void> {
+  const uniqueShows = dedupeShows(shows);
+
+  for (const show of uniqueShows) {
+    const searchResults = await deps.client.searchShows(show.normalizedTitle);
+    if (searchResults === null) {
+      deps.log(
+        `plex show refresh skipped for ${show.normalizedTitle}: search unavailable`,
+      );
+      continue;
+    }
+
+    const best = selectBestShowMatch(show, searchResults);
+    const cachedAt = new Date().toISOString();
+
+    if (!best) {
+      deps.cache.upsertTv({
+        normalizedTitle: show.normalizedTitle,
+        plexRatingKey: null,
+        inLibrary: false,
+        watchCount: 0,
+        lastWatchedAt: null,
+        cachedAt,
+      });
+      continue;
+    }
+
+    deps.cache.upsertTv({
+      normalizedTitle: show.normalizedTitle,
+      plexRatingKey: best.ratingKey ?? null,
+      inLibrary: true,
+      watchCount: best.viewCount ?? 0,
+      lastWatchedAt:
+        best.lastViewedAt != null
+          ? new Date(best.lastViewedAt * 1000).toISOString()
+          : null,
+      cachedAt,
+    });
+  }
+}
+
+export function isPlexShowCacheExpired(
+  cachedAt: string,
+  refreshIntervalMinutes: number,
+): boolean {
+  const parsed = Date.parse(cachedAt);
+  if (Number.isNaN(parsed)) {
+    return true;
+  }
+
+  return parsed + refreshIntervalMinutes * 2 * 60_000 <= Date.now();
+}
+
+function dedupeShows(shows: ShowBreakdown[]): ShowBreakdown[] {
+  const seen = new Set<string>();
+  const unique: ShowBreakdown[] = [];
+
+  for (const show of shows) {
+    const key = show.normalizedTitle.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    unique.push(show);
+  }
+
+  return unique;
+}
+
+function selectBestShowMatch(
+  show: ShowBreakdown,
+  candidates: PlexSearchResult[],
+): PlexSearchResult | undefined {
+  let best: { score: number; result: PlexSearchResult } | undefined;
+
+  for (const candidate of candidates) {
+    const score = showMatchScore(show, candidate);
+    if (score < PLEX_SHOW_MATCH_THRESHOLD) {
+      continue;
+    }
+    if (!best || score > best.score) {
+      best = { score, result: candidate };
+    }
+  }
+
+  return best?.result;
+}
+
+function showMatchScore(
+  show: ShowBreakdown,
+  candidate: PlexSearchResult,
+): number {
+  const title = normalizeForMatch(show.normalizedTitle);
+  const candidateTitle = normalizeForMatch(candidate.title ?? '');
+  if (!candidateTitle) {
+    return 0;
+  }
+
+  let score = diceCoefficient(title, candidateTitle);
+  if (candidate.type && candidate.type !== 'show') {
+    score -= 0.2;
+  }
+
+  return score;
+}
+
+function normalizeForMatch(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function diceCoefficient(left: string, right: string): number {
+  if (left === right) {
+    return 1;
+  }
+  if (left.length < 2 || right.length < 2) {
+    return 0;
+  }
+
+  const leftPairs = pairCounts(left);
+  const rightPairs = pairCounts(right);
+  let overlap = 0;
+
+  for (const [pair, leftCount] of leftPairs) {
+    const rightCount = rightPairs.get(pair) ?? 0;
+    overlap += Math.min(leftCount, rightCount);
+  }
+
+  return (2 * overlap) / (left.length - 1 + (right.length - 1));
+}
+
+function pairCounts(input: string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (let index = 0; index < input.length - 1; index += 1) {
+    const pair = input.slice(index, index + 2);
+    counts.set(pair, (counts.get(pair) ?? 0) + 1);
+  }
+  return counts;
+}

--- a/test/plex-shows.test.ts
+++ b/test/plex-shows.test.ts
@@ -2,6 +2,7 @@ import { Database } from 'bun:sqlite';
 import { describe, expect, it } from 'bun:test';
 
 import { createApiFetch, createHealthState } from '../src/api';
+import { runPlexBackgroundRefresh } from '../src/plex/background-refresh';
 import { PlexCache } from '../src/plex/cache';
 import {
   enrichShowBreakdownsFromPlexCache,
@@ -223,5 +224,144 @@ describe('plex show enrichment', () => {
       watchCount: 5,
       lastWatchedAt: '2026-04-15T00:00:00.000Z',
     });
+  });
+
+  it('continues refreshing later shows when one show lookup throws', async () => {
+    const db = new Database(':memory:');
+    ensurePlexSchema(db);
+    const cache = new PlexCache(db);
+
+    await refreshShowLibraryCache(
+      [
+        {
+          normalizedTitle: 'Broken Show',
+          seasons: [],
+          plexStatus: 'unknown',
+          watchCount: null,
+          lastWatchedAt: null,
+        },
+        {
+          normalizedTitle: 'Healthy Show',
+          seasons: [],
+          plexStatus: 'unknown',
+          watchCount: null,
+          lastWatchedAt: null,
+        },
+      ],
+      {
+        cache,
+        client: {
+          searchShows: async (title: string) => {
+            if (title === 'Broken Show') {
+              throw new Error('boom');
+            }
+            return [
+              {
+                ratingKey: '789',
+                title: 'Healthy Show',
+                type: 'show',
+                viewCount: 1,
+              },
+            ];
+          },
+        } as never,
+        refreshIntervalMinutes: 30,
+        log: () => {},
+      },
+    );
+
+    expect(cache.getTv('Broken Show')).toBeUndefined();
+    expect(cache.getTv('Healthy Show')).toMatchObject({
+      inLibrary: true,
+      plexRatingKey: '789',
+    });
+  });
+
+  it('continues the show sweep when the movie sweep fails', async () => {
+    const db = new Database(':memory:');
+    ensurePlexSchema(db);
+    const cache = new PlexCache(db);
+    const log: string[] = [];
+
+    await runPlexBackgroundRefresh({
+      repository: {
+        ...stubRepository(),
+        listCandidateStates: () =>
+          [
+            {
+              identityKey: 'movie:example film|2024',
+              mediaType: 'movie',
+              status: 'queued',
+              ruleName: 'Example Film',
+              score: 100,
+              reasons: ['matched'],
+              rawTitle: 'Example Film 2024 1080p',
+              normalizedTitle: 'Example Film',
+              year: 2024,
+              feedName: 'Movie Feed',
+              guidOrLink: 'https://example.test/movie',
+              publishedAt: '2026-01-01T00:00:00Z',
+              downloadUrl: 'https://example.test/movie.torrent',
+              firstSeenRunId: 1,
+              lastSeenRunId: 1,
+              updatedAt: '2026-01-01T00:00:00Z',
+            },
+            {
+              identityKey: 'tv:example show|1|1',
+              mediaType: 'tv',
+              status: 'queued',
+              ruleName: 'Example Show',
+              score: 100,
+              reasons: ['matched'],
+              rawTitle: 'Example.Show.S01E01.1080p',
+              normalizedTitle: 'Example Show',
+              season: 1,
+              episode: 1,
+              feedName: 'TV Feed',
+              guidOrLink: 'https://example.test/show',
+              publishedAt: '2026-01-01T00:00:00Z',
+              downloadUrl: 'https://example.test/show.torrent',
+              firstSeenRunId: 1,
+              lastSeenRunId: 1,
+              updatedAt: '2026-01-01T00:00:00Z',
+            },
+          ] as never,
+      },
+      plexMovies: {
+        cache,
+        client: {
+          searchMovies: async () => {
+            throw new Error('movie sweep failed');
+          },
+        } as never,
+        refreshIntervalMinutes: 30,
+        log: () => {},
+      },
+      plexShows: {
+        cache,
+        client: {
+          searchShows: async () => [
+            {
+              ratingKey: '456',
+              title: 'Example Show',
+              type: 'show',
+              viewCount: 2,
+            },
+          ],
+        } as never,
+        refreshIntervalMinutes: 30,
+        log: () => {},
+      },
+      log: (message: string) => log.push(message),
+    });
+
+    expect(cache.getTv('Example Show')).toMatchObject({
+      inLibrary: true,
+      plexRatingKey: '456',
+    });
+    expect(log.some((entry) => entry.includes('movie refresh failed'))).toBe(
+      true,
+    );
+    expect(log).toContain('[plex] background refresh completed');
   });
 });

--- a/test/plex-shows.test.ts
+++ b/test/plex-shows.test.ts
@@ -1,0 +1,227 @@
+import { Database } from 'bun:sqlite';
+import { describe, expect, it } from 'bun:test';
+
+import { createApiFetch, createHealthState } from '../src/api';
+import { PlexCache } from '../src/plex/cache';
+import {
+  enrichShowBreakdownsFromPlexCache,
+  isPlexShowCacheExpired,
+  refreshShowLibraryCache,
+} from '../src/plex/shows';
+import { ensurePlexSchema } from '../src/plex/schema';
+import type { Repository } from '../src/repository';
+
+function stubRepository(): Repository {
+  return {
+    startRun: () => ({ id: 1, startedAt: '', status: 'running' }),
+    getRun: () => undefined,
+    completeRun: () => ({ id: 1, startedAt: '', status: 'completed' }),
+    failRun: () => ({ id: 1, startedAt: '', status: 'failed' }),
+    recordFeedItem: () => ({}) as never,
+    getCandidateState: () => undefined,
+    isCandidateQueued: () => false,
+    recordCandidateOutcome: () => ({}) as never,
+    recordCandidateReconciliation: () => ({}) as never,
+    recordFeedItemOutcome: () => ({}) as never,
+    listFeedItemOutcomes: () => [],
+    listRecentRunSummaries: () => [],
+    listCandidateStates: () => [],
+    listReconcilableCandidates: () => [],
+    listRetryableCandidates: () => [],
+    listSkippedNoMatchOutcomes: () => [],
+  };
+}
+
+describe('plex show enrichment', () => {
+  it('writes an in-library show cache row when Plex returns a strong match', async () => {
+    const db = new Database(':memory:');
+    ensurePlexSchema(db);
+    const cache = new PlexCache(db);
+
+    await refreshShowLibraryCache(
+      [
+        {
+          normalizedTitle: 'Example Show',
+          seasons: [],
+          plexStatus: 'unknown',
+          watchCount: null,
+          lastWatchedAt: null,
+        },
+      ],
+      {
+        cache,
+        client: {
+          searchShows: async () => [
+            {
+              ratingKey: '456',
+              title: 'Example Show',
+              type: 'show',
+              viewCount: 6,
+              lastViewedAt: 1_712_793_600,
+            },
+          ],
+        } as never,
+        refreshIntervalMinutes: 30,
+        log: () => {},
+      },
+    );
+
+    expect(cache.getTv('Example Show')).toMatchObject({
+      inLibrary: true,
+      plexRatingKey: '456',
+      watchCount: 6,
+      lastWatchedAt: '2024-04-11T00:00:00.000Z',
+    });
+  });
+
+  it('writes a missing show cache row when Plex returns no match', async () => {
+    const db = new Database(':memory:');
+    ensurePlexSchema(db);
+    const cache = new PlexCache(db);
+
+    await refreshShowLibraryCache(
+      [
+        {
+          normalizedTitle: 'Missing Show',
+          seasons: [],
+          plexStatus: 'unknown',
+          watchCount: null,
+          lastWatchedAt: null,
+        },
+      ],
+      {
+        cache,
+        client: {
+          searchShows: async () => [],
+        } as never,
+        refreshIntervalMinutes: 30,
+        log: () => {},
+      },
+    );
+
+    expect(cache.getTv('Missing Show')).toMatchObject({
+      inLibrary: false,
+      watchCount: 0,
+      lastWatchedAt: null,
+    });
+  });
+
+  it('treats stale show cache rows as unknown on API enrichment', () => {
+    const db = new Database(':memory:');
+    ensurePlexSchema(db);
+    const cache = new PlexCache(db);
+    cache.upsertTv({
+      normalizedTitle: 'Stale Show',
+      plexRatingKey: '456',
+      inLibrary: true,
+      watchCount: 3,
+      lastWatchedAt: '2026-04-01T00:00:00.000Z',
+      cachedAt: '2026-04-01T00:00:00.000Z',
+    });
+
+    const shows = enrichShowBreakdownsFromPlexCache(
+      [
+        {
+          normalizedTitle: 'Stale Show',
+          seasons: [],
+          plexStatus: 'unknown',
+          watchCount: null,
+          lastWatchedAt: null,
+        },
+      ],
+      {
+        cache,
+        refreshIntervalMinutes: 30,
+      },
+    );
+
+    expect(shows[0]).toMatchObject({
+      plexStatus: 'unknown',
+      watchCount: null,
+      lastWatchedAt: null,
+    });
+    expect(isPlexShowCacheExpired('2026-04-01T00:00:00.000Z', 30)).toBe(true);
+  });
+
+  it('surfaces Plex cache fields in GET /api/shows', async () => {
+    const db = new Database(':memory:');
+    ensurePlexSchema(db);
+    const cache = new PlexCache(db);
+    cache.upsertTv({
+      normalizedTitle: 'Example Show',
+      plexRatingKey: '456',
+      inLibrary: true,
+      watchCount: 5,
+      lastWatchedAt: '2026-04-15T00:00:00.000Z',
+      cachedAt: new Date().toISOString(),
+    });
+
+    const handler = createApiFetch({
+      repository: {
+        ...stubRepository(),
+        listCandidateStates: () =>
+          [
+            {
+              identityKey: 'tv:example show|1|1',
+              mediaType: 'tv',
+              status: 'queued',
+              ruleName: 'Example Show',
+              score: 100,
+              reasons: ['matched'],
+              rawTitle: 'Example.Show.S01E01.1080p',
+              normalizedTitle: 'Example Show',
+              season: 1,
+              episode: 1,
+              feedName: 'TV Feed',
+              guidOrLink: 'https://example.test/show',
+              publishedAt: '2026-01-01T00:00:00Z',
+              downloadUrl: 'https://example.test/show.torrent',
+              firstSeenRunId: 1,
+              lastSeenRunId: 1,
+              updatedAt: '2026-01-01T00:00:00Z',
+            },
+          ] as never,
+      },
+      health: createHealthState(),
+      config: {
+        feeds: [],
+        tv: [],
+        movies: {
+          years: [2024],
+          resolutions: ['1080p'],
+          codecs: ['x265'],
+          codecPolicy: 'prefer',
+        },
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+        },
+        runtime: {
+          runIntervalMinutes: 30,
+          reconcileIntervalMinutes: 1,
+          artifactDir: '.pirate-claw/runtime',
+          artifactRetentionDays: 7,
+        },
+      },
+      configPath: '/nonexistent/pirate-claw.config.json',
+      pollStatePath: '/nonexistent/poll-state.json',
+      loadPollState: () => ({ feeds: {} }),
+      plexShows: {
+        cache,
+        client: {} as never,
+        refreshIntervalMinutes: 30,
+        log: () => {},
+      },
+    });
+
+    const response = await handler(new Request('http://localhost/api/shows'));
+    const body = await response.json();
+
+    expect(body.shows[0]).toMatchObject({
+      plexStatus: 'in_library',
+      watchCount: 5,
+      lastWatchedAt: '2026-04-15T00:00:00.000Z',
+    });
+  });
+});

--- a/web/src/routes/shows/+page.svelte
+++ b/web/src/routes/shows/+page.svelte
@@ -44,6 +44,35 @@
 		return max;
 	}
 
+	function plexChipClass(status: ShowBreakdown['plexStatus']): string {
+		switch (status) {
+			case 'in_library':
+				return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200';
+			case 'missing':
+				return 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200';
+			default:
+				return 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300';
+		}
+	}
+
+	function plexStatusLabel(status: ShowBreakdown['plexStatus']): string {
+		switch (status) {
+			case 'in_library':
+				return 'In library';
+			case 'missing':
+				return 'Missing';
+			default:
+				return 'Unknown';
+		}
+	}
+
+	function formatLastWatched(value: string | null): string {
+		if (!value) return '—';
+		const date = new Date(value);
+		if (Number.isNaN(date.getTime())) return '—';
+		return date.toLocaleDateString();
+	}
+
 	const sortedShows = $derived(
 		[...data.shows].sort((a, b) => {
 			if (sortKey === 'progress') return maxProgress(b) - maxProgress(a);
@@ -149,6 +178,21 @@
 										{/if}
 									</p>
 								{/if}
+								<div class="text-muted-foreground mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs">
+									<span class="inline-flex items-center gap-1">
+										<span>Plex:</span>
+										<Badge variant="secondary" class={plexChipClass(show.plexStatus)}>
+											{plexStatusLabel(show.plexStatus)}
+										</Badge>
+									</span>
+									<span>Watches: <span class="text-foreground">{show.watchCount ?? '—'}</span></span
+									>
+									<span
+										>Last watched:
+										<span class="text-foreground">{formatLastWatched(show.lastWatchedAt)}</span
+										></span
+									>
+								</div>
 							</div>
 						</CardContent>
 					</Card>

--- a/web/src/routes/shows/[slug]/+page.svelte
+++ b/web/src/routes/shows/[slug]/+page.svelte
@@ -82,6 +82,35 @@
 				return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300';
 		}
 	}
+
+	function plexChipClass(status: NonNullable<PageData['show']>['plexStatus']): string {
+		switch (status) {
+			case 'in_library':
+				return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200';
+			case 'missing':
+				return 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200';
+			default:
+				return 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300';
+		}
+	}
+
+	function plexStatusLabel(status: NonNullable<PageData['show']>['plexStatus']): string {
+		switch (status) {
+			case 'in_library':
+				return 'In library';
+			case 'missing':
+				return 'Missing';
+			default:
+				return 'Unknown';
+		}
+	}
+
+	function formatLastWatched(value: string | null): string {
+		if (!value) return '—';
+		const date = new Date(value);
+		if (Number.isNaN(date.getTime())) return '—';
+		return date.toLocaleDateString();
+	}
 </script>
 
 <div class="mb-4">
@@ -146,6 +175,19 @@
 			{#if data.show.tmdb?.overview}
 				<p class="text-muted-foreground mt-3 text-sm leading-relaxed">{data.show.tmdb.overview}</p>
 			{/if}
+			<div class="text-muted-foreground mt-3 flex flex-wrap gap-x-3 gap-y-1 text-sm">
+				<span class="inline-flex items-center gap-1">
+					<span>Plex:</span>
+					<Badge variant="secondary" class={plexChipClass(data.show.plexStatus)}>
+						{plexStatusLabel(data.show.plexStatus)}
+					</Badge>
+				</span>
+				<span>Watches: <span class="text-foreground">{data.show.watchCount ?? '—'}</span></span>
+				<span
+					>Last watched:
+					<span class="text-foreground">{formatLastWatched(data.show.lastWatchedAt)}</span></span
+				>
+			</div>
 		</div>
 	</div>
 

--- a/web/src/routes/shows/[slug]/shows.test.ts
+++ b/web/src/routes/shows/[slug]/shows.test.ts
@@ -49,6 +49,27 @@ describe('/shows/[slug]', () => {
 		expect(screen.getByText('E01')).toBeInTheDocument();
 	});
 
+	it('renders Plex status details in the show header', () => {
+		render(Page, {
+			data: {
+				show: {
+					...mockShow,
+					plexStatus: 'in_library',
+					watchCount: 2,
+					lastWatchedAt: '2026-04-15T00:00:00.000Z'
+				},
+				torrents: null,
+				error: null
+			}
+		});
+
+		expect(screen.getByText('In library')).toBeInTheDocument();
+		expect(screen.getByText('2')).toBeInTheDocument();
+		expect(
+			screen.getByText(new Date('2026-04-15T00:00:00.000Z').toLocaleDateString())
+		).toBeInTheDocument();
+	});
+
 	it('renders progress bar and speed/ETA for active downloading episode', () => {
 		render(Page, { data: { show: mockShow, torrents: [mockTorrent], error: null } });
 		// 42% progress from live torrent

--- a/web/src/routes/shows/shows.test.ts
+++ b/web/src/routes/shows/shows.test.ts
@@ -76,6 +76,29 @@ describe('/shows', () => {
 		expect(screen.getByText(/50% complete/)).toBeInTheDocument();
 	});
 
+	it('renders Plex status, watch count, and last watched date on show cards', () => {
+		render(Page, {
+			data: {
+				shows: [
+					{
+						...mockShow,
+						plexStatus: 'in_library',
+						watchCount: 7,
+						lastWatchedAt: '2026-04-15T00:00:00.000Z'
+					}
+				],
+				torrents: null,
+				error: null
+			}
+		});
+
+		expect(screen.getByText('In library')).toBeInTheDocument();
+		expect(screen.getByText('7')).toBeInTheDocument();
+		expect(
+			screen.getByText(new Date('2026-04-15T00:00:00.000Z').toLocaleDateString())
+		).toBeInTheDocument();
+	});
+
 	it('sort by Progress orders shows by max transmissionPercentDone desc', async () => {
 		render(Page, {
 			data: { shows: [mockShow, mockShow2], torrents: null, error: null }


### PR DESCRIPTION
## Summary

- delivery ticket: `P18.03 TV shows vertical slice: Plex match, cache enrichment, /api/shows fields, shows UI`
- ticket file: [docs/02-delivery/phase-18/ticket-03-tv-shows-vertical-slice.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-18/ticket-03-tv-shows-vertical-slice.md)
- stacked base branch: `agents/p18-02-movies-vertical-slice-plex-match-cache-enrichment-api-movies-fields-movie-ui`
- self-audit: outcome `clean` completed at 2026-04-16 13:52 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`854c7dca710b`](https://github.com/cesarnml/pirate_claw/commit/854c7dca710bedc42e57d1f91b4c75fba43d8ce5)
- current branch head: [`ee6f4b6727ca`](https://github.com/cesarnml/pirate_claw/commit/ee6f4b6727ca143d0942badcbc38b367c55de6af)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `854c7dca710b` address all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Isolate movie/show refresh failures so one path doesn’t cancel the other. (native GitHub thread resolved) `src/plex/background-refresh.ts:31` [thread](https://github.com/cesarnml/pirate_claw/pull/166#discussion_r3093719277)
- [coderabbit] Handle per-show search failures so one error doesn’t stop all refreshes. (native GitHub thread resolved) `src/plex/shows.ts:49` [thread](https://github.com/cesarnml/pirate_claw/pull/166#discussion_r3093719295)
