### PR TITLE
feat(web): add setup state UI — starter splash and partial-config banner [P21.03]

### DIFF
--- a/orchestrator.config.json
+++ b/orchestrator.config.json
@@ -6,7 +6,7 @@
   "ticketBoundaryMode": "cook",
   "reviewPolicy": {
     "selfAudit": "skip_doc_only",
-    "codexPreflight": "disabled",
-    "externalReview": "skip_doc_only"
+    "codexPreflight": "skip_doc_only",
+    "externalReview": "disabled"
   }
 }

--- a/orchestrator.config.json
+++ b/orchestrator.config.json
@@ -6,7 +6,7 @@
   "ticketBoundaryMode": "cook",
   "reviewPolicy": {
     "selfAudit": "skip_doc_only",
-    "codexPreflight": "skip_doc_only",
-    "externalReview": "disabled"
+    "codexPreflight": "disabled",
+    "externalReview": "skip_doc_only"
   }
 }

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -4,6 +4,12 @@ import type { LayoutServerLoad } from './$types';
 
 type SetupStateResponse = { state: 'starter' | 'partially_configured' | 'ready' };
 
+function normalizeSetupState(state: unknown): SetupStateResponse['state'] {
+	return state === 'starter' || state === 'partially_configured' || state === 'ready'
+		? state
+		: 'partially_configured';
+}
+
 export const load: LayoutServerLoad = async () => {
 	const [healthResult, sessionResult, configResult, setupStateResult] = await Promise.allSettled([
 		apiFetch<DaemonHealth>('/api/health'),
@@ -34,7 +40,7 @@ export const load: LayoutServerLoad = async () => {
 		plexConfigured: configResult.status === 'fulfilled' && configResult.value.plex !== undefined,
 		setupState:
 			setupStateResult.status === 'fulfilled'
-				? setupStateResult.value.state
+				? normalizeSetupState(setupStateResult.value.state)
 				: 'partially_configured'
 	};
 };

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -2,11 +2,14 @@ import { apiFetch } from '$lib/server/api';
 import type { AppConfig, DaemonHealth, SessionInfo } from '$lib/types';
 import type { LayoutServerLoad } from './$types';
 
+type SetupStateResponse = { state: 'starter' | 'partially_configured' | 'ready' };
+
 export const load: LayoutServerLoad = async () => {
-	const [healthResult, sessionResult, configResult] = await Promise.allSettled([
+	const [healthResult, sessionResult, configResult, setupStateResult] = await Promise.allSettled([
 		apiFetch<DaemonHealth>('/api/health'),
 		apiFetch<SessionInfo>('/api/transmission/session'),
-		apiFetch<AppConfig>('/api/config')
+		apiFetch<AppConfig>('/api/config'),
+		apiFetch<SetupStateResponse>('/api/setup/state')
 	]);
 
 	if (healthResult.status === 'rejected') {
@@ -21,9 +24,17 @@ export const load: LayoutServerLoad = async () => {
 		console.error('[layout] failed to load /api/config:', configResult.reason);
 	}
 
+	if (setupStateResult.status === 'rejected') {
+		console.error('[layout] failed to load /api/setup/state:', setupStateResult.reason);
+	}
+
 	return {
 		health: healthResult.status === 'fulfilled' ? healthResult.value : null,
 		transmissionSession: sessionResult.status === 'fulfilled' ? sessionResult.value : null,
-		plexConfigured: configResult.status === 'fulfilled' && configResult.value.plex !== undefined
+		plexConfigured: configResult.status === 'fulfilled' && configResult.value.plex !== undefined,
+		setupState:
+			setupStateResult.status === 'fulfilled'
+				? setupStateResult.value.state
+				: 'partially_configured'
 	};
 };

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -39,9 +39,10 @@
 	const daemonUptime = $derived(formatUptime(data.health?.uptime ?? null));
 	const transmissionConnected = $derived(data.transmissionSession !== null);
 	const plexConfigured = $derived(data.plexConfigured === true);
-	const showSidebar = $derived($page.url.pathname !== '/onboarding');
+	const isOnboarding = $derived($page.url.pathname === '/onboarding');
+	const showSidebar = $derived(!isOnboarding);
 	const setupState = $derived(data.setupState ?? 'partially_configured');
-	const isStarter = $derived(setupState === 'starter');
+	const isStarter = $derived(setupState === 'starter' && !isOnboarding);
 	const isPartiallyConfigured = $derived(setupState === 'partially_configured');
 </script>
 
@@ -125,6 +126,12 @@
 						Use the setup wizard to connect Transmission, Plex, and configure your media
 						preferences.
 					</p>
+					<a
+						href="/onboarding"
+						class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center rounded-lg px-4 py-2 text-sm font-medium"
+					>
+						Open setup wizard
+					</a>
 				</div>
 			{:else}
 				{#if isPartiallyConfigured}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -122,7 +122,8 @@
 					/>
 					<h1 class="text-foreground text-2xl font-semibold">Pirate Claw is not yet configured</h1>
 					<p class="text-muted-foreground max-w-sm text-sm">
-						Use the setup wizard to connect Transmission, Plex, and configure your media preferences.
+						Use the setup wizard to connect Transmission, Plex, and configure your media
+						preferences.
 					</p>
 				</div>
 			{:else}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -122,8 +122,7 @@
 					/>
 					<h1 class="text-foreground text-2xl font-semibold">Pirate Claw is not yet configured</h1>
 					<p class="text-muted-foreground max-w-sm text-sm">
-						Edit <code class="font-mono">config.json</code> to connect Transmission, Plex, and set your
-						media preferences. Then restart the daemon.
+						Use the setup wizard to connect Transmission, Plex, and configure your media preferences.
 					</p>
 				</div>
 			{:else}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -40,6 +40,9 @@
 	const transmissionConnected = $derived(data.transmissionSession !== null);
 	const plexConfigured = $derived(data.plexConfigured === true);
 	const showSidebar = $derived($page.url.pathname !== '/onboarding');
+	const setupState = $derived(data.setupState ?? 'partially_configured');
+	const isStarter = $derived(setupState === 'starter');
+	const isPartiallyConfigured = $derived(setupState === 'partially_configured');
 </script>
 
 <svelte:head>
@@ -105,7 +108,35 @@
 		{/if}
 
 		<main class="min-w-0 flex-1 overflow-y-auto px-4 py-6 md:px-6 md:py-8 lg:px-10">
-			{@render children()}
+			{#if isStarter}
+				<div
+					class="flex flex-col items-center justify-center gap-4 py-24 text-center"
+					data-testid="starter-mode-splash"
+				>
+					<img
+						src="/pirate-claw-logo.webp"
+						alt="Pirate Claw"
+						width="80"
+						height="80"
+						class="rounded-2xl opacity-60"
+					/>
+					<h1 class="text-foreground text-2xl font-semibold">Pirate Claw is not yet configured</h1>
+					<p class="text-muted-foreground max-w-sm text-sm">
+						Edit <code class="font-mono">config.json</code> to connect Transmission, Plex, and set your
+						media preferences. Then restart the daemon.
+					</p>
+				</div>
+			{:else}
+				{#if isPartiallyConfigured}
+					<div
+						class="bg-warning/10 border-warning/30 text-warning mb-4 rounded-lg border px-4 py-2 text-sm"
+						data-testid="partial-config-banner"
+					>
+						Setup incomplete — some services may be unavailable until configuration is complete.
+					</div>
+				{/if}
+				{@render children()}
+			{/if}
 		</main>
 	</div>
 

--- a/web/src/routes/dashboard.test.ts
+++ b/web/src/routes/dashboard.test.ts
@@ -80,6 +80,7 @@ const baseData = {
 	health: mockHealth,
 	transmissionSession: null,
 	plexConfigured: false,
+	setupState: 'ready' as const,
 	transmissionTorrents: [],
 	candidates: [],
 	runSummaries: [],

--- a/web/src/routes/layout.server.test.ts
+++ b/web/src/routes/layout.server.test.ts
@@ -66,6 +66,26 @@ describe('layout server load', () => {
 		expect(result.setupState).toBe('starter');
 	});
 
+	it('normalizes unknown setup state values to partially_configured', async () => {
+		const { load } = await import('./+layout.server');
+
+		apiFetchMock
+			.mockResolvedValueOnce({ uptime: 1, startedAt: '2024-01-01T00:00:00Z' })
+			.mockResolvedValueOnce({
+				version: '3.0',
+				downloadSpeed: 0,
+				uploadSpeed: 0,
+				activeTorrentCount: 0
+			})
+			.mockResolvedValueOnce({
+				plex: { url: 'http://localhost:32400', token: '', refreshIntervalMinutes: 30 }
+			})
+			.mockResolvedValueOnce({ state: 'mystery' });
+
+		const result = (await load({} as never)) as { setupState: string };
+		expect(result.setupState).toBe('partially_configured');
+	});
+
 	it('tolerates unavailable shared endpoints and returns nulls', async () => {
 		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		try {

--- a/web/src/routes/layout.server.test.ts
+++ b/web/src/routes/layout.server.test.ts
@@ -28,7 +28,8 @@ describe('layout server load', () => {
 					token: '[redacted]',
 					refreshIntervalMinutes: 30
 				}
-			});
+			})
+			.mockResolvedValueOnce({ state: 'ready' });
 
 		const result = await load({} as never);
 
@@ -40,8 +41,29 @@ describe('layout server load', () => {
 				uploadSpeed: 0,
 				activeTorrentCount: 0
 			},
-			plexConfigured: true
+			plexConfigured: true,
+			setupState: 'ready'
 		});
+	});
+
+	it('returns setupState=starter when setup/state reports starter', async () => {
+		const { load } = await import('./+layout.server');
+
+		apiFetchMock
+			.mockResolvedValueOnce({ uptime: 1, startedAt: '2024-01-01T00:00:00Z' })
+			.mockResolvedValueOnce({
+				version: '3.0',
+				downloadSpeed: 0,
+				uploadSpeed: 0,
+				activeTorrentCount: 0
+			})
+			.mockResolvedValueOnce({
+				plex: { url: 'http://localhost:32400', token: '', refreshIntervalMinutes: 30 }
+			})
+			.mockResolvedValueOnce({ state: 'starter' });
+
+		const result = (await load({} as never)) as { setupState: string };
+		expect(result.setupState).toBe('starter');
 	});
 
 	it('tolerates unavailable shared endpoints and returns nulls', async () => {
@@ -52,14 +74,16 @@ describe('layout server load', () => {
 			apiFetchMock
 				.mockRejectedValueOnce(new Error('health down'))
 				.mockRejectedValueOnce(new Error('tx down'))
-				.mockRejectedValueOnce(new Error('config down'));
+				.mockRejectedValueOnce(new Error('config down'))
+				.mockRejectedValueOnce(new Error('setup down'));
 
 			const result = await load({} as never);
 
 			expect(result).toEqual({
 				health: null,
 				transmissionSession: null,
-				plexConfigured: false
+				plexConfigured: false,
+				setupState: 'partially_configured'
 			});
 		} finally {
 			errorSpy.mockRestore();

--- a/web/src/routes/layout.test.ts
+++ b/web/src/routes/layout.test.ts
@@ -1,11 +1,28 @@
 import { render, screen, within } from '@testing-library/svelte';
-import { writable } from 'svelte/store';
+import { createRawSnippet } from 'svelte';
 import { describe, expect, it, vi } from 'vitest';
 import type { DaemonHealth, SessionInfo } from '$lib/types';
 import Layout from './+layout.svelte';
 
-vi.mock('$app/stores', () => ({
-	page: writable({ url: new URL('http://localhost/') })
+const { page } = vi.hoisted(() => ({
+	page: (() => {
+		let current = { url: new URL('http://localhost/') };
+		const subscribers = new Set<(value: typeof current) => void>();
+
+		return {
+			subscribe(callback: (value: typeof current) => void) {
+				subscribers.add(callback);
+				callback(current);
+				return () => subscribers.delete(callback);
+			},
+			set(value: typeof current) {
+				current = value;
+				for (const subscriber of subscribers) {
+					subscriber(current);
+				}
+			}
+		};
+	})()
 }));
 
 vi.mock('$lib/components/ui/sonner', () => ({
@@ -13,12 +30,7 @@ vi.mock('$lib/components/ui/sonner', () => ({
 }));
 
 vi.mock('$app/stores', () => ({
-	page: {
-		subscribe: vi.fn((cb: (val: { url: { pathname: string } }) => void) => {
-			cb({ url: { pathname: '/' } });
-			return () => {};
-		})
-	}
+	page
 }));
 
 const mockHealth: DaemonHealth = {
@@ -33,8 +45,18 @@ const mockSession: SessionInfo = {
 	activeTorrentCount: 0
 };
 
+function setPathname(pathname: string) {
+	page.set({ url: new URL(`http://localhost${pathname}`) });
+}
+
+const childSnippet = createRawSnippet(() => ({
+	render: () => '<div data-testid="layout-child">Layout child</div>'
+}));
+
 describe('+layout.svelte', () => {
 	it('renders the phase 19 shell nav and footer status strip', () => {
+		setPathname('/');
+
 		render(Layout, {
 			props: {
 				children: (() => {}) as unknown as import('svelte').Snippet,
@@ -71,6 +93,8 @@ describe('+layout.svelte', () => {
 	});
 
 	it('surfaces unavailable shell status when shared API data is missing', () => {
+		setPathname('/');
+
 		render(Layout, {
 			props: {
 				children: (() => {}) as unknown as import('svelte').Snippet,
@@ -93,9 +117,11 @@ describe('+layout.svelte', () => {
 	});
 
 	it('renders starter-mode splash and hides children when setupState is starter', () => {
+		setPathname('/');
+
 		render(Layout, {
 			props: {
-				children: (() => {}) as unknown as import('svelte').Snippet,
+				children: childSnippet,
 				data: {
 					health: null,
 					transmissionSession: null,
@@ -107,10 +133,37 @@ describe('+layout.svelte', () => {
 
 		expect(screen.getByTestId('starter-mode-splash')).toBeInTheDocument();
 		expect(screen.getByText('Pirate Claw is not yet configured')).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'Open setup wizard' })).toHaveAttribute(
+			'href',
+			'/onboarding'
+		);
+		expect(screen.queryByTestId('layout-child')).not.toBeInTheDocument();
 		expect(screen.queryByTestId('partial-config-banner')).not.toBeInTheDocument();
 	});
 
+	it('renders onboarding children during starter mode', () => {
+		setPathname('/onboarding');
+
+		render(Layout, {
+			props: {
+				children: childSnippet,
+				data: {
+					health: null,
+					transmissionSession: null,
+					plexConfigured: false,
+					setupState: 'starter' as const
+				}
+			}
+		});
+
+		expect(screen.queryByTestId('starter-mode-splash')).not.toBeInTheDocument();
+		expect(screen.getByTestId('layout-child')).toBeInTheDocument();
+		expect(screen.queryByRole('navigation', { name: 'Main navigation' })).not.toBeInTheDocument();
+	});
+
 	it('renders partial-config banner when setupState is partially_configured', () => {
+		setPathname('/');
+
 		render(Layout, {
 			props: {
 				children: (() => {}) as unknown as import('svelte').Snippet,
@@ -128,6 +181,8 @@ describe('+layout.svelte', () => {
 	});
 
 	it('renders no setup indicator when setupState is ready', () => {
+		setPathname('/');
+
 		render(Layout, {
 			props: {
 				children: (() => {}) as unknown as import('svelte').Snippet,

--- a/web/src/routes/layout.test.ts
+++ b/web/src/routes/layout.test.ts
@@ -41,7 +41,8 @@ describe('+layout.svelte', () => {
 				data: {
 					health: mockHealth,
 					transmissionSession: mockSession,
-					plexConfigured: true
+					plexConfigured: true,
+					setupState: 'ready' as const
 				}
 			}
 		});
@@ -76,7 +77,8 @@ describe('+layout.svelte', () => {
 				data: {
 					health: null,
 					transmissionSession: null,
-					plexConfigured: false
+					plexConfigured: false,
+					setupState: 'partially_configured' as const
 				}
 			}
 		});
@@ -88,5 +90,57 @@ describe('+layout.svelte', () => {
 
 		expect(sidebarQueries.getAllByText('Unavailable').length).toBeGreaterThanOrEqual(2);
 		expect(sidebarQueries.getByText('Transmission')).toBeInTheDocument();
+	});
+
+	it('renders starter-mode splash and hides children when setupState is starter', () => {
+		render(Layout, {
+			props: {
+				children: (() => {}) as unknown as import('svelte').Snippet,
+				data: {
+					health: null,
+					transmissionSession: null,
+					plexConfigured: false,
+					setupState: 'starter' as const
+				}
+			}
+		});
+
+		expect(screen.getByTestId('starter-mode-splash')).toBeInTheDocument();
+		expect(screen.getByText('Pirate Claw is not yet configured')).toBeInTheDocument();
+		expect(screen.queryByTestId('partial-config-banner')).not.toBeInTheDocument();
+	});
+
+	it('renders partial-config banner when setupState is partially_configured', () => {
+		render(Layout, {
+			props: {
+				children: (() => {}) as unknown as import('svelte').Snippet,
+				data: {
+					health: mockHealth,
+					transmissionSession: mockSession,
+					plexConfigured: true,
+					setupState: 'partially_configured' as const
+				}
+			}
+		});
+
+		expect(screen.getByTestId('partial-config-banner')).toBeInTheDocument();
+		expect(screen.queryByTestId('starter-mode-splash')).not.toBeInTheDocument();
+	});
+
+	it('renders no setup indicator when setupState is ready', () => {
+		render(Layout, {
+			props: {
+				children: (() => {}) as unknown as import('svelte').Snippet,
+				data: {
+					health: mockHealth,
+					transmissionSession: mockSession,
+					plexConfigured: true,
+					setupState: 'ready' as const
+				}
+			}
+		});
+
+		expect(screen.queryByTestId('starter-mode-splash')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('partial-config-banner')).not.toBeInTheDocument();
 	});
 });

--- a/web/src/routes/movies/movies.test.ts
+++ b/web/src/routes/movies/movies.test.ts
@@ -4,10 +4,14 @@ import Page from './+page.svelte';
 import type { MovieBreakdown, TorrentStatSnapshot } from '$lib/types';
 import type { PageData } from './$types';
 
-const sharedLayoutData: Pick<PageData, 'health' | 'transmissionSession' | 'plexConfigured'> = {
+const sharedLayoutData: Pick<
+	PageData,
+	'health' | 'transmissionSession' | 'plexConfigured' | 'setupState'
+> = {
 	health: null,
 	transmissionSession: null,
-	plexConfigured: false
+	plexConfigured: false,
+	setupState: 'ready' as const
 };
 
 const mockMovie = (overrides: Partial<MovieBreakdown> = {}): MovieBreakdown => ({

--- a/web/src/routes/onboarding/onboarding.test.ts
+++ b/web/src/routes/onboarding/onboarding.test.ts
@@ -14,7 +14,12 @@ const feedOnlyConfigFixture = feedOnlyConfig as AppConfig;
 const configWithMoviesFixture = configWithMovies as AppConfig;
 const configWithTvDefaultsFixture = configWithTvDefaults as AppConfig;
 
-const sharedLayoutData = { health: null, transmissionSession: null, plexConfigured: false };
+const sharedLayoutData = {
+	health: null,
+	transmissionSession: null,
+	plexConfigured: false,
+	setupState: 'ready' as const
+};
 
 function renderPage(data: Record<string, unknown>) {
 	return render(Page, {

--- a/web/src/routes/shows/[slug]/shows.test.ts
+++ b/web/src/routes/shows/[slug]/shows.test.ts
@@ -4,10 +4,14 @@ import Page from './+page.svelte';
 import type { ShowBreakdown, TorrentStatSnapshot } from '$lib/types';
 import type { PageData } from './$types';
 
-const sharedLayoutData: Pick<PageData, 'health' | 'transmissionSession' | 'plexConfigured'> = {
+const sharedLayoutData: Pick<
+	PageData,
+	'health' | 'transmissionSession' | 'plexConfigured' | 'setupState'
+> = {
 	health: null,
 	transmissionSession: null,
-	plexConfigured: false
+	plexConfigured: false,
+	setupState: 'ready' as const
 };
 
 const detailShow: ShowBreakdown = {

--- a/web/src/routes/shows/shows.test.ts
+++ b/web/src/routes/shows/shows.test.ts
@@ -3,7 +3,12 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import Page from './+page.svelte';
 import type { ShowBreakdown, TorrentStatSnapshot } from '$lib/types';
 
-const sharedLayoutData = { health: null, transmissionSession: null, plexConfigured: false };
+const sharedLayoutData = {
+	health: null,
+	transmissionSession: null,
+	plexConfigured: false,
+	setupState: 'ready' as const
+};
 
 const exampleShow: ShowBreakdown = {
 	normalizedTitle: 'The Example Show',


### PR DESCRIPTION
## Summary

- delivery ticket: `P21.03 Web App Starter Mode UI`
- ticket file: [docs/02-delivery/phase-21/ticket-03-web-starter-mode-ui.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-21/ticket-03-web-starter-mode-ui.md)
- stacked base branch: `agents/p21-02-get-api-setup-state-endpoint`
- self-audit: outcome `clean` completed at 2026-04-20 20:31 UTC
- codexPreflight: outcome `clean` completed at 2026-04-20 20:42 UTC

## Late Review Follow-up

- patched late CodeRabbit findings in `237b1ab`
- normalized unexpected `/api/setup/state` values to `partially_configured` before layout data is returned
- allowed `/onboarding` to render during starter mode and added a splash CTA into the setup wizard
- tightened route tests to assert starter-mode child suppression and onboarding passthrough behavior
- closed the three resolved CodeRabbit review threads after the patch landed
