### PR TITLE
feat(bootstrap): ensureStarterConfig writes valid starter config on first boot [P21.01]

### DIFF
--- a/docs/02-delivery/phase-21/implementation-plan.md
+++ b/docs/02-delivery/phase-21/implementation-plan.md
@@ -40,6 +40,7 @@ Follow the shared guidance in [`docs/02-delivery/phase-implementation-guidance.m
 2. `P21.02 GET /api/setup/state Endpoint`
 3. `P21.03 Web App Starter Mode UI`
 4. `P21.04 README: Plex Version Prereq and First-Boot Operator Contract`
+5. `P21.05 Phase 21 Retrospective and Doc Update`
 
 ## Ticket Files
 
@@ -47,6 +48,7 @@ Follow the shared guidance in [`docs/02-delivery/phase-implementation-guidance.m
 - `ticket-02-setup-state-endpoint.md`
 - `ticket-03-web-starter-mode-ui.md`
 - `ticket-04-readme-first-boot-contract.md`
+- `ticket-05-retrospective.md`
 
 ## Exit Condition
 

--- a/docs/02-delivery/phase-21/ticket-05-retrospective.md
+++ b/docs/02-delivery/phase-21/ticket-05-retrospective.md
@@ -1,0 +1,40 @@
+# P21.05 Phase 21 Retrospective and Doc Update
+
+## Type
+
+`docs`
+
+## Summary
+
+Capture Phase 21 delivery lessons and update relevant docs. This is the closeout ticket for the bootstrap-contract phase.
+
+## Scope
+
+- Update `delivery-orchestrator.md` for any behavioral changes or clarifications that emerged during P21 delivery.
+- Add a retrospective section to this ticket summarizing: what went smoothly, what was deferred, key design decisions that held, and anything that should inform P22 planning.
+- Update `MEMORY.md` / `project-state.md` if the project state snapshot is stale after phase completion.
+- Update the Phase 21 implementation plan `Delivery status` field to reflect completion.
+
+## Acceptance
+
+- All doc updates are committed.
+- Retrospective section is filled in below.
+- `project-state.md` reflects P21 as complete.
+
+## Review Policy
+
+Doc-only ticket — all three review stages (`selfAudit`, `codexPreflight`, `externalReview`) auto-skip under the repo `skip_doc_only` policy.
+
+## Retrospective
+
+_To be filled in after P21.01–P21.04 are complete._
+
+### What went smoothly
+
+### What was harder than expected
+
+### Key design decisions that held
+
+### Deferrals that held (do not revisit without a clear trigger)
+
+### Inputs for P22 planning

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -17,7 +17,7 @@ export async function ensureStarterConfig(path: string): Promise<void> {
     plex: {
       url: 'http://localhost:32400',
       token: '',
-      refreshIntervalMinutes: 30,
+      refreshIntervalMinutes: 0,
     },
     movies: {
       years: [year - 1, year],

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,0 +1,36 @@
+export async function ensureStarterConfig(path: string): Promise<void> {
+  const file = Bun.file(path);
+
+  if (await file.exists()) {
+    return;
+  }
+
+  const year = new Date().getFullYear();
+
+  const starter = {
+    _starter: true,
+    transmission: {
+      url: 'http://localhost:9091/transmission/rpc',
+      username: 'admin',
+      password: 'admin',
+    },
+    plex: {
+      url: 'http://localhost:32400',
+      token: '',
+      refreshIntervalMinutes: 30,
+    },
+    movies: {
+      years: [year - 1, year],
+      resolutions: ['1080p'],
+      codecs: ['x264'],
+      codecPolicy: 'prefer',
+    },
+    tv: {
+      defaults: { resolutions: ['1080p'], codecs: ['x264'] },
+      shows: [],
+    },
+    feeds: [],
+  };
+
+  await Bun.write(path, JSON.stringify(starter, null, 2) + '\n');
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import type { Database } from 'bun:sqlite';
 
 import { createApiFetch, createHealthState, recordCycleInHealth } from './api';
+import { ensureStarterConfig } from './bootstrap';
 import {
   type AppConfig,
   ConfigError,
@@ -349,6 +350,7 @@ export async function runCli(argv: string[]): Promise<number> {
     if (command === 'daemon') {
       const configPath = parseConfigPath(rest);
       const resolvedConfigPath = resolveConfigPath(configPath);
+      await ensureStarterConfig(resolvedConfigPath);
       const config = await loadConfig(resolvedConfigPath);
       const database = openDatabase();
       const log = console.log;

--- a/src/config.ts
+++ b/src/config.ts
@@ -258,9 +258,9 @@ function requireCompactTvShows(
   input: unknown,
   path: string,
 ): CompactTvShowEntry[] {
-  if (!Array.isArray(input) || input.length === 0) {
+  if (!Array.isArray(input)) {
     throw new ConfigError(
-      `Config file "${path} tv shows" must be a non-empty array like ["Example Show"] or [{ "name": "Example Show" }].`,
+      `Config file "${path} tv shows" must be an array like ["Example Show"] or [{ "name": "Example Show" }].`,
     );
   }
 
@@ -796,8 +796,10 @@ function resolveSecretFromInlineOrEnv(
   envValue: string | undefined,
   path: string,
 ): string {
-  if (typeof inlineValue === 'string' && inlineValue.length > 0) {
-    return inlineValue;
+  if (typeof inlineValue === 'string') {
+    if (inlineValue.length > 0) return inlineValue;
+    // Explicit empty string: env override wins, otherwise accept empty (starter mode)
+    return typeof envValue === 'string' && envValue.length > 0 ? envValue : '';
   }
 
   if (typeof envValue === 'string' && envValue.length > 0) {

--- a/test/bootstrap.test.ts
+++ b/test/bootstrap.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { ensureStarterConfig } from '../src/bootstrap';
+import { validateConfig } from '../src/config';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'pirate-claw-bootstrap-'));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('ensureStarterConfig', () => {
+  it('writes a starter config when the file does not exist', async () => {
+    const path = join(dir, 'pirate-claw.config.json');
+
+    await ensureStarterConfig(path);
+
+    const written = await Bun.file(path).json();
+    expect(written._starter).toBe(true);
+    expect(written.transmission.url).toBe(
+      'http://localhost:9091/transmission/rpc',
+    );
+    expect(written.plex.url).toBe('http://localhost:32400');
+    expect(written.plex.token).toBe('');
+    expect(Array.isArray(written.feeds)).toBe(true);
+    expect(written.feeds.length).toBe(0);
+    expect(Array.isArray(written.tv.shows)).toBe(true);
+    expect(written.tv.shows.length).toBe(0);
+
+    const year = new Date().getFullYear();
+    expect(written.movies.years).toEqual([year - 1, year]);
+  });
+
+  it('does nothing when the file already exists', async () => {
+    const path = join(dir, 'pirate-claw.config.json');
+    const original = JSON.stringify({ existing: true });
+    await Bun.write(path, original);
+
+    await ensureStarterConfig(path);
+
+    const content = await Bun.file(path).text();
+    expect(content).toBe(original);
+  });
+
+  it('written config passes validateConfig without modification', async () => {
+    const path = join(dir, 'pirate-claw.config.json');
+    await ensureStarterConfig(path);
+
+    const written = await Bun.file(path).json();
+    const env: Record<string, string | undefined> = {};
+
+    expect(() => validateConfig(written, path, env)).not.toThrow();
+  });
+
+  it('empty compact tv shows array is valid', () => {
+    const config = {
+      transmission: {
+        url: 'http://localhost:9091/transmission/rpc',
+        username: 'admin',
+        password: 'admin',
+      },
+      plex: { url: 'http://localhost:32400', token: '' },
+      movies: {
+        years: [2024, 2025],
+        resolutions: ['1080p'],
+        codecs: ['x264'],
+        codecPolicy: 'prefer',
+      },
+      tv: { defaults: { resolutions: ['1080p'], codecs: ['x264'] }, shows: [] },
+      feeds: [],
+    };
+
+    expect(() => validateConfig(config, 'test', {})).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- delivery ticket: `P21.01 ensureStarterConfig: Write Valid Starter Config on First Boot`
- ticket file: [docs/02-delivery/phase-21/ticket-01-ensure-starter-config.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-21/ticket-01-ensure-starter-config.md)
- stacked base branch: `main`
- self-audit: outcome `clean` completed at 2026-04-20 19:57 UTC

## External AI Review

- outcome: `patched`
- reviewed commit: [`c474d65cb332`](https://github.com/cesarnml/Pirate-Claw/commit/c474d65cb3320ad19da3760d9e64e6e60d800926)
- current branch head: [`b4afa26cf070`](https://github.com/cesarnml/Pirate-Claw/commit/b4afa26cf07052642defe4a27cdfa098be34e02b)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `c474d65cb332` address all findings from that review.
- vendors: `coderabbit`

### Resolved Review Findings

- [coderabbit] Remove in-ticket retrospective section; follow established convention of `notes/public/phase-21-retrospective.md`. (native GitHub thread resolved) `docs/02-delivery/phase-21/ticket-05-retrospective.md:40` [thread](https://github.com/cesarnml/Pirate-Claw/pull/195#discussion_r3113357960)
- [coderabbit] `_starter: true` is a dead flag after validation. (native GitHub thread resolved) `src/bootstrap.ts:11` [thread](https://github.com/cesarnml/Pirate-Claw/pull/195#discussion_r3113357975)
- [coderabbit] Starter `plex` block will schedule failing background refreshes on first boot. (native GitHub thread resolved) `src/bootstrap.ts:21` [thread](https://github.com/cesarnml/Pirate-Claw/pull/195#discussion_r3113357978)
