### PR TITLE
docs: close out phase 19 [P19.08]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pirate Claw is a local CLI for pulling media candidates from RSS feeds, matching them against your rules, and queueing approved downloads in Transmission.
 
-Phases **01–18** are implemented on `main`. **Phases 19–20** are in product-definition/planning mode under `docs/01-product/`.
+Phases **01–19** are implemented in the current delivery stack. **Phase 20** remains in product-definition/planning mode under `docs/01-product/`.
 
 It currently supports:
 
@@ -19,7 +19,7 @@ It currently supports:
 - daemon HTTP API with read endpoints and bounded config writes when `runtime.apiPort` is set
 - optional TMDB-backed posters, ratings, and metadata when a `tmdb` API key is configured
 - optional Plex-backed library status, watch counts, and last-watched timestamps when a `plex` server is configured
-- browser dashboard (`web/`) with unified config editing, in-context daemon controls, full feed and target management, live Transmission stats, skipped-no-match outcomes, and an unmatched candidates page
+- browser dashboard (`web/`) with Obsidian Tide styling, sidebar navigation, unified config editing, in-context daemon controls, poster-forward TV/movie views, live Transmission stats, and dashboard panels for active downlinks and unmatched events
 
 ## Commands
 
@@ -150,22 +150,23 @@ Set `runtime.apiPort` to start an HTTP JSON API alongside the daemon:
 
 ### Endpoints
 
-| Endpoint                         | Description                                                                     |
-| -------------------------------- | ------------------------------------------------------------------------------- |
-| `GET /api/health`                | Uptime, start time, last run/reconcile snapshots                                |
-| `GET /api/status`                | Recent run summaries                                                            |
-| `GET /api/candidates`            | All tracked candidate state records                                             |
-| `GET /api/shows`                 | TV candidates grouped by show → season → episode, with Plex status/watch fields |
-| `GET /api/movies`                | Movie candidates sorted by title, with Plex status/watch fields                 |
-| `GET /api/feeds`                 | Feed config with poll state and `isDue`                                         |
-| `GET /api/config`                | Effective config (credentials redacted); returns `ETag`                         |
-| `PUT /api/config`                | Bounded runtime + tv.shows write (token + `If-Match` required)                  |
-| `PUT /api/config/feeds`          | Replace feeds array (token + `If-Match` required)                               |
-| `PUT /api/config/movies`         | Replace movie policy (token + `If-Match` required)                              |
-| `PUT /api/config/tv/defaults`    | Replace TV defaults (token + `If-Match` required)                               |
-| `GET /api/transmission/session`  | Transmission session stats                                                      |
-| `GET /api/transmission/torrents` | Pirate Claw-managed torrents with progress, speed, ETA                          |
-| `GET /api/outcomes`              | Feed item outcomes (`?status=skipped_no_match`)                                 |
+| Endpoint                             | Description                                                                     |
+| ------------------------------------ | ------------------------------------------------------------------------------- |
+| `GET /api/health`                    | Uptime, start time, last run/reconcile snapshots                                |
+| `GET /api/status`                    | Recent run summaries                                                            |
+| `GET /api/candidates`                | All tracked candidate state records                                             |
+| `GET /api/shows`                     | TV candidates grouped by show → season → episode, with Plex status/watch fields |
+| `GET /api/movies`                    | Movie candidates sorted by title, with Plex status/watch fields                 |
+| `GET /api/feeds`                     | Feed config with poll state and `isDue`                                         |
+| `GET /api/config`                    | Effective config (credentials redacted); returns `ETag`                         |
+| `PUT /api/config`                    | Bounded runtime + tv.shows write (token + `If-Match` required)                  |
+| `PUT /api/config/feeds`              | Replace feeds array (token + `If-Match` required)                               |
+| `PUT /api/config/movies`             | Replace movie policy (token + `If-Match` required)                              |
+| `PUT /api/config/tv/defaults`        | Replace TV defaults (token + `If-Match` required)                               |
+| `POST /api/shows/:slug/tmdb/refresh` | Refresh TMDB metadata for one TV show (token required)                          |
+| `GET /api/transmission/session`      | Transmission session stats                                                      |
+| `GET /api/transmission/torrents`     | Pirate Claw-managed torrents with progress, speed, ETA                          |
+| `GET /api/outcomes`                  | Feed item outcomes (`?status=skipped_no_match`)                                 |
 
 Write rules: `runtime.apiWriteToken` (or env `PIRATE_CLAW_API_WRITE_TOKEN`) must be set; all writes require `Authorization: Bearer <token>` and `If-Match` from the latest `GET /api/config` ETag. Writes are atomic file updates.
 
@@ -198,9 +199,7 @@ cd web && PIRATE_CLAW_API_URL=http://localhost:5555 PORT=5174 node build/index.j
 
 Pirate Claw is a local operator tool for a personal NAS. The roadmap through Phase 20 targets a polished, fully-featured v1.0.0 release.
 
-**Implemented (Phases 01–18):** RSS ingestion, policy matching, Transmission queuing, lifecycle reconciliation, TMDB enrichment, read dashboard, unified config editing from the UI, post-save daemon restart and Transmission ping controls, full feed and target management, onboarding/resume flow, explicit empty states across the dashboard and key routes, and optional read-only Plex Media Server enrichment.
-
-**Planned (Phase 19):** Full UI/UX redesign — Obsidian Tide design language, left sidebar navigation, poster-forward layouts, and consolidation of the Candidates and Unmatched views into a redesigned Dashboard.
+**Implemented (Phases 01–19):** RSS ingestion, policy matching, Transmission queuing, lifecycle reconciliation, TMDB enrichment, read dashboard, unified config editing from the UI, post-save daemon restart and Transmission ping controls, full feed and target management, onboarding/resume flow, explicit empty states across the dashboard and key routes, optional read-only Plex Media Server enrichment, and the Phase 19 Obsidian Tide redesign with sidebar navigation, dashboard consolidation, poster-forward layouts, movie backdrops, Plex chips, and a TMDB refresh control on TV detail.
 
 **Planned (Phase 20):** v1.0.0 release ceremony — config `schemaVersion`, SQLite `PRAGMA user_version`, `VERSIONING.md`, CHANGELOG, and tagged release.
 

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -483,6 +483,12 @@ Goal:
 - restructure navigation to a left sidebar; absorb Candidates and Unmatched into Dashboard
 - surface existing API data that the current UI leaves on the table (movie backdrops, Phase 18 Plex state)
 
+Current status:
+
+- implemented in the current delivery stack via `P19.01`-`P19.08`
+- shipped the Obsidian Tide visual system, responsive sidebar shell, redesigned Dashboard / TV Shows / TV Show Detail / Movies / Config routes, and dashboard consolidation of the old Candidates and Unmatched surfaces
+- one approved scope exception landed during `P19.05`: show-level TMDB network metadata, episode spec tags on `/api/shows`, and a write-authenticated TMDB refresh action for the show detail route
+
 Committed scope:
 
 - Obsidian Tide design tokens replacing current oklch vars in `web/src/app.css`
@@ -505,6 +511,7 @@ Explicitly deferred:
 Working notes:
 
 - `docs/01-product/phase-19-ui-redesign-razzle-dazzle.md`
+- `docs/02-delivery/phase-19/implementation-plan.md`
 
 ## Phase 20: v1.0.0 Release and Schema Versioning
 
@@ -536,8 +543,8 @@ The following items are **mapped** to numbered phases (no longer “unbounded”
 
 ## Current Planning Posture
 
-- product phases `01`–`18` are implemented on `main`; **Phase 18** is delivered via `P18.01`–`P18.04` stacked delivery
-- product phases `19`–`20` are defined in `docs/01-product/`; both remain product-definition-first until their tickets are approved and implemented
+- product phases `01`–`19` are implemented in the current delivery stack; **Phase 19** is delivered via `P19.01`–`P19.08`
+- product phase `20` remains product-definition-first until its tickets are approved and implemented
 - engineering epic write-ups **`EE01`–`EE09`** live under `docs/03-engineering/` (orchestrator, PR hygiene, and delivery workflow tooling)
 - each new phase requires an explicit planning pass, approved ticket decomposition, and developer sign-off before implementation starts
 - smaller bounded changes can still proceed as standalone PR work without inventing a new phase
@@ -556,4 +563,4 @@ Working notes:
 - promote durable technical choices into ADRs
 - numbered phases are planning buckets, not a promise of strict implementation sequence when dependencies allow independent work
 
-Last verified against `README.md` and active delivery plans: 2026-04-15 (Phases 18–20 arc planned).
+Last verified against `README.md` and active delivery plans: 2026-04-17 (Phase 19 delivered; Phase 20 next).

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -10,7 +10,7 @@ Its job is to answer three questions quickly:
 
 ## Current Repo State
 
-Pirate Claw is implemented through **Phase 18** on `main` (product phases 01–18; see [`roadmap.md`](./roadmap.md)). Delivery artifacts for Phases 12–18 live under [`docs/02-delivery/`](../02-delivery/). The Phase 18 product spec is now the contract reference for the latest shipped scope. Phase **19** is the next product-definition-only phase under [`docs/01-product/`](../01-product/).
+Pirate Claw is implemented through **Phase 19** in the current delivery stack (product phases 01–19; see [`roadmap.md`](./roadmap.md)). Delivery artifacts for Phases 12–19 live under [`docs/02-delivery/`](../02-delivery/). The Phase 19 product spec is now the contract reference for the latest delivered UI surface. Phase **20** is the next product-definition-only phase under [`docs/01-product/`](../01-product/).
 
 Current delivered surface:
 
@@ -29,7 +29,7 @@ Current delivered surface:
 - queue-time Transmission `movie` / `tv` labels with warning+retry fallback when labels are unsupported
 - per-media-type Transmission download directories via `transmission.downloadDirs`
 - SvelteKit dashboard in `web/` that consumes the daemon HTTP API, including bounded runtime Settings writes and full feed and target management (add/remove feeds, TV defaults, movie policy, TV show targets) through server-side actions
-- Phase 15 dashboard visibility: home overview (Transmission session strip, active downloads, recent outcomes, archive grid), TV and movie library views with live transfer stats where a `transmissionTorrentHash` joins to Transmission, skipped-no-match outcomes, and `/candidates/unmatched` — refresh on page reload only (no WebSocket/SSE push)
+- Phase 19 UI surface: Obsidian Tide design tokens, persistent left sidebar on desktop with mobile drawer fallback, 4 top-level routes (`/`, `/shows`, `/movies`, `/config`), Dashboard panels for active downlinks and unmatched events, poster-forward TV/movie views, show-detail TMDB refresh, and Plex chips/watch-state across supported library views
 - optional TMDB enrichment: `tmdb` config block and/or `PIRATE_CLAW_TMDB_API_KEY`, SQLite-backed cache, lazy enrichment on API reads, and an optional daemon background refresh cadence via `runtime.tmdbRefreshIntervalMinutes` (default 6 hours; set `0` to disable)
 - optional Plex enrichment: `plex` config block and/or `PIRATE_CLAW_PLEX_TOKEN`, SQLite-backed movie/show cache, background refresh sweeps, and read-only `plexStatus` / `watchCount` / `lastWatchedAt` fields on `/api/movies` and `/api/shows`
 - Phase 16 config editing: unified `/config` accordion cards, per-section toast feedback, post-save daemon restart affordance, Transmission ping, and read-only tooltips when write auth is absent
@@ -46,10 +46,10 @@ Current product boundary:
 - per-feed polling cadence with persistent poll state
 - shared runtime lock prevents overlapping cycles
 - machine-readable and human-readable cycle artifacts with bounded retention
-- read-only daemon HTTP API (`/api/health`, `/api/status`, `/api/candidates`, `/api/shows`, `/api/movies`, `/api/feeds`, `/api/config`, plus Phase 15 `/api/transmission/session`, `/api/transmission/torrents`, `/api/outcomes`) when `runtime.apiPort` is configured
+- daemon HTTP API with read endpoints plus bounded write controls (`/api/config*`, `/api/daemon/restart`, `/api/transmission/ping`, and the Phase 19 TV-detail TMDB refresh action) when `runtime.apiPort` is configured
 - TMDB metadata is display-only and does not gate RSS intake
 
-Still deferred (Phase 19 and beyond):
+Still deferred (Phase 20 and beyond):
 
 - v1.0.0 release and config/DB schema versioning (Phase 20)
 - remote feed capture
@@ -58,14 +58,14 @@ Still deferred (Phase 19 and beyond):
 - Synology archiving
 - ingestion redesign beyond the local SQLite model
 
-Last verified against `README.md` and Phase 18 delivery artifacts: 2026-04-16.
+Last verified against `README.md` and Phase 19 delivery artifacts: 2026-04-17.
 
 Current planning focus:
 
 - see [`roadmap.md`](./roadmap.md) for numbered phases and what is implemented on `main`
 - use the roadmap to confirm whether the request is a bounded standalone change or needs a new approved phase/epic planning pass
 - treat the current Phase 07 config surface and the current extracted delivery-orchestrator module boundaries as the baseline for future work
-- Phase 19 UI redesign work is the next numbered product phase after the shipped Plex enrichment surface
+- Phase 20 release/versioning work is the next numbered product phase after the shipped UI redesign surface
 
 ## Read These Docs By Task Type
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,7 @@ Execution plans, issue conventions, and ticket breakdowns.
 - `phase-16/implementation-plan.md`: config editing, hot reload, and daemon controls delivery plan (tickets P16.01–P16.09; delivered on `main`)
 - `phase-17/implementation-plan.md`: onboarding and empty-state delivery plan (tickets P17.01–P17.07; delivered on `main`)
 - `phase-18/implementation-plan.md`: Plex Media Server enrichment delivery plan (tickets P18.01–P18.04; delivered on `main`)
+- `phase-19/implementation-plan.md`: UI/UX redesign delivery plan (tickets P19.01–P19.08; delivered in the current stacked phase)
 
 ### `03-engineering`
 

--- a/notes/public/phase-19-retrospective.md
+++ b/notes/public/phase-19-retrospective.md
@@ -1,0 +1,33 @@
+# Phase 19 Retrospective
+
+## Scope delivered
+
+Phase 19 shipped through stacked PRs `#168`-`#174` plus this closeout slice on branch `agents/p19-08-docs-index-updates-exit-verification`. The phase delivered the Obsidian Tide design system, responsive sidebar shell, dashboard consolidation of Candidates and Unmatched, redesigned TV/movie/config routes, the TV detail TMDB refresh flow, and the final doc/index/verification pass.
+
+## What went well
+
+The ticket decomposition was mostly correct for the visual surface because each slice mapped to a route or cross-route shell boundary the reviewer could evaluate quickly. That kept review comments local, let the orchestrator restack cleanly, and made it cheap to patch small UI defects without reopening unrelated surfaces. The existing API surface also proved richer than the old UI used, so most of the redesign landed as route-level presentation work instead of backend churn.
+
+## Pain points
+
+The orchestrator artifact mirroring was still fragile across worktrees. Generated handoff files repeatedly failed to appear in the next worktree, which forced manual copying of `state.json`, `reviews/`, and handoff artifacts at every ticket boundary. That was avoidable waste, not inherent work. The other recurring cost was orchestrator command sequencing: `record-review` and `advance`, or `post-verify-self-audit` and `open-pr`, can race if launched in parallel, so stateful transitions had to be rerun serially.
+
+## Surprises
+
+The reference design for `P19.05` implicitly required data the repo did not yet expose: show network metadata, episode spec tags on `/api/shows`, and a manual TMDB refresh action. That forced an approved scope exception inside a phase that was originally documented as frontend-only. A second surprise was that the final Config footer screenshot asked for host-level metrics that the existing endpoints do not publish; the implementation had to preserve the four-metric shape with operator-facing live proxies instead of literal storage/CPU telemetry.
+
+## What we'd do differently
+
+We would add an explicit orchestrator mirror step for delivery artifacts instead of treating it as a manual workaround described in docs. The original assumption was that worktree-local state would be sufficient because the orchestrator creates the next handoff itself, but the missing-handoff failures showed that assumption is not durable. We would also make state-transition commands explicitly serial in the workflow examples and tooling so agents are not tempted to parallelize commands that read and write the same delivery state.
+
+## Net assessment
+
+Phase 19 achieved its stated goal. The web UI now reads as a coherent, premium media command center instead of a set of utilitarian admin pages, and the redesigned shell plus route consolidation make the dashboard surface materially easier to navigate. The only meaningful scope bend was the approved `P19.05` API exception, and that exception stayed narrow enough to preserve the phase intent.
+
+## Follow-up
+
+- Fix the orchestrator handoff mirroring gap so new ticket worktrees always receive the generated handoff artifact without manual copying.
+- Encode serial-state guidance for `post-verify-self-audit` → `open-pr` and `record-review` → `advance` in the Son-of-Anton skill or orchestrator CLI.
+- Decide in Phase 20 whether the Config footer should keep its current operator-proxy metrics or whether true host-level storage/CPU telemetry deserves a dedicated future API surface.
+
+_Created: 2026-04-17. PR stack #168-#174 open; P19.08 closeout slice pending._


### PR DESCRIPTION
## Summary

- delivery ticket: `P19.08 Docs, index updates, exit verification`
- ticket file: [docs/02-delivery/phase-19/ticket-08-docs-exit-verification.md](https://github.com/cesarnml/pirate_claw/blob/main/docs/02-delivery/phase-19/ticket-08-docs-exit-verification.md)
- stacked base branch: `agents/p19-07-config-redesign`
- self-audit: outcome `skipped` completed at 2026-04-17 01:56 UTC

## External AI Review
