### PR TITLE
docs: close Phase 18 and record retrospective [P18.04]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pirate Claw is a local CLI for pulling media candidates from RSS feeds, matching them against your rules, and queueing approved downloads in Transmission.
 
-Phases **01–17** are implemented on `main`. **Phases 18–20** are in product-definition/planning mode under `docs/01-product/`.
+Phases **01–18** are implemented on `main`. **Phases 19–20** are in product-definition/planning mode under `docs/01-product/`.
 
 It currently supports:
 
@@ -18,6 +18,7 @@ It currently supports:
 - env-backed Transmission credentials via process env or `.env`
 - daemon HTTP API with read endpoints and bounded config writes when `runtime.apiPort` is set
 - optional TMDB-backed posters, ratings, and metadata when a `tmdb` API key is configured
+- optional Plex-backed library status, watch counts, and last-watched timestamps when a `plex` server is configured
 - browser dashboard (`web/`) with unified config editing, in-context daemon controls, full feed and target management, live Transmission stats, skipped-no-match outcomes, and an unmatched candidates page
 
 ## Commands
@@ -55,6 +56,7 @@ Config file: `pirate-claw.config.json` (see [`pirate-claw.config.example.json`](
 - `transmission` — RPC URL, credentials, optional `downloadDirs` per media type
 - `runtime` — daemon scheduling and artifacts; `apiPort` enables HTTP API; `apiWriteToken` enables config writes; `tmdbRefreshIntervalMinutes` controls background TMDB refresh (default 360, `0` disables)
 - `tmdb` — optional `apiKey` (or env `PIRATE_CLAW_TMDB_API_KEY`) and cache TTL overrides
+- `plex` — optional `url`, `token` (or env `PIRATE_CLAW_PLEX_TOKEN`), and `refreshIntervalMinutes` for read-only library/watch enrichment
 
 ```json
 {
@@ -103,6 +105,11 @@ Config file: `pirate-claw.config.json` (see [`pirate-claw.config.example.json`](
     "artifactDir": ".pirate-claw/runtime",
     "artifactRetentionDays": 7,
     "apiPort": 5555
+  },
+  "plex": {
+    "url": "http://192.168.1.10:32400",
+    "token": "YOUR_PLEX_TOKEN",
+    "refreshIntervalMinutes": 30
   }
 }
 ```
@@ -143,22 +150,22 @@ Set `runtime.apiPort` to start an HTTP JSON API alongside the daemon:
 
 ### Endpoints
 
-| Endpoint                         | Description                                                    |
-| -------------------------------- | -------------------------------------------------------------- |
-| `GET /api/health`                | Uptime, start time, last run/reconcile snapshots               |
-| `GET /api/status`                | Recent run summaries                                           |
-| `GET /api/candidates`            | All tracked candidate state records                            |
-| `GET /api/shows`                 | TV candidates grouped by show → season → episode               |
-| `GET /api/movies`                | Movie candidates sorted by title                               |
-| `GET /api/feeds`                 | Feed config with poll state and `isDue`                        |
-| `GET /api/config`                | Effective config (credentials redacted); returns `ETag`        |
-| `PUT /api/config`                | Bounded runtime + tv.shows write (token + `If-Match` required) |
-| `PUT /api/config/feeds`          | Replace feeds array (token + `If-Match` required)              |
-| `PUT /api/config/movies`         | Replace movie policy (token + `If-Match` required)             |
-| `PUT /api/config/tv/defaults`    | Replace TV defaults (token + `If-Match` required)              |
-| `GET /api/transmission/session`  | Transmission session stats                                     |
-| `GET /api/transmission/torrents` | Pirate Claw-managed torrents with progress, speed, ETA         |
-| `GET /api/outcomes`              | Feed item outcomes (`?status=skipped_no_match`)                |
+| Endpoint                         | Description                                                                     |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| `GET /api/health`                | Uptime, start time, last run/reconcile snapshots                                |
+| `GET /api/status`                | Recent run summaries                                                            |
+| `GET /api/candidates`            | All tracked candidate state records                                             |
+| `GET /api/shows`                 | TV candidates grouped by show → season → episode, with Plex status/watch fields |
+| `GET /api/movies`                | Movie candidates sorted by title, with Plex status/watch fields                 |
+| `GET /api/feeds`                 | Feed config with poll state and `isDue`                                         |
+| `GET /api/config`                | Effective config (credentials redacted); returns `ETag`                         |
+| `PUT /api/config`                | Bounded runtime + tv.shows write (token + `If-Match` required)                  |
+| `PUT /api/config/feeds`          | Replace feeds array (token + `If-Match` required)                               |
+| `PUT /api/config/movies`         | Replace movie policy (token + `If-Match` required)                              |
+| `PUT /api/config/tv/defaults`    | Replace TV defaults (token + `If-Match` required)                               |
+| `GET /api/transmission/session`  | Transmission session stats                                                      |
+| `GET /api/transmission/torrents` | Pirate Claw-managed torrents with progress, speed, ETA                          |
+| `GET /api/outcomes`              | Feed item outcomes (`?status=skipped_no_match`)                                 |
 
 Write rules: `runtime.apiWriteToken` (or env `PIRATE_CLAW_API_WRITE_TOKEN`) must be set; all writes require `Authorization: Bearer <token>` and `If-Match` from the latest `GET /api/config` ETag. Writes are atomic file updates.
 
@@ -191,9 +198,7 @@ cd web && PIRATE_CLAW_API_URL=http://localhost:5555 PORT=5174 node build/index.j
 
 Pirate Claw is a local operator tool for a personal NAS. The roadmap through Phase 20 targets a polished, fully-featured v1.0.0 release.
 
-**Implemented (Phases 01–17):** RSS ingestion, policy matching, Transmission queuing, lifecycle reconciliation, TMDB enrichment, read dashboard, unified config editing from the UI, post-save daemon restart and Transmission ping controls, full feed and target management, onboarding/resume flow, and explicit empty states across the dashboard and key routes.
-
-**Planned (Phase 18):** Optional Plex Media Server enrichment — library status (`in_library` / `missing`), watch counts, and last-watched timestamps surfaced in the dashboard alongside download state. Display-only; no intake gating.
+**Implemented (Phases 01–18):** RSS ingestion, policy matching, Transmission queuing, lifecycle reconciliation, TMDB enrichment, read dashboard, unified config editing from the UI, post-save daemon restart and Transmission ping controls, full feed and target management, onboarding/resume flow, explicit empty states across the dashboard and key routes, and optional read-only Plex Media Server enrichment.
 
 **Planned (Phase 19):** Full UI/UX redesign — Obsidian Tide design language, left sidebar navigation, poster-forward layouts, and consolidation of the Candidates and Unmatched views into a redesigned Dashboard.
 
@@ -203,7 +208,7 @@ Not in scope through v1:
 
 - remote feed capture or hosted persistence
 - post-completion file handling or download renaming
-- Jellyfin / Emby / Kodi integration (Plex is Phase 18; other providers are v2)
+- Jellyfin / Emby / Kodi integration (Plex is implemented; other providers are v2)
 - multi-user access or auth beyond the single write token
 - broader ingestion redesign
 

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -448,6 +448,12 @@ Goal:
 - enrich `/api/shows` and `/api/movies` with `plexStatus` (in_library | missing | unknown), `watchCount`, and `lastWatchedAt`
 - display-only; no intake gating in v1
 
+Current status:
+
+- implemented on `main` via `P18.01`-`P18.04` stacked delivery
+- optional `plex` config now drives background movie/show refresh, read-only API enrichment, and dashboard badges/details for movies and shows
+- resilience follow-up landed during review: movie and show sweeps fail independently, and per-show lookup failures no longer abort the rest of the refresh pass
+
 Committed scope:
 
 - optional `plex` config block (`url`, `token`, `refreshIntervalMinutes`)
@@ -466,6 +472,7 @@ Explicitly deferred:
 Working notes:
 
 - `docs/01-product/phase-18-plex-media-server-enrichment.md`
+- `docs/02-delivery/phase-18/implementation-plan.md`
 
 ## Phase 19: UI/UX Redesign ("Razzle-Dazzle")
 
@@ -525,8 +532,8 @@ The following items are **mapped** to numbered phases (no longer “unbounded”
 
 ## Current Planning Posture
 
-- product phases `01`–`17` are implemented on `main`; **Phase 17** is delivered via `P17.01`–`P17.07` stacked delivery
-- product phases `18`–`20` are defined in `docs/01-product/`; all three remain product-definition-first until their tickets are approved and implemented
+- product phases `01`–`18` are implemented on `main`; **Phase 18** is delivered via `P18.01`–`P18.04` stacked delivery
+- product phases `19`–`20` are defined in `docs/01-product/`; both remain product-definition-first until their tickets are approved and implemented
 - engineering epic write-ups **`EE01`–`EE09`** live under `docs/03-engineering/` (orchestrator, PR hygiene, and delivery workflow tooling)
 - each new phase requires an explicit planning pass, approved ticket decomposition, and developer sign-off before implementation starts
 - smaller bounded changes can still proceed as standalone PR work without inventing a new phase

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -10,7 +10,7 @@ Its job is to answer three questions quickly:
 
 ## Current Repo State
 
-Pirate Claw is implemented through **Phase 17** on `main` (product phases 01–17; see [`roadmap.md`](./roadmap.md)). Delivery artifacts for Phases 12–17 live under [`docs/02-delivery/`](../02-delivery/). The product definition for **Phase 18** lives under [`docs/01-product/`](../01-product/) ahead of implementation; the Phase 17 product spec is the contract reference for the latest shipped scope. Phase **18** is **not yet implemented** in code.
+Pirate Claw is implemented through **Phase 18** on `main` (product phases 01–18; see [`roadmap.md`](./roadmap.md)). Delivery artifacts for Phases 12–18 live under [`docs/02-delivery/`](../02-delivery/). The Phase 18 product spec is now the contract reference for the latest shipped scope. Phase **19** is the next product-definition-only phase under [`docs/01-product/`](../01-product/).
 
 Current delivered surface:
 
@@ -31,6 +31,7 @@ Current delivered surface:
 - SvelteKit dashboard in `web/` that consumes the daemon HTTP API, including bounded runtime Settings writes and full feed and target management (add/remove feeds, TV defaults, movie policy, TV show targets) through server-side actions
 - Phase 15 dashboard visibility: home overview (Transmission session strip, active downloads, recent outcomes, archive grid), TV and movie library views with live transfer stats where a `transmissionTorrentHash` joins to Transmission, skipped-no-match outcomes, and `/candidates/unmatched` — refresh on page reload only (no WebSocket/SSE push)
 - optional TMDB enrichment: `tmdb` config block and/or `PIRATE_CLAW_TMDB_API_KEY`, SQLite-backed cache, lazy enrichment on API reads, and an optional daemon background refresh cadence via `runtime.tmdbRefreshIntervalMinutes` (default 6 hours; set `0` to disable)
+- optional Plex enrichment: `plex` config block and/or `PIRATE_CLAW_PLEX_TOKEN`, SQLite-backed movie/show cache, background refresh sweeps, and read-only `plexStatus` / `watchCount` / `lastWatchedAt` fields on `/api/movies` and `/api/shows`
 - Phase 16 config editing: unified `/config` accordion cards, per-section toast feedback, post-save daemon restart affordance, Transmission ping, and read-only tooltips when write auth is absent
 - Phase 17 onboarding and empty states: `/onboarding` guided first-run flow, strict initial-empty auto-trigger plus dismissal suppression/resume, blocked onboarding when writes are disabled, and explicit empty-state guidance across `/`, `/config`, `/shows`, `/movies`, and `/candidates/unmatched`
 
@@ -48,23 +49,23 @@ Current product boundary:
 - read-only daemon HTTP API (`/api/health`, `/api/status`, `/api/candidates`, `/api/shows`, `/api/movies`, `/api/feeds`, `/api/config`, plus Phase 15 `/api/transmission/session`, `/api/transmission/torrents`, `/api/outcomes`) when `runtime.apiPort` is configured
 - TMDB metadata is display-only and does not gate RSS intake
 
-Still deferred (Phase 18 and beyond):
+Still deferred (Phase 19 and beyond):
 
-- v1.0.0 release and config/DB schema versioning (Phase 18)
+- v1.0.0 release and config/DB schema versioning (Phase 20)
 - remote feed capture
 - hosted persistence
 - download renaming or organization rules
 - Synology archiving
 - ingestion redesign beyond the local SQLite model
 
-Last verified against `README.md` and CLI commands: 2026-04-14 (Phase 17 delivered).
+Last verified against `README.md` and Phase 18 delivery artifacts: 2026-04-16.
 
 Current planning focus:
 
 - see [`roadmap.md`](./roadmap.md) for numbered phases and what is implemented on `main`
 - use the roadmap to confirm whether the request is a bounded standalone change or needs a new approved phase/epic planning pass
 - treat the current Phase 07 config surface and the current extracted delivery-orchestrator module boundaries as the baseline for future work
-- Phase 18 release/versioning work is the next numbered product phase after the shipped onboarding and empty-state surface
+- Phase 19 UI redesign work is the next numbered product phase after the shipped Plex enrichment surface
 
 ## Read These Docs By Task Type
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ Phase-level product definitions.
 - `phase-15-rich-visual-state-and-activity-views.md`: live Transmission progress, TV/movie enriched views, unmatched candidates (implemented)
 - `phase-16-config-editing-hot-reload-and-daemon-controls.md`: unified Config page, inline validation, post-save daemon restart (implemented)
 - `phase-17-onboarding-and-empty-state.md`: first-time setup wizard and per-section empty states (implemented)
-- `phase-18-plex-media-server-enrichment.md`: Plex read-only enrichment — library status, watch state, background refresh (product definition)
+- `phase-18-plex-media-server-enrichment.md`: Plex read-only enrichment — library status, watch state, background refresh (implemented)
 - `phase-19-ui-redesign-razzle-dazzle.md`: Obsidian Tide UI/UX redesign — left sidebar, poster-forward layouts, view consolidation (product definition)
 - `phase-20-v1-release-and-schema-versioning.md`: v1.0.0 release, config schemaVersion, SQLite PRAGMA user_version (product definition)
 
@@ -82,6 +82,7 @@ Execution plans, issue conventions, and ticket breakdowns.
 - `phase-15/implementation-plan.md`: rich visual state and activity views delivery plan (tickets P15.01–P15.07; delivered on `main`)
 - `phase-16/implementation-plan.md`: config editing, hot reload, and daemon controls delivery plan (tickets P16.01–P16.09; delivered on `main`)
 - `phase-17/implementation-plan.md`: onboarding and empty-state delivery plan (tickets P17.01–P17.07; delivered on `main`)
+- `phase-18/implementation-plan.md`: Plex Media Server enrichment delivery plan (tickets P18.01–P18.04; delivered on `main`)
 
 ### `03-engineering`
 

--- a/notes/public/phase-18-retrospective.md
+++ b/notes/public/phase-18-retrospective.md
@@ -1,0 +1,32 @@
+## Scope delivered
+
+Phase 18 shipped through PRs [#164](https://github.com/cesarnml/pirate_claw/pull/164), [#165](https://github.com/cesarnml/pirate_claw/pull/165), and [#166](https://github.com/cesarnml/pirate_claw/pull/166) on the stacked `agents/p18-*` branches. Delivered scope: optional `plex` config and secret handling, Plex HTTP client plus SQLite cache tables, daemon background refresh for movies and shows, read-only `plexStatus` / `watchCount` / `lastWatchedAt` fields on `/api/movies` and `/api/shows`, minimal movie/show dashboard affordances, doc updates, and review-driven resilience follow-up for independent movie/show sweep failures.
+
+## What went well
+
+Mirroring the Phase 11 TMDB shape kept the new boundary legible. Reusing the same pattern of optional config, SQLite cache, background refresh, and API-only enrichment meant each ticket stayed small and the call sites were obvious enough that TypeScript surfaced integration misses quickly instead of burying them in runtime behavior. The pirate-claw-first refresh pattern also held up well because the tracked-item set is tiny relative to a real Plex library, so the implementation stayed cheap and easy to reason about without introducing a full-library crawl.
+
+## Pain points
+
+The delivery orchestrator reported generated handoff paths for later tickets, but those handoff files were not actually present under `.agents/delivery/phase-18/handoffs/`. That was avoidable workflow waste because the ticket docs were enough to proceed, but the missing artifact weakened the intended context-reset contract. A second friction point was that Phase 18 added required Plex fields to shared API types in P18.01, which meant later web fixture updates showed up during unrelated ticket verification rather than at the exact change site.
+
+## Surprises
+
+The most useful surprise was external AI review on P18.03 catching a real resilience gap: one movie/show sweep failure could cancel the other, and one show lookup exception could abort the rest of the show pass. That was not explicit in the ticket spec, but it materially affected the daemon's "best-effort optional enrichment" contract, so patching it immediately made the phase outcome stronger. Another surprise was how little extra code the UI needed once the API shape was right; the main complexity stayed in refresh/cache semantics rather than presentation.
+
+## What we'd do differently
+
+We would formalize the shared Plex matching helpers earlier instead of duplicating the movie and show similarity logic in separate modules. The initial choice to keep each vertical slice self-contained was reasonable because it reduced ticket coupling, but by the end of P18.03 the duplicated normalization/scoring code was clearly reusable infrastructure. We would also fix the orchestrator handoff-generation gap before starting another stacked product phase so the workflow contract matches the actual repo behavior.
+
+## Net assessment
+
+Phase 18 achieved its stated goals. Operators can now configure Plex once and see read-only library/watch state in the daemon API and dashboard, while operators without Plex keep the pre-existing behavior and defaults. The implementation stayed inside the intended product boundary: optional external service, cached locally, display-only in v1, and resilient when Plex is unreachable.
+
+## Follow-up
+
+- Fix the missing generated handoff artifacts for later tickets in stacked cook-mode runs before the next multi-ticket product phase.
+- Extract shared Plex matching utilities if Phase 18 gets follow-up work or another media-library provider is introduced.
+- Revisit cache refresh strategy if tracked items grow enough that per-item searches stop being obviously cheap, or if a future provider lacks a fast title-search path.
+- Keep intake gating explicitly deferred until the current display-only Plex signals are exercised by real operators.
+
+_Created: 2026-04-16. PR #166 open._


### PR DESCRIPTION
## Summary

- delivery ticket: `P18.04 Docs, index updates, exit verification`
- ticket file: [docs/02-delivery/phase-18/ticket-04-docs-exit-verification.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-18/ticket-04-docs-exit-verification.md)
- stacked base branch: `agents/p18-03-tv-shows-vertical-slice-plex-match-cache-enrichment-api-shows-fields-shows-ui`
- self-audit: outcome `skipped` completed at 2026-04-16 14:05 UTC

## External AI Review

- outcome: `clean`
- current branch head: [`36b4a2b2f5b8`](https://github.com/cesarnml/pirate_claw/commit/36b4a2b2f5b8851830a9a1a67b1f0c11cec8ebc3)
- no prudent follow-up changes were required.
