### PR TITLE
feat(api): add GET /api/setup/state endpoint and getSetupState [P21.02]

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { getSetupState } from './bootstrap';
 import { renameSync, writeFileSync } from 'node:fs';
 import {
   fetchSessionInfo,
@@ -357,6 +358,15 @@ export function createApiFetch(
         lastRunCycle: health.lastRunCycle,
         lastReconcileCycle: health.lastReconcileCycle,
       });
+    }
+
+    if (path === '/api/setup/state' && request.method === 'GET') {
+      try {
+        const state = await getSetupState(configPath);
+        return Response.json({ state });
+      } catch {
+        return json500();
+      }
     }
 
     if (path === '/api/status') {

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -17,7 +17,7 @@ export async function ensureStarterConfig(path: string): Promise<void> {
     plex: {
       url: 'http://localhost:32400',
       token: '',
-      refreshIntervalMinutes: 30,
+      refreshIntervalMinutes: 0,
     },
     movies: {
       years: [year - 1, year],

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,3 +1,55 @@
+export type SetupState = 'starter' | 'partially_configured' | 'ready';
+
+const DEFAULT_TRANSMISSION_URL = 'http://localhost:9091/transmission/rpc';
+
+export async function getSetupState(path: string): Promise<SetupState> {
+  const file = Bun.file(path);
+
+  if (!(await file.exists())) {
+    return 'starter';
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(await file.text());
+  } catch {
+    return 'partially_configured';
+  }
+
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return 'partially_configured';
+  }
+
+  const config = raw as Record<string, unknown>;
+
+  if (config._starter === true) {
+    return 'starter';
+  }
+
+  const feeds = config.feeds;
+  const tv = config.tv;
+  const transmission = config.transmission as
+    | Record<string, unknown>
+    | undefined;
+
+  const feedsNonEmpty = Array.isArray(feeds) && feeds.length > 0;
+  const tvNonEmpty = Array.isArray(tv)
+    ? tv.length > 0
+    : typeof tv === 'object' &&
+      tv !== null &&
+      Array.isArray((tv as Record<string, unknown>).shows) &&
+      ((tv as Record<string, unknown>).shows as unknown[]).length > 0;
+  const transmissionCustom =
+    typeof transmission?.url === 'string' &&
+    transmission.url !== DEFAULT_TRANSMISSION_URL;
+
+  if (feedsNonEmpty && tvNonEmpty && transmissionCustom) {
+    return 'ready';
+  }
+
+  return 'partially_configured';
+}
+
 export async function ensureStarterConfig(path: string): Promise<void> {
   const file = Bun.file(path);
 

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -155,6 +155,97 @@ describe('createApiFetch', () => {
   });
 });
 
+describe('GET /api/setup/state', () => {
+  it('returns "starter" state for a starter config file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'pirate-claw-api-test-'));
+    const configPath = join(dir, 'pirate-claw.config.json');
+    await Bun.write(
+      configPath,
+      JSON.stringify({
+        _starter: true,
+        transmission: { url: 'http://localhost:9091/transmission/rpc' },
+        feeds: [],
+        tv: {
+          defaults: { resolutions: ['1080p'], codecs: ['x264'] },
+          shows: [],
+        },
+      }),
+    );
+
+    const deps = { ...createDeps(), configPath };
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/setup/state'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ state: 'starter' });
+  });
+
+  it('returns "partially_configured" state when _starter absent but not ready', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'pirate-claw-api-test-'));
+    const configPath = join(dir, 'pirate-claw.config.json');
+    await Bun.write(
+      configPath,
+      JSON.stringify({
+        transmission: { url: 'http://localhost:9091/transmission/rpc' },
+        feeds: [],
+        tv: [],
+      }),
+    );
+
+    const deps = { ...createDeps(), configPath };
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/setup/state'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ state: 'partially_configured' });
+  });
+
+  it('returns "ready" state when fully configured', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'pirate-claw-api-test-'));
+    const configPath = join(dir, 'pirate-claw.config.json');
+    await Bun.write(
+      configPath,
+      JSON.stringify({
+        transmission: {
+          url: 'http://192.168.1.100:9091/transmission/rpc',
+          username: 'op',
+          password: 'secret',
+        },
+        tv: [
+          { name: 'Breaking Bad', resolutions: ['1080p'], codecs: ['x264'] },
+        ],
+        feeds: [
+          { name: 'rss', url: 'https://example.com/rss', mediaType: 'tv' },
+        ],
+      }),
+    );
+
+    const deps = { ...createDeps(), configPath };
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/setup/state'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ state: 'ready' });
+  });
+
+  it('requires no auth', async () => {
+    const deps = createDeps();
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/setup/state'),
+    );
+
+    expect(response.status).not.toBe(401);
+    expect(response.status).not.toBe(403);
+  });
+});
+
 describe('GET /api/health', () => {
   it('returns uptime and startedAt', async () => {
     const deps = createDeps();

--- a/test/bootstrap.test.ts
+++ b/test/bootstrap.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { copyFile, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { ensureStarterConfig } from '../src/bootstrap';
+import { ensureStarterConfig, getSetupState } from '../src/bootstrap';
 import { validateConfig } from '../src/config';
 
 let dir: string;
@@ -78,5 +78,72 @@ describe('ensureStarterConfig', () => {
     };
 
     expect(() => validateConfig(config, 'test', {})).not.toThrow();
+  });
+});
+
+const FIXTURE_DIR = join(import.meta.dir, 'fixtures/setup-state');
+
+describe('getSetupState', () => {
+  it('returns "starter" when file does not exist', async () => {
+    const path = join(dir, 'missing.json');
+    expect(await getSetupState(path)).toBe('starter');
+  });
+
+  it('returns "starter" for starter fixture (_starter: true)', async () => {
+    const path = join(dir, 'starter.json');
+    await copyFile(join(FIXTURE_DIR, 'starter.json'), path);
+    expect(await getSetupState(path)).toBe('starter');
+  });
+
+  it('returns "partially_configured" for partially-configured fixture', async () => {
+    const path = join(dir, 'partial.json');
+    await copyFile(join(FIXTURE_DIR, 'partially-configured.json'), path);
+    expect(await getSetupState(path)).toBe('partially_configured');
+  });
+
+  it('returns "ready" for ready fixture', async () => {
+    const path = join(dir, 'ready.json');
+    await copyFile(join(FIXTURE_DIR, 'ready.json'), path);
+    expect(await getSetupState(path)).toBe('ready');
+  });
+
+  it('returns "partially_configured" when _starter absent but feeds empty', async () => {
+    const path = join(dir, 'no-feeds.json');
+    await Bun.write(
+      path,
+      JSON.stringify({
+        transmission: { url: 'http://mybox:9091/transmission/rpc' },
+        tv: {
+          defaults: { resolutions: ['1080p'], codecs: ['x264'] },
+          shows: ['Breaking Bad'],
+        },
+        feeds: [],
+      }),
+    );
+    expect(await getSetupState(path)).toBe('partially_configured');
+  });
+
+  it('returns "partially_configured" when tv is empty', async () => {
+    const path = join(dir, 'no-tv.json');
+    await Bun.write(
+      path,
+      JSON.stringify({
+        transmission: { url: 'http://mybox:9091/transmission/rpc' },
+        tv: {
+          defaults: { resolutions: ['1080p'], codecs: ['x264'] },
+          shows: [],
+        },
+        feeds: [
+          { name: 'rss', url: 'https://example.com/rss', mediaType: 'tv' },
+        ],
+      }),
+    );
+    expect(await getSetupState(path)).toBe('partially_configured');
+  });
+
+  it('returns "partially_configured" for invalid JSON', async () => {
+    const path = join(dir, 'bad.json');
+    await Bun.write(path, 'not json');
+    expect(await getSetupState(path)).toBe('partially_configured');
   });
 });

--- a/test/fixtures/setup-state/partially-configured.json
+++ b/test/fixtures/setup-state/partially-configured.json
@@ -1,0 +1,18 @@
+{
+  "transmission": {
+    "url": "http://localhost:9091/transmission/rpc",
+    "username": "admin",
+    "password": "admin"
+  },
+  "movies": {
+    "years": [2024, 2025],
+    "resolutions": ["1080p"],
+    "codecs": ["x264"],
+    "codecPolicy": "prefer"
+  },
+  "tv": {
+    "defaults": { "resolutions": ["1080p"], "codecs": ["x264"] },
+    "shows": []
+  },
+  "feeds": []
+}

--- a/test/fixtures/setup-state/ready.json
+++ b/test/fixtures/setup-state/ready.json
@@ -1,0 +1,24 @@
+{
+  "transmission": {
+    "url": "http://192.168.1.100:9091/transmission/rpc",
+    "username": "operator",
+    "password": "secret"
+  },
+  "movies": {
+    "years": [2024, 2025],
+    "resolutions": ["1080p"],
+    "codecs": ["x264"],
+    "codecPolicy": "prefer"
+  },
+  "tv": {
+    "defaults": { "resolutions": ["1080p"], "codecs": ["x264"] },
+    "shows": ["Breaking Bad"]
+  },
+  "feeds": [
+    {
+      "name": "Example Feed",
+      "url": "https://example.com/rss",
+      "mediaType": "tv"
+    }
+  ]
+}

--- a/test/fixtures/setup-state/starter.json
+++ b/test/fixtures/setup-state/starter.json
@@ -1,0 +1,24 @@
+{
+  "_starter": true,
+  "transmission": {
+    "url": "http://localhost:9091/transmission/rpc",
+    "username": "admin",
+    "password": "admin"
+  },
+  "plex": {
+    "url": "http://localhost:32400",
+    "token": "",
+    "refreshIntervalMinutes": 0
+  },
+  "movies": {
+    "years": [2024, 2025],
+    "resolutions": ["1080p"],
+    "codecs": ["x264"],
+    "codecPolicy": "prefer"
+  },
+  "tv": {
+    "defaults": { "resolutions": ["1080p"], "codecs": ["x264"] },
+    "shows": []
+  },
+  "feeds": []
+}


### PR DESCRIPTION
## Summary

- delivery ticket: `P21.02 GET /api/setup/state Endpoint`
- ticket file: [docs/02-delivery/phase-21/ticket-02-setup-state-endpoint.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-21/ticket-02-setup-state-endpoint.md)
- stacked base branch: `agents/p21-01-ensurestarterconfig-write-valid-starter-config-on-first-boot`
- self-audit: outcome `clean` completed at 2026-04-20 20:15 UTC

## External AI Review

- outcome: `clean`
- reviewed commit: [`17c144e43456`](https://github.com/cesarnml/Pirate-Claw/commit/17c144e43456c5d19564eb5f0ac2518abf9c777a)
- current branch head: [`17c144e43456`](https://github.com/cesarnml/Pirate-Claw/commit/17c144e43456c5d19564eb5f0ac2518abf9c777a)
- vendors: `coderabbit`
