### PR TITLE
feat(dashboard): transmission lifecycle API, deduped failures, and action UX fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It currently supports:
 - daemon HTTP API with read endpoints and bounded config writes when `runtime.apiPort` is set
 - optional TMDB-backed posters, ratings, and metadata when a `tmdb` API key is configured
 - optional Plex-backed library status, watch counts, and last-watched timestamps when a `plex` server is configured
-- browser dashboard (`web/`) with Obsidian Tide styling, sidebar navigation, unified config editing, in-context daemon controls, poster-forward TV/movie views, live Transmission stats, and dashboard panels for active downlinks and unmatched events
+- browser dashboard (`web/`) with Obsidian Tide styling, sidebar navigation, unified config editing, in-context daemon controls, poster-forward TV/movie views, live Transmission stats, Torrent Manager (context-menu pause, resume, remove, and remove-with-delete), and a Transmission failures panel (deduped matched candidates whose enqueue to Transmission failed and are still retryable)
 
 ## Commands
 
@@ -151,25 +151,31 @@ Set `runtime.apiPort` to start an HTTP JSON API alongside the daemon:
 
 ### Endpoints
 
-| Endpoint                             | Description                                                                     |
-| ------------------------------------ | ------------------------------------------------------------------------------- |
-| `GET /api/health`                    | Uptime, start time, last run/reconcile snapshots                                |
-| `GET /api/status`                    | Recent run summaries                                                            |
-| `GET /api/candidates`                | All tracked candidate state records                                             |
-| `GET /api/shows`                     | TV candidates grouped by show → season → episode, with Plex status/watch fields |
-| `GET /api/movies`                    | Movie candidates sorted by title, with Plex status/watch fields                 |
-| `GET /api/feeds`                     | Feed config with poll state and `isDue`                                         |
-| `GET /api/config`                    | Effective config (credentials redacted); returns `ETag`                         |
-| `PUT /api/config`                    | Bounded runtime + tv.shows write (token + `If-Match` required)                  |
-| `PUT /api/config/feeds`              | Replace feeds array (token + `If-Match` required)                               |
-| `PUT /api/config/movies`             | Replace movie policy (token + `If-Match` required)                              |
-| `PUT /api/config/tv/defaults`        | Replace TV defaults (token + `If-Match` required)                               |
-| `POST /api/shows/:slug/tmdb/refresh` | Refresh TMDB metadata for one TV show (token required)                          |
-| `GET /api/transmission/session`      | Transmission session stats                                                      |
-| `GET /api/transmission/torrents`     | Pirate Claw-managed torrents with progress, speed, ETA                          |
-| `GET /api/outcomes`                  | Feed item outcomes (`?status=skipped_no_match`)                                 |
+| Endpoint                                           | Description                                                                                                                                              |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /api/health`                                  | Uptime, start time, last run/reconcile snapshots                                                                                                         |
+| `GET /api/status`                                  | Recent run summaries                                                                                                                                     |
+| `GET /api/candidates`                              | All tracked candidate state records                                                                                                                      |
+| `GET /api/shows`                                   | TV candidates grouped by show → season → episode, with Plex status/watch fields                                                                          |
+| `GET /api/movies`                                  | Movie candidates sorted by title, with Plex status/watch fields                                                                                          |
+| `GET /api/feeds`                                   | Feed config with poll state and `isDue`                                                                                                                  |
+| `GET /api/config`                                  | Effective config (credentials redacted); returns `ETag`                                                                                                  |
+| `PUT /api/config`                                  | Bounded runtime + tv.shows write (token + `If-Match` required)                                                                                           |
+| `PUT /api/config/feeds`                            | Replace feeds array (token + `If-Match` required)                                                                                                        |
+| `PUT /api/config/movies`                           | Replace movie policy (token + `If-Match` required)                                                                                                       |
+| `PUT /api/config/tv/defaults`                      | Replace TV defaults (token + `If-Match` required)                                                                                                        |
+| `POST /api/shows/:slug/tmdb/refresh`               | Refresh TMDB metadata for one TV show (token required)                                                                                                   |
+| `GET /api/transmission/session`                    | Transmission session stats                                                                                                                               |
+| `GET /api/transmission/torrents`                   | Live stats for torrents referenced by tracked candidates (progress, speed, ETA)                                                                          |
+| `GET /api/outcomes`                                | Dashboard enqueue failures (`?status=skipped_no_match`): deduped rows per matched candidate still in `failed` state (historical query param name)        |
+| `POST /api/transmission/torrent/pause`             | Pause a managed torrent (`{ "hash": "<transmission hash>" }`, bearer token)                                                                              |
+| `POST /api/transmission/torrent/resume`            | Resume a managed torrent (JSON body + bearer token)                                                                                                      |
+| `POST /api/transmission/torrent/remove`            | Remove torrent from Transmission (JSON body + bearer token)                                                                                              |
+| `POST /api/transmission/torrent/remove-and-delete` | Remove torrent and delete local data (JSON + bearer)                                                                                                     |
+| `POST /api/transmission/torrent/dispose`           | Mark a missing torrent as removed or deleted (`hash`, `disposition`, bearer)                                                                             |
+| `POST /api/candidates/:id/requeue`                 | Re-submit a failed candidate’s download URL to Transmission (bearer token); requires daemon API to be started with an in-process Transmission downloader |
 
-Write rules: `runtime.apiWriteToken` (or env `PIRATE_CLAW_API_WRITE_TOKEN`) must be set; all writes require `Authorization: Bearer <token>` and `If-Match` from the latest `GET /api/config` ETag. Writes are atomic file updates.
+Write rules: `runtime.apiWriteToken` (or env `PIRATE_CLAW_API_WRITE_TOKEN`) must be set; all writes require `Authorization: Bearer <token>` and `If-Match` from the latest `GET /api/config` ETag. Writes are atomic file updates. Torrent lifecycle and requeue actions use the bearer token only (no config ETag).
 
 ## SvelteKit Dashboard (`web/`)
 

--- a/README.md
+++ b/README.md
@@ -204,11 +204,11 @@ cd web && PIRATE_CLAW_API_URL=http://localhost:5555 PORT=5174 node build/index.j
 
 ## Current Scope
 
-Pirate Claw is a local operator tool for a personal NAS. The roadmap through Phase 20 targets a polished, fully-featured v1.0.0 release.
+Pirate Claw is a local operator tool for a personal NAS. The roadmap targets Phase 20 (dashboard Transmission proxy) and Phase 25 (v1.0.0 / schema versioning) as the next numbered product milestones after the shipped Phase 19 UI work.
 
 **Implemented (Phases 01–19):** RSS ingestion, policy matching, Transmission queuing, lifecycle reconciliation, TMDB enrichment, read dashboard, unified config editing from the UI, post-save daemon restart and Transmission ping controls, full feed and target management, onboarding/resume flow, explicit empty states across the dashboard and key routes, optional read-only Plex Media Server enrichment, and the Phase 19 Obsidian Tide redesign with sidebar navigation, dashboard consolidation, poster-forward layouts, movie backdrops, Plex chips, and a TMDB refresh control on TV detail.
 
-**Planned (Phase 20):** v1.0.0 release ceremony — config `schemaVersion`, SQLite `PRAGMA user_version`, `VERSIONING.md`, CHANGELOG, and tagged release.
+**Planned (Phase 25):** v1.0.0 release ceremony — config `schemaVersion`, SQLite `PRAGMA user_version`, `VERSIONING.md`, CHANGELOG, and tagged release (see `docs/01-product/phase-25-v1-release-and-schema-versioning.md`).
 
 Not in scope through v1:
 

--- a/README.md
+++ b/README.md
@@ -204,9 +204,11 @@ cd web && PIRATE_CLAW_API_URL=http://localhost:5555 PORT=5174 node build/index.j
 
 ## Current Scope
 
-Pirate Claw is a local operator tool for a personal NAS. The roadmap targets Phase 20 (dashboard Transmission proxy) and Phase 25 (v1.0.0 / schema versioning) as the next numbered product milestones after the shipped Phase 19 UI work.
+Pirate Claw is a local operator tool for a personal NAS. **Phase 20** (dashboard Transmission proxy) is shipped on `main`; **Phase 25** (v1.0.0 / schema versioning) is the next numbered product milestone.
 
 **Implemented (Phases 01–19):** RSS ingestion, policy matching, Transmission queuing, lifecycle reconciliation, TMDB enrichment, read dashboard, unified config editing from the UI, post-save daemon restart and Transmission ping controls, full feed and target management, onboarding/resume flow, explicit empty states across the dashboard and key routes, optional read-only Plex Media Server enrichment, and the Phase 19 Obsidian Tide redesign with sidebar navigation, dashboard consolidation, poster-forward layouts, movie backdrops, Plex chips, and a TMDB refresh control on TV detail.
+
+**Implemented (Phase 20):** Dashboard Torrent Manager actions (pause, resume, remove, remove-with-delete), missing-torrent disposition, Transmission failures / requeue, related daemon JSON endpoints, and the `pirateClawDisposition` + derived display-state model (see `docs/01-product/phase-20-dashboard-torrent-actions.md`).
 
 **Planned (Phase 25):** v1.0.0 release ceremony — config `schemaVersion`, SQLite `PRAGMA user_version`, `VERSIONING.md`, CHANGELOG, and tagged release (see `docs/01-product/phase-25-v1-release-and-schema-versioning.md`).
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Set `runtime.apiPort` to start an HTTP JSON API alongside the daemon:
 | `POST /api/shows/:slug/tmdb/refresh`               | Refresh TMDB metadata for one TV show (token required)                                                                                                   |
 | `GET /api/transmission/session`                    | Transmission session stats                                                                                                                               |
 | `GET /api/transmission/torrents`                   | Live stats for torrents referenced by tracked candidates (progress, speed, ETA)                                                                          |
-| `GET /api/outcomes`                                | Dashboard enqueue failures (`?status=skipped_no_match`): deduped rows per matched candidate still in `failed` state (historical query param name)        |
+| `GET /api/outcomes`                                | Dashboard enqueue failures (`?status=failed_enqueue`; legacy alias `skipped_no_match`): deduped rows per matched candidate still in `failed` state       |
 | `POST /api/transmission/torrent/pause`             | Pause a managed torrent (`{ "hash": "<transmission hash>" }`, bearer token)                                                                              |
 | `POST /api/transmission/torrent/resume`            | Resume a managed torrent (JSON body + bearer token)                                                                                                      |
 | `POST /api/transmission/torrent/remove`            | Remove torrent from Transmission (JSON body + bearer token)                                                                                              |

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -513,18 +513,30 @@ Working notes:
 - `docs/01-product/phase-19-ui-redesign-razzle-dazzle.md`
 - `docs/02-delivery/phase-19/implementation-plan.md`
 
-## Phase 20: v1.0.0 Release and Schema Versioning
+## Phase 20: Dashboard Torrent Actions
 
 Goal:
 
-- `package.json` bumped to `1.0.0`; tagged release with CHANGELOG covering Phases 13–20
+- make the dashboard a functional proxy for the Transmission client (pause, resume, remove, remove-with-delete, missing disposition, failed-candidate requeue)
+- replace redundant lifecycle columns with derived `torrentDisplayState()` plus optional `pirateClawDisposition` terminal writes
+
+Current status:
+
+- product definition: [`docs/01-product/phase-20-dashboard-torrent-actions.md`](../01-product/phase-20-dashboard-torrent-actions.md)
+- parts of the surface already run on `main` ahead of a formal Phase 20 delivery closeout
+
+## Phase 25: v1.0.0 Release and Schema Versioning
+
+Goal:
+
+- `package.json` bumped to `1.0.0`; tagged release with CHANGELOG summarizing shipped product work
 - config file stamped with `schemaVersion: 1` on next write; absent = v1 (silent)
 - SQLite DB stamped with `PRAGMA user_version = 1` on first startup
 - `VERSIONING.md` documents breaking change policy: major version = config/db schema pair
 
 Current status:
 
-- product definition only; see [`docs/01-product/phase-20-v1-release-and-schema-versioning.md`](../01-product/phase-20-v1-release-and-schema-versioning.md)
+- product definition only; see [`docs/01-product/phase-25-v1-release-and-schema-versioning.md`](../01-product/phase-25-v1-release-and-schema-versioning.md)
 
 ## Future Deferrals
 
@@ -539,12 +551,13 @@ The following items are **mapped** to numbered phases (no longer “unbounded”
 - **Config editor via web UI** — Phase 13 (runtime subset); Phase 14 (feeds, movies, TV defaults); Phase 16 (unified UX)
 - **Visual polish / design system iteration** — Phase 12 (baseline); Phase 19 (full Obsidian Tide redesign)
 - **Plex Media Server enrichment** — Phase 18
-- **v1.0.0 release** — Phase 20
+- **v1.0.0 release / schema versioning** — Phase 25
+- **Dashboard Transmission proxy** — Phase 20
 
 ## Current Planning Posture
 
 - product phases `01`–`19` are implemented in the current delivery stack; **Phase 19** is delivered via `P19.01`–`P19.08`
-- product phase `20` remains product-definition-first until its tickets are approved and implemented
+- **Phase 20** (dashboard torrent proxy) and **Phase 25** (v1.0.0 / schema versioning) remain product-definition-first until their tickets are approved and implemented; parts of Phase 20 already exist on `main`
 - engineering epic write-ups **`EE01`–`EE09`** live under `docs/03-engineering/` (orchestrator, PR hygiene, and delivery workflow tooling)
 - each new phase requires an explicit planning pass, approved ticket decomposition, and developer sign-off before implementation starts
 - smaller bounded changes can still proceed as standalone PR work without inventing a new phase
@@ -563,4 +576,4 @@ Working notes:
 - promote durable technical choices into ADRs
 - numbered phases are planning buckets, not a promise of strict implementation sequence when dependencies allow independent work
 
-Last verified against `README.md` and active delivery plans: 2026-04-17 (Phase 19 delivered; Phase 20 next).
+Last verified against `README.md` and active delivery plans: 2026-04-19 (Phase 19 delivered; Phase 20 dashboard + Phase 25 v1 release are next numbered product buckets).

--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -522,8 +522,8 @@ Goal:
 
 Current status:
 
-- product definition: [`docs/01-product/phase-20-dashboard-torrent-actions.md`](../01-product/phase-20-dashboard-torrent-actions.md)
-- parts of the surface already run on `main` ahead of a formal Phase 20 delivery closeout
+- shipped on `main`; product contract: [`docs/01-product/phase-20-dashboard-torrent-actions.md`](../01-product/phase-20-dashboard-torrent-actions.md)
+- delivery record: [`docs/02-delivery/phase-20/implementation-plan.md`](../02-delivery/phase-20/implementation-plan.md)
 
 ## Phase 25: v1.0.0 Release and Schema Versioning
 
@@ -557,7 +557,7 @@ The following items are **mapped** to numbered phases (no longer “unbounded”
 ## Current Planning Posture
 
 - product phases `01`–`19` are implemented in the current delivery stack; **Phase 19** is delivered via `P19.01`–`P19.08`
-- **Phase 20** (dashboard torrent proxy) and **Phase 25** (v1.0.0 / schema versioning) remain product-definition-first until their tickets are approved and implemented; parts of Phase 20 already exist on `main`
+- **Phase 20** (dashboard torrent proxy) is **shipped** on `main`; **Phase 25** (v1.0.0 / schema versioning) remains product-definition-first until its tickets are approved and implemented
 - engineering epic write-ups **`EE01`–`EE09`** live under `docs/03-engineering/` (orchestrator, PR hygiene, and delivery workflow tooling)
 - each new phase requires an explicit planning pass, approved ticket decomposition, and developer sign-off before implementation starts
 - smaller bounded changes can still proceed as standalone PR work without inventing a new phase
@@ -576,4 +576,4 @@ Working notes:
 - promote durable technical choices into ADRs
 - numbered phases are planning buckets, not a promise of strict implementation sequence when dependencies allow independent work
 
-Last verified against `README.md` and active delivery plans: 2026-04-19 (Phase 19 delivered; Phase 20 dashboard + Phase 25 v1 release are next numbered product buckets).
+Last verified against `README.md` and active delivery plans: 2026-04-19 (Phase 19 and Phase 20 delivered on `main`; Phase 25 v1 release is the next numbered product bucket).

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -10,7 +10,7 @@ Its job is to answer three questions quickly:
 
 ## Current Repo State
 
-Pirate Claw is implemented through **Phase 19** in the current delivery stack (product phases 01–19; see [`roadmap.md`](./roadmap.md)). Delivery artifacts for Phases 12–19 live under [`docs/02-delivery/`](../02-delivery/). The Phase 19 product spec is now the contract reference for the latest delivered UI surface. Phase **20** is the next product-definition-only phase under [`docs/01-product/`](../01-product/).
+Pirate Claw is implemented through **Phase 19** in the current delivery stack (product phases 01–19; see [`roadmap.md`](./roadmap.md)). Delivery artifacts for Phases 12–19 live under [`docs/02-delivery/`](../02-delivery/). The Phase 19 product spec is the contract reference for the Obsidian Tide redesign and related dashboard/TV/movie read UI. **Phase 20** ([`phase-20-dashboard-torrent-actions.md`](../01-product/phase-20-dashboard-torrent-actions.md)) owns the dashboard-as-Transmission-proxy work; parts of that product definition already run on `main` while the Phase 20 **versioning / v1.0.0 release** slice remains planned.
 
 Current delivered surface:
 
@@ -29,7 +29,8 @@ Current delivered surface:
 - queue-time Transmission `movie` / `tv` labels with warning+retry fallback when labels are unsupported
 - per-media-type Transmission download directories via `transmission.downloadDirs`
 - SvelteKit dashboard in `web/` that consumes the daemon HTTP API, including bounded runtime Settings writes and full feed and target management (add/remove feeds, TV defaults, movie policy, TV show targets) through server-side actions
-- Phase 19 UI surface: Obsidian Tide design tokens, persistent left sidebar on desktop with mobile drawer fallback, 4 top-level routes (`/`, `/shows`, `/movies`, `/config`), dashboard Torrent Manager (live rows plus right-click pause, resume, remove, remove-with-delete) and Transmission failures (deduped enqueue-failure list with Queue-to-retry), poster-forward TV/movie views, show-detail TMDB refresh, and Plex chips/watch-state across supported library views
+- Phase 19 UI surface: Obsidian Tide design tokens, persistent left sidebar on desktop with mobile drawer fallback, four top-level routes (`/`, `/shows`, `/movies`, `/config`), poster-forward TV/movie views, show-detail TMDB refresh, and Plex chips/watch-state across supported library views
+- Phase 20 dashboard torrent proxy (partially on `main`, see product doc above): Torrent Manager with live Transmission rows and context-menu pause, resume, remove, and remove-with-delete; Transmission failures card listing deduped enqueue failures with Queue-to-retry; daemon API and downloader wiring that support those flows
 - optional TMDB enrichment: `tmdb` config block and/or `PIRATE_CLAW_TMDB_API_KEY`, SQLite-backed cache, lazy enrichment on API reads, and an optional daemon background refresh cadence via `runtime.tmdbRefreshIntervalMinutes` (default 6 hours; set `0` to disable)
 - optional Plex enrichment: `plex` config block and/or `PIRATE_CLAW_PLEX_TOKEN`, SQLite-backed movie/show cache, background refresh sweeps, and read-only `plexStatus` / `watchCount` / `lastWatchedAt` fields on `/api/movies` and `/api/shows`
 - Phase 16 config editing: unified `/config` accordion cards, per-section toast feedback, post-save daemon restart affordance, Transmission ping, and read-only tooltips when write auth is absent
@@ -46,7 +47,7 @@ Current product boundary:
 - per-feed polling cadence with persistent poll state
 - shared runtime lock prevents overlapping cycles
 - machine-readable and human-readable cycle artifacts with bounded retention
-- daemon HTTP API with read endpoints plus bounded write controls (`/api/config*`, `/api/daemon/restart`, `/api/transmission/ping`, Phase 19 TV-detail TMDB refresh, Transmission torrent lifecycle JSON actions, and failed-candidate requeue) when `runtime.apiPort` is configured; requeue requires the daemon process to host the Transmission downloader alongside the API
+- daemon HTTP API with read endpoints plus bounded write controls (`/api/config*`, `/api/daemon/restart`, `/api/transmission/ping`, and Phase 19 TV-detail TMDB refresh) when `runtime.apiPort` is configured; **Phase 20** adds Transmission torrent lifecycle JSON actions, missing-torrent dispose, and `POST /api/candidates/:id/requeue` on the same port — requeue requires the daemon process to host the Transmission downloader alongside the API
 - TMDB metadata is display-only and does not gate RSS intake
 
 Still deferred (Phase 20 and beyond):
@@ -65,7 +66,7 @@ Current planning focus:
 - see [`roadmap.md`](./roadmap.md) for numbered phases and what is implemented on `main`
 - use the roadmap to confirm whether the request is a bounded standalone change or needs a new approved phase/epic planning pass
 - treat the current Phase 07 config surface and the current extracted delivery-orchestrator module boundaries as the baseline for future work
-- Phase 20 release/versioning work is the next numbered product phase after the shipped UI redesign surface
+- Phase 20 release/versioning (`schemaVersion`, tagged v1, changelog) is the remaining numbered exit after the shipped Phase 19 redesign; keep Phase 20 dashboard torrent work in the Phase 20 product doc, not under the Phase 19 contract
 
 ## Read These Docs By Task Type
 

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -29,7 +29,7 @@ Current delivered surface:
 - queue-time Transmission `movie` / `tv` labels with warning+retry fallback when labels are unsupported
 - per-media-type Transmission download directories via `transmission.downloadDirs`
 - SvelteKit dashboard in `web/` that consumes the daemon HTTP API, including bounded runtime Settings writes and full feed and target management (add/remove feeds, TV defaults, movie policy, TV show targets) through server-side actions
-- Phase 19 UI surface: Obsidian Tide design tokens, persistent left sidebar on desktop with mobile drawer fallback, 4 top-level routes (`/`, `/shows`, `/movies`, `/config`), Dashboard panels for active downlinks and unmatched events, poster-forward TV/movie views, show-detail TMDB refresh, and Plex chips/watch-state across supported library views
+- Phase 19 UI surface: Obsidian Tide design tokens, persistent left sidebar on desktop with mobile drawer fallback, 4 top-level routes (`/`, `/shows`, `/movies`, `/config`), dashboard Torrent Manager (live rows plus right-click pause, resume, remove, remove-with-delete) and Transmission failures (deduped enqueue-failure list with Queue-to-retry), poster-forward TV/movie views, show-detail TMDB refresh, and Plex chips/watch-state across supported library views
 - optional TMDB enrichment: `tmdb` config block and/or `PIRATE_CLAW_TMDB_API_KEY`, SQLite-backed cache, lazy enrichment on API reads, and an optional daemon background refresh cadence via `runtime.tmdbRefreshIntervalMinutes` (default 6 hours; set `0` to disable)
 - optional Plex enrichment: `plex` config block and/or `PIRATE_CLAW_PLEX_TOKEN`, SQLite-backed movie/show cache, background refresh sweeps, and read-only `plexStatus` / `watchCount` / `lastWatchedAt` fields on `/api/movies` and `/api/shows`
 - Phase 16 config editing: unified `/config` accordion cards, per-section toast feedback, post-save daemon restart affordance, Transmission ping, and read-only tooltips when write auth is absent
@@ -46,7 +46,7 @@ Current product boundary:
 - per-feed polling cadence with persistent poll state
 - shared runtime lock prevents overlapping cycles
 - machine-readable and human-readable cycle artifacts with bounded retention
-- daemon HTTP API with read endpoints plus bounded write controls (`/api/config*`, `/api/daemon/restart`, `/api/transmission/ping`, and the Phase 19 TV-detail TMDB refresh action) when `runtime.apiPort` is configured
+- daemon HTTP API with read endpoints plus bounded write controls (`/api/config*`, `/api/daemon/restart`, `/api/transmission/ping`, Phase 19 TV-detail TMDB refresh, Transmission torrent lifecycle JSON actions, and failed-candidate requeue) when `runtime.apiPort` is configured; requeue requires the daemon process to host the Transmission downloader alongside the API
 - TMDB metadata is display-only and does not gate RSS intake
 
 Still deferred (Phase 20 and beyond):
@@ -58,7 +58,7 @@ Still deferred (Phase 20 and beyond):
 - Synology archiving
 - ingestion redesign beyond the local SQLite model
 
-Last verified against `README.md` and Phase 19 delivery artifacts: 2026-04-17.
+Last verified against `README.md` and Phase 19 delivery artifacts: 2026-04-19.
 
 Current planning focus:
 

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -10,7 +10,7 @@ Its job is to answer three questions quickly:
 
 ## Current Repo State
 
-Pirate Claw is implemented through **Phase 19** in the current delivery stack (product phases 01–19; see [`roadmap.md`](./roadmap.md)). Delivery artifacts for Phases 12–19 live under [`docs/02-delivery/`](../02-delivery/). The Phase 19 product spec is the contract reference for the Obsidian Tide redesign and related dashboard/TV/movie read UI. **Phase 20** ([`phase-20-dashboard-torrent-actions.md`](../01-product/phase-20-dashboard-torrent-actions.md)) owns the dashboard-as-Transmission-proxy work; parts of that product definition already run on `main` while the Phase 20 **versioning / v1.0.0 release** slice remains planned.
+Pirate Claw is implemented through **Phase 19** in the current delivery stack (product phases 01–19; see [`roadmap.md`](./roadmap.md)). Delivery artifacts for Phases 12–19 live under [`docs/02-delivery/`](../02-delivery/). The Phase 19 product spec is the contract reference for the Obsidian Tide redesign and related dashboard/TV/movie read UI. **Phase 20** ([`phase-20-dashboard-torrent-actions.md`](../01-product/phase-20-dashboard-torrent-actions.md)) owns the dashboard-as-Transmission-proxy work; parts of that product definition already run on `main`. **Phase 25** ([`phase-25-v1-release-and-schema-versioning.md`](../01-product/phase-25-v1-release-and-schema-versioning.md)) is the v1.0.0 / schema-versioning release ceremony (product definition only until tickets land).
 
 Current delivered surface:
 
@@ -50,9 +50,9 @@ Current product boundary:
 - daemon HTTP API with read endpoints plus bounded write controls (`/api/config*`, `/api/daemon/restart`, `/api/transmission/ping`, and Phase 19 TV-detail TMDB refresh) when `runtime.apiPort` is configured; **Phase 20** adds Transmission torrent lifecycle JSON actions, missing-torrent dispose, and `POST /api/candidates/:id/requeue` on the same port — requeue requires the daemon process to host the Transmission downloader alongside the API
 - TMDB metadata is display-only and does not gate RSS intake
 
-Still deferred (Phase 20 and beyond):
+Still deferred (Phase 25+ and later):
 
-- v1.0.0 release and config/DB schema versioning (Phase 20)
+- v1.0.0 release and config/DB schema versioning (Phase 25)
 - remote feed capture
 - hosted persistence
 - download renaming or organization rules
@@ -66,7 +66,7 @@ Current planning focus:
 - see [`roadmap.md`](./roadmap.md) for numbered phases and what is implemented on `main`
 - use the roadmap to confirm whether the request is a bounded standalone change or needs a new approved phase/epic planning pass
 - treat the current Phase 07 config surface and the current extracted delivery-orchestrator module boundaries as the baseline for future work
-- Phase 20 release/versioning (`schemaVersion`, tagged v1, changelog) is the remaining numbered exit after the shipped Phase 19 redesign; keep Phase 20 dashboard torrent work in the Phase 20 product doc, not under the Phase 19 contract
+- Phase 25 (`schemaVersion`, tagged v1, `VERSIONING.md`, changelog) is the remaining numbered release exit; keep Phase 20 dashboard torrent work in [`phase-20-dashboard-torrent-actions.md`](../01-product/phase-20-dashboard-torrent-actions.md), not under the Phase 19 contract
 
 ## Read These Docs By Task Type
 

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -10,7 +10,7 @@ Its job is to answer three questions quickly:
 
 ## Current Repo State
 
-Pirate Claw is implemented through **Phase 19** in the current delivery stack (product phases 01–19; see [`roadmap.md`](./roadmap.md)). Delivery artifacts for Phases 12–19 live under [`docs/02-delivery/`](../02-delivery/). The Phase 19 product spec is the contract reference for the Obsidian Tide redesign and related dashboard/TV/movie read UI. **Phase 20** ([`phase-20-dashboard-torrent-actions.md`](../01-product/phase-20-dashboard-torrent-actions.md)) owns the dashboard-as-Transmission-proxy work; parts of that product definition already run on `main`. **Phase 25** ([`phase-25-v1-release-and-schema-versioning.md`](../01-product/phase-25-v1-release-and-schema-versioning.md)) is the v1.0.0 / schema-versioning release ceremony (product definition only until tickets land).
+Pirate Claw is implemented through **Phase 19** in the current delivery stack (product phases 01–19; see [`roadmap.md`](./roadmap.md)). Delivery artifacts for Phases 12–19 live under [`docs/02-delivery/`](../02-delivery/). The Phase 19 product spec is the contract reference for the Obsidian Tide redesign and related dashboard/TV/movie read UI. **Phase 20** ([`phase-20-dashboard-torrent-actions.md`](../01-product/phase-20-dashboard-torrent-actions.md)) is the dashboard-as-Transmission-proxy product contract; that scope is **shipped on `main`**. **Phase 25** ([`phase-25-v1-release-and-schema-versioning.md`](../01-product/phase-25-v1-release-and-schema-versioning.md)) is the v1.0.0 / schema-versioning release ceremony (product definition only until tickets land).
 
 Current delivered surface:
 
@@ -30,7 +30,7 @@ Current delivered surface:
 - per-media-type Transmission download directories via `transmission.downloadDirs`
 - SvelteKit dashboard in `web/` that consumes the daemon HTTP API, including bounded runtime Settings writes and full feed and target management (add/remove feeds, TV defaults, movie policy, TV show targets) through server-side actions
 - Phase 19 UI surface: Obsidian Tide design tokens, persistent left sidebar on desktop with mobile drawer fallback, four top-level routes (`/`, `/shows`, `/movies`, `/config`), poster-forward TV/movie views, show-detail TMDB refresh, and Plex chips/watch-state across supported library views
-- Phase 20 dashboard torrent proxy (partially on `main`, see product doc above): Torrent Manager with live Transmission rows and context-menu pause, resume, remove, and remove-with-delete; Transmission failures card listing deduped enqueue failures with Queue-to-retry; daemon API and downloader wiring that support those flows
+- Phase 20 dashboard torrent proxy (shipped on `main`, see product doc above): Torrent Manager with live Transmission rows and context-menu pause, resume, remove, and remove-with-delete; Transmission failures card listing deduped enqueue failures with Queue-to-retry; daemon API and downloader wiring that support those flows
 - optional TMDB enrichment: `tmdb` config block and/or `PIRATE_CLAW_TMDB_API_KEY`, SQLite-backed cache, lazy enrichment on API reads, and an optional daemon background refresh cadence via `runtime.tmdbRefreshIntervalMinutes` (default 6 hours; set `0` to disable)
 - optional Plex enrichment: `plex` config block and/or `PIRATE_CLAW_PLEX_TOKEN`, SQLite-backed movie/show cache, background refresh sweeps, and read-only `plexStatus` / `watchCount` / `lastWatchedAt` fields on `/api/movies` and `/api/shows`
 - Phase 16 config editing: unified `/config` accordion cards, per-section toast feedback, post-save daemon restart affordance, Transmission ping, and read-only tooltips when write auth is absent
@@ -47,7 +47,7 @@ Current product boundary:
 - per-feed polling cadence with persistent poll state
 - shared runtime lock prevents overlapping cycles
 - machine-readable and human-readable cycle artifacts with bounded retention
-- daemon HTTP API with read endpoints plus bounded write controls (`/api/config*`, `/api/daemon/restart`, `/api/transmission/ping`, and Phase 19 TV-detail TMDB refresh) when `runtime.apiPort` is configured; **Phase 20** adds Transmission torrent lifecycle JSON actions, missing-torrent dispose, and `POST /api/candidates/:id/requeue` on the same port — requeue requires the daemon process to host the Transmission downloader alongside the API
+- daemon HTTP API with read endpoints plus bounded write controls (`/api/config*`, `/api/daemon/restart`, `/api/transmission/ping`, and Phase 19 TV-detail TMDB refresh) when `runtime.apiPort` is configured; **Phase 20** (shipped) adds Transmission torrent lifecycle JSON actions, missing-torrent dispose, and `POST /api/candidates/:id/requeue` on the same port — requeue requires the daemon process to host the Transmission downloader alongside the API
 - TMDB metadata is display-only and does not gate RSS intake
 
 Still deferred (Phase 25+ and later):

--- a/docs/01-product/phase-19-ui-redesign-razzle-dazzle.md
+++ b/docs/01-product/phase-19-ui-redesign-razzle-dazzle.md
@@ -1,6 +1,6 @@
 # Phase 19: UI/UX Redesign ("Razzle-Dazzle")
 
-**Delivery status:** Not started — product definition only; no `docs/02-delivery/phase-19/` implementation plan until tickets are approved.
+**Delivery status:** Delivered in the current stack via `P19.01`–`P19.08` (see [`docs/02-delivery/phase-19/implementation-plan.md`](../02-delivery/phase-19/implementation-plan.md)). This file stays the product-facing design contract; ticket evidence and execution notes live under `docs/02-delivery/phase-19/`.
 
 ## TL;DR
 
@@ -8,11 +8,11 @@
 
 **Ships:** Obsidian Tide design tokens; left sidebar layout with mobile drawer; redesigned Dashboard, TV Shows, TV Show Detail, Movies, and Config views; consolidated navigation (4 top-level routes); movie backdrops surfaced from existing API.
 
-**Defers:** New daemon API endpoints; new intake behavior; new config surface beyond what Phases 13–18 delivered.
+**Defers:** New daemon API endpoints beyond the approved `P19.05` show-detail TMDB refresh; new intake behavior; new config surface beyond what Phases 13–18 delivered.
 
 ---
 
-Phase 19 is the v1 UI/UX milestone. It makes Pirate Claw look as good as it works. No new daemon surface — every visual improvement draws from data the API already returns.
+Phase 19 is the v1 UI/UX milestone. It makes Pirate Claw look as good as it works. Visual work draws from data the API already returns; the **only** approved new write path on the daemon for this phase is the authenticated TMDB refresh on TV show detail (`P19.05`).
 
 ## Design Contract
 

--- a/docs/01-product/phase-20-dashboard-torrent-actions.md
+++ b/docs/01-product/phase-20-dashboard-torrent-actions.md
@@ -98,14 +98,14 @@ In-flight: menu disabled while request is in flight. On failure: inline error di
 
 All new endpoints are flat `if (path === ... && request.method === 'POST')` blocks in `createApiFetch`. Request body is JSON. All transmission action endpoints accept `{ hash: string }`.
 
-| Endpoint                                           | Transmission RPC                             | DB Write                                                      |
-| -------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------- |
-| `POST /api/transmission/torrent/pause`             | `torrent-stop`                               | none                                                          |
-| `POST /api/transmission/torrent/resume`            | `torrent-start`                              | none                                                          |
-| `POST /api/transmission/torrent/remove`            | `torrent-remove`                             | `pirateClawDisposition = 'removed'` (if not completed)        |
-| `POST /api/transmission/torrent/remove-and-delete` | `torrent-remove` + `delete-local-data: true` | `pirateClawDisposition = 'deleted'`                           |
-| `POST /api/transmission/torrent/dispose`           | none                                         | `pirateClawDisposition = body.disposition` (resolves missing) |
-| `POST /api/candidates/:id/requeue`                 | none (calls `downloader.submit` directly)    | writes `transmissionTorrentId/Hash` on success                |
+| Endpoint                                           | Transmission RPC                             | DB Write                                                             |
+| -------------------------------------------------- | -------------------------------------------- | -------------------------------------------------------------------- |
+| `POST /api/transmission/torrent/pause`             | `torrent-stop`                               | none                                                                 |
+| `POST /api/transmission/torrent/resume`            | `torrent-start`                              | none                                                                 |
+| `POST /api/transmission/torrent/remove`            | `torrent-remove`                             | `pirateClawDisposition = 'removed'` (downloading, paused, completed) |
+| `POST /api/transmission/torrent/remove-and-delete` | `torrent-remove` + `delete-local-data: true` | `pirateClawDisposition = 'deleted'`                                  |
+| `POST /api/transmission/torrent/dispose`           | none                                         | `pirateClawDisposition = body.disposition` (resolves missing)        |
+| `POST /api/candidates/:id/requeue`                 | none (calls `downloader.submit` directly)    | writes `transmissionTorrentId/Hash` on success                       |
 
 ### New Transmission Service Functions (in `src/transmission.ts`)
 

--- a/docs/01-product/phase-20-dashboard-torrent-actions.md
+++ b/docs/01-product/phase-20-dashboard-torrent-actions.md
@@ -4,9 +4,9 @@
 
 ## TL;DR
 
-**Goal:** Make the dashboard a functional proxy for the Transmission client. Add torrent lifecycle actions via a right-click context menu on TorrentManagerCard rows, wire up the Queue button in FeedEventLogCard, and clean up the data model by replacing the redundant `CandidateLifecycleStatus` with a derived state pattern and a new `pirateClawDisposition` field.
+**Goal:** Make the dashboard a functional proxy for the Transmission client. Add torrent lifecycle actions via a right-click context menu on TorrentManagerCard rows, wire the Queue control on the Transmission failures card (failed enqueue retries), and clean up the data model by replacing the redundant `CandidateLifecycleStatus` with a derived state pattern and a new `pirateClawDisposition` field.
 
-**Ships:** Pause, resume, remove, remove+delete torrent actions; missing-torrent disposition resolution; manual requeue of failed/skipped candidates; data model clean break.
+**Ships:** Pause, resume, remove, remove+delete torrent actions; missing-torrent disposition resolution; manual requeue for candidates still in `failed` after a Transmission enqueue failure; data model clean break.
 
 **Defers:** Router extraction (future Hono migration); multi-torrent bulk actions; audit log.
 
@@ -115,14 +115,14 @@ Following the existing session-negotiation pattern (409 retry):
 
 ---
 
-## FeedEventLogCard — Queue Button
+## TransmissionFailuresCard — Queue button
 
-The existing stub Queue button is wired to `POST /api/candidates/:id/requeue`.
+The dashboard lists **deduped** matched candidates whose latest feed outcome is `failed` while `candidate_state` is still `failed` (Transmission enqueue rejected or errored). Each row exposes **Queue**, wired to `POST /api/candidates/:id/requeue`.
 
-- Endpoint calls `downloader.submit(candidate.downloadUrl)` immediately (Option A: synchronous, not deferred to next daemon cycle)
-- On success: writes `transmissionTorrentId`, `transmissionTorrentHash` back to candidate record
-- UI: button disabled per-row while in flight; shows brief green "Queued" confirmation on success; inline red error on failure
-- Eligible candidates: `status === 'failed'` or `status === 'skipped_no_match'`
+- Endpoint calls `downloader.submit(candidate.downloadUrl)` immediately (Option A: synchronous, not deferred to next daemon cycle). The daemon’s embedded API must be constructed with the same Transmission **downloader** instance used for feed runs; otherwise the handler returns **503** (`requeue is not available`).
+- On success: writes `transmissionTorrentId`, `transmissionTorrentHash` back to the candidate record; the row disappears from this list on the next refresh once the candidate leaves the failed state.
+- UI: deserialize SvelteKit action results (HTTP 200 can still mean `failure`); show errors inline; brief green “Queued ✓” only on real success.
+- **Queue** is shown only for rows in that failed-enqueue list (not for `skipped_duplicate` or unmatched `skipped_no_match` noise on the home dashboard).
 
 ---
 

--- a/docs/01-product/phase-20-dashboard-torrent-actions.md
+++ b/docs/01-product/phase-20-dashboard-torrent-actions.md
@@ -2,6 +2,8 @@
 
 **Delivery status:** Not started — product definition only; no `docs/02-delivery/phase-20/` implementation plan until tickets are approved.
 
+**Numbering note:** The v1.0.0 / schema-versioning milestone that previously occupied the “Phase 20” planning slot is now **[Phase 25: v1.0.0 release and schema versioning](./phase-25-v1-release-and-schema-versioning.md)**. This document keeps **Phase 20** exclusively for the dashboard-as-Transmission-proxy work below.
+
 ## TL;DR
 
 **Goal:** Make the dashboard a functional proxy for the Transmission client. Add torrent lifecycle actions via a right-click context menu on TorrentManagerCard rows, wire the Queue control on the Transmission failures card (failed enqueue retries), and clean up the data model by replacing the redundant `CandidateLifecycleStatus` with a derived state pattern and a new `pirateClawDisposition` field.

--- a/docs/01-product/phase-20-dashboard-torrent-actions.md
+++ b/docs/01-product/phase-20-dashboard-torrent-actions.md
@@ -1,14 +1,14 @@
 # Phase 20: Dashboard Torrent Actions
 
-**Delivery status:** Not started — product definition only; no `docs/02-delivery/phase-20/` implementation plan until tickets are approved.
+**Delivery status:** **Shipped on `main`.** Dashboard Transmission proxy, daemon JSON actions, `pirateClawDisposition` + derived `torrentDisplayState()`, and Transmission failures / requeue are live. Ticket stack and verification notes: [`docs/02-delivery/phase-20/implementation-plan.md`](../02-delivery/phase-20/implementation-plan.md); retrospective: [`notes/public/phase-20-retrospective.md`](../../notes/public/phase-20-retrospective.md).
 
 **Numbering note:** The v1.0.0 / schema-versioning milestone that previously occupied the “Phase 20” planning slot is now **[Phase 25: v1.0.0 release and schema versioning](./phase-25-v1-release-and-schema-versioning.md)**. This document keeps **Phase 20** exclusively for the dashboard-as-Transmission-proxy work below.
 
 ## TL;DR
 
-**Goal:** Make the dashboard a functional proxy for the Transmission client. Add torrent lifecycle actions via a right-click context menu on TorrentManagerCard rows, wire the Queue control on the Transmission failures card (failed enqueue retries), and clean up the data model by replacing the redundant `CandidateLifecycleStatus` with a derived state pattern and a new `pirateClawDisposition` field.
+**Goal (met on `main`):** The dashboard acts as a functional proxy for the Transmission client: torrent lifecycle actions from a right-click context menu on Torrent Manager rows, a **Queue** control on the Transmission failures card for failed enqueue retries, and a data-model clean break replacing redundant `CandidateLifecycleStatus` with derived display state plus `pirateClawDisposition`.
 
-**Ships:** Pause, resume, remove, remove+delete torrent actions; missing-torrent disposition resolution; manual requeue for candidates still in `failed` after a Transmission enqueue failure; data model clean break.
+**Ships (on `main`):** Pause, resume, remove, remove-with-delete torrent actions; missing-torrent disposition resolution; manual requeue for candidates still in `failed` after a Transmission enqueue failure; startup migration dropping `lifecycle_status` and adding `pirate_claw_disposition`; reconciler guard for terminal dispositions.
 
 **Defers:** Router extraction (future Hono migration); multi-torrent bulk actions; audit log.
 
@@ -141,6 +141,8 @@ The dashboard lists **deduped** matched candidates whose latest feed outcome is 
 ## Exit Condition
 
 A user can pause, resume, remove, and requeue torrents entirely from the Pirate Claw dashboard without opening the Transmission web UI. Missing torrents can be resolved to a terminal state. The data model has a single source of truth for torrent state. The DB carries no `lifecycle_status` column.
+
+**Status:** This exit condition is satisfied on `main` (see delivery plan and retrospective above).
 
 ## Retrospective
 

--- a/docs/01-product/phase-25-v1-release-and-schema-versioning.md
+++ b/docs/01-product/phase-25-v1-release-and-schema-versioning.md
@@ -12,16 +12,16 @@
 
 ---
 
-Phase 20 is the formal v1.0.0 milestone. It stamps the config and database with versioning, establishes the breaking change policy, and cuts the first tagged release. No new features, no new API endpoints, no new auth enforcement — Phase 13 already delivered the security model.
+Phase 25 is the formal v1.0.0 milestone. It stamps the config and database with versioning, establishes the breaking change policy, and cuts the first tagged release. No new features, no new API endpoints, no new auth enforcement — Phase 13 already delivered the security model.
 
 ## Phase Goal
 
-Phase 20 should leave Pirate Claw in a state where:
+Phase 25 should leave Pirate Claw in a state where:
 
 - the running daemon, config file, and SQLite database are all stamped with a schema version that future operators and tooling can inspect
 - the breaking change policy is documented: major version bump = new config/db schema pair; no cross-version migration path is guaranteed
 - `package.json` version is `1.0.0` and a tagged release exists on the repository
-- existing installs are not broken by any of the above — an unversioned config or DB from before Phase 20 is treated as v1 automatically
+- existing installs are not broken by any of the above — an unversioned config or DB from before Phase 25 ships is treated as v1 automatically
 
 ## Committed Scope
 
@@ -34,7 +34,7 @@ Phase 20 should leave Pirate Claw in a state where:
 ### Database schema versioning
 
 - use SQLite `PRAGMA user_version` — built in, no extra table needed
-- on first startup after Phase 20 ships: if `user_version` is `0` (the default for all existing DBs), set it to `1` — this is non-destructive and silent
+- on first startup after Phase 25 ships: if `user_version` is `0` (the default for all existing DBs), set it to `1` — this is non-destructive and silent
 - future breaking DB changes increment `user_version`; the startup check refuses to run if the DB version is ahead of what the binary knows
 - the existing ad-hoc `ALTER TABLE ADD COLUMN` guards in `src/repository.ts` are preserved as the migration mechanism for non-breaking additive changes; `user_version` only changes on breaking schema changes
 
@@ -42,7 +42,7 @@ Phase 20 should leave Pirate Claw in a state where:
 
 - `package.json` version bumped to `1.0.0`
 - `web/package.json` version bumped to `1.0.0`
-- tagged release on `main` with a CHANGELOG entry covering Phase 13–20 deliverables
+- tagged release on `main` with a CHANGELOG entry summarizing shipped product work through Phase 20 (dashboard Transmission proxy) and prior numbered phases
 - `VERSIONING.md` added to the repo root documenting the breaking change policy (see below)
 
 ### Breaking change policy (`VERSIONING.md`)
@@ -74,11 +74,11 @@ columns) are backward-compatible and do not require operator action.
 - automated migration tooling between major versions (manual re-import is the policy)
 - audit logs, plugin or extension support (not in v1)
 - new auth enforcement beyond what Phase 13 delivered (bearer token + localhost bind)
-- any new user-visible features — Phase 20 is infrastructure and release only
+- any new user-visible features — Phase 25 is infrastructure and release only
 
 ## Exit Condition
 
-The repo has a `v1.0.0` tag. A fresh install sees `"schemaVersion": 1` in the config after first write and `PRAGMA user_version = 1` in the DB. An operator upgrading from a pre-Phase-20 install sees no errors — the unversioned config is silently treated as v1, and the DB is silently stamped on first startup.
+The repo has a `v1.0.0` tag. A fresh install sees `"schemaVersion": 1` in the config after first write and `PRAGMA user_version = 1` in the DB. An operator upgrading from an install before Phase 25 versioning ships sees no errors — the unversioned config is silently treated as v1, and the DB is silently stamped on first startup.
 
 ## Retrospective
 

--- a/docs/02-delivery/phase-06/synology-runbook.md
+++ b/docs/02-delivery/phase-06/synology-runbook.md
@@ -895,7 +895,7 @@ Expected: a line reading `api listening on port 5555`. Since pirate-claw runs on
 
 Phase 15 added three additional read endpoints:
 
-- `GET /api/outcomes?status=skipped_no_match` — outcomes for feed items that were skipped because no candidate matched the policy
+- `GET /api/outcomes?status=failed_enqueue` (preferred) or `?status=skipped_no_match` (legacy alias) — deduped Transmission enqueue failures for matched candidates still in `failed` state
 - `GET /api/transmission/torrents` — live torrent stats for pirate-claw-managed torrents (proxied from Transmission RPC)
 - `GET /api/transmission/session` — Transmission session metadata including download/upload speed limits (proxied from Transmission RPC; returns 502 if Transmission is unreachable)
 

--- a/docs/02-delivery/phase-18/ticket-04-docs-exit-verification.md
+++ b/docs/02-delivery/phase-18/ticket-04-docs-exit-verification.md
@@ -42,5 +42,5 @@ Retrospective is marked `required` in the implementation plan because Phase 18
 introduces a durable optional external-service boundary with decisions (matching
 strategy, cache TTL policy, pirate-claw-first refresh pattern, display-only v1
 constraint) that future phases will revisit. Recording the learning now prevents
-context loss before Phase 20 (v1 release) or any future media-library provider
+context loss before Phase 25 (v1 release) or any future media-library provider
 expansion.

--- a/docs/02-delivery/phase-20/ticket-03-remove.md
+++ b/docs/02-delivery/phase-20/ticket-03-remove.md
@@ -62,8 +62,7 @@ Same pattern as P20.02:
 
 ## Exit Condition
 
-- `POST /api/transmission/torrent/remove` on a `downloading` candidate: torrent removed from Transmission, `pirateClawDisposition = 'removed'` written
-- `POST /api/transmission/torrent/remove` on a `completed` candidate: torrent removed, no disposition written
+- `POST /api/transmission/torrent/remove` on a `downloading`, `paused`, or `completed` candidate: torrent removed from Transmission, `pirateClawDisposition = 'removed'` written
 - `POST /api/transmission/torrent/remove-and-delete` on any active candidate: torrent and data removed, `pirateClawDisposition = 'deleted'` written
 - `POST /api/transmission/torrent/remove` on a `missing` candidate: returns `400`
 - `bun run typecheck` passes

--- a/docs/02-delivery/phase-20/ticket-07-exit-verification.md
+++ b/docs/02-delivery/phase-20/ticket-07-exit-verification.md
@@ -25,14 +25,14 @@ Must return zero matches.
 
 ### 3. Endpoint smoke tests (manual)
 
-| Endpoint                                           | Test                                                                                        |
-| -------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `POST /api/transmission/torrent/pause`             | Valid downloading hash → 200; non-downloading hash → 400                                    |
-| `POST /api/transmission/torrent/resume`            | Valid paused hash → 200; non-paused hash → 400                                              |
-| `POST /api/transmission/torrent/remove`            | Downloading candidate → 200, disposition written; completed candidate → 200, no disposition |
-| `POST /api/transmission/torrent/remove-and-delete` | Any active candidate → 200, disposition = deleted                                           |
-| `POST /api/transmission/torrent/dispose`           | Missing candidate + valid disposition → 200; non-missing → 400                              |
-| `POST /api/candidates/:id/requeue`                 | Failed candidate → 200, torrent fields written; non-eligible → 400                          |
+| Endpoint                                           | Test                                                                             |
+| -------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `POST /api/transmission/torrent/pause`             | Valid downloading hash → 200; non-downloading hash → 400                         |
+| `POST /api/transmission/torrent/resume`            | Valid paused hash → 200; non-paused hash → 400                                   |
+| `POST /api/transmission/torrent/remove`            | Downloading, paused, or completed candidate → 200, `removed` disposition written |
+| `POST /api/transmission/torrent/remove-and-delete` | Any active candidate → 200, disposition = deleted                                |
+| `POST /api/transmission/torrent/dispose`           | Missing candidate + valid disposition → 200; non-missing → 400                   |
+| `POST /api/candidates/:id/requeue`                 | Failed candidate → 200, torrent fields written; non-eligible → 400               |
 
 ### 4. UI verification
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,8 @@ Phase-level product definitions.
 - `phase-17-onboarding-and-empty-state.md`: first-time setup wizard and per-section empty states (implemented)
 - `phase-18-plex-media-server-enrichment.md`: Plex read-only enrichment — library status, watch state, background refresh (implemented)
 - `phase-19-ui-redesign-razzle-dazzle.md`: Obsidian Tide UI/UX redesign — left sidebar, poster-forward layouts, view consolidation (product definition)
-- `phase-20-v1-release-and-schema-versioning.md`: v1.0.0 release, config schemaVersion, SQLite PRAGMA user_version (product definition)
+- `phase-20-dashboard-torrent-actions.md`: dashboard as Transmission proxy — torrent lifecycle actions, requeue, data model clean break (product definition)
+- `phase-25-v1-release-and-schema-versioning.md`: v1.0.0 release, config `schemaVersion`, SQLite `PRAGMA user_version` (product definition; renumbered from the former “Phase 20 v1-only” slot)
 
 ### `02-delivery`
 

--- a/docs/synology-runbook.md
+++ b/docs/synology-runbook.md
@@ -358,8 +358,10 @@ Expected checks:
 
 ## Deploying new daemon and web images (from a dev machine)
 
-Use this when you have a fresh checkout on your laptop and want the same
-`pirate-claw.config.json`, repo-root `.env`, and `web/.env` on the NAS.
+Use this when you want to ship a new `main` tree to the NAS and **rebuild
+container images only**. Keep the operator files already on the NAS under
+`/volume1/pirate-claw/config/` (`.env`, `pirate-claw.config.json`, `web.env`) —
+do not overwrite them from the repo when redeploying.
 
 ### 1. Copy source to the NAS (tar over SSH)
 
@@ -385,30 +387,24 @@ tar czf - \
   . | ssh -p "$SSH_PORT" "$DEST" "cd \"$BUILD_DIR\" && tar xzf -"
 ```
 
-### 2. Copy secrets and config (repo `.env`, `pirate-claw.config.json`, `web/.env`)
+### 2. NAS config (leave unchanged on upgrades)
 
-Files under `/volume1/pirate-claw/config/` are often owned by `root`, so use
-`sudo tee` from stdin:
+The running stack reads secrets and web env from the host paths described in
+**Config And Secrets Contract** (typically `.env`, `pirate-claw.config.json`,
+and `web.env` under `/volume1/pirate-claw/config/`). For routine image upgrades,
+**do not replace those files** from a developer laptop.
 
-```sh
-ssh -p "$SSH_PORT" "$DEST" "sudo -n tee /volume1/pirate-claw/config/.env > /dev/null" < .env
-ssh -p "$SSH_PORT" "$DEST" "sudo -n tee /volume1/pirate-claw/config/pirate-claw.config.json > /dev/null" < pirate-claw.config.json
-ssh -p "$SSH_PORT" "$DEST" "sudo -n tee /volume1/pirate-claw/config/web.env > /dev/null" < web/.env
-```
+Bootstrap only (new host or missing `web.env`): create the files on the NAS
+once, then continue with the build steps. `web.env` is the env-file passed to
+`pirate-claw-web` (`--env-file`; Docker format: `KEY=value` lines only).
 
-`web/.env` is stored as `**web.env**` on the NAS so the web container can use
-`--env-file` (Docker env-file format: `KEY=value` lines only).
-
-Ensure `**ORIGIN**` is set for SvelteKit `adapter-node` (add if missing):
+If `web.env` exists but is missing `ORIGIN`, append it once (adjust the URL if
+your browser-facing origin differs):
 
 ```sh
 ssh -p "$SSH_PORT" "$DEST" \
   'grep -q "^ORIGIN=" /volume1/pirate-claw/config/web.env || echo "ORIGIN=http://100.108.117.42:3001" | sudo -n tee -a /volume1/pirate-claw/config/web.env >/dev/null'
 ```
-
-Optional daemon secrets (same `/config/.env` as today):
-
-- `PIRATE_CLAW_PLEX_TOKEN` — omit `plex.token` from JSON if you set this
 
 ### 3. Build `pirate-claw:latest` on the NAS
 

--- a/notes/public/p11-retrospective.md
+++ b/notes/public/p11-retrospective.md
@@ -10,12 +10,12 @@ Six stacked PRs across the TMDB enrichment stack. All six slices reached `done`;
 
 | PR                                                     | Branch → base              | Title                                                  |
 | ------------------------------------------------------ | -------------------------- | ------------------------------------------------------ |
-| [#94](https://github.com/cesarnml/pirate_claw/pull/94) | `agents/p11-01-…` → `main` | Foundation: TMDB config, client, SQLite cache [P11.01] |
-| [#95](https://github.com/cesarnml/pirate_claw/pull/95) | `p11-02` → `p11-01`        | Movies vertical slice [P11.02]                         |
-| [#96](https://github.com/cesarnml/pirate_claw/pull/96) | `p11-03` → `p11-02`        | TV lazy enrich, `/api/shows`, show UI [P11.03]         |
-| [#97](https://github.com/cesarnml/pirate_claw/pull/97) | `p11-04` → `p11-03`        | `GET /api/candidates` TMDB cache attach [P11.04]       |
-| [#98](https://github.com/cesarnml/pirate_claw/pull/98) | `p11-05` → `p11-04`        | Background TMDB refresh scheduler [P11.05]             |
-| [#99](https://github.com/cesarnml/pirate_claw/pull/99) | `p11-06` → `p11-05`        | Docs, roadmap, README exit alignment [P11.06]          |
+| [#94](https://github.com/cesarnml/Pirate-Claw/pull/94) | `agents/p11-01-…` → `main` | Foundation: TMDB config, client, SQLite cache [P11.01] |
+| [#95](https://github.com/cesarnml/Pirate-Claw/pull/95) | `p11-02` → `p11-01`        | Movies vertical slice [P11.02]                         |
+| [#96](https://github.com/cesarnml/Pirate-Claw/pull/96) | `p11-03` → `p11-02`        | TV lazy enrich, `/api/shows`, show UI [P11.03]         |
+| [#97](https://github.com/cesarnml/Pirate-Claw/pull/97) | `p11-04` → `p11-03`        | `GET /api/candidates` TMDB cache attach [P11.04]       |
+| [#98](https://github.com/cesarnml/Pirate-Claw/pull/98) | `p11-05` → `p11-04`        | Background TMDB refresh scheduler [P11.05]             |
+| [#99](https://github.com/cesarnml/Pirate-Claw/pull/99) | `p11-06` → `p11-05`        | Docs, roadmap, README exit alignment [P11.06]          |
 
 Merge strategy: `bun run closeout-stack --plan docs/02-delivery/phase-11/implementation-plan.md` after developer approval.
 

--- a/notes/public/p14-retrospective.md
+++ b/notes/public/p14-retrospective.md
@@ -10,12 +10,12 @@ Six stacked PRs delivering two backend write endpoints, three UI sections with s
 
 | Ticket                                      | PR                                                       | CI               | Review outcome |
 | ------------------------------------------- | -------------------------------------------------------- | ---------------- | -------------- |
-| P14.01 TV Defaults + Movie Policy Endpoints | [#117](https://github.com/cesarnml/pirate_claw/pull/117) | fail (inherited) | clean          |
-| P14.02 Feeds Write Endpoint                 | [#118](https://github.com/cesarnml/pirate_claw/pull/118) | fail (inherited) | clean          |
-| P14.03 TV Section UI                        | [#119](https://github.com/cesarnml/pirate_claw/pull/119) | fail (inherited) | clean          |
-| P14.04 Movies Policy UI                     | [#120](https://github.com/cesarnml/pirate_claw/pull/120) | pass             | clean          |
-| P14.05 Feeds UI                             | [#121](https://github.com/cesarnml/pirate_claw/pull/121) | pass             | patched        |
-| P14.06 Docs and Phase Exit                  | [#122](https://github.com/cesarnml/pirate_claw/pull/122) | pass             | clean          |
+| P14.01 TV Defaults + Movie Policy Endpoints | [#117](https://github.com/cesarnml/Pirate-Claw/pull/117) | fail (inherited) | clean          |
+| P14.02 Feeds Write Endpoint                 | [#118](https://github.com/cesarnml/Pirate-Claw/pull/118) | fail (inherited) | clean          |
+| P14.03 TV Section UI                        | [#119](https://github.com/cesarnml/Pirate-Claw/pull/119) | fail (inherited) | clean          |
+| P14.04 Movies Policy UI                     | [#120](https://github.com/cesarnml/Pirate-Claw/pull/120) | pass             | clean          |
+| P14.05 Feeds UI                             | [#121](https://github.com/cesarnml/Pirate-Claw/pull/121) | pass             | patched        |
+| P14.06 Docs and Phase Exit                  | [#122](https://github.com/cesarnml/Pirate-Claw/pull/122) | pass             | clean          |
 
 "fail (inherited)" = pre-existing test regressions from Phase 13 code, fixed in P14.04. The `closeout-stack` squash sequence lands all fixes on `main` in order.
 

--- a/notes/public/p15-retrospective.md
+++ b/notes/public/p15-retrospective.md
@@ -10,13 +10,13 @@ Seven stacked PRs across two sessions. P15.01–P15.06 completed in one session;
 
 | Ticket                                      | PR                                                       | Review outcome |
 | ------------------------------------------- | -------------------------------------------------------- | -------------- |
-| P15.01 GET /api/outcomes Endpoint           | [#125](https://github.com/cesarnml/pirate_claw/pull/125) | clean          |
-| P15.02 Transmission Proxy Endpoints         | [#126](https://github.com/cesarnml/pirate_claw/pull/126) | clean          |
-| P15.03 Dashboard Overview Enhancement       | [#127](https://github.com/cesarnml/pirate_claw/pull/127) | patched        |
-| P15.04 TV Shows View — Progress and Sort    | [#128](https://github.com/cesarnml/pirate_claw/pull/128) | patched        |
-| P15.05 Movies View — Filter, Sort, Progress | [#129](https://github.com/cesarnml/pirate_claw/pull/129) | patched        |
-| P15.06 Unmatched Candidates View            | [#130](https://github.com/cesarnml/pirate_claw/pull/130) | clean          |
-| P15.07 Docs and Phase Exit                  | [#131](https://github.com/cesarnml/pirate_claw/pull/131) | clean          |
+| P15.01 GET /api/outcomes Endpoint           | [#125](https://github.com/cesarnml/Pirate-Claw/pull/125) | clean          |
+| P15.02 Transmission Proxy Endpoints         | [#126](https://github.com/cesarnml/Pirate-Claw/pull/126) | clean          |
+| P15.03 Dashboard Overview Enhancement       | [#127](https://github.com/cesarnml/Pirate-Claw/pull/127) | patched        |
+| P15.04 TV Shows View — Progress and Sort    | [#128](https://github.com/cesarnml/Pirate-Claw/pull/128) | patched        |
+| P15.05 Movies View — Filter, Sort, Progress | [#129](https://github.com/cesarnml/Pirate-Claw/pull/129) | patched        |
+| P15.06 Unmatched Candidates View            | [#130](https://github.com/cesarnml/Pirate-Claw/pull/130) | clean          |
+| P15.07 Docs and Phase Exit                  | [#131](https://github.com/cesarnml/Pirate-Claw/pull/131) | clean          |
 
 What shipped: `GET /api/outcomes?status=skipped_no_match`; Transmission RPC proxy endpoints (`/api/transmission/torrents`, `/api/transmission/session`); dashboard active downloads section; TV shows per-episode progress bars and sort; movies filter tabs, sort, and progress; unmatched candidates view with title search.
 

--- a/notes/public/p16-retrospective.md
+++ b/notes/public/p16-retrospective.md
@@ -6,7 +6,7 @@ _Phase 16: Config Editing, Hot Reload, and Daemon Controls — P16.01–P16.09_
 
 ## Scope delivered
 
-Phase 16 shipped across stacked PRs [#133](https://github.com/cesarnml/pirate_claw/pull/133) through [#141](https://github.com/cesarnml/pirate_claw/pull/141). Delivered scope: `POST /api/daemon/restart`, `POST /api/transmission/ping`, `tvDefaults` in `GET /api/config`, toast-based save feedback, Transmission card enhancements, TV defaults pre-population fix, runtime/TV-shows form split, collapsible config cards, read-only audit, and phase-exit docs/runbook updates. The product outcome landed: `/config` is now the unified editable surface the Phase 16 product doc described.
+Phase 16 shipped across stacked PRs [#133](https://github.com/cesarnml/Pirate-Claw/pull/133) through [#141](https://github.com/cesarnml/Pirate-Claw/pull/141). Delivered scope: `POST /api/daemon/restart`, `POST /api/transmission/ping`, `tvDefaults` in `GET /api/config`, toast-based save feedback, Transmission card enhancements, TV defaults pre-population fix, runtime/TV-shows form split, collapsible config cards, read-only audit, and phase-exit docs/runbook updates. The product outcome landed: `/config` is now the unified editable surface the Phase 16 product doc described.
 
 ---
 
@@ -53,8 +53,8 @@ Phase 16 achieved its stated product goal. The browser config surface is now mea
 
 ## Follow-up
 
-- **Standalone tooling fix:** make docs-only PRs advertise the skip path immediately in `open-pr` output rather than the generic 6/12-minute review window. Opened as [#142](https://github.com/cesarnml/pirate_claw/pull/142).
-- **Standalone tooling fix:** enforce a Conventional-Commit fallback in PR-title generation so malformed upstream subjects cannot leak bare ticket titles into PRs. Opened as [#143](https://github.com/cesarnml/pirate_claw/pull/143).
+- **Standalone tooling fix:** make docs-only PRs advertise the skip path immediately in `open-pr` output rather than the generic 6/12-minute review window. Opened as [#142](https://github.com/cesarnml/Pirate-Claw/pull/142).
+- **Standalone tooling fix:** enforce a Conventional-Commit fallback in PR-title generation so malformed upstream subjects cannot leak bare ticket titles into PRs. Opened as [#143](https://github.com/cesarnml/Pirate-Claw/pull/143).
 - **Planning/process follow-up:** when a ticket is intentionally “infrastructure only,” restate the out-of-scope boundaries aggressively in the implementation prompt so the first implementation PR does not absorb adjacent ticket scope.
 - **Delivery-state follow-up:** resolve why authoritative delivery-plan docs can be absent from the ticket worktree lineage during docs-exit tickets, because that adds unnecessary operator/tool friction at exactly the point where the phase should be simplest.
 

--- a/notes/public/phase-18-retrospective.md
+++ b/notes/public/phase-18-retrospective.md
@@ -1,6 +1,6 @@
 ## Scope delivered
 
-Phase 18 shipped through PRs [#164](https://github.com/cesarnml/pirate_claw/pull/164), [#165](https://github.com/cesarnml/pirate_claw/pull/165), and [#166](https://github.com/cesarnml/pirate_claw/pull/166) on the stacked `agents/p18-*` branches. Delivered scope: optional `plex` config and secret handling, Plex HTTP client plus SQLite cache tables, daemon background refresh for movies and shows, read-only `plexStatus` / `watchCount` / `lastWatchedAt` fields on `/api/movies` and `/api/shows`, minimal movie/show dashboard affordances, doc updates, and review-driven resilience follow-up for independent movie/show sweep failures.
+Phase 18 shipped through PRs [#164](https://github.com/cesarnml/Pirate-Claw/pull/164), [#165](https://github.com/cesarnml/Pirate-Claw/pull/165), and [#166](https://github.com/cesarnml/Pirate-Claw/pull/166) on the stacked `agents/p18-*` branches. Delivered scope: optional `plex` config and secret handling, Plex HTTP client plus SQLite cache tables, daemon background refresh for movies and shows, read-only `plexStatus` / `watchCount` / `lastWatchedAt` fields on `/api/movies` and `/api/shows`, minimal movie/show dashboard affordances, doc updates, and review-driven resilience follow-up for independent movie/show sweep failures.
 
 ## What went well
 

--- a/notes/public/phase-20-retrospective.md
+++ b/notes/public/phase-20-retrospective.md
@@ -6,7 +6,7 @@ _Phase 20: Dashboard Torrent Actions — P20.01–P20.07_
 
 ## Scope delivered
 
-Phase 20 shipped across stacked PRs [#181](https://github.com/cesarnml/pirate_claw/pull/181) through [#187](https://github.com/cesarnml/pirate_claw/pull/187) on branches `agents/p20-01-data-model-clean-break` through `agents/p20-07-docs-exit-verification`. Delivered scope: data model clean break (drop `CandidateLifecycleStatus`, add `pirateClawDisposition` terminal field, `torrentDisplayState()` derived function, startup migration, reconciler skip guard); pause/resume torrent RPC endpoints; remove/remove+delete endpoints with disposition writes; dispose endpoint for missing-candidate resolution; right-click context menu UI for torrent row actions; Queue button in FeedEventLogCard for manual candidate requeue; and this exit verification pass.
+Phase 20 shipped across stacked PRs [#181](https://github.com/cesarnml/Pirate-Claw/pull/181) through [#187](https://github.com/cesarnml/Pirate-Claw/pull/187) on branches `agents/p20-01-data-model-clean-break` through `agents/p20-07-docs-exit-verification`. Delivered scope: data model clean break (drop `CandidateLifecycleStatus`, add `pirateClawDisposition` terminal field, `torrentDisplayState()` derived function, startup migration, reconciler skip guard); pause/resume torrent RPC endpoints; remove/remove+delete endpoints with disposition writes; dispose endpoint for missing-candidate resolution; right-click context menu UI for torrent row actions; Queue button in FeedEventLogCard for manual candidate requeue; and this exit verification pass.
 
 ---
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1073,7 +1073,11 @@ export function createApiFetch(
         return Response.json({ error: rpc.message }, { status: 502 });
       }
 
-      if (ctx.rowState === 'downloading' || ctx.rowState === 'paused') {
+      if (
+        ctx.rowState === 'downloading' ||
+        ctx.rowState === 'paused' ||
+        ctx.rowState === 'completed'
+      ) {
         repository.setPirateClawDisposition(
           ctx.candidate.identityKey,
           'removed',

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,13 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { renameSync, writeFileSync } from 'node:fs';
-import { fetchSessionInfo, fetchTorrentStats } from './transmission';
-import type { Downloader } from './transmission';
+import {
+  fetchSessionInfo,
+  fetchTorrentStats,
+  pauseTorrent,
+  removeTorrent,
+  resumeTorrent,
+} from './transmission';
+import type { Downloader, TorrentStatSnapshot } from './transmission';
 import type {
   AppConfig,
   CompactTvDefaults,
@@ -29,7 +35,11 @@ export type {
 } from './tv-api-types';
 import { isDueFeed } from './poll-state';
 import type { PollState } from './poll-state';
-import type { CandidateStateRecord, Repository } from './repository';
+import type {
+  CandidateStateRecord,
+  PirateClawDisposition,
+  Repository,
+} from './repository';
 import type { CycleResult } from './runtime-artifacts';
 import type { TmdbCache } from './tmdb/cache';
 import { enrichCandidatesFromCache } from './tmdb/candidate-cache-enrich';
@@ -139,6 +149,168 @@ function jsonMethodNotAllowed(allow: string): Response {
   );
 }
 
+/** Repository default is 20; HTTP dashboards need a full slice for joins and torrent polling. */
+const API_CANDIDATE_LIST_LIMIT = 50_000;
+
+type ManagedTorrentRowState =
+  | 'missing'
+  | 'downloading'
+  | 'paused'
+  | 'completed';
+
+function managedTorrentRowState(
+  torrent: TorrentStatSnapshot | undefined,
+): ManagedTorrentRowState {
+  if (!torrent) return 'missing';
+  if (torrent.percentDone >= 1) return 'completed';
+  if (torrent.status === 'downloading') return 'downloading';
+  return 'paused';
+}
+
+async function parseJsonTorrentHash(
+  request: Request,
+): Promise<{ ok: true; hash: string } | { ok: false; response: Response }> {
+  let parsed: unknown;
+  try {
+    parsed = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: 'request body must be valid JSON' },
+        { status: 400 },
+      ),
+    };
+  }
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    typeof (parsed as { hash?: unknown }).hash !== 'string'
+  ) {
+    return {
+      ok: false,
+      response: Response.json({ error: 'hash is required' }, { status: 400 }),
+    };
+  }
+  const hash = (parsed as { hash: string }).hash.trim();
+  if (!hash) {
+    return {
+      ok: false,
+      response: Response.json({ error: 'hash is required' }, { status: 400 }),
+    };
+  }
+  return { ok: true, hash };
+}
+
+async function resolveManagedTorrentAction(
+  repository: Repository,
+  transmissionConfig: AppConfig['transmission'],
+  hash: string,
+): Promise<
+  | {
+      ok: true;
+      candidate: CandidateStateRecord;
+      rowState: ManagedTorrentRowState;
+    }
+  | { ok: false; response: Response }
+> {
+  const candidate = repository.getCandidateStateByTransmissionHash(hash);
+  if (!candidate?.transmissionTorrentHash) {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: 'no candidate matches this torrent hash' },
+        { status: 404 },
+      ),
+    };
+  }
+  if (
+    candidate.pirateClawDisposition === 'removed' ||
+    candidate.pirateClawDisposition === 'deleted'
+  ) {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: 'candidate is already in a terminal disposition' },
+        { status: 400 },
+      ),
+    };
+  }
+  const statsResult = await fetchTorrentStats(transmissionConfig, [
+    candidate.transmissionTorrentHash,
+  ]);
+  if (!statsResult.ok) {
+    return {
+      ok: false,
+      response: Response.json({ error: statsResult.message }, { status: 502 }),
+    };
+  }
+  const torrent = statsResult.torrents.find(
+    (t) => t.hash === candidate.transmissionTorrentHash,
+  );
+  return {
+    ok: true,
+    candidate,
+    rowState: managedTorrentRowState(torrent),
+  };
+}
+
+async function parseJsonDisposeBody(
+  request: Request,
+): Promise<
+  | { ok: true; hash: string; disposition: PirateClawDisposition }
+  | { ok: false; response: Response }
+> {
+  let parsed: unknown;
+  try {
+    parsed = await request.json();
+  } catch {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: 'request body must be valid JSON' },
+        { status: 400 },
+      ),
+    };
+  }
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    typeof (parsed as { hash?: unknown }).hash !== 'string' ||
+    typeof (parsed as { disposition?: unknown }).disposition !== 'string'
+  ) {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: 'hash and disposition are required' },
+        { status: 400 },
+      ),
+    };
+  }
+  const dispositionRaw = (parsed as { disposition: string }).disposition;
+  if (dispositionRaw !== 'removed' && dispositionRaw !== 'deleted') {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: 'invalid disposition' },
+        { status: 400 },
+      ),
+    };
+  }
+  const hash = (parsed as { hash: string }).hash.trim();
+  if (!hash) {
+    return {
+      ok: false,
+      response: Response.json({ error: 'hash is required' }, { status: 400 }),
+    };
+  }
+  return {
+    ok: true,
+    hash,
+    disposition: dispositionRaw as PirateClawDisposition,
+  };
+}
+
 function safeJson<T>(body: () => T): Response {
   try {
     return Response.json(body());
@@ -191,7 +363,7 @@ export function createApiFetch(
 
     if (path === '/api/candidates') {
       try {
-        const list = repository.listCandidateStates();
+        const list = repository.listCandidateStates(API_CANDIDATE_LIST_LIMIT);
         const candidates = tmdbCache
           ? enrichCandidatesFromCache(
               list,
@@ -753,6 +925,7 @@ export function createApiFetch(
 
     if (path === '/api/outcomes' && request.method === 'GET') {
       const status = new URL(request.url).searchParams.get('status');
+      // Historical filter name: returns deduped matched Transmission enqueue failures only.
       if (status !== 'skipped_no_match') {
         return Response.json(
           { error: 'unsupported status filter' },
@@ -764,10 +937,16 @@ export function createApiFetch(
     }
 
     if (path === '/api/transmission/torrents' && request.method === 'GET') {
-      const candidates = repository.listCandidateStates();
+      const candidates = repository.listCandidateStates(
+        API_CANDIDATE_LIST_LIMIT,
+      );
       const hashes = candidates
-        .map((c) => c.transmissionTorrentHash)
-        .filter((h): h is string => h !== undefined);
+        .filter(
+          (c) =>
+            c.transmissionTorrentHash !== undefined &&
+            c.pirateClawDisposition === undefined,
+        )
+        .map((c) => c.transmissionTorrentHash as string);
 
       if (hashes.length === 0) {
         return Response.json({ torrents: [] });
@@ -798,6 +977,182 @@ export function createApiFetch(
       }
 
       return Response.json(result.session);
+    }
+
+    if (
+      path === '/api/transmission/torrent/pause' &&
+      request.method === 'POST'
+    ) {
+      const authError = checkWriteAuth(request, activeConfig);
+      if (authError) return authError;
+
+      const body = await parseJsonTorrentHash(request);
+      if (!body.ok) return body.response;
+
+      const ctx = await resolveManagedTorrentAction(
+        repository,
+        activeConfig.transmission,
+        body.hash,
+      );
+      if (!ctx.ok) return ctx.response;
+      if (ctx.rowState !== 'downloading') {
+        return Response.json(
+          { error: 'torrent is not in a state that can be paused' },
+          { status: 400 },
+        );
+      }
+
+      const rpc = await pauseTorrent(activeConfig.transmission, body.hash);
+      if (!rpc.ok) {
+        return Response.json({ error: rpc.message }, { status: 502 });
+      }
+      return Response.json({ ok: true });
+    }
+
+    if (
+      path === '/api/transmission/torrent/resume' &&
+      request.method === 'POST'
+    ) {
+      const authError = checkWriteAuth(request, activeConfig);
+      if (authError) return authError;
+
+      const body = await parseJsonTorrentHash(request);
+      if (!body.ok) return body.response;
+
+      const ctx = await resolveManagedTorrentAction(
+        repository,
+        activeConfig.transmission,
+        body.hash,
+      );
+      if (!ctx.ok) return ctx.response;
+      if (ctx.rowState !== 'paused') {
+        return Response.json(
+          { error: 'torrent is not in a state that can be resumed' },
+          { status: 400 },
+        );
+      }
+
+      const rpc = await resumeTorrent(activeConfig.transmission, body.hash);
+      if (!rpc.ok) {
+        return Response.json({ error: rpc.message }, { status: 502 });
+      }
+      return Response.json({ ok: true });
+    }
+
+    if (
+      path === '/api/transmission/torrent/remove' &&
+      request.method === 'POST'
+    ) {
+      const authError = checkWriteAuth(request, activeConfig);
+      if (authError) return authError;
+
+      const body = await parseJsonTorrentHash(request);
+      if (!body.ok) return body.response;
+
+      const ctx = await resolveManagedTorrentAction(
+        repository,
+        activeConfig.transmission,
+        body.hash,
+      );
+      if (!ctx.ok) return ctx.response;
+      if (ctx.rowState === 'missing') {
+        return Response.json(
+          {
+            error: 'torrent is missing from Transmission; use dispose instead',
+          },
+          { status: 400 },
+        );
+      }
+
+      const rpc = await removeTorrent(
+        activeConfig.transmission,
+        body.hash,
+        false,
+      );
+      if (!rpc.ok) {
+        return Response.json({ error: rpc.message }, { status: 502 });
+      }
+
+      if (ctx.rowState === 'downloading' || ctx.rowState === 'paused') {
+        repository.setPirateClawDisposition(
+          ctx.candidate.identityKey,
+          'removed',
+        );
+      }
+
+      return Response.json({ ok: true });
+    }
+
+    if (
+      path === '/api/transmission/torrent/remove-and-delete' &&
+      request.method === 'POST'
+    ) {
+      const authError = checkWriteAuth(request, activeConfig);
+      if (authError) return authError;
+
+      const body = await parseJsonTorrentHash(request);
+      if (!body.ok) return body.response;
+
+      const ctx = await resolveManagedTorrentAction(
+        repository,
+        activeConfig.transmission,
+        body.hash,
+      );
+      if (!ctx.ok) return ctx.response;
+      if (ctx.rowState === 'missing') {
+        return Response.json(
+          {
+            error: 'torrent is missing from Transmission; use dispose instead',
+          },
+          { status: 400 },
+        );
+      }
+
+      const rpc = await removeTorrent(
+        activeConfig.transmission,
+        body.hash,
+        true,
+      );
+      if (!rpc.ok) {
+        return Response.json({ error: rpc.message }, { status: 502 });
+      }
+
+      repository.setPirateClawDisposition(ctx.candidate.identityKey, 'deleted');
+
+      return Response.json({ ok: true });
+    }
+
+    if (
+      path === '/api/transmission/torrent/dispose' &&
+      request.method === 'POST'
+    ) {
+      const authError = checkWriteAuth(request, activeConfig);
+      if (authError) return authError;
+
+      const body = await parseJsonDisposeBody(request);
+      if (!body.ok) return body.response;
+
+      const ctx = await resolveManagedTorrentAction(
+        repository,
+        activeConfig.transmission,
+        body.hash,
+      );
+      if (!ctx.ok) return ctx.response;
+      if (ctx.rowState !== 'missing') {
+        return Response.json(
+          {
+            error:
+              'dispose is only valid when the torrent is missing from Transmission',
+          },
+          { status: 400 },
+        );
+      }
+
+      repository.setPirateClawDisposition(
+        ctx.candidate.identityKey,
+        body.disposition,
+      );
+      return Response.json({ ok: true });
     }
 
     if (path === '/api/transmission/ping' && request.method === 'POST') {

--- a/src/api.ts
+++ b/src/api.ts
@@ -925,8 +925,10 @@ export function createApiFetch(
 
     if (path === '/api/outcomes' && request.method === 'GET') {
       const status = new URL(request.url).searchParams.get('status');
-      // Historical filter name: returns deduped matched Transmission enqueue failures only.
-      if (status !== 'skipped_no_match') {
+      // Preferred name describes the payload: deduped Transmission enqueue failures for
+      // matched candidates still in `failed` state. `skipped_no_match` is a legacy alias
+      // from Phase 15 when this endpoint returned a different slice.
+      if (status !== 'failed_enqueue' && status !== 'skipped_no_match') {
         return Response.json(
           { error: 'unsupported status filter' },
           { status: 400 },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -478,6 +478,7 @@ export async function runCli(argv: string[]): Promise<number> {
                         err instanceof Error ? err.message : String(err)
                       }`,
                     ),
+                  downloader,
                 })
               : undefined,
         });

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -113,11 +113,11 @@ export type RecordFeedItemOutcomeInput = {
 export type SkippedOutcomeRecord = {
   id: number;
   runId: number;
-  status: 'skipped_no_match' | 'failed';
+  status: 'failed';
   recordedAt: string;
   title: string | null;
   feedName: string | null;
-  identityKey: string | null;
+  identityKey: string;
 };
 
 export type RecordCandidateReconciliationInput = {
@@ -154,6 +154,10 @@ export type Repository = {
   failRun(runId: number, failedAt?: string): RunRecord;
   recordFeedItem(runId: number, item: RawFeedItem): FeedItemRecord;
   getCandidateState(identityKey: string): CandidateStateRecord | undefined;
+  /** First candidate row with this Transmission hash, if any. */
+  getCandidateStateByTransmissionHash(
+    hash: string,
+  ): CandidateStateRecord | undefined;
   isCandidateQueued(identityKey: string): boolean;
   recordCandidateOutcome(
     input: RecordCandidateOutcomeInput,
@@ -169,6 +173,11 @@ export type Repository = {
   listCandidateStates(limit?: number): CandidateStateRecord[];
   listReconcilableCandidates(limit?: number): CandidateStateRecord[];
   listRetryableCandidates(limit?: number): CandidateStateRecord[];
+  /**
+   * One row per matched `identity_key`: latest `failed` feed outcome while
+   * `candidate_state` is still failed (Transmission enqueue failure), within the
+   * day window.
+   */
   listSkippedNoMatchOutcomes(days: number): SkippedOutcomeRecord[];
   requeueCandidate(
     identityKey: string,
@@ -382,8 +391,7 @@ export function createRepository(database: Database): Repository {
     FROM feed_items
     WHERE id = ?1`,
   );
-  const selectCandidateState = database.query(
-    `SELECT
+  const candidateStateSelectColumns = `
       identity_key AS identityKey,
       media_type AS mediaType,
       status,
@@ -414,9 +422,17 @@ export function createRepository(database: Database): Repository {
       first_seen_run_id AS firstSeenRunId,
       last_seen_run_id AS lastSeenRunId,
       last_feed_item_id AS lastFeedItemId,
-      updated_at AS updatedAt
+      updated_at AS updatedAt`;
+  const selectCandidateState = database.query(
+    `SELECT ${candidateStateSelectColumns}
     FROM candidate_state
     WHERE identity_key = ?1`,
+  );
+  const selectCandidateStateByTransmissionHash = database.query(
+    `SELECT ${candidateStateSelectColumns}
+    FROM candidate_state
+    WHERE transmission_torrent_hash = ?1
+    LIMIT 1`,
   );
   const upsertCandidateState = database.query(
     `INSERT INTO candidate_state (
@@ -667,28 +683,40 @@ export function createRepository(database: Database): Repository {
     ORDER BY identity_key ASC
     LIMIT ?1`,
   );
+  /** Latest failed enqueue outcome per matched candidate for the dashboard. */
   const listSkippedNoMatchOutcomesStatement = database.prepare(
     `SELECT
-      fo.id,
-      fo.run_id AS runId,
-      fo.status,
-      fo.created_at AS recordedAt,
-      fi.raw_title AS title,
-      fi.feed_name AS feedName,
-      fo.identity_key AS identityKey
-    FROM feed_item_outcomes fo
-    LEFT JOIN feed_items fi ON fo.feed_item_id = fi.id
-    LEFT JOIN candidate_state cs ON cs.identity_key = fo.identity_key
-    WHERE (
-        fo.status = 'skipped_no_match'
-        OR (
-          fo.status = 'failed'
-          AND cs.status = 'failed'
-          AND cs.pirate_claw_disposition IS NULL
-        )
-      )
-      AND fo.created_at >= datetime('now', '-' || ?1 || ' days')
-    ORDER BY fo.created_at DESC`,
+      id,
+      runId,
+      status,
+      recordedAt,
+      title,
+      feedName,
+      identityKey
+    FROM (
+      SELECT
+        fo.id AS id,
+        fo.run_id AS runId,
+        fo.status AS status,
+        fo.created_at AS recordedAt,
+        fi.raw_title AS title,
+        fi.feed_name AS feedName,
+        fo.identity_key AS identityKey,
+        ROW_NUMBER() OVER (
+          PARTITION BY fo.identity_key
+          ORDER BY fo.created_at DESC, fo.id DESC
+        ) AS rn
+      FROM feed_item_outcomes fo
+      LEFT JOIN feed_items fi ON fo.feed_item_id = fi.id
+      LEFT JOIN candidate_state cs ON cs.identity_key = fo.identity_key
+      WHERE fo.identity_key IS NOT NULL
+        AND fo.created_at >= datetime('now', '-' || ?1 || ' days')
+        AND fo.status = 'failed'
+        AND cs.status = 'failed'
+        AND cs.pirate_claw_disposition IS NULL
+    ) ranked
+    WHERE rn = 1
+    ORDER BY recordedAt DESC`,
   );
   const requeueCandidateStatement = database.prepare(
     `UPDATE candidate_state
@@ -819,6 +847,16 @@ export function createRepository(database: Database): Repository {
 
     getCandidateState(identityKey: string): CandidateStateRecord | undefined {
       const row = selectCandidateState.get(identityKey) as
+        | CandidateStateRow
+        | null
+        | undefined;
+      return row ? mapCandidateStateRow(row) : undefined;
+    },
+
+    getCandidateStateByTransmissionHash(
+      hash: string,
+    ): CandidateStateRecord | undefined {
+      const row = selectCandidateStateByTransmissionHash.get(hash) as
         | CandidateStateRow
         | null
         | undefined;
@@ -984,11 +1022,11 @@ export function createRepository(database: Database): Repository {
       type Row = {
         id: number;
         runId: number;
-        status: 'skipped_no_match' | 'failed';
+        status: 'failed';
         recordedAt: string;
         title: string | null;
         feedName: string | null;
-        identityKey: string | null;
+        identityKey: string;
       };
       return (listSkippedNoMatchOutcomesStatement.all(days) as Row[]).map(
         (row) => ({
@@ -998,7 +1036,7 @@ export function createRepository(database: Database): Repository {
           recordedAt: row.recordedAt,
           title: row.title,
           feedName: row.feedName,
-          identityKey: row.identityKey ?? null,
+          identityKey: row.identityKey,
         }),
       );
     },

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -31,6 +31,7 @@ function stubRepository(overrides: Partial<Repository> = {}): Repository {
     recordFeedItemOutcome: () => {},
     recordCandidateOutcome: () => ({}) as never,
     getCandidateState: () => undefined,
+    getCandidateStateByTransmissionHash: () => undefined,
     updateCandidateReconciliation: () => ({}) as never,
     retryCandidate: () => ({}) as never,
     listFeedItemOutcomes: () => [],
@@ -2078,20 +2079,20 @@ describe('GET /api/outcomes', () => {
       {
         id: 1,
         runId: 42,
-        status: 'skipped_no_match' as const,
+        status: 'failed' as const,
         recordedAt: '2026-04-10T12:00:00.000Z',
         title: 'Some.Show.S01E01.720p',
         feedName: 'main-tv',
-        identityKey: null,
+        identityKey: 'tv:some.show|s05e01',
       },
       {
         id: 2,
         runId: 42,
-        status: 'skipped_no_match' as const,
+        status: 'failed' as const,
         recordedAt: '2026-04-10T12:00:05.000Z',
         title: null,
         feedName: null,
-        identityKey: null,
+        identityKey: 'movie:broken|2025',
       },
     ];
 

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -2061,7 +2061,7 @@ describe('GET /api/outcomes', () => {
     });
   });
 
-  it('returns 400 when status param is not skipped_no_match', async () => {
+  it('returns 400 when status param is not a supported filter', async () => {
     const deps = createDeps();
     const handler = createApiFetch(deps);
     const response = await handler(
@@ -2074,7 +2074,7 @@ describe('GET /api/outcomes', () => {
     });
   });
 
-  it('returns outcomes from repository on valid request', async () => {
+  it('returns outcomes from repository when status=failed_enqueue', async () => {
     const mockOutcomes = [
       {
         id: 1,
@@ -2101,12 +2101,37 @@ describe('GET /api/outcomes', () => {
     });
     const handler = createApiFetch(deps);
     const response = await handler(
-      new Request('http://localhost/api/outcomes?status=skipped_no_match'),
+      new Request('http://localhost/api/outcomes?status=failed_enqueue'),
     );
 
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body).toEqual({ outcomes: mockOutcomes });
+  });
+
+  it('accepts legacy status=skipped_no_match filter for the same payload', async () => {
+    const mockOutcomes = [
+      {
+        id: 1,
+        runId: 42,
+        status: 'failed' as const,
+        recordedAt: '2026-04-10T12:00:00.000Z',
+        title: 'Legacy.Param',
+        feedName: 'main-tv',
+        identityKey: 'tv:legacy|s01e01',
+      },
+    ];
+
+    const deps = createDeps({
+      listSkippedNoMatchOutcomes: () => mockOutcomes,
+    });
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/outcomes?status=skipped_no_match'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ outcomes: mockOutcomes });
   });
 
   it('returns empty outcomes array when repository returns none', async () => {

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -590,7 +590,7 @@ describe('SQLite repository', () => {
   });
 
   describe('listSkippedNoMatchOutcomes', () => {
-    it('returns skipped_no_match and failed-candidate outcomes, excluding queued and post-requeue failed', async () => {
+    it('returns one row per identity_key for latest failed enqueue while candidate is still failed', async () => {
       const repository = createTestRepository(await createDatabasePath());
       const run = repository.startRun('2026-04-01T00:00:00.000Z');
       const feedItem = repository.recordFeedItem(run.id, {
@@ -601,7 +601,6 @@ describe('SQLite repository', () => {
         downloadUrl: 'https://example.test/item1.torrent',
       });
 
-      // skipped_no_match row — no candidate, no identity_key
       repository.recordFeedItemOutcome({
         runId: run.id,
         feedItemId: feedItem.id,
@@ -609,14 +608,6 @@ describe('SQLite repository', () => {
         createdAt: '2026-04-01T00:01:00.000Z',
       });
 
-      // queued row — should NOT appear
-      repository.recordFeedItemOutcome({
-        runId: run.id,
-        status: 'queued',
-        createdAt: '2026-04-01T00:02:00.000Z',
-      });
-
-      // failed feed item outcome with a matching failed candidate_state
       const failedFeedItem = repository.recordFeedItem(run.id, {
         feedName: 'main-tv',
         guidOrLink: 'https://example.test/movie-2024-1080p-x265',
@@ -640,41 +631,76 @@ describe('SQLite repository', () => {
         identityKey: failedMatch.identityKey,
         createdAt: '2026-04-01T00:03:00.000Z',
       });
+      repository.recordFeedItemOutcome({
+        runId: run.id,
+        feedItemId: failedFeedItem.id,
+        status: 'failed',
+        identityKey: failedMatch.identityKey,
+        createdAt: '2026-04-01T00:04:00.000Z',
+        message: 'later run',
+      });
+
+      const dupFeed = repository.recordFeedItem(run.id, {
+        feedName: 'main-movie',
+        guidOrLink: 'https://example.test/dup1',
+        rawTitle: 'Other Movie 2024 1080p',
+        publishedAt: '2026-04-01T00:05:00.000Z',
+        downloadUrl: 'https://example.test/other.torrent',
+      });
+      const dupMatch = requireMovieMatch(dupFeed.rawTitle);
+      repository.recordFeedItemOutcome({
+        runId: run.id,
+        feedItemId: dupFeed.id,
+        status: 'skipped_duplicate',
+        identityKey: dupMatch.identityKey,
+        ruleName: dupMatch.ruleName,
+        createdAt: '2026-04-01T00:05:30.000Z',
+      });
 
       const results = repository.listSkippedNoMatchOutcomes(30);
 
-      expect(results).toHaveLength(2);
-      const statuses = results.map((r) => r.status);
-      expect(statuses).toContain('skipped_no_match');
-      expect(statuses).toContain('failed');
-      expect(statuses).not.toContain('queued');
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe('failed');
+      expect(results[0].identityKey).toBe(failedMatch.identityKey);
+      expect(results[0].recordedAt).toBe('2026-04-01T00:04:00.000Z');
 
-      const skipped = results.find((r) => r.status === 'skipped_no_match')!;
-      expect(skipped.runId).toBe(run.id);
-      expect(skipped.title).toBe('Some.Show.S01E01.720p');
-      expect(skipped.feedName).toBe('main-tv');
-      expect(skipped.recordedAt).toBe('2026-04-01T00:01:00.000Z');
-      expect(skipped.identityKey).toBeNull();
-
-      const failed = results.find((r) => r.status === 'failed')!;
-      expect(failed.identityKey).toBe(failedMatch.identityKey);
-
-      // After requeue, the failed outcome should disappear because cs.status = 'queued'
       repository.requeueCandidate(failedMatch.identityKey, {});
       const afterRequeue = repository.listSkippedNoMatchOutcomes(30);
-      expect(afterRequeue).toHaveLength(1);
-      expect(afterRequeue[0].status).toBe('skipped_no_match');
+      expect(afterRequeue).toEqual([]);
     });
 
-    it('returns null title and feedName when feed_item_id is null', async () => {
+    it('returns null title and feedName when the latest failed outcome row has no feed item', async () => {
       const repository = createTestRepository(await createDatabasePath());
       const run = repository.startRun('2026-04-01T00:00:00.000Z');
-
+      const failedFeedItem = repository.recordFeedItem(run.id, {
+        feedName: 'main-tv',
+        guidOrLink: 'https://example.test/movie-2024-1080p-x265',
+        rawTitle: 'Movie 2024 1080p x265',
+        publishedAt: '2026-04-01T00:03:00.000Z',
+        downloadUrl: 'https://example.test/movie.torrent',
+      });
+      const failedMatch = requireMovieMatch(failedFeedItem.rawTitle);
+      repository.recordCandidateOutcome({
+        runId: run.id,
+        feedItemId: failedFeedItem.id,
+        feedItem: failedFeedItem,
+        match: failedMatch,
+        status: 'failed',
+        updatedAt: '2026-04-01T00:03:10.000Z',
+      });
+      repository.recordFeedItemOutcome({
+        runId: run.id,
+        feedItemId: failedFeedItem.id,
+        status: 'failed',
+        identityKey: failedMatch.identityKey,
+        createdAt: '2026-04-01T00:03:00.000Z',
+      });
       repository.recordFeedItemOutcome({
         runId: run.id,
         feedItemId: undefined,
-        status: 'skipped_no_match',
-        createdAt: '2026-04-01T00:01:00.000Z',
+        status: 'failed',
+        identityKey: failedMatch.identityKey,
+        createdAt: '2026-04-01T00:04:00.000Z',
       });
 
       const results = repository.listSkippedNoMatchOutcomes(30);
@@ -682,23 +708,60 @@ describe('SQLite repository', () => {
       expect(results).toHaveLength(1);
       expect(results[0].title).toBeNull();
       expect(results[0].feedName).toBeNull();
+      expect(results[0].identityKey).toBe(failedMatch.identityKey);
     });
 
     it('excludes outcomes older than the specified day window', async () => {
       const repository = createTestRepository(await createDatabasePath());
       const run = repository.startRun('2026-04-01T00:00:00.000Z');
 
-      // Recent outcome (within window)
+      const recentItem = repository.recordFeedItem(run.id, {
+        feedName: 'main-movie',
+        guidOrLink: 'https://example.test/recent',
+        rawTitle: 'Recent Movie 2024 1080p',
+        publishedAt: '2026-04-01T00:00:00.000Z',
+        downloadUrl: 'https://example.test/recent.torrent',
+      });
+      const recentMatch = requireMovieMatch(recentItem.rawTitle);
+      repository.recordCandidateOutcome({
+        runId: run.id,
+        feedItemId: recentItem.id,
+        feedItem: recentItem,
+        match: recentMatch,
+        status: 'failed',
+        updatedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+      });
       repository.recordFeedItemOutcome({
         runId: run.id,
-        status: 'skipped_no_match',
+        feedItemId: recentItem.id,
+        status: 'failed',
+        identityKey: recentMatch.identityKey,
         createdAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
       });
 
-      // Old outcome (outside window)
+      const oldItem = repository.recordFeedItem(run.id, {
+        feedName: 'main-movie',
+        guidOrLink: 'https://example.test/old',
+        rawTitle: 'Old Movie 2024 1080p',
+        publishedAt: '2026-04-01T00:00:00.000Z',
+        downloadUrl: 'https://example.test/old.torrent',
+      });
+      const oldMatch = requireMovieMatch(oldItem.rawTitle);
+      repository.recordCandidateOutcome({
+        runId: run.id,
+        feedItemId: oldItem.id,
+        feedItem: oldItem,
+        match: oldMatch,
+        status: 'failed',
+        updatedAt: new Date(
+          Date.now() - 35 * 24 * 60 * 60 * 1000,
+        ).toISOString(),
+      });
       repository.recordFeedItemOutcome({
         runId: run.id,
-        status: 'skipped_no_match',
+        feedItemId: oldItem.id,
+        status: 'failed',
+        identityKey: oldMatch.identityKey,
         createdAt: new Date(
           Date.now() - 35 * 24 * 60 * 60 * 1000,
         ).toISOString(),
@@ -707,6 +770,7 @@ describe('SQLite repository', () => {
       const results = repository.listSkippedNoMatchOutcomes(30);
 
       expect(results).toHaveLength(1);
+      expect(results[0].identityKey).toBe(recentMatch.identityKey);
     });
 
     it('returns empty array when no matching outcomes', async () => {
@@ -716,6 +780,17 @@ describe('SQLite repository', () => {
         runId: run.id,
         status: 'queued',
         createdAt: '2026-04-01T00:01:00.000Z',
+      });
+      repository.recordFeedItemOutcome({
+        runId: run.id,
+        status: 'skipped_no_match',
+        createdAt: '2026-04-01T00:02:00.000Z',
+      });
+      repository.recordFeedItemOutcome({
+        runId: run.id,
+        status: 'skipped_duplicate',
+        identityKey: 'movie:dup|2024',
+        createdAt: '2026-04-01T00:03:00.000Z',
       });
 
       expect(repository.listSkippedNoMatchOutcomes(30)).toEqual([]);

--- a/tools/delivery/orchestrator.test.ts
+++ b/tools/delivery/orchestrator.test.ts
@@ -1010,7 +1010,7 @@ describe('delivery orchestrator', () => {
       {
         githubRepo: {
           owner: 'cesarnml',
-          name: 'pirate_claw',
+          name: 'Pirate-Claw',
           defaultBranch: 'main',
         },
       },
@@ -1025,10 +1025,10 @@ describe('delivery orchestrator', () => {
     expect(body).toContain('### Self-Audit Patch Commits');
     expect(body).toContain('### Codex Preflight Patch Commits');
     expect(body).toContain(
-      '[`aaaaaaaaaaaa`](https://github.com/cesarnml/pirate_claw/commit/aaaaaaaaaaaa1111111111111111111111111111) fix: clarify PR body review state [self-audit]',
+      '[`aaaaaaaaaaaa`](https://github.com/cesarnml/Pirate-Claw/commit/aaaaaaaaaaaa1111111111111111111111111111) fix: clarify PR body review state [self-audit]',
     );
     expect(body).toContain(
-      '[`bbbbbbbbbbbb`](https://github.com/cesarnml/pirate_claw/commit/bbbbbbbbbbbb2222222222222222222222222222) fix: surface codex preflight patch commits [codexPreflight]',
+      '[`bbbbbbbbbbbb`](https://github.com/cesarnml/Pirate-Claw/commit/bbbbbbbbbbbb2222222222222222222222222222) fix: surface codex preflight patch commits [codexPreflight]',
     );
   });
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -118,11 +118,11 @@ export type MovieBreakdown = {
 export type SkippedOutcomeRecord = {
 	id: number;
 	runId: number;
-	status: 'skipped_no_match' | 'failed';
+	status: 'failed';
 	recordedAt: string;
 	title: string | null;
 	feedName: string | null;
-	identityKey: string | null;
+	identityKey: string;
 };
 
 export type FeedConfig = {

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -80,16 +80,30 @@ export const load: PageServerLoad = async () => {
 	};
 };
 
+function requireWriteToken(): string | ReturnType<typeof fail> {
+	const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+	if (!writeToken) {
+		return fail(500, { error: 'Server write token is not configured.' });
+	}
+	return writeToken;
+}
+
 async function torrentAction(
 	path: string,
 	request: Request
 ): Promise<ReturnType<typeof fail> | { ok: boolean }> {
+	const tokenOrFail = requireWriteToken();
+	if (typeof tokenOrFail !== 'string') return tokenOrFail;
+
 	const formData = await request.formData();
 	const hash = formData.get('hash');
 	if (typeof hash !== 'string') return fail(400, { error: 'hash is required' });
 	const res = await apiRequest(path, {
 		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
+		headers: {
+			'Content-Type': 'application/json',
+			authorization: `Bearer ${tokenOrFail}`
+		},
 		body: JSON.stringify({ hash })
 	});
 	if (!res.ok) {
@@ -107,6 +121,9 @@ async function torrentAction(
 
 export const actions: Actions = {
 	dispose: async ({ request }) => {
+		const tokenOrFail = requireWriteToken();
+		if (typeof tokenOrFail !== 'string') return tokenOrFail;
+
 		const formData = await request.formData();
 		const hash = formData.get('hash');
 		const disposition = formData.get('disposition');
@@ -117,7 +134,10 @@ export const actions: Actions = {
 
 		const res = await apiRequest('/api/transmission/torrent/dispose', {
 			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
+			headers: {
+				'Content-Type': 'application/json',
+				authorization: `Bearer ${tokenOrFail}`
+			},
 			body: JSON.stringify({ hash, disposition })
 		});
 
@@ -142,11 +162,15 @@ export const actions: Actions = {
 		torrentAction('/api/transmission/torrent/remove-and-delete', request),
 
 	requeue: async ({ request }) => {
+		const tokenOrFail = requireWriteToken();
+		if (typeof tokenOrFail !== 'string') return tokenOrFail;
+
 		const formData = await request.formData();
 		const identityKey = formData.get('identityKey');
 		if (typeof identityKey !== 'string') return fail(400, { error: 'identityKey is required' });
 		const res = await apiRequest(`/api/candidates/${encodeURIComponent(identityKey)}/requeue`, {
-			method: 'POST'
+			method: 'POST',
+			headers: { authorization: `Bearer ${tokenOrFail}` }
 		});
 		if (!res.ok) {
 			let error = 'Request failed';

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -30,7 +30,7 @@ export const load: PageServerLoad = async () => {
 		apiFetch<{ torrents: TorrentStatSnapshot[] }>('/api/transmission/torrents'),
 		apiFetch<{ candidates: CandidateStateRecord[] }>('/api/candidates'),
 		apiFetch<{ runs: RunSummaryRecord[] }>('/api/status'),
-		apiFetch<{ outcomes: SkippedOutcomeRecord[] }>('/api/outcomes?status=skipped_no_match'),
+		apiFetch<{ outcomes: SkippedOutcomeRecord[] }>('/api/outcomes?status=failed_enqueue'),
 		apiFetch<AppConfig>('/api/config')
 	]);
 

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -11,7 +11,7 @@
 	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
 	import ArchiveStrip from './components/ArchiveStrip.svelte';
 	import DashboardHeader from './components/DashboardHeader.svelte';
-	import FeedEventLogCard from './components/FeedEventLogCard.svelte';
+	import TransmissionFailuresCard from './components/TransmissionFailuresCard.svelte';
 	import OnboardingBanner from './components/OnboardingBanner.svelte';
 	import StatusCardGrid from './components/StatusCardGrid.svelte';
 	import TorrentManagerCard from './components/TorrentManagerCard.svelte';
@@ -33,11 +33,13 @@
 	const outcomes = $derived(data.outcomes);
 
 	const activeDownloads = $derived(
-		torrents.map((torrent) => {
-			const candidate =
-				candidates.find((item) => item.transmissionTorrentHash === torrent.hash) ?? null;
-			return { torrent, candidate };
-		})
+		torrents
+			.map((torrent) => {
+				const candidate =
+					candidates.find((item) => item.transmissionTorrentHash === torrent.hash) ?? null;
+				return { torrent, candidate };
+			})
+			.filter(({ candidate }) => !candidate?.pirateClawDisposition)
 	);
 
 	const transmissionLoaded = $derived(data.transmissionTorrents !== null);
@@ -156,7 +158,7 @@
 				{missingCandidates}
 				transmissionSession={data.transmissionSession}
 			/>
-			<FeedEventLogCard {outcomes} />
+			<TransmissionFailuresCard {outcomes} />
 		</div>
 
 		<ArchiveStrip {archiveItems} />

--- a/web/src/routes/components/TorrentManagerCard.svelte
+++ b/web/src/routes/components/TorrentManagerCard.svelte
@@ -10,7 +10,8 @@
 	import StatusChip from '$lib/components/StatusChip.svelte';
 	import { Card, CardContent, CardHeader } from '$lib/components/ui/card';
 	import type { CandidateStateRecord, SessionInfo, TorrentStatSnapshot } from '$lib/types';
-	import { enhance } from '$app/forms';
+	import { deserialize, enhance } from '$app/forms';
+	import { base } from '$app/paths';
 	import { invalidateAll } from '$app/navigation';
 
 	type ActiveDownload = {
@@ -105,13 +106,40 @@
 		delete actionErrors[hash];
 		const formData = new FormData();
 		formData.append('hash', hash);
+		const actionHref = `${base}/?/${action}`;
 		try {
-			const res = await fetch(`?/${action}`, { method: 'POST', body: formData });
-			if (res.ok) {
+			const res = await fetch(actionHref, {
+				method: 'POST',
+				headers: {
+					accept: 'application/json',
+					'x-sveltekit-action': 'true'
+				},
+				body: formData,
+				cache: 'no-store'
+			});
+
+			const result = deserialize(await res.text());
+
+			if (result.type === 'error') {
+				actionErrors[hash] = typeof result.error === 'string' ? result.error : 'Request failed';
+				return;
+			}
+			if (result.type === 'failure') {
+				const data = result.data as { error?: string } | undefined;
+				actionErrors[hash] = data?.error ?? 'Request failed';
+				return;
+			}
+			if (result.type === 'redirect') {
+				return;
+			}
+
+			// Refresh load data; avoid applyAction(result) so a stale serialized snapshot cannot
+			// overwrite a newer invalidate (e.g. pause right after requeue finishes invalidating).
+			await invalidateAll();
+			// Follow-up load: Transmission can lag one torrent-get behind stop/remove RPCs.
+			if (action === 'pause' || action === 'remove' || action === 'removeAndDelete') {
+				await new Promise((r) => setTimeout(r, 150));
 				await invalidateAll();
-			} else {
-				const body = (await res.json().catch(() => ({}))) as { error?: string };
-				actionErrors[hash] = body.error ?? 'Request failed';
 			}
 		} catch {
 			actionErrors[hash] = 'Network error';
@@ -185,7 +213,7 @@
 			</div>
 		{:else}
 			<ul class="space-y-4">
-				{#each activeDownloads as { torrent, candidate }}
+				{#each activeDownloads as { torrent, candidate } (torrent.hash)}
 					{@const title = candidate ? candidateTitle(candidate) : torrent.name}
 					{@const posterUrl = candidate ? candidatePosterUrl(candidate) : null}
 					{@const inFlightRow = inflightAction === torrent.hash}
@@ -275,7 +303,7 @@
 								{/if}
 							</div>
 							<div class="flex shrink-0 gap-2">
-								<form method="POST" action="?/dispose" use:enhance={enhanceDispose(hash)}>
+								<form method="POST" action={`${base}/?/dispose`} use:enhance={enhanceDispose(hash)}>
 									<input type="hidden" name="hash" value={hash} />
 									<input type="hidden" name="disposition" value="removed" />
 									<button
@@ -286,7 +314,7 @@
 										Mark Removed
 									</button>
 								</form>
-								<form method="POST" action="?/dispose" use:enhance={enhanceDispose(hash)}>
+								<form method="POST" action={`${base}/?/dispose`} use:enhance={enhanceDispose(hash)}>
 									<input type="hidden" name="hash" value={hash} />
 									<input type="hidden" name="disposition" value="deleted" />
 									<button

--- a/web/src/routes/components/TransmissionFailuresCard.svelte
+++ b/web/src/routes/components/TransmissionFailuresCard.svelte
@@ -160,7 +160,8 @@
 									{:else if canRequeue}
 										<button
 											type="button"
-											disabled={!!inflightRequeue && inflightRequeue !== outcome.identityKey}
+											disabled={(!!inflightRequeue && inflightRequeue !== outcome.identityKey) ||
+												isInflight}
 											onclick={() => requeue(outcome.identityKey)}
 											class="bg-primary/15 text-primary border-primary/30 hover:bg-primary/22 inline-flex h-6 cursor-pointer items-center rounded-md border px-2 text-[11px] font-medium transition disabled:cursor-not-allowed disabled:opacity-40"
 										>

--- a/web/src/routes/components/TransmissionFailuresCard.svelte
+++ b/web/src/routes/components/TransmissionFailuresCard.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { deserialize } from '$app/forms';
+	import { base } from '$app/paths';
 	import { invalidateAll } from '$app/navigation';
 	import { formatDate } from '$lib/helpers';
 	import StatusChip from '$lib/components/StatusChip.svelte';
@@ -22,24 +24,56 @@
 	let queuedKeys = $state<Record<string, true>>({});
 	let requeueErrors = $state<Record<string, string>>({});
 
+	function actionFailureMessage(data: unknown): string {
+		if (data && typeof data === 'object' && 'error' in data) {
+			const err = (data as { error: unknown }).error;
+			if (typeof err === 'string') return err;
+		}
+		return 'Request failed';
+	}
+
 	async function requeue(identityKey: string) {
 		if (inflightRequeue) return;
 		inflightRequeue = identityKey;
 		delete requeueErrors[identityKey];
 		const formData = new FormData();
 		formData.append('identityKey', identityKey);
+		const actionHref = `${base}/?/requeue`;
 		try {
-			const res = await fetch('?/requeue', { method: 'POST', body: formData });
-			if (res.ok) {
-				queuedKeys[identityKey] = true;
-				await invalidateAll();
-				setTimeout(() => {
-					delete queuedKeys[identityKey];
-				}, 2000);
-			} else {
-				const body = (await res.json().catch(() => ({}))) as { error?: string };
-				requeueErrors[identityKey] = body.error ?? 'Request failed';
+			const res = await fetch(actionHref, {
+				method: 'POST',
+				headers: {
+					accept: 'application/json',
+					'x-sveltekit-action': 'true'
+				},
+				body: formData,
+				cache: 'no-store'
+			});
+
+			const result = deserialize(await res.text());
+
+			if (result.type === 'error') {
+				requeueErrors[identityKey] =
+					typeof result.error === 'string' ? result.error : 'Request failed';
+				return;
 			}
+			if (result.type === 'failure') {
+				requeueErrors[identityKey] = actionFailureMessage(result.data);
+				return;
+			}
+			if (result.type === 'redirect') {
+				return;
+			}
+
+			queuedKeys[identityKey] = true;
+			await invalidateAll();
+			await new Promise((r) => setTimeout(r, 150));
+			await invalidateAll();
+			// Do not call applyAction(result): it can merge a stale action snapshot after a later
+			// invalidate (e.g. user pauses the new torrent immediately) and revert the UI.
+			setTimeout(() => {
+				delete queuedKeys[identityKey];
+			}, 2000);
 		} catch {
 			requeueErrors[identityKey] = 'Network error';
 		} finally {
@@ -47,25 +81,11 @@
 		}
 	}
 
-	type StatusSort = 'asc' | 'desc' | null;
-	let statusSort = $state<StatusSort>(null);
-
-	function cycleStatusSort() {
-		statusSort = statusSort === null ? 'asc' : statusSort === 'asc' ? 'desc' : null;
-		page = 0;
-	}
-
 	const sortedOutcomes = $derived(() => {
 		if (!outcomes) return null;
-		if (statusSort === null) {
-			return [...outcomes].sort(
-				(a, b) => new Date(b.recordedAt).getTime() - new Date(a.recordedAt).getTime()
-			);
-		}
-		return [...outcomes].sort((a, b) => {
-			const cmp = a.status.localeCompare(b.status);
-			return statusSort === 'asc' ? cmp : -cmp;
-		});
+		return [...outcomes].sort(
+			(a, b) => new Date(b.recordedAt).getTime() - new Date(a.recordedAt).getTime()
+		);
 	});
 
 	const pageCount = $derived(() =>
@@ -83,25 +103,25 @@
 <Card class="bg-card/70 max-h-136 rounded-[30px] border-white/10">
 	<CardHeader class="pb-4">
 		<p class="text-muted-foreground text-[11px] font-semibold tracking-[0.24em] uppercase">
-			Candidate outcomes
+			Transmission failures
 		</p>
-		<h2 class="mt-2 text-2xl font-semibold tracking-[-0.03em]">Skipped/Failed Candidates</h2>
+		<h2 class="mt-2 text-2xl font-semibold tracking-[-0.03em]">Failed candidates</h2>
 	</CardHeader>
 	<CardContent>
 		{#if outcomes === null}
 			<div class="border-border bg-background/55 rounded-3xl border border-dashed px-5 py-8">
-				<p class="text-sm font-medium">Recent outcome data is unavailable.</p>
+				<p class="text-sm font-medium">Transmission failure data is unavailable.</p>
 				<p class="text-muted-foreground mt-2 text-sm">
-					The dashboard could not load `/api/outcomes`, so skipped and failed candidates are not
+					The dashboard could not load `/api/outcomes`, so nothing from the “failed enqueue” list is
 					shown right now.
 				</p>
 			</div>
 		{:else if outcomes.length === 0}
 			<div class="border-border bg-background/55 rounded-3xl border border-dashed px-5 py-8">
-				<p class="text-sm font-medium">No skipped or failed candidates yet.</p>
+				<p class="text-sm font-medium">All quiet on the Transmission front.</p>
 				<p class="text-muted-foreground mt-2 text-sm">
-					Items skipped by rules or that failed to reach Transmission will appear here for manual
-					review.
+					No enqueue rejects in the last window — either the daemon is behaving, or it’s plotting
+					something for the next run.
 				</p>
 			</div>
 		{:else}
@@ -110,33 +130,22 @@
 					<TableHeader>
 						<TableRow class="hover:bg-transparent">
 							<TableHead class="pl-4">Title</TableHead>
-							<TableHead class="w-26 whitespace-nowrap">
-								<button
-									type="button"
-									class="hover:text-foreground inline-flex cursor-pointer items-center gap-1 transition"
-									onclick={cycleStatusSort}
-								>
-									Status
-									<span class="text-[10px] leading-none">
-										{statusSort === 'asc' ? '▲' : statusSort === 'desc' ? '▼' : '⇅'}
-									</span>
-								</button>
-							</TableHead>
+							<TableHead class="w-26 whitespace-nowrap">Status</TableHead>
 							<TableHead class="w-20 text-right"></TableHead>
 						</TableRow>
 					</TableHeader>
 					<TableBody>
 						{#each sortedOutcomes()!.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE) as outcome (outcome.id)}
-							{@const canRequeue = outcome.identityKey !== null && outcome.status === 'failed'}
+							{@const canRequeue = outcome.status === 'failed'}
 							{@const isInflight = inflightRequeue === outcome.identityKey}
-							{@const isQueued = outcome.identityKey !== null && queuedKeys[outcome.identityKey]}
+							{@const isQueued = !!queuedKeys[outcome.identityKey]}
 							<TableRow>
 								<TableCell class="min-w-0 pl-4 text-sm font-medium">
 									<p class="truncate">{outcome.title ?? '—'}</p>
 									<p class="text-muted-foreground mt-0.5 text-[11px] font-normal">
 										{formatDate(outcome.recordedAt)}
 									</p>
-									{#if outcome.identityKey && requeueErrors[outcome.identityKey]}
+									{#if requeueErrors[outcome.identityKey]}
 										<p class="mt-0.5 text-[11px] text-red-400">
 											{requeueErrors[outcome.identityKey]}
 										</p>
@@ -148,14 +157,14 @@
 								<TableCell class="pr-4 text-right">
 									{#if isQueued}
 										<span class="text-[11px] font-medium text-green-400">Queued ✓</span>
-									{:else}
+									{:else if canRequeue}
 										<button
 											type="button"
-											disabled={!canRequeue || !!inflightRequeue}
-											onclick={() => outcome.identityKey && requeue(outcome.identityKey)}
+											disabled={!!inflightRequeue && inflightRequeue !== outcome.identityKey}
+											onclick={() => requeue(outcome.identityKey)}
 											class="bg-primary/15 text-primary border-primary/30 hover:bg-primary/22 inline-flex h-6 cursor-pointer items-center rounded-md border px-2 text-[11px] font-medium transition disabled:cursor-not-allowed disabled:opacity-40"
 										>
-											{isInflight ? '…' : 'Queue'}
+											{isInflight ? 'Loading' : 'Queue'}
 										</button>
 									{/if}
 								</TableCell>

--- a/web/src/routes/dashboard.test.ts
+++ b/web/src/routes/dashboard.test.ts
@@ -42,11 +42,11 @@ const mockRunSummary = (overrides: Partial<RunSummaryRecord> = {}): RunSummaryRe
 const mockOutcome = (overrides: Partial<SkippedOutcomeRecord> = {}): SkippedOutcomeRecord => ({
 	id: 1,
 	runId: 42,
-	status: 'skipped_no_match',
+	status: 'failed',
 	recordedAt: '2026-04-10T12:00:00.000Z',
 	title: 'Stranger.Things.S05E01.4K.WEB.x265-GROUP',
 	feedName: 'main-tv',
-	identityKey: null,
+	identityKey: 'tv:stranger.things|s05e01',
 	...overrides
 });
 
@@ -150,19 +150,44 @@ describe('/', () => {
 		expect(screen.getAllByText('1.0 MB/s').length).toBeGreaterThan(0);
 	});
 
-	it('renders the event log from unmatched outcomes', () => {
+	it('renders Transmission failure rows from matched enqueue failures', () => {
 		render(Page, {
 			data: {
 				...baseData,
-				outcomes: [mockOutcome(), mockOutcome({ id: 2, title: 'The.Brutalist.2025.2160p.WEB-DL' })]
+				outcomes: [
+					mockOutcome(),
+					mockOutcome({
+						id: 2,
+						title: 'The.Brutalist.2025.2160p.WEB-DL',
+						identityKey: 'movie:the.brutalist|2025'
+					})
+				]
 			}
 		});
 
-		expect(
-			screen.getByRole('heading', { name: /Skipped\/Failed Candidates/i })
-		).toBeInTheDocument();
+		expect(screen.getByText(/Transmission failures/i)).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: /Failed candidates/i })).toBeInTheDocument();
 		expect(screen.getByText('Stranger.Things.S05E01.4K.WEB.x265-GROUP')).toBeInTheDocument();
-		expect(screen.getAllByText('SKIPPED')).toHaveLength(2);
+		expect(screen.getAllByText('FAILED')).toHaveLength(2);
+		expect(screen.getAllByRole('button', { name: 'Queue' })).toHaveLength(2);
+	});
+
+	it('shows a Queue control for each failed enqueue row', () => {
+		render(Page, {
+			data: {
+				...baseData,
+				outcomes: [
+					mockOutcome({ id: 1, title: 'Alpha.2025.1080p', identityKey: 'movie:alpha|2025' }),
+					mockOutcome({
+						id: 2,
+						title: 'Broken.Release.2025',
+						identityKey: 'movie:broken|2025'
+					})
+				]
+			}
+		});
+
+		expect(screen.getAllByRole('button', { name: 'Queue' })).toHaveLength(2);
 	});
 
 	it('shows unavailable copy when outcome and run summary fetches fail', () => {
@@ -176,7 +201,7 @@ describe('/', () => {
 
 		expect(screen.getByText('Failures').parentElement).toHaveTextContent('—');
 		expect(screen.getByText('Skipped').parentElement).toHaveTextContent('—');
-		expect(screen.getByText('Recent outcome data is unavailable.')).toBeInTheDocument();
+		expect(screen.getByText('Transmission failure data is unavailable.')).toBeInTheDocument();
 	});
 
 	it('renders the archive strip with links for completed items', () => {

--- a/web/src/routes/page.server.test.ts
+++ b/web/src/routes/page.server.test.ts
@@ -37,6 +37,9 @@ describe('dashboard page server load', () => {
 		expect((result as { onboarding: { state: string } | null }).onboarding?.state).toBe(
 			'initial_empty'
 		);
+		expect(
+			apiFetchMock.mock.calls.some((args) => args[0] === '/api/outcomes?status=failed_enqueue')
+		).toBe(true);
 	});
 
 	it('derives partial_setup onboarding state for feed-only config', async () => {


### PR DESCRIPTION
Phase 20 dashboard / daemon follow-ups: correct requeue wiring, honest failure listing, SvelteKit action handling, and UI race fixes. README, start-here, and the Phase 20 product doc describe the operator-visible behavior.

- Pass the Transmission downloader into the daemon embedded `createApiFetch` so `POST /api/candidates/:id/requeue` works when `runtime.apiPort` is set (fixes 503 requeue is not available).
- `GET /api/transmission/torrents` polls hashes for tracked candidates only; add Transmission lifecycle JSON endpoints and hash-to-candidate resolution for pause, resume, remove, remove-and-delete, and missing disposition.
- Dashboard: Torrent Manager uses `deserialize` for Kit actions; drop `applyAction` after `invalidateAll` so a fast pause after Queue cannot be overwritten by a stale requeue snapshot.
- Transmission failures card replaces the old feed log; `listSkippedNoMatchOutcomes` returns deduped matched enqueue failures only; requeue and dashboard tests updated.
- Docs: README API table and feature bullets; `docs/00-overview/start-here.md`; `docs/01-product/phase-20-dashboard-torrent-actions.md`.