### PR TITLE
feat: redesign config view [P19.07]

### DIFF
--- a/docs/02-delivery/phase-19/ticket-07-config-redesign.md
+++ b/docs/02-delivery/phase-19/ticket-07-config-redesign.md
@@ -54,3 +54,9 @@ Config is the lowest-risk view in this phase: it introduces no new data
 patterns, no route changes, and no new components beyond the write-access chip.
 Placing it last means the design token system, sidebar, and more complex view
 patterns are all proven before tackling the write-critical form surface.
+
+Implementation note: the footer keeps the screenshot's four-metric shape while
+staying inside the existing endpoint constraint. Host-level storage/CPU stats do
+not exist on `/api/health` or `/api/status`, so the footer uses the available
+live operator proxies instead: storage target path, transfer speed, last run
+cycle duration, and daemon uptime.

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -2,21 +2,23 @@ import { env } from '$env/dynamic/private';
 import { fail } from '@sveltejs/kit';
 import { deriveOnboardingStatus } from '$lib/onboarding';
 import { apiRequest } from '$lib/server/api';
-import type { AppConfig, OnboardingStatus } from '$lib/types';
+import type { AppConfig, OnboardingStatus, RunSummaryRecord, SessionInfo } from '$lib/types';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
 	const canWrite = !!env.PIRATE_CLAW_API_WRITE_TOKEN;
 
-	const [configResult, sessionResult] = await Promise.allSettled([
+	const [configResult, sessionResult, statusResult] = await Promise.allSettled([
 		apiRequest('/api/config'),
-		apiRequest('/api/transmission/session')
+		apiRequest('/api/transmission/session'),
+		apiRequest('/api/status')
 	]);
 
 	let config: AppConfig | null = null;
 	let etag: string | null = null;
 	let error: string | null = null;
-	let transmissionSession: { version: string } | null = null;
+	let transmissionSession: SessionInfo | null = null;
+	let runSummaries: RunSummaryRecord[] | null = null;
 	let onboarding: OnboardingStatus | null = null;
 
 	if (configResult.status === 'fulfilled' && configResult.value.ok) {
@@ -29,11 +31,15 @@ export const load: PageServerLoad = async () => {
 	}
 
 	if (sessionResult.status === 'fulfilled' && sessionResult.value.ok) {
-		const sessionData = (await sessionResult.value.json()) as { version: string };
-		transmissionSession = { version: sessionData.version };
+		transmissionSession = (await sessionResult.value.json()) as SessionInfo;
 	}
 
-	return { config, etag, canWrite, error, transmissionSession, onboarding };
+	if (statusResult.status === 'fulfilled' && statusResult.value.ok) {
+		const statusData = (await statusResult.value.json()) as { runs: RunSummaryRecord[] };
+		runSummaries = statusData.runs;
+	}
+
+	return { config, etag, canWrite, error, transmissionSession, runSummaries, onboarding };
 };
 
 function parseOptionalInt(input: unknown): number | undefined {

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -66,7 +66,7 @@
 	$effect(() => {
 		const c = data.config;
 		if (c) {
-			showRows = c.tv.map((rule) => rule.name);
+			showRows = c.tv.map((rule) => rule.matchPattern ?? rule.name);
 			tvResolutions = [...(c.tvDefaults?.resolutions ?? [])];
 			tvCodecs = [...(c.tvDefaults?.codecs ?? [])];
 			movieYears = [...c.movies.years];
@@ -156,8 +156,13 @@
 		}
 	}
 
-	function maskToken(active: boolean): string {
-		return active ? '••••••••' : 'not configured';
+	function transmissionAuthConfigured(): boolean {
+		if (!data.config) return false;
+		return !!(data.config.transmission.username || data.config.transmission.password);
+	}
+
+	function maskToken(configured: boolean): string {
+		return configured ? '••••••••' : 'not configured';
 	}
 
 	function formatUptime(value: number | undefined | null): string {
@@ -345,7 +350,7 @@
 							<p class="text-muted-foreground text-xs font-semibold tracking-[0.18em] uppercase">
 								Auth Token
 							</p>
-							<p class="mt-2 text-lg font-semibold">{maskToken(canWrite)}</p>
+							<p class="mt-2 text-lg font-semibold">{maskToken(transmissionAuthConfigured())}</p>
 						</div>
 					</div>
 
@@ -677,6 +682,7 @@
 								{#each ALL_RESOLUTIONS as resolution}
 									<button
 										type="button"
+										aria-pressed={tvResolutions.includes(resolution)}
 										class={`rounded-full border px-4 py-2 text-xs font-semibold tracking-[0.16em] uppercase transition-colors ${pillClass(
 											tvResolutions.includes(resolution)
 										)}`}
@@ -698,6 +704,7 @@
 								{#each ALL_CODECS as codec}
 									<button
 										type="button"
+										aria-pressed={tvCodecs.includes(codec)}
 										class={`rounded-full border px-4 py-2 text-xs font-semibold tracking-[0.16em] uppercase transition-colors ${pillClass(
 											tvCodecs.includes(codec)
 										)}`}
@@ -911,6 +918,7 @@
 								{#each ALL_RESOLUTIONS as resolution}
 									<button
 										type="button"
+										aria-pressed={movieResolutions.includes(resolution)}
 										class={`rounded-full border px-4 py-2 text-xs font-semibold tracking-[0.16em] uppercase transition-colors ${pillClass(
 											movieResolutions.includes(resolution)
 										)}`}
@@ -928,6 +936,7 @@
 								{#each ALL_CODECS as codec}
 									<button
 										type="button"
+										aria-pressed={movieCodecs.includes(codec)}
 										class={`rounded-full border px-4 py-2 text-xs font-semibold tracking-[0.16em] uppercase transition-colors ${pillClass(
 											movieCodecs.includes(codec)
 										)}`}
@@ -949,6 +958,7 @@
 								{#each ['prefer', 'require'] as policy}
 									<button
 										type="button"
+										aria-pressed={movieCodecPolicy === policy}
 										class={`rounded-2xl border px-4 py-3 text-sm font-semibold uppercase transition-colors ${
 											movieCodecPolicy === policy
 												? 'border-primary bg-primary/12 text-primary'

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import ActivityIcon from '@lucide/svelte/icons/activity';
+	import CableIcon from '@lucide/svelte/icons/cable';
+	import Clock3Icon from '@lucide/svelte/icons/clock-3';
+	import CpuIcon from '@lucide/svelte/icons/cpu';
+	import HardDriveIcon from '@lucide/svelte/icons/hard-drive';
+	import RadarIcon from '@lucide/svelte/icons/radar';
 	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
-	import {
-		Accordion,
-		AccordionContent,
-		AccordionItem,
-		AccordionTrigger
-	} from '$lib/components/ui/accordion';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Button } from '$lib/components/ui/button';
+	import { Card, CardContent, CardHeader } from '$lib/components/ui/card';
 	import { toast } from '$lib/toast';
 	import type { ActionData, PageData } from './$types';
-	import type { FeedConfig } from '$lib/types';
+	import type { FeedConfig, RunSummaryRecord } from '$lib/types';
 
 	const ALL_RESOLUTIONS = ['2160p', '1080p', '720p', '480p'];
 	const ALL_CODECS = ['x264', 'x265'];
@@ -46,15 +49,6 @@
 	let restarting = $state(false);
 	let restartOfferId = $state<ReturnType<typeof setTimeout> | null>(null);
 
-	let accordionValue = $state<string[]>([
-		'feeds',
-		'tv-configuration',
-		'movie-policy',
-		'transmission',
-		'tv-shows',
-		'runtime'
-	]);
-
 	function offerRestart() {
 		showRestartOffer = true;
 		if (restartOfferId) clearTimeout(restartOfferId);
@@ -72,7 +66,7 @@
 	$effect(() => {
 		const c = data.config;
 		if (c) {
-			showRows = c.tv.map((r) => r.name);
+			showRows = c.tv.map((rule) => rule.name);
 			tvResolutions = [...(c.tvDefaults?.resolutions ?? [])];
 			tvCodecs = [...(c.tvDefaults?.codecs ?? [])];
 			movieYears = [...c.movies.years];
@@ -93,48 +87,48 @@
 	}
 
 	function updateShowName(index: number, value: string) {
-		showRows = showRows.map((row, j) => (j === index ? value : row));
+		showRows = showRows.map((row, i) => (i === index ? value : row));
 	}
 
-	function toggleResolution(res: string) {
-		if (tvResolutions.includes(res)) {
-			tvResolutions = tvResolutions.filter((r) => r !== res);
+	function toggleResolution(resolution: string) {
+		if (tvResolutions.includes(resolution)) {
+			tvResolutions = tvResolutions.filter((value) => value !== resolution);
 		} else {
-			tvResolutions = [...tvResolutions, res];
+			tvResolutions = [...tvResolutions, resolution];
 		}
 	}
 
 	function toggleCodec(codec: string) {
 		if (tvCodecs.includes(codec)) {
-			tvCodecs = tvCodecs.filter((c) => c !== codec);
+			tvCodecs = tvCodecs.filter((value) => value !== codec);
 		} else {
 			tvCodecs = [...tvCodecs, codec];
 		}
 	}
 
 	function addMovieYear() {
-		const n = Number(movieYearInput.trim());
-		if (Number.isInteger(n) && n >= 1900 && n <= 2100 && !movieYears.includes(n)) {
-			movieYears = [...movieYears, n].sort((a, b) => a - b);
+		const value = Number(movieYearInput.trim());
+		if (Number.isInteger(value) && value >= 1900 && value <= 2100 && !movieYears.includes(value)) {
+			movieYears = [...movieYears, value].sort((left, right) => left - right);
 			movieYearInput = '';
 		}
 	}
 
 	function removeMovieYear(year: number) {
-		movieYears = movieYears.filter((y) => y !== year);
+		movieYears = movieYears.filter((value) => value !== year);
 	}
 
-	function toggleMovieResolution(res: string) {
-		if (movieResolutions.includes(res)) {
-			movieResolutions = movieResolutions.filter((r) => r !== res);
+	function toggleMovieResolution(resolution: string) {
+		if (movieResolutions.includes(resolution)) {
+			movieResolutions = movieResolutions.filter((value) => value !== resolution);
 		} else {
-			movieResolutions = [...movieResolutions, res];
+			movieResolutions = [...movieResolutions, resolution];
 		}
 	}
 
 	function toggleMovieCodec(codec: string) {
 		if (movieCodecs.includes(codec)) {
-			movieCodecs = movieCodecs.filter((c) => c !== codec);
+			movieCodecs = movieCodecs.filter((value) => value !== codec);
 		} else {
 			movieCodecs = [...movieCodecs, codec];
 		}
@@ -143,498 +137,229 @@
 	function removeFeed(index: number) {
 		feedsList = feedsList.filter((_, i) => i !== index);
 	}
+
+	function pillClass(selected: boolean): string {
+		return selected
+			? 'border-primary bg-primary/12 text-primary'
+			: 'border-border bg-card/60 text-muted-foreground hover:border-primary/25 hover:text-foreground';
+	}
+
+	function parseTransmissionUrl(value: string): { host: string; port: string } {
+		try {
+			const url = new URL(value);
+			return {
+				host: url.hostname || 'unknown',
+				port: url.port || (url.protocol === 'https:' ? '443' : '80')
+			};
+		} catch {
+			return { host: value, port: 'unknown' };
+		}
+	}
+
+	function maskToken(active: boolean): string {
+		return active ? '••••••••' : 'not configured';
+	}
+
+	function formatUptime(value: number | undefined | null): string {
+		if (typeof value !== 'number' || value <= 0) return 'Unavailable';
+		const totalMinutes = Math.floor(value / 60_000);
+		const days = Math.floor(totalMinutes / 1440);
+		const hours = Math.floor((totalMinutes % 1440) / 60);
+		const minutes = totalMinutes % 60;
+		if (days > 0) return `${days}d ${hours}h`;
+		if (hours > 0) return `${hours}h ${minutes}m`;
+		return `${minutes}m`;
+	}
+
+	function formatRate(bytesPerSecond: number | undefined): string {
+		if (typeof bytesPerSecond !== 'number' || bytesPerSecond <= 0) return 'Idle';
+		if (bytesPerSecond >= 1_048_576) return `${(bytesPerSecond / 1_048_576).toFixed(1)} MB/s`;
+		return `${(bytesPerSecond / 1024).toFixed(0)} KB/s`;
+	}
+
+	function totalRunItems(summary: RunSummaryRecord | null): number | null {
+		if (!summary) return null;
+		return Object.values(summary.counts).reduce((sum, count) => sum + count, 0);
+	}
+
+	function formatCycleLoad(durationMs: number | undefined): string {
+		if (typeof durationMs !== 'number' || durationMs <= 0) return 'Unavailable';
+		if (durationMs >= 60_000) return `${(durationMs / 60_000).toFixed(1)} min`;
+		return `${(durationMs / 1000).toFixed(1)} sec`;
+	}
+
+	function storagePoolLabel(): string {
+		if (!data.config) return 'Unavailable';
+		return (
+			data.config.transmission.downloadDirs?.movie ??
+			data.config.transmission.downloadDir ??
+			data.config.runtime.artifactDir
+		);
+	}
+
+	const transmissionEndpoint = $derived(
+		data.config
+			? parseTransmissionUrl(data.config.transmission.url)
+			: { host: 'Unavailable', port: '—' }
+	);
+	const latestRunSummary = $derived(data.runSummaries?.[0] ?? null);
+	const metrics = $derived([
+		{
+			label: 'Storage Pool',
+			value: storagePoolLabel(),
+			detail: 'Active transfer target',
+			icon: HardDriveIcon
+		},
+		{
+			label: 'Transfer Rate',
+			value: formatRate(data.transmissionSession?.downloadSpeed),
+			detail:
+				typeof data.transmissionSession?.uploadSpeed === 'number'
+					? `Upload ${formatRate(data.transmissionSession.uploadSpeed)}`
+					: 'Download telemetry',
+			icon: RadarIcon
+		},
+		{
+			label: 'CPU Load',
+			value: formatCycleLoad(data.health?.lastRunCycle?.durationMs),
+			detail:
+				totalRunItems(latestRunSummary) !== null
+					? `${totalRunItems(latestRunSummary)} items in last run`
+					: 'Last automation cycle',
+			icon: CpuIcon
+		},
+		{
+			label: 'Uptime',
+			value: formatUptime(data.health?.uptime),
+			detail: data.health?.startedAt
+				? `Started ${new Date(data.health.startedAt).toLocaleString()}`
+				: 'Daemon availability',
+			icon: Clock3Icon
+		}
+	]);
 </script>
 
-<h1 class="text-3xl font-bold tracking-tight">Config</h1>
-<p class="text-muted-foreground mt-1 text-sm">
-	Effective configuration from the API (secrets redacted).
-</p>
+<section class="space-y-6">
+	<div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+		<div class="space-y-3">
+			<p class="text-primary font-mono text-xs font-semibold tracking-[0.28em] uppercase">
+				System Configuration
+			</p>
+			<div class="space-y-2">
+				<h1 class="max-w-3xl text-4xl font-semibold tracking-[-0.04em] text-balance">Config</h1>
+				<p class="text-muted-foreground max-w-3xl text-sm leading-6">
+					Reconfigure ingestion, transfer rules, and acquisition policy without leaving the command
+					deck.
+				</p>
+			</div>
+		</div>
 
-{#if data.onboarding && data.onboarding.state !== 'ready'}
-	<Alert class="mt-6">
-		<AlertTitle>
-			{data.onboarding.state === 'partial_setup' ? 'Resume onboarding' : 'Start onboarding'}
-		</AlertTitle>
-		<AlertDescription class="flex flex-wrap items-center gap-3">
-			<span>
-				{#if data.onboarding.state === 'writes_disabled'}
-					Config writes are disabled, so guided onboarding is unavailable until write access is
-					enabled.
-				{:else if data.onboarding.state === 'partial_setup'}
-					Your setup is still incomplete. Resume onboarding or keep editing the config directly
-					here.
-				{:else}
-					If you want the guided setup path, start onboarding here instead of editing JSON by hand.
-				{/if}
-			</span>
-			{#if data.onboarding.state !== 'writes_disabled'}
-				<a href="/onboarding" class="text-primary text-sm font-medium hover:underline">
-					{data.onboarding.state === 'partial_setup' ? 'Resume onboarding' : 'Start onboarding'}
-				</a>
-			{/if}
-		</AlertDescription>
-	</Alert>
-{/if}
-
-{#if data.error}
-	<Alert variant="destructive" class="mt-6">
-		<AlertTitle>API unavailable</AlertTitle>
-		<AlertDescription>{data.error}</AlertDescription>
-	</Alert>
-{:else if data.config}
-	{@const config = data.config}
-
-	<Accordion type="multiple" bind:value={accordionValue} class="mt-8 space-y-3 pr-1">
-		<!-- RSS Feeds -->
-		<AccordionItem id="feeds" value="feeds" class="border-border bg-card rounded-lg border px-4">
-			<form
-				method="POST"
-				action="?/saveFeeds"
-				use:enhance={() => {
-					feedsSubmitting = true;
-					return async ({ result, update }) => {
-						feedsSubmitting = false;
-						if (result.type === 'success') {
-							newFeedName = '';
-							newFeedUrl = '';
-							newFeedMediaType = 'tv';
-							toast('Saved', 'success');
-						} else if (result.type === 'failure') {
-							if (result.status === 409) {
-								toast('Config changed elsewhere — reload and try again', 'error');
-							} else {
-								toast('Save failed — see errors above', 'error');
-							}
-						}
-						await update();
-					};
-				}}
-			>
-				<input type="hidden" name="feedsIfMatch" value={currentEtag ?? ''} />
-				<input type="hidden" name="existingFeedsJson" value={JSON.stringify(feedsList)} />
-				<AccordionTrigger class="text-base font-semibold">RSS Feeds</AccordionTrigger>
-				<AccordionContent>
-					<div class="space-y-4 pb-4">
-						{#if feedsList.length === 0}
-							<p class="text-muted-foreground text-sm">
-								No feeds configured yet. Add your first RSS feed to start onboarding or manual
-								setup.
-							</p>
-						{:else}
-							<ul class="list-none space-y-2">
-								{#each feedsList as feed, i}
-									<li
-										class="border-border bg-card/50 flex items-start justify-between gap-3 rounded-md border p-3 text-sm"
-									>
-										<div class="min-w-0 flex-1">
-											<div class="text-foreground font-medium">{feed.name}</div>
-											<div class="text-muted-foreground mt-1 flex flex-wrap items-center gap-2">
-												<span
-													class="border-border rounded-full border px-2 py-0.5 text-xs font-medium"
-													>{feed.mediaType}</span
-												>
-												<span class="break-all">{feed.url}</span>
-												{#if feed.pollIntervalMinutes !== undefined}
-													<span>Poll: {feed.pollIntervalMinutes}m</span>
-												{/if}
-											</div>
-										</div>
-										<button
-											type="button"
-											class="text-muted-foreground hover:text-foreground shrink-0 disabled:opacity-40"
-											disabled={!canWrite || feedsSubmitting}
-											title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-											aria-label="Remove feed {feed.name}"
-											onclick={() => removeFeed(i)}
-										>
-											×
-										</button>
-									</li>
-								{/each}
-							</ul>
-						{/if}
-						<div
-							class="border-border space-y-3 rounded-md border p-3"
-							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-						>
-							<p class="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-								Add feed
-							</p>
-							<div class="grid gap-2">
-								<input
-									name="newFeedName"
-									type="text"
-									placeholder="Feed name"
-									bind:value={newFeedName}
-									disabled={!canWrite || feedsSubmitting}
-									class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
-								/>
-								<div class="space-y-1">
-									<input
-										name="newFeedUrl"
-										type="url"
-										placeholder="https://example.com/feed.rss"
-										bind:value={newFeedUrl}
-										disabled={!canWrite || feedsSubmitting}
-										class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
-									/>
-									{#if form?.feedsUrlError}
-										<p class="text-destructive text-xs">{form.feedsUrlError}</p>
-									{/if}
-								</div>
-								<select
-									name="newFeedMediaType"
-									bind:value={newFeedMediaType}
-									disabled={!canWrite || feedsSubmitting}
-									class="border-input bg-background ring-offset-background focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
-								>
-									<option value="tv">TV</option>
-									<option value="movie">Movie</option>
-								</select>
-							</div>
-						</div>
-						<div>
-							<button
-								type="submit"
-								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
-								disabled={!canWrite || !currentEtag || feedsSubmitting}
-								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-							>
-								{#if feedsSubmitting}
-									Saving…
-								{:else}
-									Save feeds
-								{/if}
-							</button>
-						</div>
-					</div>
-				</AccordionContent>
-			</form>
-		</AccordionItem>
-
-		<!-- TV Configuration (defaults) -->
-		<AccordionItem value="tv-configuration" class="border-border bg-card rounded-lg border px-4">
-			<form
-				method="POST"
-				action="?/saveTvDefaults"
-				use:enhance={() => {
-					return async ({ result, update }) => {
-						if (result.type === 'success') {
-							toast('Saved', 'success');
-						} else if (result.type === 'failure') {
-							if (result.status === 409) {
-								toast('Config changed elsewhere — reload and try again', 'error');
-							} else {
-								toast('Save failed — see errors above', 'error');
-							}
-						}
-						await update();
-					};
-				}}
-			>
-				<input type="hidden" name="tvDefaultsIfMatch" value={currentEtag ?? ''} />
-				{#each tvResolutions as res}
-					<input type="hidden" name="tvResolution" value={res} />
-				{/each}
-				{#each tvCodecs as codec}
-					<input type="hidden" name="tvCodec" value={codec} />
-				{/each}
-				<AccordionTrigger class="text-base font-semibold">TV Configuration</AccordionTrigger>
-				<AccordionContent>
-					<div class="space-y-4 pb-4">
-						<p class="text-muted-foreground text-sm">
-							Global resolution and codec defaults inherited by all TV shows.
-						</p>
-						<div class="space-y-2">
-							<p class="text-muted-foreground text-sm font-medium">Resolutions</p>
-							<div
-								class="flex flex-wrap gap-2"
-								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-							>
-								{#each ALL_RESOLUTIONS as res}
-									<button
-										type="button"
-										class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {tvResolutions.includes(
-											res
-										)
-											? 'bg-primary text-primary-foreground border-primary'
-											: 'border-border text-muted-foreground hover:bg-muted'}"
-										disabled={!canWrite}
-										onclick={() => toggleResolution(res)}
-									>
-										{res}
-									</button>
-								{/each}
-							</div>
-						</div>
-						<div class="space-y-2">
-							<p class="text-muted-foreground text-sm font-medium">Codecs</p>
-							<div
-								class="flex flex-wrap gap-2"
-								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-							>
-								{#each ALL_CODECS as codec}
-									<button
-										type="button"
-										class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {tvCodecs.includes(
-											codec
-										)
-											? 'bg-primary text-primary-foreground border-primary'
-											: 'border-border text-muted-foreground hover:bg-muted'}"
-										disabled={!canWrite}
-										onclick={() => toggleCodec(codec)}
-									>
-										{codec}
-									</button>
-								{/each}
-							</div>
-						</div>
-						<div>
-							<button
-								type="submit"
-								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
-								disabled={!canWrite || !currentEtag}
-								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-							>
-								Save TV defaults
-							</button>
-						</div>
-					</div>
-				</AccordionContent>
-			</form>
-		</AccordionItem>
-
-		<!-- Movie Policy -->
-		<AccordionItem
-			id="movie-policy"
-			value="movie-policy"
-			class="border-border bg-card rounded-lg border px-4"
+		<div
+			class={`inline-flex items-center rounded-full border px-4 py-2 font-mono text-[11px] font-semibold tracking-[0.18em] uppercase ${
+				canWrite
+					? 'border-primary/35 bg-primary/16 text-primary'
+					: 'border-white/8 bg-white/6 text-slate-300'
+			}`}
 		>
-			<form
-				method="POST"
-				action="?/saveMovies"
-				use:enhance={() => {
-					return async ({ result, update }) => {
-						if (result.type === 'success') {
-							toast('Saved', 'success');
-						} else if (result.type === 'failure') {
-							if (result.status === 409) {
-								toast('Config changed elsewhere — reload and try again', 'error');
-							} else {
-								const detail =
-									typeof result.data?.moviesMessage === 'string'
-										? result.data.moviesMessage
-										: undefined;
-								toast('Save failed — see errors above', 'error', detail);
-							}
-						}
-						await update();
-					};
-				}}
-			>
-				<input type="hidden" name="moviesIfMatch" value={currentEtag ?? ''} />
-				{#each movieYears as year}
-					<input type="hidden" name="movieYear" value={year} />
-				{/each}
-				{#each movieResolutions as res}
-					<input type="hidden" name="movieResolution" value={res} />
-				{/each}
-				{#each movieCodecs as codec}
-					<input type="hidden" name="movieCodec" value={codec} />
-				{/each}
-				<input type="hidden" name="movieCodecPolicy" value={movieCodecPolicy} />
-				<AccordionTrigger class="text-base font-semibold">Movie Policy</AccordionTrigger>
-				<AccordionContent>
-					<div class="space-y-4 pb-4">
-						<div class="space-y-2">
-							<p class="text-muted-foreground text-sm font-medium">Years</p>
-							<div class="flex flex-wrap gap-2">
-								{#each movieYears as year}
-									<span
-										class="border-border bg-card/50 inline-flex h-8 items-center gap-1 rounded-full border px-3 text-sm"
-									>
-										{year}
-										<button
-											type="button"
-											class="text-muted-foreground hover:text-foreground ml-1"
-											disabled={!canWrite}
-											title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-											aria-label="Remove year {year}"
-											onclick={() => removeMovieYear(year)}>×</button
-										>
-									</span>
-								{/each}
-							</div>
-							<div class="flex gap-2" title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}>
-								<input
-									type="number"
-									min="1900"
-									max="2100"
-									step="1"
-									placeholder="e.g. 2025"
-									bind:value={movieYearInput}
-									disabled={!canWrite}
-									class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-32 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
-									onkeydown={(e) => {
-										if (e.key === 'Enter') {
-											e.preventDefault();
-											addMovieYear();
-										}
-									}}
-								/>
-								<button
-									type="button"
-									class="border-border bg-card hover:bg-muted/50 inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-50"
-									disabled={!canWrite}
-									onclick={addMovieYear}
-								>
-									Add year
-								</button>
-							</div>
-						</div>
-						<div class="space-y-2">
-							<p class="text-muted-foreground text-sm font-medium">Resolutions</p>
-							<div
-								class="flex flex-wrap gap-2"
-								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-							>
-								{#each ALL_RESOLUTIONS as res}
-									<button
-										type="button"
-										class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {movieResolutions.includes(
-											res
-										)
-											? 'bg-primary text-primary-foreground border-primary'
-											: 'border-border text-muted-foreground hover:bg-muted'}"
-										disabled={!canWrite}
-										onclick={() => toggleMovieResolution(res)}
-									>
-										{res}
-									</button>
-								{/each}
-							</div>
-						</div>
-						<div class="space-y-2">
-							<p class="text-muted-foreground text-sm font-medium">Codecs</p>
-							<div
-								class="flex flex-wrap gap-2"
-								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-							>
-								{#each ALL_CODECS as codec}
-									<button
-										type="button"
-										class="inline-flex h-8 items-center rounded-full border px-3 text-sm font-medium transition-colors {movieCodecs.includes(
-											codec
-										)
-											? 'bg-primary text-primary-foreground border-primary'
-											: 'border-border text-muted-foreground hover:bg-muted'}"
-										disabled={!canWrite}
-										onclick={() => toggleMovieCodec(codec)}
-									>
-										{codec}
-									</button>
-								{/each}
-							</div>
-						</div>
-						<div class="space-y-2">
-							<p class="text-muted-foreground text-sm font-medium">Codec policy</p>
-							<div
-								class="flex gap-0 overflow-hidden rounded-md border"
-								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-							>
-								{#each ['prefer', 'require'] as policy}
-									<button
-										type="button"
-										class="flex-1 px-4 py-2 text-sm font-medium transition-colors {movieCodecPolicy ===
-										policy
-											? 'bg-primary text-primary-foreground'
-											: 'text-muted-foreground hover:bg-muted'}"
-										disabled={!canWrite}
-										onclick={() => {
-											movieCodecPolicy = policy as 'prefer' | 'require';
-										}}
-									>
-										{policy.charAt(0).toUpperCase() + policy.slice(1)}
-									</button>
-								{/each}
-							</div>
-						</div>
-						<div>
-							<button
-								type="submit"
-								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
-								disabled={!canWrite || !currentEtag}
-								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-							>
-								Save movies policy
-							</button>
-						</div>
-					</div>
-				</AccordionContent>
-			</form>
-		</AccordionItem>
+			Write Access: {canWrite ? 'Active' : 'Restricted'}
+		</div>
+	</div>
 
-		<!-- Transmission -->
-		<AccordionItem value="transmission" class="border-border bg-card rounded-lg border px-4">
-			<AccordionTrigger class="text-base font-semibold">
-				<span class="flex items-center gap-2">
-					<span
-						class="inline-block h-2 w-2 rounded-full {data.transmissionSession
-							? 'bg-green-500'
-							: 'bg-red-500'}"
-						aria-label={data.transmissionSession ? 'connected' : 'disconnected'}
-					></span>
-					Transmission
-					{#if data.transmissionSession}
-						<span class="text-muted-foreground text-xs font-normal"
-							>v{data.transmissionSession.version}</span
-						>
+	{#if data.onboarding && data.onboarding.state !== 'ready'}
+		<Alert>
+			<AlertTitle>
+				{data.onboarding.state === 'partial_setup' ? 'Resume onboarding' : 'Start onboarding'}
+			</AlertTitle>
+			<AlertDescription class="flex flex-wrap items-center gap-3">
+				<span>
+					{#if data.onboarding.state === 'writes_disabled'}
+						Config writes are disabled, so guided onboarding is unavailable until write access is
+						enabled.
+					{:else if data.onboarding.state === 'partial_setup'}
+						Your setup is still incomplete. Resume onboarding or keep editing the config directly
+						here.
+					{:else}
+						If you want the guided setup path, start onboarding here instead of editing JSON by
+						hand.
 					{/if}
 				</span>
-			</AccordionTrigger>
-			<AccordionContent>
-				<div class="space-y-4 pb-4">
-					<dl class="grid gap-2 text-sm">
-						<div class="flex flex-wrap gap-2">
-							<dt class="text-muted-foreground">URL:</dt>
-							<dd class="text-foreground">{config.transmission.url}</dd>
+				{#if data.onboarding.state !== 'writes_disabled'}
+					<a href="/onboarding" class="text-primary text-sm font-medium hover:underline">
+						{data.onboarding.state === 'partial_setup' ? 'Resume onboarding' : 'Start onboarding'}
+					</a>
+				{/if}
+			</AlertDescription>
+		</Alert>
+	{/if}
+
+	{#if data.error}
+		<Alert variant="destructive">
+			<AlertTitle>API unavailable</AlertTitle>
+			<AlertDescription>{data.error}</AlertDescription>
+		</Alert>
+	{:else if data.config}
+		{@const config = data.config}
+
+		<div class="grid gap-5 xl:grid-cols-2">
+			<Card class="bg-card/75 rounded-[30px] border-white/10">
+				<CardHeader class="space-y-4">
+					<div class="flex items-center justify-between gap-3">
+						<div class="space-y-1">
+							<p class="text-primary font-mono text-xs font-semibold tracking-[0.2em] uppercase">
+								01 · Transmission Protocol
+							</p>
+							<h2 class="text-2xl font-semibold tracking-[-0.03em]">Transmission Protocol</h2>
 						</div>
-						<div class="flex flex-wrap gap-2">
-							<dt class="text-muted-foreground">Username:</dt>
-							<dd class="text-foreground">
-								{config.transmission.username ? '[configured]' : '[not set]'}
-							</dd>
+						<div class="text-muted-foreground inline-flex items-center gap-2 text-xs uppercase">
+							<span
+								class={`inline-block size-2 rounded-full ${data.transmissionSession ? 'bg-emerald-400' : 'bg-rose-400'}`}
+								aria-label={data.transmissionSession ? 'connected' : 'disconnected'}
+							></span>
+							{data.transmissionSession ? 'Connected' : 'Unavailable'}
 						</div>
-						<div class="flex flex-wrap gap-2">
-							<dt class="text-muted-foreground">Password:</dt>
-							<dd class="text-foreground">
-								{config.transmission.password ? '[redacted]' : '[not set]'}
-							</dd>
+					</div>
+				</CardHeader>
+				<CardContent class="space-y-6">
+					<div class="grid gap-3 sm:grid-cols-2">
+						<div class="border-border bg-background/50 rounded-2xl border p-4">
+							<p class="text-muted-foreground text-xs font-semibold tracking-[0.18em] uppercase">
+								Host
+							</p>
+							<p class="mt-2 text-lg font-semibold">{transmissionEndpoint.host}</p>
 						</div>
-						{#if config.transmission.downloadDir}
-							<div class="flex flex-wrap gap-2">
-								<dt class="text-muted-foreground">Download dir:</dt>
-								<dd class="text-foreground">{config.transmission.downloadDir}</dd>
-							</div>
-						{/if}
-						{#if config.transmission.downloadDirs}
-							{#if config.transmission.downloadDirs.tv}
-								<div class="flex flex-wrap gap-2">
-									<dt class="text-muted-foreground">TV dir:</dt>
-									<dd class="text-foreground">{config.transmission.downloadDirs.tv}</dd>
-								</div>
-							{/if}
-							{#if config.transmission.downloadDirs.movie}
-								<div class="flex flex-wrap gap-2">
-									<dt class="text-muted-foreground">Movie dir:</dt>
-									<dd class="text-foreground">{config.transmission.downloadDirs.movie}</dd>
-								</div>
-							{/if}
-						{/if}
-					</dl>
-					<p class="text-muted-foreground text-xs">
-						Edit credentials in <code class="font-mono">.env</code>
-					</p>
+						<div class="border-border bg-background/50 rounded-2xl border p-4">
+							<p class="text-muted-foreground text-xs font-semibold tracking-[0.18em] uppercase">
+								Port
+							</p>
+							<p class="mt-2 text-lg font-semibold">{transmissionEndpoint.port}</p>
+						</div>
+						<div class="border-border bg-background/50 rounded-2xl border p-4">
+							<p class="text-muted-foreground text-xs font-semibold tracking-[0.18em] uppercase">
+								RPC Version
+							</p>
+							<p class="mt-2 text-lg font-semibold">
+								{data.transmissionSession?.version ?? 'Unavailable'}
+							</p>
+						</div>
+						<div class="border-border bg-background/50 rounded-2xl border p-4">
+							<p class="text-muted-foreground text-xs font-semibold tracking-[0.18em] uppercase">
+								Auth Token
+							</p>
+							<p class="mt-2 text-lg font-semibold">{maskToken(canWrite)}</p>
+						</div>
+					</div>
+
+					<div class="grid gap-3 text-sm sm:grid-cols-2">
+						<div>
+							<p class="text-muted-foreground">URL</p>
+							<p class="mt-1 break-all">{config.transmission.url}</p>
+						</div>
+						<div>
+							<p class="text-muted-foreground">Download target</p>
+							<p class="mt-1 break-all">{storagePoolLabel()}</p>
+						</div>
+					</div>
+
 					<form
 						method="POST"
 						action="?/testConnection"
@@ -656,266 +381,667 @@
 							};
 						}}
 					>
-						<button
+						<Button
 							type="submit"
-							class="border-border bg-card hover:bg-muted/50 inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-50"
+							variant="outline"
+							class="rounded-full"
 							disabled={testingConnection}
 						>
+							<CableIcon class="size-4" />
 							{#if testingConnection}
 								Checking…
 							{:else}
 								Test Connection
 							{/if}
-						</button>
+						</Button>
 					</form>
-				</div>
-			</AccordionContent>
-		</AccordionItem>
 
-		<!-- TV Shows -->
-		<AccordionItem
-			id="tv-shows"
-			value="tv-shows"
-			class="border-border bg-card rounded-lg border px-4"
-		>
-			<form
-				method="POST"
-				action="?/saveShows"
-				use:enhance={() => {
-					return async ({ result, update }) => {
-						if (result.type === 'success') {
-							toast('TV shows saved.', 'success');
-						} else if (result.type === 'failure') {
-							if (result.status === 409) {
-								toast('Config changed elsewhere — reload and try again', 'error');
-							} else {
-								toast('Save failed — see errors above', 'error');
-							}
-						}
-						await update();
-					};
-				}}
-			>
-				<input type="hidden" name="ifMatch" value={currentEtag ?? ''} />
-				<AccordionTrigger class="text-base font-semibold">TV Shows</AccordionTrigger>
-				<AccordionContent>
-					<div class="space-y-4 pb-4">
-						<p class="text-muted-foreground text-sm">
-							Each row is a tracked show title (inherits codec/resolution defaults from your config
-							file). Remove the last show by removing the feed instead.
-						</p>
-						<ul class="list-none space-y-3">
-							{#each showRows as name, i}
-								<li class="flex flex-wrap items-center gap-2">
-									<input
-										name="showName"
-										type="text"
-										value={name}
-										autocomplete="off"
-										aria-label={`TV show ${i + 1}`}
-										disabled={!canWrite}
-										title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-										class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring min-w-[12rem] flex-1 rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
-										oninput={(e) => updateShowName(i, e.currentTarget.value)}
-									/>
+					<form
+						method="POST"
+						action="?/saveRuntime"
+						class="space-y-4 border-t border-white/8 pt-5"
+						use:enhance={() => {
+							return async ({ result, update }) => {
+								if (result.type === 'success') {
+									toast('Saved — restart the daemon for this change to take effect', 'success');
+									offerRestart();
+								} else if (result.type === 'failure') {
+									if (result.status === 409) {
+										toast('Config changed elsewhere — reload and try again', 'error');
+									} else {
+										toast('Save failed — see errors above', 'error');
+									}
+								}
+								await update();
+							};
+						}}
+					>
+						<input type="hidden" name="runtimeIfMatch" value={currentEtag ?? ''} />
+						{#each showRows as name}
+							<input type="hidden" name="currentShow" value={name} />
+						{/each}
+
+						<div class="space-y-2">
+							<p
+								class="text-muted-foreground font-mono text-xs font-semibold tracking-[0.18em] uppercase"
+							>
+								Runtime Controls
+							</p>
+							<p class="text-muted-foreground text-sm">
+								Daemon timers and the API listen port still require a restart after save.
+							</p>
+						</div>
+
+						<div class="grid gap-3 sm:grid-cols-2">
+							<label class="grid gap-1 text-sm">
+								<span class="text-muted-foreground">Run interval (minutes)</span>
+								<input
+									name="runIntervalMinutes"
+									type="number"
+									min="1"
+									step="1"
+									value={config.runtime.runIntervalMinutes}
+									disabled={!canWrite}
+									title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+									class="border-input bg-background ring-offset-background focus-visible:ring-ring h-10 rounded-2xl border px-3 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+								/>
+							</label>
+							<label class="grid gap-1 text-sm">
+								<span class="text-muted-foreground">Reconcile interval (minutes)</span>
+								<input
+									name="reconcileIntervalMinutes"
+									type="number"
+									min="1"
+									step="1"
+									value={config.runtime.reconcileIntervalMinutes}
+									disabled={!canWrite}
+									title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+									class="border-input bg-background ring-offset-background focus-visible:ring-ring h-10 rounded-2xl border px-3 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+								/>
+							</label>
+							<label class="grid gap-1 text-sm">
+								<span class="text-muted-foreground">TMDB refresh interval</span>
+								<input
+									name="tmdbRefreshIntervalMinutes"
+									type="number"
+									min="0"
+									step="1"
+									value={config.runtime.tmdbRefreshIntervalMinutes ?? 0}
+									disabled={!canWrite}
+									title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+									class="border-input bg-background ring-offset-background focus-visible:ring-ring h-10 rounded-2xl border px-3 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+								/>
+							</label>
+							<label class="grid gap-1 text-sm">
+								<span class="text-muted-foreground">API port</span>
+								<input
+									name="apiPort"
+									type="number"
+									min="1"
+									max="65535"
+									step="1"
+									value={config.runtime.apiPort ?? ''}
+									placeholder="unset"
+									disabled={!canWrite}
+									title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+									class="border-input bg-background ring-offset-background focus-visible:ring-ring h-10 rounded-2xl border px-3 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+								/>
+							</label>
+						</div>
+
+						{#if form?.runtimeMessage}
+							<p class="text-destructive text-xs">{form.runtimeMessage}</p>
+						{/if}
+
+						<div class="flex flex-wrap items-center gap-3">
+							<Button
+								type="submit"
+								class="rounded-full px-5"
+								disabled={!canWrite || !currentEtag}
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								<ActivityIcon class="size-4" />
+								Save runtime
+							</Button>
+							<p class="text-muted-foreground text-xs">
+								Revision <code>{currentEtag ?? 'missing'}</code>
+							</p>
+						</div>
+					</form>
+				</CardContent>
+			</Card>
+
+			<Card class="bg-card/75 rounded-[30px] border-white/10">
+				<CardHeader class="space-y-4">
+					<p class="text-primary font-mono text-xs font-semibold tracking-[0.2em] uppercase">
+						02 · RSS Ingestion Hubs
+					</p>
+					<h2 class="text-2xl font-semibold tracking-[-0.03em]">RSS Feeds</h2>
+				</CardHeader>
+				<CardContent>
+					<form
+						method="POST"
+						action="?/saveFeeds"
+						class="space-y-5"
+						use:enhance={() => {
+							feedsSubmitting = true;
+							return async ({ result, update }) => {
+								feedsSubmitting = false;
+								if (result.type === 'success') {
+									newFeedName = '';
+									newFeedUrl = '';
+									newFeedMediaType = 'tv';
+									toast('Saved', 'success');
+								} else if (result.type === 'failure') {
+									if (result.status === 409) {
+										toast('Config changed elsewhere — reload and try again', 'error');
+									} else {
+										toast('Save failed — see errors above', 'error');
+									}
+								}
+								await update();
+							};
+						}}
+					>
+						<input type="hidden" name="feedsIfMatch" value={currentEtag ?? ''} />
+						<input type="hidden" name="existingFeedsJson" value={JSON.stringify(feedsList)} />
+
+						{#if feedsList.length === 0}
+							<p class="text-muted-foreground text-sm">No feeds configured yet.</p>
+						{:else}
+							<ul class="grid list-none gap-3">
+								{#each feedsList as feed, index}
+									<li
+										class="border-border bg-background/50 flex items-center justify-between gap-3 rounded-2xl border p-3"
+									>
+										<div class="min-w-0 space-y-2">
+											<div class="flex flex-wrap items-center gap-2">
+												<p class="font-semibold">{feed.name}</p>
+												<Badge variant="secondary" class="bg-white/8 text-slate-200">
+													{feed.mediaType === 'tv' ? 'TV_SHOWS' : 'MOVIES'}
+												</Badge>
+											</div>
+											<p class="text-muted-foreground text-sm break-all">{feed.url}</p>
+										</div>
+										<button
+											type="button"
+											class="border-border text-muted-foreground hover:bg-muted inline-flex size-9 items-center justify-center rounded-full border text-lg disabled:opacity-50"
+											disabled={!canWrite || feedsSubmitting}
+											title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+											aria-label={`Remove feed ${feed.name}`}
+											onclick={() => removeFeed(index)}
+										>
+											×
+										</button>
+									</li>
+								{/each}
+							</ul>
+						{/if}
+
+						<div class="bg-background/40 grid gap-3 rounded-[24px] border border-white/8 p-4">
+							<p
+								class="text-muted-foreground font-mono text-xs font-semibold tracking-[0.18em] uppercase"
+							>
+								Add Feed
+							</p>
+							<input
+								name="newFeedName"
+								type="text"
+								placeholder="Feed name"
+								bind:value={newFeedName}
+								disabled={!canWrite || feedsSubmitting}
+								class="border-input bg-background ring-offset-background focus-visible:ring-ring h-10 rounded-2xl border px-3 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+							/>
+							<div class="space-y-1">
+								<input
+									name="newFeedUrl"
+									type="url"
+									placeholder="https://example.com/feed.rss"
+									bind:value={newFeedUrl}
+									disabled={!canWrite || feedsSubmitting}
+									class="border-input bg-background ring-offset-background focus-visible:ring-ring h-10 rounded-2xl border px-3 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+								/>
+								{#if form?.feedsUrlError}
+									<p class="text-destructive text-xs">{form.feedsUrlError}</p>
+								{/if}
+							</div>
+							<select
+								name="newFeedMediaType"
+								bind:value={newFeedMediaType}
+								disabled={!canWrite || feedsSubmitting}
+								class="border-input bg-background ring-offset-background focus-visible:ring-ring h-10 rounded-2xl border px-3 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+							>
+								<option value="tv">TV</option>
+								<option value="movie">Movie</option>
+							</select>
+						</div>
+
+						<div class="flex flex-wrap items-center gap-3">
+							<Button
+								type="submit"
+								class="rounded-full px-5"
+								disabled={!canWrite || !currentEtag || feedsSubmitting}
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								Save feeds
+							</Button>
+							{#if form?.feedsMessage}
+								<p class="text-destructive text-xs">{form.feedsMessage}</p>
+							{/if}
+						</div>
+					</form>
+				</CardContent>
+			</Card>
+
+			<Card class="bg-card/75 rounded-[30px] border-white/10">
+				<CardHeader class="space-y-4">
+					<p class="text-primary font-mono text-xs font-semibold tracking-[0.2em] uppercase">
+						03 · TV Serial Parameters
+					</p>
+					<h2 class="text-2xl font-semibold tracking-[-0.03em]">TV Configuration</h2>
+				</CardHeader>
+				<CardContent class="space-y-6">
+					<form
+						method="POST"
+						action="?/saveTvDefaults"
+						class="space-y-4"
+						use:enhance={() => {
+							return async ({ result, update }) => {
+								if (result.type === 'success') {
+									toast('Saved', 'success');
+								} else if (result.type === 'failure') {
+									if (result.status === 409) {
+										toast('Config changed elsewhere — reload and try again', 'error');
+									} else {
+										toast('Save failed — see errors above', 'error');
+									}
+								}
+								await update();
+							};
+						}}
+					>
+						<input type="hidden" name="tvDefaultsIfMatch" value={currentEtag ?? ''} />
+						{#each tvResolutions as resolution}
+							<input type="hidden" name="tvResolution" value={resolution} />
+						{/each}
+						{#each tvCodecs as codec}
+							<input type="hidden" name="tvCodec" value={codec} />
+						{/each}
+
+						<div class="space-y-2">
+							<p class="text-muted-foreground text-sm font-medium">Target resolutions</p>
+							<div
+								class="flex flex-wrap gap-2"
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								{#each ALL_RESOLUTIONS as resolution}
 									<button
 										type="button"
-										class="border-border text-muted-foreground hover:bg-muted inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border text-sm font-medium disabled:opacity-50"
-										disabled={!canWrite || showRows.length <= 1}
-										title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-										aria-label="Remove show"
-										onclick={() => removeShow(i)}>×</button
+										class={`rounded-full border px-4 py-2 text-xs font-semibold tracking-[0.16em] uppercase transition-colors ${pillClass(
+											tvResolutions.includes(resolution)
+										)}`}
+										disabled={!canWrite}
+										onclick={() => toggleResolution(resolution)}
 									>
-								</li>
-							{/each}
-						</ul>
-						<div>
-							<button
+										{resolution}
+									</button>
+								{/each}
+							</div>
+						</div>
+
+						<div class="space-y-2">
+							<p class="text-muted-foreground text-sm font-medium">Preferred codecs</p>
+							<div
+								class="flex flex-wrap gap-2"
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								{#each ALL_CODECS as codec}
+									<button
+										type="button"
+										class={`rounded-full border px-4 py-2 text-xs font-semibold tracking-[0.16em] uppercase transition-colors ${pillClass(
+											tvCodecs.includes(codec)
+										)}`}
+										disabled={!canWrite}
+										onclick={() => toggleCodec(codec)}
+									>
+										{codec}
+									</button>
+								{/each}
+							</div>
+						</div>
+
+						<Button
+							type="submit"
+							class="rounded-full px-5"
+							disabled={!canWrite || !currentEtag}
+							title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+						>
+							Save TV defaults
+						</Button>
+					</form>
+
+					<form
+						method="POST"
+						action="?/saveShows"
+						class="space-y-4 border-t border-white/8 pt-5"
+						use:enhance={() => {
+							return async ({ result, update }) => {
+								if (result.type === 'success') {
+									toast('TV shows saved.', 'success');
+								} else if (result.type === 'failure') {
+									if (result.status === 409) {
+										toast('Config changed elsewhere — reload and try again', 'error');
+									} else {
+										toast('Save failed — see errors above', 'error');
+									}
+								}
+								await update();
+							};
+						}}
+					>
+						<input type="hidden" name="ifMatch" value={currentEtag ?? ''} />
+
+						<div class="space-y-2">
+							<p class="text-muted-foreground text-sm font-medium">Active watchlist</p>
+							<div class="flex flex-wrap gap-2">
+								{#if showRows.length === 0}
+									<p class="text-muted-foreground text-sm">No tracked shows configured yet.</p>
+								{:else}
+									{#each showRows as name, index}
+										<div
+											class="border-border bg-background/50 flex items-center gap-2 rounded-full border pr-2 pl-4"
+										>
+											<input
+												name="showName"
+												type="text"
+												value={name}
+												autocomplete="off"
+												aria-label={`TV show ${index + 1}`}
+												disabled={!canWrite}
+												title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+												class="min-w-[10rem] bg-transparent py-2 text-sm outline-none disabled:opacity-50"
+												oninput={(event) => updateShowName(index, event.currentTarget.value)}
+											/>
+											<button
+												type="button"
+												class="text-muted-foreground hover:bg-muted inline-flex size-7 items-center justify-center rounded-full disabled:opacity-50"
+												disabled={!canWrite || showRows.length <= 1}
+												title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+												aria-label="Remove show"
+												onclick={() => removeShow(index)}
+											>
+												×
+											</button>
+										</div>
+									{/each}
+								{/if}
+							</div>
+						</div>
+
+						<div class="flex flex-wrap items-center gap-3">
+							<Button
 								type="button"
-								class="border-border bg-card hover:bg-muted/50 inline-flex h-9 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-50"
+								variant="outline"
+								class="rounded-full px-5"
 								disabled={!canWrite}
 								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
 								onclick={addShow}
 							>
 								Add show
-							</button>
-						</div>
-						{#if form?.showsMessage}
-							<p class="text-destructive text-xs">{form.showsMessage}</p>
-						{/if}
-						<div>
-							<button
+							</Button>
+							<Button
 								type="submit"
-								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
+								class="rounded-full px-5"
 								disabled={!canWrite || !currentEtag}
 								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
 							>
 								Save shows
-							</button>
-						</div>
-					</div>
-				</AccordionContent>
-			</form>
-		</AccordionItem>
-
-		<!-- Runtime -->
-		<AccordionItem value="runtime" class="border-border bg-card rounded-lg border px-4">
-			<form
-				method="POST"
-				action="?/saveRuntime"
-				use:enhance={() => {
-					return async ({ result, update }) => {
-						if (result.type === 'success') {
-							toast('Saved — restart the daemon for this change to take effect', 'success');
-							offerRestart();
-						} else if (result.type === 'failure') {
-							if (result.status === 409) {
-								toast('Config changed elsewhere — reload and try again', 'error');
-							} else {
-								toast('Save failed — see errors above', 'error');
-							}
-						}
-						await update();
-					};
-				}}
-			>
-				<input type="hidden" name="runtimeIfMatch" value={currentEtag ?? ''} />
-				{#each showRows as name}
-					<input type="hidden" name="currentShow" value={name} />
-				{/each}
-				<AccordionTrigger class="text-base font-semibold">Runtime</AccordionTrigger>
-				<AccordionContent>
-					<div class="grid gap-4 pb-4 text-sm">
-						<div class="grid gap-1">
-							<label class="text-muted-foreground" for="runIntervalMinutes"
-								>Run interval (minutes)</label
-							>
-							<input
-								id="runIntervalMinutes"
-								name="runIntervalMinutes"
-								type="number"
-								min="1"
-								step="1"
-								value={config.runtime.runIntervalMinutes}
-								disabled={!canWrite}
-								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
-							/>
+							</Button>
 						</div>
 
-						<div class="grid gap-1">
-							<label class="text-muted-foreground" for="reconcileIntervalMinutes">
-								Reconcile interval (minutes)
-							</label>
-							<input
-								id="reconcileIntervalMinutes"
-								name="reconcileIntervalMinutes"
-								type="number"
-								min="1"
-								step="1"
-								value={config.runtime.reconcileIntervalMinutes}
-								disabled={!canWrite}
-								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
-							/>
-						</div>
-
-						<div class="grid gap-1">
-							<label class="text-muted-foreground" for="tmdbRefreshIntervalMinutes">
-								TMDB refresh interval (minutes, 0 disables)
-							</label>
-							<input
-								id="tmdbRefreshIntervalMinutes"
-								name="tmdbRefreshIntervalMinutes"
-								type="number"
-								min="0"
-								step="1"
-								value={config.runtime.tmdbRefreshIntervalMinutes ?? 0}
-								disabled={!canWrite}
-								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
-							/>
-						</div>
-
-						<div class="grid gap-1">
-							<label class="text-muted-foreground" for="apiPort">API port (optional)</label>
-							<input
-								id="apiPort"
-								name="apiPort"
-								type="number"
-								min="1"
-								max="65535"
-								step="1"
-								value={config.runtime.apiPort ?? ''}
-								placeholder="unset"
-								disabled={!canWrite}
-								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
-								class="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring h-9 w-full rounded-md border px-3 py-1 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
-							/>
-						</div>
-
-						<div class="text-muted-foreground text-xs">
-							Revision: <code>{currentEtag ?? 'missing'}</code>
-						</div>
-						<p class="text-muted-foreground text-xs">
-							Daemon timers and the API listen port are fixed at process start — restart after
-							changing those fields.
-						</p>
-						{#if form?.runtimeMessage}
-							<p class="text-destructive text-xs">{form.runtimeMessage}</p>
+						{#if form?.showsMessage}
+							<p class="text-destructive text-xs">{form.showsMessage}</p>
 						{/if}
+					</form>
+				</CardContent>
+			</Card>
+
+			<Card id="movie-policy" class="bg-card/75 rounded-[30px] border-white/10">
+				<CardHeader class="space-y-4">
+					<p class="text-primary font-mono text-xs font-semibold tracking-[0.2em] uppercase">
+						04 · Movie Acquisition Policies
+					</p>
+					<h2 class="text-2xl font-semibold tracking-[-0.03em]">Movie Policy</h2>
+				</CardHeader>
+				<CardContent>
+					<form
+						method="POST"
+						action="?/saveMovies"
+						class="space-y-5"
+						use:enhance={() => {
+							return async ({ result, update }) => {
+								if (result.type === 'success') {
+									toast('Saved', 'success');
+								} else if (result.type === 'failure') {
+									if (result.status === 409) {
+										toast('Config changed elsewhere — reload and try again', 'error');
+									} else {
+										const detail =
+											typeof result.data?.moviesMessage === 'string'
+												? result.data.moviesMessage
+												: undefined;
+										toast('Save failed — see errors above', 'error', detail);
+									}
+								}
+								await update();
+							};
+						}}
+					>
+						<input type="hidden" name="moviesIfMatch" value={currentEtag ?? ''} />
+						{#each movieYears as year}
+							<input type="hidden" name="movieYear" value={year} />
+						{/each}
+						{#each movieResolutions as resolution}
+							<input type="hidden" name="movieResolution" value={resolution} />
+						{/each}
+						{#each movieCodecs as codec}
+							<input type="hidden" name="movieCodec" value={codec} />
+						{/each}
+						<input type="hidden" name="movieCodecPolicy" value={movieCodecPolicy} />
+
+						<div class="space-y-2">
+							<p class="text-muted-foreground text-sm font-medium">Release year range</p>
+							<div class="flex flex-wrap gap-2">
+								{#each movieYears as year}
+									<span
+										class="border-border bg-background/50 inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm"
+									>
+										{year}
+										<button
+											type="button"
+											class="text-muted-foreground hover:text-foreground disabled:opacity-50"
+											disabled={!canWrite}
+											title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+											aria-label={`Remove year ${year}`}
+											onclick={() => removeMovieYear(year)}
+										>
+											×
+										</button>
+									</span>
+								{/each}
+							</div>
+							<div
+								class="flex flex-wrap gap-2"
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								<input
+									type="number"
+									min="1900"
+									max="2100"
+									step="1"
+									placeholder="e.g. 2025"
+									bind:value={movieYearInput}
+									disabled={!canWrite}
+									class="border-input bg-background ring-offset-background focus-visible:ring-ring h-10 w-36 rounded-2xl border px-3 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+									onkeydown={(event) => {
+										if (event.key === 'Enter') {
+											event.preventDefault();
+											addMovieYear();
+										}
+									}}
+								/>
+								<Button
+									type="button"
+									variant="outline"
+									class="rounded-full px-5"
+									disabled={!canWrite}
+									onclick={addMovieYear}
+								>
+									Add year
+								</Button>
+							</div>
+						</div>
+
+						<div class="space-y-2">
+							<p class="text-muted-foreground text-sm font-medium">Required specs</p>
+							<div
+								class="flex flex-wrap gap-2"
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								{#each ALL_RESOLUTIONS as resolution}
+									<button
+										type="button"
+										class={`rounded-full border px-4 py-2 text-xs font-semibold tracking-[0.16em] uppercase transition-colors ${pillClass(
+											movieResolutions.includes(resolution)
+										)}`}
+										disabled={!canWrite}
+										onclick={() => toggleMovieResolution(resolution)}
+									>
+										{resolution}
+									</button>
+								{/each}
+							</div>
+							<div
+								class="flex flex-wrap gap-2"
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								{#each ALL_CODECS as codec}
+									<button
+										type="button"
+										class={`rounded-full border px-4 py-2 text-xs font-semibold tracking-[0.16em] uppercase transition-colors ${pillClass(
+											movieCodecs.includes(codec)
+										)}`}
+										disabled={!canWrite}
+										onclick={() => toggleMovieCodec(codec)}
+									>
+										{codec}
+									</button>
+								{/each}
+							</div>
+						</div>
+
+						<div class="space-y-2">
+							<p class="text-muted-foreground text-sm font-medium">Constraint level</p>
+							<div
+								class="grid grid-cols-2 gap-2"
+								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+							>
+								{#each ['prefer', 'require'] as policy}
+									<button
+										type="button"
+										class={`rounded-2xl border px-4 py-3 text-sm font-semibold uppercase transition-colors ${
+											movieCodecPolicy === policy
+												? 'border-primary bg-primary/12 text-primary'
+												: 'border-border bg-background/50 text-muted-foreground hover:border-primary/25 hover:text-foreground'
+										}`}
+										disabled={!canWrite}
+										onclick={() => {
+											movieCodecPolicy = policy as 'prefer' | 'require';
+										}}
+									>
+										{policy}
+									</button>
+								{/each}
+							</div>
+						</div>
+
 						<div class="flex flex-wrap items-center gap-3">
-							<button
+							<Button
 								type="submit"
-								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium disabled:opacity-50"
+								class="rounded-full px-5"
 								disabled={!canWrite || !currentEtag}
 								title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
 							>
-								Save runtime
-							</button>
+								Save movies policy
+							</Button>
+							{#if form?.moviesMessage}
+								<p class="text-destructive text-xs">{form.moviesMessage}</p>
+							{/if}
 						</div>
-					</div>
-				</AccordionContent>
-			</form>
-		</AccordionItem>
-	</Accordion>
+					</form>
+				</CardContent>
+			</Card>
+		</div>
 
-	{#if showRestartOffer}
-		<form
-			method="POST"
-			action="?/restartDaemon"
-			class="mt-3 pr-1"
-			use:enhance={() => {
-				restarting = true;
-				return async ({ result, update }) => {
-					showRestartOffer = false;
-					restarting = false;
-					if (result.type === 'success') {
-						toast('Restarting… the page may become temporarily unavailable', 'success');
-					} else {
-						toast('Restart failed — try again or restart manually', 'error');
-					}
-					await update({ reset: false });
-				};
-			}}
-		>
-			<div class="border-border bg-card/50 flex items-center gap-3 rounded-md border p-3 text-sm">
-				<p class="text-muted-foreground flex-1">
-					Restart the daemon for your changes to take effect.
-				</p>
-				<button
-					type="submit"
-					class="border-border hover:bg-muted inline-flex h-8 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-50"
-					disabled={!canWrite || restarting}
-					title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+		<div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+			{#each metrics as metric}
+				<article class="bg-card/70 border-border/70 rounded-[24px] border p-4">
+					<div class="flex items-start justify-between gap-3">
+						<div class="space-y-2">
+							<p class="text-muted-foreground text-xs font-semibold tracking-[0.18em] uppercase">
+								{metric.label}
+							</p>
+							<p class="text-xl font-semibold tracking-[-0.03em] break-all">{metric.value}</p>
+							<p class="text-muted-foreground text-xs leading-5">{metric.detail}</p>
+						</div>
+						<metric.icon class="text-primary size-4 shrink-0" />
+					</div>
+				</article>
+			{/each}
+		</div>
+
+		{#if showRestartOffer}
+			<form
+				method="POST"
+				action="?/restartDaemon"
+				use:enhance={() => {
+					restarting = true;
+					return async ({ result, update }) => {
+						showRestartOffer = false;
+						restarting = false;
+						if (result.type === 'success') {
+							toast('Restarting… the page may become temporarily unavailable', 'success');
+						} else {
+							toast('Restart failed — try again or restart manually', 'error');
+						}
+						await update({ reset: false });
+					};
+				}}
+			>
+				<div
+					class="border-border bg-card/60 flex flex-col gap-3 rounded-[24px] border p-4 sm:flex-row sm:items-center sm:justify-between"
 				>
-					{#if restarting}
-						Restarting…
-					{:else}
-						Restart Daemon
-					{/if}
-				</button>
-			</div>
-		</form>
+					<div class="space-y-1">
+						<p class="font-semibold">Runtime changes are staged.</p>
+						<p class="text-muted-foreground text-sm">
+							Restart the daemon to apply interval and port updates.
+						</p>
+					</div>
+					<Button
+						type="submit"
+						variant="outline"
+						class="rounded-full px-5"
+						disabled={!canWrite || restarting}
+						title={!canWrite ? WRITE_DISABLED_TOOLTIP : undefined}
+					>
+						{#if restarting}
+							Restarting…
+						{:else}
+							Restart Daemon
+						{/if}
+					</Button>
+				</div>
+			</form>
+		{/if}
 	{/if}
-{/if}
+</section>

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -121,6 +121,28 @@ describe('/config', () => {
 		);
 	});
 
+	it('seeds the editable watchlist from matchPattern when present', () => {
+		renderPage({
+			config: {
+				...mockConfig,
+				tv: [
+					{
+						name: 'hd-tv',
+						matchPattern: 'The Show',
+						resolutions: ['1080p'],
+						codecs: ['x265']
+					}
+				]
+			},
+			error: null,
+			etag: '"rev-1"',
+			canWrite: true,
+			onboarding: null
+		});
+
+		expect(screen.getByRole('textbox', { name: 'TV show 1' })).toHaveValue('The Show');
+	});
+
 	it('does not render restart offer by default', () => {
 		renderPage({
 			config: mockConfig,

--- a/web/src/routes/config/config.test.ts
+++ b/web/src/routes/config/config.test.ts
@@ -68,13 +68,14 @@ describe('/config', () => {
 		expect(screen.getByRole('heading', { name: 'RSS Feeds' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'TV Configuration' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Movie Policy' })).toBeInTheDocument();
-		expect(screen.getByRole('heading', { name: 'TV Shows' })).toBeInTheDocument();
-		expect(screen.getByRole('heading', { name: 'Runtime' })).toBeInTheDocument();
-		expect(screen.getByRole('heading', { name: /Transmission/ })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Transmission Protocol' })).toBeInTheDocument();
+		expect(screen.getByText('Write Access: Active')).toBeInTheDocument();
 		expect(screen.getByText('TestFeed')).toBeInTheDocument();
 		expect(screen.getByRole('textbox', { name: 'TV show 1' })).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Save shows' })).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Save runtime' })).toBeInTheDocument();
+		expect(screen.getByText('Storage Pool')).toBeInTheDocument();
+		expect(screen.getByText('Transfer Rate')).toBeInTheDocument();
 	});
 
 	it('renders error state when API is unreachable', () => {
@@ -184,30 +185,10 @@ describe('/config', () => {
 			onboarding: null
 		});
 
-		expect(screen.getByRole('button', { name: 'RSS Feeds' })).toHaveAttribute(
-			'aria-expanded',
-			'true'
-		);
-		expect(screen.getByRole('button', { name: 'TV Configuration' })).toHaveAttribute(
-			'aria-expanded',
-			'true'
-		);
-		expect(screen.getByRole('button', { name: 'Movie Policy' })).toHaveAttribute(
-			'aria-expanded',
-			'true'
-		);
-		expect(screen.getByRole('button', { name: /Transmission/ })).toHaveAttribute(
-			'aria-expanded',
-			'true'
-		);
-		expect(screen.getByRole('button', { name: 'TV Shows' })).toHaveAttribute(
-			'aria-expanded',
-			'true'
-		);
-		expect(screen.getByRole('button', { name: 'Runtime' })).toHaveAttribute(
-			'aria-expanded',
-			'true'
-		);
+		expect(screen.getByRole('heading', { name: 'Transmission Protocol' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'RSS Feeds' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'TV Configuration' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Movie Policy' })).toBeInTheDocument();
 	});
 
 	it('disables all write controls in read-only mode but keeps Test Connection enabled', () => {
@@ -219,6 +200,7 @@ describe('/config', () => {
 			onboarding: null
 		});
 
+		expect(screen.getByText('Write Access: Restricted')).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Save feeds' })).toBeDisabled();
 		expect(screen.getByRole('button', { name: 'Save TV defaults' })).toBeDisabled();
 		expect(screen.getByRole('button', { name: 'Save movies policy' })).toBeDisabled();

--- a/web/src/routes/config/page.server.test.ts
+++ b/web/src/routes/config/page.server.test.ts
@@ -36,7 +36,8 @@ describe('config page server actions', () => {
 						{ status: 200 }
 					)
 				)
-				.mockRejectedValueOnce(new Error('network error'));
+				.mockRejectedValueOnce(new Error('network error'))
+				.mockResolvedValueOnce(new Response(JSON.stringify({ runs: [] }), { status: 200 }));
 
 			const result = await load({} as never);
 			expect((result as { onboarding: { state: string } | null }).onboarding?.state).toBe(
@@ -68,7 +69,8 @@ describe('config page server actions', () => {
 						{ status: 200 }
 					)
 				)
-				.mockRejectedValueOnce(new Error('network error'));
+				.mockRejectedValueOnce(new Error('network error'))
+				.mockResolvedValueOnce(new Response(JSON.stringify({ runs: [] }), { status: 200 }));
 
 			const result = await load({} as never);
 			expect((result as { transmissionSession: unknown }).transmissionSession).toBeNull();
@@ -99,12 +101,24 @@ describe('config page server actions', () => {
 					)
 				)
 				.mockResolvedValueOnce(
-					new Response(JSON.stringify({ version: '3.00 (bb6b5a062ef)' }), { status: 200 })
-				);
+					new Response(
+						JSON.stringify({
+							version: '3.00 (bb6b5a062ef)',
+							downloadSpeed: 2_097_152,
+							uploadSpeed: 524_288,
+							activeTorrentCount: 4
+						}),
+						{ status: 200 }
+					)
+				)
+				.mockResolvedValueOnce(new Response(JSON.stringify({ runs: [] }), { status: 200 }));
 
 			const result = await load({} as never);
 			expect((result as { transmissionSession: unknown }).transmissionSession).toEqual({
-				version: '3.00 (bb6b5a062ef)'
+				version: '3.00 (bb6b5a062ef)',
+				downloadSpeed: 2_097_152,
+				uploadSpeed: 524_288,
+				activeTorrentCount: 4
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

- delivery ticket: `P19.07 Config redesign`
- ticket file: [docs/02-delivery/phase-19/ticket-07-config-redesign.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-19/ticket-07-config-redesign.md)
- stacked base branch: `agents/p19-06-movies-redesign`
- self-audit: outcome `clean` completed at 2026-04-17 01:44 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`655478c807b4`](https://github.com/cesarnml/pirate_claw/commit/655478c807b4f05bcb16eeaef5c9eaee35b2a94b)
- current branch head: [`fcaa47617122`](https://github.com/cesarnml/pirate_claw/commit/fcaa47617122fc2ff931e0fda081f7b98c43dfe7)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `655478c807b4` address all findings from that review.
- vendors: `coderabbit`, `sonarqube`

### Resolved Review Findings

- [coderabbit] Populate the editable watchlist from the user-facing title, not `rule.name`. (native GitHub thread resolved) `web/src/routes/config/+page.svelte:70` [thread](https://github.com/cesarnml/pirate_claw/pull/174#discussion_r3097437264)
- [coderabbit] Don't derive the Transmission auth indicator from `canWrite`. (native GitHub thread resolved) `web/src/routes/config/+page.svelte:160` [thread](https://github.com/cesarnml/pirate_claw/pull/174#discussion_r3097437265)
- [coderabbit] Expose the pressed state on these toggle buttons. (native GitHub thread resolved) `web/src/routes/config/+page.svelte:685` [thread](https://github.com/cesarnml/pirate_claw/pull/174#discussion_r3097437270)
