### PR TITLE
feat: redesign TV shows view [P19.04]

### DIFF
--- a/web/src/routes/shows/+page.svelte
+++ b/web/src/routes/shows/+page.svelte
@@ -19,6 +19,7 @@
 
 	let sortKey = $state<SortKey>('title');
 	let expandedShow = $state<string | null>(null);
+	let hasInitializedExpandedShow = $state(false);
 	let selectedSeasonByShow = $state<Record<string, number>>({});
 
 	const torrents = $derived(data.torrents ?? []);
@@ -154,8 +155,9 @@
 	}
 
 	$effect(() => {
-		if (expandedShow !== null || data.shows.length === 0) return;
+		if (hasInitializedExpandedShow || data.shows.length === 0) return;
 		expandedShow = data.shows[0].normalizedTitle;
+		hasInitializedExpandedShow = true;
 	});
 
 	const sortedShows = $derived(

--- a/web/src/routes/shows/+page.svelte
+++ b/web/src/routes/shows/+page.svelte
@@ -1,203 +1,552 @@
 <script lang="ts">
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+	import ChevronUpIcon from '@lucide/svelte/icons/chevron-up';
+	import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
+	import LayersIcon from '@lucide/svelte/icons/layers-3';
+	import StarIcon from '@lucide/svelte/icons/star';
+	import StatusChip from '$lib/components/StatusChip.svelte';
 	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
 	import { Badge } from '$lib/components/ui/badge';
+	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent } from '$lib/components/ui/card';
-	import type { ShowBreakdown } from '$lib/types';
+	import type { ShowBreakdown, ShowEpisode, ShowSeason, TorrentStatSnapshot } from '$lib/types';
 	import type { PageData } from './$types';
 
-	let { data }: { data: PageData } = $props();
+	const props = $props<{ data: PageData }>();
+	const data = $derived(props.data);
 
-	type SortKey = 'title' | 'progress';
+	type SortKey = 'title' | 'rating' | 'progress' | 'recent';
+
 	let sortKey = $state<SortKey>('title');
+	let expandedShow = $state<string | null>(null);
+	let selectedSeasonByShow = $state<Record<string, number>>({});
+
+	const torrents = $derived(data.torrents ?? []);
+
+	function showKey(show: ShowBreakdown): string {
+		return show.normalizedTitle;
+	}
 
 	function showHref(show: ShowBreakdown): string {
 		return `/shows/${encodeURIComponent(show.normalizedTitle.toLowerCase())}`;
-	}
-
-	function formatRating(v: number): string {
-		return v.toFixed(1);
 	}
 
 	function displayTitle(show: ShowBreakdown): string {
 		return show.tmdb?.name ?? show.normalizedTitle;
 	}
 
+	function formatRating(value: number): string {
+		return value.toFixed(1);
+	}
+
+	function seasonCount(show: ShowBreakdown): number {
+		return show.seasons.length;
+	}
+
 	function episodeCount(show: ShowBreakdown): number {
-		return show.seasons.reduce((sum, s) => sum + s.episodes.length, 0);
+		return show.seasons.reduce((sum, season) => sum + season.episodes.length, 0);
 	}
 
 	function completionPct(show: ShowBreakdown): number | null {
-		const eps = show.seasons.flatMap((s) => s.episodes);
-		if (eps.length === 0) return null;
-		const done = eps.filter((e) => e.status === 'completed').length;
-		return Math.round((done / eps.length) * 100);
+		const totalEpisodes = episodeCount(show);
+		if (totalEpisodes === 0) return null;
+		const completed = show.seasons
+			.flatMap((season) => season.episodes)
+			.filter((episode) => episode.status === 'completed').length;
+		return Math.round((completed / totalEpisodes) * 100);
 	}
 
-	/** Max transmissionPercentDone across all episodes (for progress sort) */
-	function maxProgress(show: ShowBreakdown): number {
-		let max = 0;
-		for (const s of show.seasons) {
-			for (const e of s.episodes) {
-				if ((e.transmissionPercentDone ?? 0) > max) max = e.transmissionPercentDone ?? 0;
+	function mostRecentQueuedAt(show: ShowBreakdown): number {
+		return show.seasons.reduce((latest, season) => {
+			for (const episode of season.episodes) {
+				if (!episode.queuedAt) continue;
+				const timestamp = Date.parse(episode.queuedAt);
+				if (!Number.isNaN(timestamp) && timestamp > latest) latest = timestamp;
 			}
-		}
-		return max;
+			return latest;
+		}, 0);
 	}
 
-	function plexChipClass(status: ShowBreakdown['plexStatus']): string {
-		switch (status) {
-			case 'in_library':
-				return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200';
-			case 'missing':
-				return 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200';
-			default:
-				return 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300';
+	function networkLabel(show: ShowBreakdown): string {
+		const overview = show.tmdb?.overview;
+		if (!overview) return 'Library target';
+		if (overview.toLowerCase().includes('apple')) return 'APPLE TV+';
+		if (overview.toLowerCase().includes('hbo')) return 'HBO';
+		if (overview.toLowerCase().includes('fx')) return 'FX';
+		return 'TMDB METADATA';
+	}
+
+	function safePosterUrl(show: ShowBreakdown): string | null {
+		const poster = show.tmdb?.posterUrl;
+		if (!poster) return null;
+		try {
+			const url = new URL(poster);
+			return url.protocol === 'https:' ? url.href : null;
+		} catch {
+			return null;
 		}
 	}
 
-	function plexStatusLabel(status: ShowBreakdown['plexStatus']): string {
-		switch (status) {
-			case 'in_library':
-				return 'In library';
-			case 'missing':
-				return 'Missing';
-			default:
-				return 'Unknown';
-		}
+	function formatSpeed(bytesPerSecond: number): string {
+		if (bytesPerSecond >= 1_048_576) return `${(bytesPerSecond / 1_048_576).toFixed(1)} MB/s`;
+		return `${(bytesPerSecond / 1024).toFixed(0)} KB/s`;
+	}
+
+	function formatPercent(value: number): string {
+		return `${Math.round(value * 100)}%`;
 	}
 
 	function formatLastWatched(value: string | null): string {
-		if (!value) return '—';
+		if (!value) return 'No Plex activity yet';
 		const date = new Date(value);
-		if (Number.isNaN(date.getTime())) return '—';
-		return date.toLocaleDateString();
+		if (Number.isNaN(date.getTime())) return 'No Plex activity yet';
+		return `Watched ${date.toLocaleDateString()}`;
 	}
 
+	function liveTorrent(episode: ShowEpisode): TorrentStatSnapshot | undefined {
+		if (!episode.transmissionTorrentHash) return undefined;
+		return torrents.find(
+			(torrent: TorrentStatSnapshot) => torrent.hash === episode.transmissionTorrentHash
+		);
+	}
+
+	function isActivelyTransferring(
+		episode: ShowEpisode,
+		live: TorrentStatSnapshot | undefined
+	): boolean {
+		return (
+			live?.status === 'downloading' ||
+			episode.lifecycleStatus === 'active' ||
+			episode.status === 'downloading'
+		);
+	}
+
+	function activeSeason(show: ShowBreakdown): ShowSeason | null {
+		if (show.seasons.length === 0) return null;
+		const selectedSeason = selectedSeasonByShow[showKey(show)];
+		return (
+			show.seasons.find((season) => season.season === selectedSeason) ?? show.seasons[0] ?? null
+		);
+	}
+
+	function openShow(show: ShowBreakdown): void {
+		const key = showKey(show);
+		if (expandedShow === key) {
+			expandedShow = null;
+			return;
+		}
+		expandedShow = key;
+		selectedSeasonByShow = {
+			...selectedSeasonByShow,
+			[key]: show.seasons[0]?.season ?? 1
+		};
+	}
+
+	function selectSeason(show: ShowBreakdown, season: number): void {
+		selectedSeasonByShow = {
+			...selectedSeasonByShow,
+			[showKey(show)]: season
+		};
+	}
+
+	function detailButtonLabel(show: ShowBreakdown): string {
+		return `Open ${displayTitle(show)} detail page`;
+	}
+
+	$effect(() => {
+		if (expandedShow !== null || data.shows.length === 0) return;
+		expandedShow = data.shows[0].normalizedTitle;
+	});
+
 	const sortedShows = $derived(
-		[...data.shows].sort((a, b) => {
-			if (sortKey === 'progress') return maxProgress(b) - maxProgress(a);
-			return displayTitle(a).localeCompare(displayTitle(b));
+		[...data.shows].sort((left, right) => {
+			if (sortKey === 'rating') {
+				return (right.tmdb?.voteAverage ?? -1) - (left.tmdb?.voteAverage ?? -1);
+			}
+			if (sortKey === 'progress') {
+				return (completionPct(right) ?? 0) - (completionPct(left) ?? 0);
+			}
+			if (sortKey === 'recent') {
+				return mostRecentQueuedAt(right) - mostRecentQueuedAt(left);
+			}
+			return displayTitle(left).localeCompare(displayTitle(right));
 		})
 	);
+
+	const sortOptions: Array<{ key: SortKey; label: string }> = [
+		{ key: 'title', label: 'Title' },
+		{ key: 'rating', label: 'Rating' },
+		{ key: 'progress', label: 'Progress' },
+		{ key: 'recent', label: 'Recently Added' }
+	];
 </script>
 
-<h1 class="text-3xl font-bold tracking-tight">Shows</h1>
-<p class="text-muted-foreground mt-1 text-sm">
-	Tracked TV series from the daemon. Open a show for seasons and episodes.
-</p>
-
-{#if data.error}
-	<Alert variant="destructive" class="mt-6">
-		<AlertTitle>API unavailable</AlertTitle>
-		<AlertDescription>{data.error}</AlertDescription>
-	</Alert>
-{:else if data.shows.length === 0}
-	<Card class="mt-6">
-		<CardContent class="pt-6">
-			<p class="text-muted-foreground text-sm">
-				No tracked shows yet. Add a TV target in Config to start building your library view.
+<section class="space-y-6">
+	<div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+		<div class="space-y-3">
+			<p class="text-primary font-mono text-xs font-semibold tracking-[0.28em] uppercase">
+				TV Command Deck
 			</p>
-			<a
-				href="/config#tv-shows"
-				class="text-primary mt-3 inline-flex text-sm font-medium hover:underline"
-			>
-				Go to TV shows in Config
-			</a>
-		</CardContent>
-	</Card>
-{:else}
-	<div class="mt-6 flex items-center gap-2">
-		<span class="text-muted-foreground text-sm">Sort:</span>
-		<button
-			class="text-sm font-medium underline-offset-2 {sortKey === 'title'
-				? 'text-foreground underline'
-				: 'text-muted-foreground hover:text-foreground'}"
-			onclick={() => (sortKey = 'title')}
-		>
-			Title (A–Z)
-		</button>
-		<span class="text-muted-foreground text-xs">·</span>
-		<button
-			class="text-sm font-medium underline-offset-2 {sortKey === 'progress'
-				? 'text-foreground underline'
-				: 'text-muted-foreground hover:text-foreground'}"
-			onclick={() => (sortKey = 'progress')}
-		>
-			Progress
-		</button>
+			<div class="space-y-2">
+				<h1 class="max-w-3xl text-4xl font-semibold tracking-[-0.04em] text-balance">Shows</h1>
+				<p class="text-muted-foreground max-w-2xl text-sm leading-6">
+					Poster-first tracking with inline season drill-down, Plex state, and live torrent
+					progress.
+				</p>
+			</div>
+		</div>
+
+		<div class="flex flex-wrap gap-2">
+			{#each sortOptions as option}
+				<button
+					type="button"
+					class={`border-border bg-card/75 text-muted-foreground hover:border-primary/30 hover:text-foreground rounded-full border px-4 py-2 text-xs font-semibold tracking-[0.18em] uppercase transition-colors ${
+						sortKey === option.key ? 'border-primary/45 bg-primary/12 text-primary' : ''
+					}`}
+					onclick={() => (sortKey = option.key)}
+				>
+					{option.label}
+				</button>
+			{/each}
+		</div>
 	</div>
 
-	<ul class="mt-6 grid list-none gap-4 sm:grid-cols-2 lg:grid-cols-3">
-		{#each sortedShows as show (show.normalizedTitle)}
-			{@const pct = completionPct(show)}
-			{@const count = episodeCount(show)}
-			<li>
-				<a
-					href={showHref(show)}
-					class="group focus-visible:ring-ring block h-full rounded-xl outline-none focus-visible:ring-2"
-				>
+	{#if data.error}
+		<Alert variant="destructive">
+			<AlertTitle>API unavailable</AlertTitle>
+			<AlertDescription>{data.error}</AlertDescription>
+		</Alert>
+	{:else if data.shows.length === 0}
+		<Card class="bg-card/75 rounded-[30px] border-white/10">
+			<CardContent class="space-y-4 pt-8">
+				<div class="space-y-2">
+					<p class="text-lg font-semibold">No tracked shows yet.</p>
+					<p class="text-muted-foreground max-w-xl text-sm leading-6">
+						Add a TV target in Config and the library grid will populate with poster art, progress,
+						and inline season state.
+					</p>
+				</div>
+				<Button href="/config#tv-shows" class="w-fit rounded-full px-5">
+					Go to TV shows in Config
+				</Button>
+			</CardContent>
+		</Card>
+	{:else}
+		<ul class="grid list-none gap-5 lg:grid-cols-2 xl:grid-cols-3">
+			{#each sortedShows as show (show.normalizedTitle)}
+				{@const key = showKey(show)}
+				{@const pct = completionPct(show)}
+				{@const posterUrl = safePosterUrl(show)}
+				{@const expanded = expandedShow === key}
+				{@const selectedSeason = activeSeason(show)}
+				<li class="min-w-0">
 					<Card
-						class="group-hover:border-primary/40 group-hover:bg-accent/30 h-full overflow-hidden transition-colors"
+						class={`bg-card/72 overflow-hidden rounded-[30px] border-white/10 shadow-[0_24px_80px_rgba(2,6,23,0.18)] transition-colors ${
+							expanded ? 'border-primary/35 bg-card/85' : ''
+						}`}
 					>
-						<CardContent class="flex gap-4 p-4">
-							{#if show.tmdb?.posterUrl}
-								<img
-									src={show.tmdb.posterUrl}
-									alt={`Poster for ${displayTitle(show)}`}
-									class="h-28 w-[4.5rem] shrink-0 rounded-md object-cover"
-									loading="lazy"
-								/>
-							{:else}
-								<div
-									class="bg-muted text-muted-foreground flex h-28 w-[4.5rem] shrink-0 items-center justify-center rounded-md text-xs"
-								>
-									No poster
-								</div>
-							{/if}
-							<div class="min-w-0 flex-1">
-								<p class="group-hover:text-primary leading-snug font-medium">
-									{displayTitle(show)}
-								</p>
-								<div class="text-muted-foreground mt-2 flex flex-wrap items-center gap-2 text-xs">
-									{#if show.tmdb?.voteAverage !== undefined}
-										<Badge variant="secondary" title="TMDB vote average">
-											★ {formatRating(show.tmdb.voteAverage)}
-										</Badge>
-									{/if}
-									{#if show.tmdb?.numberOfSeasons !== undefined}
-										<span>
-											{show.tmdb.numberOfSeasons} season{show.tmdb.numberOfSeasons === 1 ? '' : 's'}
-										</span>
-									{/if}
-								</div>
-								{#if count > 0}
-									<p class="text-muted-foreground mt-2 text-xs">
-										{count} episode{count === 1 ? '' : 's'}
-										{#if pct !== null}
-											· {pct}% complete
+						<div class="relative">
+							<button
+								type="button"
+								aria-expanded={expanded}
+								class="group block w-full text-left"
+								onclick={() => openShow(show)}
+							>
+								<div class="grid gap-0 md:grid-cols-[200px_minmax(0,1fr)]">
+									<div class="bg-background/70 relative min-h-[19rem] overflow-hidden">
+										{#if posterUrl}
+											<img
+												src={posterUrl}
+												alt={`Poster for ${displayTitle(show)}`}
+												class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+												loading="lazy"
+											/>
+											<div
+												class="absolute inset-0 bg-gradient-to-t from-slate-950/80 via-slate-950/20 to-transparent"
+											></div>
+										{:else}
+											<div
+												class="from-primary/22 to-accent/10 text-muted-foreground flex h-full min-h-[19rem] items-center justify-center bg-linear-to-br text-xs font-semibold tracking-[0.24em] uppercase"
+											>
+												No poster
+											</div>
 										{/if}
-									</p>
+										<div
+											class="absolute right-4 bottom-4 left-4 flex items-center justify-between gap-3"
+										>
+											<Badge
+												class="border-white/12 bg-slate-950/70 text-slate-100 backdrop-blur-sm"
+											>
+												{networkLabel(show)}
+											</Badge>
+											<div
+												class="rounded-full bg-slate-950/72 px-3 py-1 text-xs font-medium text-slate-100"
+											>
+												{seasonCount(show)} season{seasonCount(show) === 1 ? '' : 's'}
+											</div>
+										</div>
+									</div>
+
+									<div class="flex min-w-0 flex-col justify-between p-5">
+										<div class="space-y-4">
+											<div class="flex items-start justify-between gap-3">
+												<div class="min-w-0 space-y-2">
+													<h2 class="truncate text-2xl font-semibold tracking-[-0.03em]">
+														{displayTitle(show)}
+													</h2>
+													<div class="text-muted-foreground flex flex-wrap gap-x-3 gap-y-1 text-xs">
+														<span>{episodeCount(show)} episodes tracked</span>
+														{#if show.tmdb?.voteAverage !== undefined}
+															<span class="inline-flex items-center gap-1">
+																<StarIcon class="h-3.5 w-3.5 fill-current" />
+																{formatRating(show.tmdb.voteAverage)}
+															</span>
+														{/if}
+														<span>{formatLastWatched(show.lastWatchedAt)}</span>
+													</div>
+												</div>
+												{#if show.plexStatus !== 'unknown'}
+													<StatusChip status={show.plexStatus} class="shrink-0" />
+												{/if}
+											</div>
+
+											{#if show.tmdb?.overview}
+												<p class="text-muted-foreground line-clamp-3 text-sm leading-6">
+													{show.tmdb.overview}
+												</p>
+											{/if}
+
+											<div class="grid gap-3 sm:grid-cols-3">
+												<div class="border-border bg-background/42 rounded-2xl border px-3 py-3">
+													<p
+														class="text-muted-foreground text-[11px] font-semibold tracking-[0.18em] uppercase"
+													>
+														Completion
+													</p>
+													<p class="mt-2 text-2xl font-semibold">{pct ?? 0}%</p>
+												</div>
+												<div class="border-border bg-background/42 rounded-2xl border px-3 py-3">
+													<p
+														class="text-muted-foreground text-[11px] font-semibold tracking-[0.18em] uppercase"
+													>
+														Plex Plays
+													</p>
+													<p class="mt-2 text-2xl font-semibold">{show.watchCount ?? '—'}</p>
+												</div>
+												<div class="border-border bg-background/42 rounded-2xl border px-3 py-3">
+													<p
+														class="text-muted-foreground text-[11px] font-semibold tracking-[0.18em] uppercase"
+													>
+														Latest Intake
+													</p>
+													<p class="mt-2 text-sm font-medium">
+														{mostRecentQueuedAt(show) > 0
+															? new Date(mostRecentQueuedAt(show)).toLocaleDateString()
+															: 'Not queued yet'}
+													</p>
+												</div>
+											</div>
+
+											<div class="space-y-2">
+												<div
+													class="text-muted-foreground flex items-center justify-between text-[11px] font-semibold tracking-[0.18em] uppercase"
+												>
+													<span>Completion progress</span>
+													<span>{pct ?? 0}% complete</span>
+												</div>
+												<div class="bg-background/70 h-2 rounded-full">
+													<div
+														class="from-primary to-secondary h-2 rounded-full bg-linear-to-r"
+														style={`width: ${pct ?? 0}%`}
+													></div>
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+							</button>
+						</div>
+
+						<div class="border-border/70 flex flex-wrap justify-between gap-2 border-t px-5 py-4">
+							<Button
+								type="button"
+								variant={expanded ? 'secondary' : 'default'}
+								class="rounded-full px-4"
+								onclick={() => openShow(show)}
+							>
+								{#if expanded}
+									<ChevronUpIcon class="mr-2 h-4 w-4" />
+									Hide season drill-down
+								{:else}
+									<ChevronDownIcon class="mr-2 h-4 w-4" />
+									Inspect seasons
 								{/if}
-								<div class="text-muted-foreground mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs">
-									<span class="inline-flex items-center gap-1">
-										<span>Plex:</span>
-										<Badge variant="secondary" class={plexChipClass(show.plexStatus)}>
-											{plexStatusLabel(show.plexStatus)}
-										</Badge>
-									</span>
-									<span>Watches: <span class="text-foreground">{show.watchCount ?? '—'}</span></span
+							</Button>
+							<Button
+								href={showHref(show)}
+								variant="outline"
+								class="rounded-full px-4"
+								aria-label={detailButtonLabel(show)}
+							>
+								<ExternalLinkIcon class="mr-2 h-4 w-4" />
+								Open detail view
+							</Button>
+						</div>
+
+						{#if expanded && selectedSeason}
+							<div class="border-border/80 bg-background/36 border-t px-5 py-5">
+								<div class="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+									<div class="space-y-2">
+										<p
+											class="text-muted-foreground text-[11px] font-semibold tracking-[0.24em] uppercase"
+										>
+											Season drill-down
+										</p>
+										<h3 class="text-xl font-semibold tracking-[-0.03em]">Inline episode state</h3>
+									</div>
+									<div class="flex flex-wrap gap-2">
+										{#each show.seasons as season (season.season)}
+											<button
+												type="button"
+												class={`border-border bg-card/75 text-muted-foreground hover:border-primary/30 hover:text-foreground rounded-full border px-3 py-2 text-xs font-semibold tracking-[0.18em] uppercase transition-colors ${
+													season.season === selectedSeason.season
+														? 'border-primary/35 bg-primary/12 text-primary'
+														: ''
+												}`}
+												onclick={() => selectSeason(show, season.season)}
+											>
+												Season {season.season}
+											</button>
+										{/each}
+									</div>
+								</div>
+
+								{#if selectedSeason.episodes.length === 0}
+									<div
+										class="border-border bg-card/65 mt-5 rounded-3xl border border-dashed px-4 py-6"
 									>
-									<span
-										>Last watched:
-										<span class="text-foreground">{formatLastWatched(show.lastWatchedAt)}</span
-										></span
-									>
+										<p class="text-sm font-medium">No episodes tracked for this season yet.</p>
+									</div>
+								{:else}
+									<div class="mt-5 space-y-3">
+										{#each selectedSeason.episodes as episode (episode.identityKey)}
+											{@const live = liveTorrent(episode)}
+											{@const percentDone = live
+												? live.percentDone
+												: (episode.transmissionPercentDone ?? 0)}
+											{@const active = isActivelyTransferring(episode, live)}
+											<div
+												class="border-border bg-card/72 grid gap-4 rounded-[26px] border p-4 lg:grid-cols-[144px_minmax(0,1fr)_auto]"
+											>
+												<div class="bg-background/75 overflow-hidden rounded-2xl">
+													{#if episode.tmdb?.stillUrl}
+														<img
+															src={episode.tmdb.stillUrl}
+															alt={episode.tmdb?.name
+																? `Still for ${episode.tmdb.name}`
+																: `Episode ${episode.episode}`}
+															class="h-full min-h-[5.6rem] w-full object-cover"
+															loading="lazy"
+														/>
+													{:else}
+														<div
+															class="text-muted-foreground flex h-full min-h-[5.6rem] items-center justify-center text-xs font-semibold tracking-[0.18em] uppercase"
+														>
+															Still pending
+														</div>
+													{/if}
+												</div>
+
+												<div class="min-w-0 space-y-3">
+													<div class="flex flex-wrap items-start justify-between gap-3">
+														<div class="min-w-0">
+															<p
+																class="text-muted-foreground text-[11px] font-semibold tracking-[0.18em] uppercase"
+															>
+																Episode {String(episode.episode).padStart(2, '0')}
+															</p>
+															<p class="truncate text-lg font-semibold">
+																{episode.tmdb?.name ?? 'Untitled episode'}
+															</p>
+														</div>
+														<StatusChip status={episode.status} />
+													</div>
+
+													<div class="flex flex-wrap gap-2">
+														{#if episode.tmdb?.airDate}
+															<Badge variant="outline">{episode.tmdb.airDate}</Badge>
+														{/if}
+														{#if episode.lifecycleStatus}
+															<Badge variant="outline">{episode.lifecycleStatus}</Badge>
+														{/if}
+														{#if episode.transmissionTorrentHash}
+															<Badge variant="secondary">Torrent linked</Badge>
+														{/if}
+													</div>
+
+													<div class="space-y-2">
+														<div
+															class="text-muted-foreground flex items-center justify-between text-xs"
+														>
+															<span>Transfer progress</span>
+															<span>{formatPercent(percentDone)}</span>
+														</div>
+														<div class="bg-background/70 h-2 rounded-full">
+															<div
+																class={`h-2 rounded-full ${active ? 'bg-secondary' : 'bg-primary'}`}
+																style={`width: ${Math.round(percentDone * 100)}%`}
+															></div>
+														</div>
+														{#if live && live.status === 'downloading'}
+															<p class="text-muted-foreground text-xs">
+																{formatSpeed(live.rateDownload)} downlink
+															</p>
+														{/if}
+													</div>
+												</div>
+
+												<div
+													class="border-border/80 bg-background/42 flex min-w-[8rem] flex-col justify-between rounded-2xl border px-3 py-3 text-right"
+												>
+													<div>
+														<p
+															class="text-muted-foreground text-[11px] font-semibold tracking-[0.18em] uppercase"
+														>
+															Torrent state
+														</p>
+														<p class="mt-2 text-sm font-medium">
+															{active ? 'Live transfer' : 'Idle'}
+														</p>
+													</div>
+													<div class="mt-4">
+														<p
+															class="text-muted-foreground text-[11px] font-semibold tracking-[0.18em] uppercase"
+														>
+															Speed
+														</p>
+														<p class="mt-2 text-sm font-medium">
+															{live && live.status === 'downloading'
+																? formatSpeed(live.rateDownload)
+																: '—'}
+														</p>
+													</div>
+												</div>
+											</div>
+										{/each}
+									</div>
+								{/if}
+
+								<div class="mt-5 flex justify-end">
+									<Button href={showHref(show)} variant="ghost" class="rounded-full px-3">
+										<LayersIcon class="mr-2 h-4 w-4" />
+										Open full show detail
+									</Button>
 								</div>
 							</div>
-						</CardContent>
+						{/if}
 					</Card>
-				</a>
-			</li>
-		{/each}
-	</ul>
-{/if}
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</section>

--- a/web/src/routes/shows/shows.test.ts
+++ b/web/src/routes/shows/shows.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import Page from './+page.svelte';
-import type { ShowBreakdown } from '$lib/types';
+import type { ShowBreakdown, TorrentStatSnapshot } from '$lib/types';
 
 const sharedLayoutData = { health: null, transmissionSession: null };
 
-const mockShow: ShowBreakdown = {
+const exampleShow: ShowBreakdown = {
 	normalizedTitle: 'The Example Show',
-	plexStatus: 'unknown',
-	watchCount: null,
-	lastWatchedAt: null,
+	plexStatus: 'in_library',
+	watchCount: 7,
+	lastWatchedAt: '2026-04-15T00:00:00.000Z',
 	seasons: [
 		{
 			season: 1,
@@ -18,14 +18,39 @@ const mockShow: ShowBreakdown = {
 					episode: 1,
 					identityKey: 'key-s01e01',
 					status: 'completed',
-					transmissionPercentDone: 1.0
+					transmissionPercentDone: 1,
+					tmdb: {
+						name: 'Pilot',
+						stillUrl: 'https://example.com/still-1.jpg',
+						airDate: '2026-01-04'
+					}
 				},
 				{
 					episode: 2,
 					identityKey: 'key-s01e02',
 					status: 'downloading',
+					lifecycleStatus: 'active',
 					transmissionPercentDone: 0.5,
-					transmissionTorrentHash: 'abc123'
+					transmissionTorrentHash: 'abc123',
+					queuedAt: '2026-04-16T00:00:00.000Z',
+					tmdb: {
+						name: 'Second Contact',
+						stillUrl: 'https://example.com/still-2.jpg',
+						airDate: '2026-01-11'
+					}
+				}
+			]
+		},
+		{
+			season: 2,
+			episodes: [
+				{
+					episode: 1,
+					identityKey: 'key-s02e01',
+					status: 'queued',
+					transmissionPercentDone: 0.1,
+					queuedAt: '2026-04-17T00:00:00.000Z',
+					tmdb: { name: 'Season Premiere' }
 				}
 			]
 		}
@@ -34,12 +59,13 @@ const mockShow: ShowBreakdown = {
 		name: 'The Example Show',
 		posterUrl: 'https://example.com/poster.jpg',
 		voteAverage: 8.1,
-		numberOfSeasons: 3
+		numberOfSeasons: 2,
+		overview: 'An HBO story about an elite media crew.'
 	}
 };
 
-const mockShow2: ShowBreakdown = {
-	normalizedTitle: 'Another Show',
+const archiveShow: ShowBreakdown = {
+	normalizedTitle: 'Archive Unit',
 	plexStatus: 'unknown',
 	watchCount: null,
 	lastWatchedAt: null,
@@ -49,87 +75,135 @@ const mockShow2: ShowBreakdown = {
 			episodes: [
 				{
 					episode: 1,
-					identityKey: 'key2-s01e01',
+					identityKey: 'archive-s01e01',
 					status: 'downloading',
 					transmissionPercentDone: 0.8,
-					transmissionTorrentHash: 'def456'
+					transmissionTorrentHash: 'def456',
+					queuedAt: '2026-04-10T00:00:00.000Z',
+					tmdb: { name: 'Archive Day' }
 				}
 			]
 		}
-	]
+	],
+	tmdb: {
+		name: 'Archive Unit',
+		posterUrl: 'https://example.com/archive-poster.jpg',
+		voteAverage: 7.4,
+		numberOfSeasons: 1,
+		overview: 'An FX procedural in archive mode.'
+	}
+};
+
+const liveTorrent: TorrentStatSnapshot = {
+	hash: 'abc123',
+	name: 'The.Example.Show.S01E02',
+	status: 'downloading',
+	percentDone: 0.42,
+	rateDownload: 1_048_576,
+	eta: 3600
 };
 
 describe('/shows', () => {
-	it('renders show cards with TMDB metadata and link to detail', () => {
-		render(Page, { data: { ...sharedLayoutData, shows: [mockShow], torrents: null, error: null } });
+	it('renders poster-first cards with rating, network badge, and plex chip', () => {
+		render(Page, {
+			data: {
+				...sharedLayoutData,
+				shows: [exampleShow],
+				torrents: [liveTorrent],
+				error: null
+			}
+		});
+
 		expect(screen.getByRole('heading', { name: 'Shows' })).toBeInTheDocument();
 		expect(screen.getByText('The Example Show')).toBeInTheDocument();
-		expect(screen.getByTitle('TMDB vote average')).toHaveTextContent('★ 8.1');
-		expect(screen.getByRole('link', { name: /The Example Show/i })).toHaveAttribute(
+		expect(screen.getByText('HBO')).toBeInTheDocument();
+		expect(screen.getByText('IN_LIBRARY')).toBeInTheDocument();
+		expect(screen.getByText('7')).toBeInTheDocument();
+		expect(screen.getByText(/Watched/)).toBeInTheDocument();
+		expect(screen.getByText('8.1')).toBeInTheDocument();
+	});
+
+	it('expands the selected show inline and switches season tabs', async () => {
+		render(Page, {
+			data: {
+				...sharedLayoutData,
+				shows: [exampleShow],
+				torrents: [liveTorrent],
+				error: null
+			}
+		});
+
+		expect(screen.getByText('Inline episode state')).toBeInTheDocument();
+		expect(screen.getByText('Pilot')).toBeInTheDocument();
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Season 2' }));
+
+		expect(screen.getByText('Season Premiere')).toBeInTheDocument();
+		expect(screen.queryByText('Pilot')).not.toBeInTheDocument();
+	});
+
+	it('supports rating, progress, and recently added sorts', async () => {
+		render(Page, {
+			data: {
+				...sharedLayoutData,
+				shows: [archiveShow, exampleShow],
+				torrents: [liveTorrent],
+				error: null
+			}
+		});
+
+		let headings = screen.getAllByRole('heading', { level: 2 });
+		expect(headings[0]).toHaveTextContent('Archive Unit');
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Rating' }));
+		headings = screen.getAllByRole('heading', { level: 2 });
+		expect(headings[0]).toHaveTextContent('The Example Show');
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Progress' }));
+		headings = screen.getAllByRole('heading', { level: 2 });
+		expect(headings[0]).toHaveTextContent('The Example Show');
+
+		await fireEvent.click(screen.getByRole('button', { name: 'Recently Added' }));
+		headings = screen.getAllByRole('heading', { level: 2 });
+		expect(headings[0]).toHaveTextContent('The Example Show');
+	});
+
+	it('renders live transfer progress and detail links inside the expanded state', () => {
+		render(Page, {
+			data: {
+				...sharedLayoutData,
+				shows: [exampleShow],
+				torrents: [liveTorrent],
+				error: null
+			}
+		});
+
+		expect(screen.getByText('42%')).toBeInTheDocument();
+		expect(screen.getAllByText('1.0 MB/s')[0]).toBeInTheDocument();
+		expect(
+			screen.getByRole('link', { name: /Open The Example Show detail page/i })
+		).toHaveAttribute('href', '/shows/the%20example%20show');
+		expect(screen.getByRole('link', { name: /Open full show detail/i })).toHaveAttribute(
 			'href',
 			'/shows/the%20example%20show'
 		);
 	});
 
-	it('renders episode count and completion % on show card', () => {
-		render(Page, { data: { ...sharedLayoutData, shows: [mockShow], torrents: null, error: null } });
-		// 2 episodes, 1 completed → 50%
-		expect(screen.getByText(/2 episodes/)).toBeInTheDocument();
-		expect(screen.getByText(/50% complete/)).toBeInTheDocument();
-	});
-
-	it('renders Plex status, watch count, and last watched date on show cards', () => {
-		render(Page, {
-			data: {
-				...sharedLayoutData,
-				shows: [
-					{
-						...mockShow,
-						plexStatus: 'in_library',
-						watchCount: 7,
-						lastWatchedAt: '2026-04-15T00:00:00.000Z'
-					}
-				],
-				torrents: null,
-				error: null
-			}
+	it('renders empty and error states', () => {
+		const { rerender } = render(Page, {
+			data: { ...sharedLayoutData, shows: [], torrents: null, error: null }
 		});
 
-		expect(screen.getByText('In library')).toBeInTheDocument();
-		expect(screen.getByText('7')).toBeInTheDocument();
-		expect(
-			screen.getByText(new Date('2026-04-15T00:00:00.000Z').toLocaleDateString())
-		).toBeInTheDocument();
-	});
-
-	it('sort by Progress orders shows by max transmissionPercentDone desc', async () => {
-		render(Page, {
-			data: { ...sharedLayoutData, shows: [mockShow, mockShow2], torrents: null, error: null }
-		});
-		const links = screen.getAllByRole('link');
-		// Default title sort: "Another Show" before "The Example Show"
-		expect(links[0]).toHaveTextContent('Another Show');
-
-		// Click Progress sort
-		await fireEvent.click(screen.getByRole('button', { name: 'Progress' }));
-		const linksAfter = screen.getAllByRole('link');
-		// mockShow has max 1.0 (100%), mockShow2 has max 0.8 (80%) → mockShow first
-		expect(linksAfter[0]).toHaveTextContent('The Example Show');
-	});
-
-	it('renders empty state when there are no shows', () => {
-		render(Page, { data: { ...sharedLayoutData, shows: [], torrents: null, error: null } });
 		expect(screen.getByText(/No tracked shows yet/)).toBeInTheDocument();
 		expect(screen.getByRole('link', { name: 'Go to TV shows in Config' })).toHaveAttribute(
 			'href',
 			'/config#tv-shows'
 		);
-	});
 
-	it('renders error state when API is unreachable', () => {
-		render(Page, {
+		rerender({
 			data: { ...sharedLayoutData, shows: [], torrents: null, error: 'Could not reach the API.' }
 		});
+
 		expect(screen.getByRole('alert')).toHaveTextContent('Could not reach the API.');
 	});
 });

--- a/web/src/routes/shows/shows.test.ts
+++ b/web/src/routes/shows/shows.test.ts
@@ -142,6 +142,24 @@ describe('/shows', () => {
 		expect(screen.queryByText('Pilot')).not.toBeInTheDocument();
 	});
 
+	it('keeps all shows collapsed after the active card is manually closed', async () => {
+		render(Page, {
+			data: {
+				...sharedLayoutData,
+				shows: [exampleShow],
+				torrents: [liveTorrent],
+				error: null
+			}
+		});
+
+		expect(screen.getByText('Inline episode state')).toBeInTheDocument();
+
+		await fireEvent.click(screen.getByRole('button', { name: /Hide season drill-down/i }));
+
+		expect(screen.queryByText('Inline episode state')).not.toBeInTheDocument();
+		expect(screen.queryByText('42%')).not.toBeInTheDocument();
+	});
+
 	it('supports rating, progress, and recently added sorts', async () => {
 		render(Page, {
 			data: {


### PR DESCRIPTION
## Summary

- delivery ticket: `P19.04 TV Shows redesign`
- ticket file: [docs/02-delivery/phase-19/ticket-04-tv-shows-redesign.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-19/ticket-04-tv-shows-redesign.md)
- stacked base branch: `agents/p19-03-dashboard-redesign`
- self-audit: outcome `clean` completed at 2026-04-17 00:43 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`0ad8a5cbfac5`](https://github.com/cesarnml/pirate_claw/commit/0ad8a5cbfac5cdcedf5e00828a760c773b1aa85f)
- current branch head: [`ff7ff7b4cd3c`](https://github.com/cesarnml/pirate_claw/commit/ff7ff7b4cd3cb648123c1e41373237b8e4bd2cdc)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `0ad8a5cbfac5` address all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] $effect causes unwanted auto-expand when user collapses a show. (native GitHub thread resolved) `web/src/routes/shows/+page.svelte:159` [thread](https://github.com/cesarnml/pirate_claw/pull/171#discussion_r3097268470)
