### PR TITLE
fix(bootstrap): replace URL-comparison ready check with media-type target check [P22.02]

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -19,6 +19,7 @@
     "emptively",
     "ENOSYS",
     "eztv",
+    "gatekeeping",
     "Geminilake",
     "gluetun",
     "greptile",

--- a/docs/01-product/phase-22-browser-only-setup.md
+++ b/docs/01-product/phase-22-browser-only-setup.md
@@ -8,9 +8,9 @@ Phase 22 turns the Phase 21 bootstrap contract into a complete browser-only setu
 
 **Goal:** go from fresh install to working ingestion setup with no SSH and no hand-edited files.
 
-**Ships:** onboarding and config flow rewritten around the new starter-state contract; dependency-ordered setup sequence; shared setup primitives between onboarding and `/config`; explicit readiness and restart-needed state; compatibility-vs-recommended-baseline setup language for Transmission; explicit optional Plex compatibility contract; browser-managed Plex authentication; bundled-Transmission VPN setup as a first-run choice.
+**Ships:** onboarding and config flow rewritten around the new starter-state contract; dependency-ordered setup sequence; shared setup primitives between onboarding and `/config`; explicit readiness and restart-needed state; compatibility-vs-recommended-baseline setup language for Transmission; `movies` made optional in schema (absence = movies matching disabled); starter config cleaned up to omit phantom defaults.
 
-**Defers:** advanced target authoring, collector-shelf polish on Movies/Shows, and broader UX refinement beyond the minimum working setup.
+**Defers:** Plex browser auth (P22.5), advanced target authoring, collector-shelf polish on Movies/Shows, broader UX refinement beyond the minimum working setup, bundled Transmission + VPN container provisioning (post-v1).
 
 ## Phase Goal
 
@@ -20,25 +20,49 @@ Phase 22 should leave Pirate Claw in a state where:
 - onboarding no longer depends on a copied template or hidden installer knowledge
 - the Config page and onboarding share the same underlying writable setup primitives
 - Pirate Claw is truly ingestion-ready when onboarding says it is done
-- the setup flow treats a compatible pre-existing Transmission instance as valid, even when it is not Pirate Claw's recommended bundled deployment
-- optional Plex integration is explicit about the minimum supported PMS version instead of being implied by stale NAS package defaults
-- Plex auth no longer depends on the operator manually inspecting XML or browser developer tools to extract an `X-Plex-Token`
-- if the operator chooses Pirate Claw's bundled Transmission path, the required VPN/downloader network choice is captured during onboarding rather than left as a hand-edited deployment detail
+- the setup flow treats a compatible pre-existing Transmission instance as valid, even when it is not Pirate Claw's recommended bundled deployment profile
+
+## Starter Config Contract (revised)
+
+The starter config written by `ensureStarterConfig` must carry honest empty/absent state — no phantom defaults that look like operator choices:
+
+- `feeds: []` — empty, operator must add at least one
+- `tv.shows: []` — empty, operator must add at least one show (compact format with defaults block is fine)
+- `movies` — **omitted entirely** (absence = movies matching disabled; operator adds the block explicitly)
+- `tmdb` — **omitted entirely** (already optional, no change)
+- `transmission` — placeholder credentials + default localhost URL (not a readiness signal)
+- `plex` — placeholder URL + empty token, labeled legacy until P22.5 delivers browser auth
+
+This aligns all target-type fields on a single principle: empty arrays and absent objects both mean "not yet configured." No field uses pre-filled defaults to simulate operator intent.
+
+## Config Schema Changes Required
+
+- `movies` becomes `movies?: MoviePolicy` in `AppConfig` (optional)
+- Config loader (`validateConfig`) must accept absent `movies` block without throwing
+- Ingestion pipeline skips movie matching when `movies` is absent
+- `getSetupState` readiness condition updated (see Readiness Model below)
 
 ## Required Setup Sequence
 
 Phase 22 should present setup in the order that actually matters operationally:
 
-1. connectivity basics
-2. auth/secrets
+1. connectivity basics (Transmission endpoint + auth)
+2. auth/secrets (write-access key)
 3. media target directories
-4. first feed
-5. first matching target rule
+4. first feed (with `mediaType` declared)
+5. first matching target rule (TV show or movies block, based on feed mediaType)
 6. completion summary and handoff
 
 The flow may combine adjacent steps if the ticket breakdown finds a cleaner boundary, but it must preserve this dependency order.
 
 ## Committed Scope
+
+### Starter Config and Schema Fix
+
+- omit `movies` from starter config; update schema to accept absent `movies`
+- align `getSetupState` ready condition: feeds non-empty + each feed's `mediaType` has a corresponding configured target (tv feed → tv.shows non-empty; movie feed → movies present) + transmission URL is a valid non-empty string
+- remove the `transmissionCustom` URL-comparison heuristic — URL non-default was a bad proxy for "operator touched this"
+- corrupt/malformed config recovery: surface a clear `partially_configured` state and guide the operator to fix it through the browser
 
 ### Onboarding
 
@@ -54,55 +78,49 @@ The flow may combine adjacent steps if the ticket breakdown finds a cleaner boun
 - the write-access key must be part of the browser-manageable setup story
 - setup state and validation must be explicit enough that the operator can tell what is still blocking readiness
 - browser-only setup means **no manual file manipulation by the operator for first-run essentials**
-- any authentication token required for optional first-run integrations must be obtainable through a supported browser/API flow, not by asking the operator to inspect raw XML/JSON payloads by hand
 
 ### Transmission Compatibility Contract
 
 - Pirate Claw must distinguish **compatible Transmission endpoint** from **recommended deployment baseline**
-- a reachable, authenticated Transmission RPC endpoint is sufficient to satisfy downloader compatibility, even if the operator already runs Transmission outside Pirate Claw's bundled VPN-wrapped container profile
-- the bundled Transmission + VPN deployment remains the recommended default, but it is not the only valid setup path
-- when the operator chooses the bundled Transmission path, onboarding/config must collect the VPN/downloader topology choices needed to make that path real
+- a reachable, authenticated Transmission RPC endpoint is sufficient to satisfy downloader compatibility, even if the operator already runs Transmission outside Pirate Claw's bundled profile
 - onboarding/config should surface whether the configured downloader is:
-  - `compatible`
-  - `compatible_custom`
-  - `recommended`
-  - `not_reachable`
+  - `compatible` — reachable, authenticated, operator-managed
+  - `compatible_custom` — reachable, authenticated, non-standard config
+  - `recommended` — reachable, authenticated, matches bundled profile
+  - `not_reachable` — connection failed
 - a custom/operator-managed Transmission deployment may produce advisory warnings, but it must not be blocked solely because it is not Pirate Claw-managed
+- downloader reachability is a **runtime readiness probe**, not a config-file check
 
 ### Bundled Downloader Setup
 
-- if Pirate Claw offers a bundled Transmission client, the accompanying VPN/network bridge requirements are part of product setup, not hidden deployer knowledge
-- onboarding should make the bundled-vs-custom downloader choice explicit
-- choosing the bundled downloader path should surface the required VPN layer and network relationship as first-class setup inputs
-- the operator should not need to hand-edit container/network files to complete the bundled downloader path promised by the browser-only setup contract
-
-### Optional Plex Compatibility Contract
-
-- Plex integration remains optional for setup completion unless a later ticket explicitly promotes it to a first-run requirement
-- when Plex integration is enabled, Pirate Claw should treat the **current published Plex Media Server API `1.2.0`** as the compatibility target
-- the official Plex developer docs state PMS API `1.2.0` is supported in **Plex Media Server `>= 1.43.0`**
-- Plex's official developer docs now recommend **JWT authentication** for new apps
-- setup UX should validate PMS reachability separately from PMS version compatibility
-- setup UX should surface a clear advisory when Plex is installed but too old for the documented API contract
-- the product should not imply that a NAS vendor's package-center default is sufficient if it ships an older PMS than the API contract requires
-- the product should stop relying on the operator manually eyeballing an `X-Plex-Token` out of Plex Media Server metadata responses
-- browser-only setup should use Plex's supported authentication flow so Pirate Claw can obtain the token it needs without requiring raw file edits or manual token extraction
-
-### Plex Authentication Contract
-
-- Phase 22 should replace manual token-copy instructions with Plex's supported browser/API authentication flow
-- Pirate Claw may still use `X-Plex-Token` when talking to PMS, but the operator should not have to discover that token manually
-- the preferred path is Plex's documented JWT-based authentication model for new apps, followed by the normal PMS resource discovery/token handoff
-- if a temporary compatibility fallback remains during migration, it should be clearly labeled as legacy and not treated as the long-term browser-only setup story
+- the bundled Transmission + VPN container provisioning path is **out of scope for P22**
+- P22 surfaces the `compatible / compatible_custom / recommended / not_reachable` status display only (reachability probe)
+- actual container/compose generation and VPN topology wiring is deferred to a dedicated post-v1 bundling phase
 
 ### Readiness Model
 
-- the UI should show one of: `not_ready`, `ready_pending_restart`, or `ready`
-- onboarding should hand off to the normal UI only when the system reaches a true working state
-- resumed onboarding and normal config editing must converge on the same readiness logic
-- downloader compatibility is a blocking readiness condition; bundled-vs-custom downloader topology is not
-- optional Plex version mismatch is an advisory readiness signal unless the operator explicitly enables Plex-dependent features that require the documented PMS API contract
-- manual operator token extraction for Plex is not an acceptable "ready" path for a browser-only setup claim
+Two separate layers:
+
+**Config completeness** (`getSetupState` — pure file check):
+
+- `starter` — `_starter: true` in config, or config file absent
+- `partially_configured` — config exists, parses, but feeds/targets incomplete or corrupt
+- `ready` — feeds non-empty + each feed's mediaType has a configured target block + transmission URL is a valid non-empty string
+
+**Runtime readiness** (new probe, owned by P22.04):
+
+- `not_ready` — maps to `starter | partially_configured`
+- `ready_pending_restart` — config is `ready` but daemon has not picked up the latest write
+- `ready` — daemon is live with current config
+
+These two layers map cleanly: setup wizard drives config completeness; runtime readiness panel shows the live daemon state.
+
+### Optional Plex Compatibility Contract
+
+- Plex integration remains optional; manual token field stays in UI for now, clearly labeled as legacy
+- setup UX validates PMS reachability separately from PMS version compatibility
+- setup UX surfaces a clear advisory when Plex is installed but too old for the documented API contract (PMS `>= 1.43.0` for API `1.2.0`)
+- browser-based Plex JWT auth (replacing manual token extraction) is **deferred to P22.5**
 
 ## Exit Condition
 
@@ -110,6 +128,8 @@ A fresh Pirate Claw install can be opened in the browser, configured end-to-end 
 
 ## Explicit Deferrals
 
+- Plex browser-based JWT authentication flow (P22.5)
+- bundled Transmission + VPN container provisioning (post-v1)
 - advanced feed/rule bulk management
 - search-to-add flows powered by TMDB or Plex
 - non-essential dashboard/UI polish on Movies/Shows
@@ -122,6 +142,8 @@ A fresh Pirate Claw install can be opened in the browser, configured end-to-end 
 
 Phase 17 proved that guided setup and empty-state guidance are useful, but it stopped short of eliminating installer knowledge and manual file concerns. Phase 22 is the real product-completion setup phase: it closes the gap between "starter state exists" and "the operator can actually make Pirate Claw work without leaving the browser."
 
-It also needs to close a product-truth gap: a reference deployment is not the same thing as the compatibility contract. Pirate Claw may recommend its bundled Transmission + VPN path, but setup should still honestly accept a valid pre-existing Transmission client. The same principle applies to Plex. If Pirate Claw claims Plex compatibility against the published PMS API, it must say which PMS versions satisfy that contract and it must not silently rely on stale NAS package-center defaults.
+The `movies` schema change and starter config cleanup are prerequisites, not polish. The current starter config pre-fills movies with year/resolution/codec defaults that look like operator choices — they are not. A field that the operator never touched must not read as configured. Omitting `movies` from the starter config and making it optional in the schema gives movies the same honest empty signal as `tv.shows: []`.
 
-To truly earn the "browser-only setup" claim, the operator must not be asked to bridge the last mile by hand. Manual Plex token extraction from server metadata is still manual setup, just with extra steps. Likewise, a bundled downloader story that still requires hidden VPN/network hand-editing is not a complete onboarding path.
+The readiness model split (config completeness vs. runtime readiness) is intentional. `getSetupState` stays a pure file check — cheap, synchronous, no network calls. Runtime reachability probes live in a separate layer owned by the setup wizard. The `transmissionCustom` URL-comparison heuristic is removed because it was always wrong: a bundled deployment at the default URL would permanently report `partially_configured` even if fully working.
+
+Plex browser auth is real scope but large enough to deserve its own phase. P22 delivers the browser-only setup claim for everything that does not require OAuth/PIN browser flows. P22.5 closes the Plex auth gap.

--- a/docs/02-delivery/phase-22/implementation-plan.md
+++ b/docs/02-delivery/phase-22/implementation-plan.md
@@ -1,0 +1,101 @@
+# Phase 22 Implementation Plan
+
+Phase 22 turns the Phase 21 bootstrap contract into a complete browser-only setup flow. The operator can move from a valid starter state to an ingestion-ready configuration entirely through the web UI — no SSH, no file editing.
+
+## Epic
+
+- `Phase 22 Browser-Only Setup and Installer Flow`
+
+Follow the shared guidance in [`docs/02-delivery/phase-implementation-guidance.md`](../phase-implementation-guidance.md) when shaping or revising tickets for this phase.
+
+## Product contract
+
+- [`docs/01-product/phase-22-browser-only-setup.md`](../../01-product/phase-22-browser-only-setup.md)
+
+## Grill-Me decisions locked for this phase (2026-04-21)
+
+- `movies` is omitted from the starter config and made optional (`movies?: MoviePolicy`) in `AppConfig`; absence means movies matching is disabled
+- `tmdb` was already optional and absent from starter config — no change
+- Starter config omits phantom `movies` defaults; all unconfigured target types signal "not yet set" via empty arrays or absent objects
+- `getSetupState` ready condition: feeds non-empty + each feed's `mediaType` has a corresponding configured target (tv feed → `tv.shows` non-empty; movie feed → `movies` present) + transmission URL is a valid non-empty string
+- `transmissionCustom` URL-comparison heuristic removed — URL ≠ default was a wrong proxy for "operator touched this"; a bundled deployment at the default URL is fully valid
+- Transmission reachability is a **runtime probe** (P22.04), not a config-file check
+- Two-layer readiness model: config completeness (`getSetupState`) vs. runtime readiness (`not_ready | ready_pending_restart | ready`)
+- Transmission compatibility status display: `compatible | compatible_custom | recommended | not_reachable` (reachability probe only, no provisioning)
+- Bundled Transmission + VPN container provisioning is **out of scope** (post-v1)
+- Plex browser-based JWT auth is **out of scope** (P22.5); manual token field stays, labeled legacy
+- Plex PMS version advisory (>= 1.43.0 for API 1.2.0) is surfaced as an advisory, not a blocking readiness condition
+
+## Stack
+
+- Bun + TypeScript daemon/API in `src/`
+- SvelteKit 2 + Svelte 5 + TypeScript in `web/`
+- Existing config validation path in [`src/config.ts`](../../../src/config.ts)
+- Existing bootstrap in [`src/bootstrap.ts`](../../../src/bootstrap.ts)
+- Existing API surface in [`src/api.ts`](../../../src/api.ts)
+
+## Ticket Order
+
+1. `P22.01 Starter Config Cleanup and movies Optional Schema`
+2. `P22.02 getSetupState Readiness Condition Fix`
+3. `P22.03 Dependency-Ordered Setup Wizard`
+4. `P22.04 Runtime Readiness Model and Daemon Liveness`
+5. `P22.05 Transmission Compatibility Status Display`
+6. `P22.06 Phase 22 Retrospective and Doc Update`
+
+## Ticket Files
+
+- `ticket-01-starter-config-cleanup-and-movies-optional.md`
+- `ticket-02-setup-state-readiness-condition-fix.md`
+- `ticket-03-dependency-ordered-setup-wizard.md`
+- `ticket-04-runtime-readiness-model.md`
+- `ticket-05-transmission-compatibility-status.md`
+- `ticket-06-retrospective.md`
+
+## Exit Condition
+
+A fresh Pirate Claw install can be opened in the browser, configured end-to-end through the setup wizard, and left in an ingestion-ready state. The operator never touches SSH, `vim`, or config files. The browser reflects true readiness — not wizard-step completion.
+
+## Phase Closeout
+
+- Retrospective: `required`
+- Artifact: `notes/public/phase-22-retrospective.md`
+- Trigger: `product-impact` — this is the phase that earns the browser-only setup claim; learning from delivery shapes P22.5 and post-v1 bundling scope
+- Final ticket P22.06 must include retrospective writing in scope
+
+## Review Rules
+
+Review and merge in ticket order.
+
+Do not start the next ticket until:
+
+- tests/checks for the current ticket are green
+- ticket rationale is updated for behavior/tradeoff changes
+- schema changes in P22.01 do not break existing tests
+
+## Explicit Deferrals
+
+- Plex browser-based JWT authentication (P22.5)
+- Bundled Transmission + VPN container provisioning (post-v1)
+- Advanced feed/rule bulk management
+- Search-to-add flows powered by TMDB or Plex
+- Non-essential Movies/Shows dashboard polish
+- Multi-user or delegated-operator setup flows
+- One-click installer packaging
+
+## Stop Conditions
+
+Pause for review if:
+
+- `movies` schema change requires changes beyond `src/config.ts`, `src/bootstrap.ts`, and `src/pipeline.ts`
+- setup wizard write path diverges from the existing config write path used by `/config`
+- readiness probe introduces network calls inside `getSetupState` (keep it file-only)
+- any ticket requires touching the Transmission container or compose files
+
+## Developer approval gate
+
+**Do not begin implementation** until this implementation plan and all Phase 22 ticket docs are merged to `main` and explicitly approved for delivery.
+
+## Delivery status
+
+Not started.

--- a/docs/02-delivery/phase-22/ticket-01-starter-config-cleanup-and-movies-optional.md
+++ b/docs/02-delivery/phase-22/ticket-01-starter-config-cleanup-and-movies-optional.md
@@ -1,0 +1,41 @@
+# P22.01 Starter Config Cleanup and `movies` Optional Schema
+
+## Goal
+
+Remove the phantom `movies` defaults from the starter config and make `movies` optional in the `AppConfig` schema so all unconfigured target types carry an honest "not yet set" signal — absent objects for single-policy blocks, empty arrays for lists.
+
+## Scope
+
+### `src/config.ts`
+
+- Change `movies: MoviePolicy` to `movies?: MoviePolicy` in `AppConfig`
+- Update `validateConfig` to accept an absent `movies` key without throwing (`requireRecord` → optional read)
+- Add `validateOptionalMoviePolicy` (mirrors `validateOptionalTmdb` pattern) — returns `undefined` when key absent, validates shape when present
+
+### `src/bootstrap.ts`
+
+- Remove the `movies` block from the object written by `ensureStarterConfig`
+- No other changes to `ensureStarterConfig`
+
+### `src/pipeline.ts`
+
+- Guard the movie-match path: when `config.movies` is `undefined`, skip movie item matching entirely (return no-match or skip, consistent with how absent TV shows behaves)
+
+### Tests
+
+- `test/bootstrap.test.ts`: assert written starter config has no `movies` key
+- `test/config.test.ts`: add case — config without `movies` key passes `validateConfig`; `config.movies` is `undefined`
+- `test/pipeline.test.ts`: add case — pipeline does not throw when `config.movies` is absent; movie items are skipped
+
+## Out Of Scope
+
+- `getSetupState` readiness condition update (P22.02)
+- UI changes (P22.03+)
+
+## Exit Condition
+
+`ensureStarterConfig` writes no `movies` key. A config file without `movies` passes `validateConfig`. The pipeline skips movie matching when `config.movies` is `undefined`. All existing tests remain green.
+
+## Rationale
+
+The starter config previously pre-filled `movies` with year/resolution/codec defaults. Those values were computed at install time, not chosen by the operator — but they looked like valid config to the validator and to any UI that reads the config. Omitting `movies` entirely gives it the same honest empty signal as `tv.shows: []`: the operator hasn't configured this yet. Making it optional in the schema is the minimum change required; the pipeline guard is a direct consequence.

--- a/docs/02-delivery/phase-22/ticket-02-setup-state-readiness-condition-fix.md
+++ b/docs/02-delivery/phase-22/ticket-02-setup-state-readiness-condition-fix.md
@@ -1,0 +1,55 @@
+# P22.02 `getSetupState` Readiness Condition Fix
+
+## Goal
+
+Replace the broken `transmissionCustom` URL-comparison heuristic with a correct feed-driven readiness check: a config is `ready` when it has feeds, each feed's `mediaType` has a configured target block, and the transmission URL is a valid non-empty string.
+
+## Scope
+
+### `src/bootstrap.ts`
+
+Replace the `getSetupState` ready condition:
+
+**Current (wrong):**
+
+```ts
+feedsNonEmpty && tvNonEmpty && transmissionCustom;
+```
+
+**New:**
+
+- `feedsNonEmpty`: `feeds` array non-empty (unchanged)
+- `transmissionUrlSet`: `transmission.url` is a non-empty string (any value — no URL comparison)
+- `targetsComplete`: for every distinct `mediaType` across the feeds array:
+  - `"tv"` → `tv.shows` non-empty (compact or flat format)
+  - `"movie"` → `movies` key is present (not absent)
+- ready = `feedsNonEmpty && transmissionUrlSet && targetsComplete`
+
+Remove the `DEFAULT_TRANSMISSION_URL` constant (no longer used for comparison).
+
+### `src/bootstrap.ts` — `SetupState` type
+
+No change to the type (`'starter' | 'partially_configured' | 'ready'`). The mapping to UI readiness states (`not_ready | ready_pending_restart | ready`) is owned by P22.04.
+
+### Tests
+
+- `test/bootstrap.test.ts`: update/add cases:
+  - TV-only feeds + tv.shows non-empty + any transmission URL → `ready`
+  - movie-only feeds + movies present + any transmission URL → `ready`
+  - mixed feeds + both targets configured → `ready`
+  - bundled deployment at default URL (`http://localhost:9091/transmission/rpc`) + feeds + targets → `ready` (was broken before)
+  - TV feeds + movies present but tv.shows empty → `partially_configured`
+  - movie feeds + tv.shows non-empty but movies absent → `partially_configured`
+
+## Out Of Scope
+
+- Transmission reachability probe (P22.04)
+- UI readiness display (P22.04)
+
+## Exit Condition
+
+`getSetupState` returns `ready` for a fully configured install regardless of whether the transmission URL is the default. A config with TV feeds requires tv.shows. A config with movie feeds requires movies. A config with both requires both. All tests green.
+
+## Rationale
+
+`transmissionCustom` checked whether the transmission URL differed from the default localhost value. A bundled deployment at the default URL would permanently return `partially_configured` even with feeds and targets fully set up. The fix aligns the readiness check with what actually determines ingestion capability: feeds exist, their target types are configured, and a transmission endpoint is specified. Reachability is a runtime concern owned by P22.04 — `getSetupState` stays a pure file check.

--- a/docs/02-delivery/phase-22/ticket-03-dependency-ordered-setup-wizard.md
+++ b/docs/02-delivery/phase-22/ticket-03-dependency-ordered-setup-wizard.md
@@ -1,0 +1,59 @@
+# P22.03 Dependency-Ordered Setup Wizard
+
+## Goal
+
+Replace the Phase 17 onboarding wizard with a dependency-ordered setup flow that handles both `starter` and `partially_configured` installs, saves incrementally through the existing config write path, and hands off to the normal UI only when the system is truly ingestion-ready.
+
+## Scope
+
+### API
+
+- `GET /api/setup/state` (P21.02) is already present — no change
+- `POST /api/config` (existing write path) is the save channel for all wizard steps — no new write endpoints required
+- If the write-access key setup step requires a dedicated endpoint, add `POST /api/setup/write-key` in this ticket
+
+### Web (`web/src/`)
+
+Wizard steps in dependency order:
+
+1. **Transmission** — URL, username, password; inline reachability ping (can use existing `/api/status` or a new lightweight probe); advisory if not reachable but not blocking
+2. **Write-access key** — set the browser-side write key; must be completed before any write step
+3. **Media directories** — download directory config (`downloadDirs.tv`, `downloadDirs.movie`)
+4. **First feed** — add one feed with `mediaType` declared; `mediaType` drives which target step follows
+5. **Target rule** — TV show (if feed is tv) or movies policy (if feed is movie); step label and form adapt to the feed's mediaType
+6. **Summary** — shows current `getSetupState` result; "Done" enabled only when state is `ready`; links to normal dashboard
+
+Incremental save: each step calls the existing config write path on completion. Returning to an incomplete wizard resumes at the first incomplete step (derived from current `getSetupState` + config shape, not wizard-local state).
+
+Both `starter` and `partially_configured` installs enter the same wizard. `partially_configured` pre-fills completed steps.
+
+### Shared primitives
+
+Config field components used in the wizard (Transmission form, feed form, TV show form, movies policy form) must be the same components used by the normal `/config` page. No wizard-only form implementations.
+
+## Fixture Snapshot Required
+
+Before implementation begins, add a fixture snapshot for the `GET /api/setup/state` response in each setup state:
+
+```
+test/fixtures/setup-state-starter.json
+test/fixtures/setup-state-partially-configured.json
+test/fixtures/setup-state-ready.json
+```
+
+The wizard reads `getSetupState` on load to determine resume point. Fixtures must exist before UI implementation.
+
+## Out Of Scope
+
+- Plex setup step (manual token field stays on `/config`, labeled legacy)
+- TMDB setup step
+- Transmission reachability as a hard blocking condition (advisory only in this ticket; P22.04 owns blocking readiness)
+- Bulk feed/rule management
+
+## Exit Condition
+
+A `starter` install opens the browser, enters the wizard, completes all six steps with incremental saves, and reaches a `getSetupState` result of `ready`. A `partially_configured` install resumes at the first incomplete step. Wizard "Done" is disabled until `ready`. Shared form components are used in both wizard and `/config`.
+
+## Rationale
+
+The Phase 17 wizard assumed the operator was starting fresh with a template config. Phase 22 starts from an honest empty state (P22.01) and a correct readiness check (P22.02). The wizard must therefore drive the operator through every required field rather than relying on pre-filled defaults. Incremental saves through the existing write path mean the wizard and config page are always consistent — there is no wizard-only state to reconcile.

--- a/docs/02-delivery/phase-22/ticket-04-runtime-readiness-model.md
+++ b/docs/02-delivery/phase-22/ticket-04-runtime-readiness-model.md
@@ -1,0 +1,61 @@
+# P22.04 Runtime Readiness Model and Daemon Liveness
+
+## Goal
+
+Add a runtime readiness layer on top of `getSetupState`. The browser reflects `not_ready | ready_pending_restart | ready` based on both config completeness and daemon liveness — not just file state.
+
+## Scope
+
+### API
+
+New endpoint: `GET /api/setup/readiness`
+
+Response shape:
+
+```ts
+{
+  state: 'not_ready' | 'ready_pending_restart' | 'ready';
+  configState: 'starter' | 'partially_configured' | 'ready';
+  transmissionReachable: boolean;
+  daemonLive: boolean;
+}
+```
+
+Logic:
+
+- `configState` = result of `getSetupState`
+- `transmissionReachable` = lightweight RPC ping to configured transmission URL (existing Transmission client, short timeout)
+- `daemonLive` = daemon process is running and responsive (can reuse existing health check)
+- `state` derivation:
+  - `configState !== 'ready'` → `not_ready`
+  - `configState === 'ready'` + `!daemonLive` → `ready_pending_restart`
+  - `configState === 'ready'` + `daemonLive` + `transmissionReachable` → `ready`
+  - `configState === 'ready'` + `daemonLive` + `!transmissionReachable` → `ready_pending_restart` (advisory: transmission unreachable)
+
+### Web (`web/src/`)
+
+- Summary step of the wizard (P22.03) polls `GET /api/setup/readiness` to gate the "Done" button on `state === 'ready'`
+- Add a persistent readiness banner to the normal dashboard: `ready_pending_restart` shows "Restart daemon to apply config changes"; `not_ready` shows "Setup incomplete"
+- `ready` clears the banner
+
+### Tests
+
+- Unit: `getSetupState` mapping to `not_ready` for `starter` and `partially_configured`
+- Integration: mock transmission ping returns unreachable → `ready_pending_restart`
+
+## Out Of Scope
+
+- Automatic daemon restart (P23)
+- Transmission provisioning
+
+## Exit Condition
+
+`GET /api/setup/readiness` returns the correct three-state result. The wizard summary step polls and gates "Done" on `ready`. The dashboard banner reflects live readiness state. Transmission unreachable produces `ready_pending_restart`, not a hard block.
+
+## Fixture Snapshot Required
+
+Add `test/fixtures/readiness-not-ready.json`, `readiness-ready-pending-restart.json`, `readiness-ready.json` before UI implementation.
+
+## Rationale
+
+`getSetupState` is a pure file check — it cannot know whether the daemon has picked up a config change or whether Transmission is reachable. The runtime readiness layer adds those two signals without polluting the file-check contract. `ready_pending_restart` is the correct state for "config is complete but daemon hasn't restarted yet" — a common post-setup condition that the operator needs to act on.

--- a/docs/02-delivery/phase-22/ticket-05-transmission-compatibility-status.md
+++ b/docs/02-delivery/phase-22/ticket-05-transmission-compatibility-status.md
@@ -1,0 +1,50 @@
+# P22.05 Transmission Compatibility Status Display
+
+## Goal
+
+Surface a `compatible | compatible_custom | recommended | not_reachable` compatibility status for the configured Transmission endpoint so the operator knows whether their downloader satisfies the Pirate Claw contract, without blocking a custom deployment.
+
+## Scope
+
+### API
+
+Extend `GET /api/setup/readiness` (P22.04) or add `GET /api/setup/transmission/status`:
+
+Response shape:
+
+```ts
+{
+  compatibility: 'recommended' | 'compatible' | 'compatible_custom' | 'not_reachable';
+  url: string;
+  reachable: boolean;
+  advisory?: string;
+}
+```
+
+Classification logic (probe-only, no provisioning):
+
+- `not_reachable` — RPC ping failed or timed out
+- `recommended` — reachable + URL matches known bundled profile default (`http://localhost:9091/transmission/rpc` or configured bundled URL)
+- `compatible` — reachable + authenticated + non-bundled URL, standard port
+- `compatible_custom` — reachable + authenticated + non-standard config (non-default port, non-standard RPC path, etc.)
+
+A custom/operator-managed deployment at `compatible` or `compatible_custom` is **not blocked**. Advisory text is surfaced but setup continues.
+
+### Web (`web/src/`)
+
+- Transmission step in the setup wizard (P22.03) shows the compatibility badge after the reachability ping
+- `/config` Transmission section shows the same badge
+- `not_reachable` shows a warning; `compatible_custom` shows an advisory note; `compatible` and `recommended` show a green confirmation
+
+## Out Of Scope
+
+- Container provisioning or VPN topology wiring (post-v1)
+- Automatic Transmission configuration changes
+
+## Exit Condition
+
+The compatibility status badge renders correctly in the wizard and on `/config` for all four states. A custom operator-managed Transmission at a non-default URL shows `compatible` or `compatible_custom` and is not blocked. `not_reachable` shows a warning but does not prevent the operator from saving the config.
+
+## Rationale
+
+Pirate Claw's recommended deployment is bundled Transmission + VPN, but many operators run their own Transmission. The compatibility display makes the distinction explicit without gatekeeping. An operator who knowingly runs a custom setup should see an advisory, not a hard error. The four-state vocabulary (`recommended | compatible | compatible_custom | not_reachable`) gives the UI enough signal to communicate nuance without requiring the backend to know anything about how Transmission was deployed.

--- a/docs/02-delivery/phase-22/ticket-06-retrospective.md
+++ b/docs/02-delivery/phase-22/ticket-06-retrospective.md
@@ -1,0 +1,29 @@
+# P22.06 Phase 22 Retrospective and Doc Update
+
+## Goal
+
+Close out Phase 22 with a retrospective, mark delivery complete, and update the product doc and implementation plan with any decisions or tradeoffs that changed during delivery.
+
+## Scope
+
+- Write `notes/public/phase-22-retrospective.md` covering:
+  - what the phase delivered vs. the original scope
+  - any decisions that shifted during delivery (schema changes, wizard UX tradeoffs, readiness model edge cases)
+  - what P22.5 (Plex browser auth) and post-v1 bundling should know before they start
+  - any durable learning that affects later phases
+- Update `docs/01-product/phase-22-browser-only-setup.md` delivery status to `Complete`
+- Update `docs/02-delivery/phase-22/implementation-plan.md` delivery status to `Complete`
+- Update `docs/02-delivery/phase-21/implementation-plan.md` P21 deferrals section if any were resolved here
+
+## Out Of Scope
+
+- New feature work
+- P22.5 Plex auth scoping (that belongs in the P22.5 product doc)
+
+## Exit Condition
+
+Retrospective written. Product doc and implementation plan marked complete. No open delivery TODOs in the phase directory.
+
+## Rationale
+
+Phase 22 earns the browser-only setup claim — a meaningful product milestone. The retrospective captures what worked, what bent during delivery, and what P22.5 and the post-v1 bundling phase need to know. Skipping it would lose the signal at the exact moment it is most legible.

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,7 +1,5 @@
 export type SetupState = 'starter' | 'partially_configured' | 'ready';
 
-const DEFAULT_TRANSMISSION_URL = 'http://localhost:9091/transmission/rpc';
-
 export async function getSetupState(path: string): Promise<SetupState> {
   const file = Bun.file(path);
 
@@ -33,17 +31,29 @@ export async function getSetupState(path: string): Promise<SetupState> {
     | undefined;
 
   const feedsNonEmpty = Array.isArray(feeds) && feeds.length > 0;
-  const tvNonEmpty = Array.isArray(tv)
-    ? tv.length > 0
-    : typeof tv === 'object' &&
-      tv !== null &&
-      Array.isArray((tv as Record<string, unknown>).shows) &&
-      ((tv as Record<string, unknown>).shows as unknown[]).length > 0;
-  const transmissionCustom =
-    typeof transmission?.url === 'string' &&
-    transmission.url !== DEFAULT_TRANSMISSION_URL;
+  const transmissionUrlSet =
+    typeof transmission?.url === 'string' && transmission.url.length > 0;
 
-  if (feedsNonEmpty && tvNonEmpty && transmissionCustom) {
+  if (!feedsNonEmpty || !transmissionUrlSet) {
+    return 'partially_configured';
+  }
+
+  const mediaTypes = new Set(
+    (feeds as Array<Record<string, unknown>>).map((f) => f.mediaType),
+  );
+
+  const tvComplete =
+    !mediaTypes.has('tv') ||
+    (Array.isArray(tv)
+      ? tv.length > 0
+      : typeof tv === 'object' &&
+        tv !== null &&
+        Array.isArray((tv as Record<string, unknown>).shows) &&
+        ((tv as Record<string, unknown>).shows as unknown[]).length > 0);
+
+  const movieComplete = !mediaTypes.has('movie') || config.movies !== undefined;
+
+  if (tvComplete && movieComplete) {
     return 'ready';
   }
 

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -56,8 +56,6 @@ export async function ensureStarterConfig(path: string): Promise<void> {
     return;
   }
 
-  const year = new Date().getFullYear();
-
   const starter = {
     _starter: true,
     transmission: {
@@ -69,12 +67,6 @@ export async function ensureStarterConfig(path: string): Promise<void> {
       url: 'http://localhost:32400',
       token: '',
       refreshIntervalMinutes: 0,
-    },
-    movies: {
-      years: [year - 1, year],
-      resolutions: ['1080p'],
-      codecs: ['x264'],
-      codecPolicy: 'prefer',
     },
     tv: {
       defaults: { resolutions: ['1080p'], codecs: ['x264'] },

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,7 +87,7 @@ export type AppConfig = {
   tv: TvRule[];
   /** Present when the config file uses compact tv format with explicit defaults. */
   tvDefaults?: CompactTvDefaults;
-  movies: MoviePolicy;
+  movies?: MoviePolicy;
   transmission: TransmissionConfig;
   runtime: RuntimeConfig;
   tmdb?: TmdbConfig;
@@ -142,14 +142,13 @@ export function validateConfig(
   }
 
   const feeds = requireArray(input, 'feeds', path);
-  const movies = requireRecord(input, 'movies', path);
   const transmission = requireRecord(input, 'transmission', path);
 
   return {
     feeds: feeds.map((entry, index) => validateFeed(entry, path, index)),
     tv: validateTvConfig(input.tv, path),
     tvDefaults: extractTvDefaults(input.tv, path),
-    movies: validateMoviePolicy(movies, path),
+    movies: validateOptionalMoviePolicy(input.movies, path),
     transmission: validateTransmission(transmission, path, env),
     runtime: validateRuntime(input.runtime, path, env),
     tmdb: validateOptionalTmdb(input.tmdb, path),
@@ -352,6 +351,17 @@ export function validateMoviePolicy(
     ),
     codecPolicy: requireMovieCodecPolicy(rule, `${path} movies codecPolicy`),
   };
+}
+
+function validateOptionalMoviePolicy(
+  input: unknown,
+  path: string,
+): MoviePolicy | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  return validateMoviePolicy(expectRecord(input, `${path} movies`), path);
 }
 
 function requireMovieCodecPolicy(

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -185,6 +185,10 @@ function matchFeedItem(
     return matchTvItem(normalized, config.tv)[0];
   }
 
+  if (!config.movies) {
+    return undefined;
+  }
+
   return matchMovieItem(normalized, config.movies);
 }
 
@@ -192,7 +196,7 @@ function getFeedItemNoMatchReason(
   normalized: NormalizedFeedItem,
   config: AppConfig,
 ): string | undefined {
-  if (normalized.mediaType === 'movie') {
+  if (normalized.mediaType === 'movie' && config.movies) {
     return getMovieNoMatchReason(normalized, config.movies);
   }
 

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1762,8 +1762,8 @@ describe('PUT /api/config/movies', () => {
       const newEtag = res.headers.get('etag');
       expect(newEtag).not.toBe(etag);
 
-      expect(holder.current.movies.years).toEqual([2023, 2024]);
-      expect(holder.current.movies.codecPolicy).toBe('require');
+      expect(holder.current.movies?.years).toEqual([2023, 2024]);
+      expect(holder.current.movies?.codecPolicy).toBe('require');
 
       const disk = await Bun.file(configPath).json();
       expect(disk.movies.codecPolicy).toBe('require');

--- a/test/bootstrap.test.ts
+++ b/test/bootstrap.test.ts
@@ -34,8 +34,7 @@ describe('ensureStarterConfig', () => {
     expect(Array.isArray(written.tv.shows)).toBe(true);
     expect(written.tv.shows.length).toBe(0);
 
-    const year = new Date().getFullYear();
-    expect(written.movies.years).toEqual([year - 1, year]);
+    expect(written.movies).toBeUndefined();
   });
 
   it('does nothing when the file already exists', async () => {
@@ -67,12 +66,6 @@ describe('ensureStarterConfig', () => {
         password: 'admin',
       },
       plex: { url: 'http://localhost:32400', token: '' },
-      movies: {
-        years: [2024, 2025],
-        resolutions: ['1080p'],
-        codecs: ['x264'],
-        codecPolicy: 'prefer',
-      },
       tv: { defaults: { resolutions: ['1080p'], codecs: ['x264'] }, shows: [] },
       feeds: [],
     };

--- a/test/bootstrap.test.ts
+++ b/test/bootstrap.test.ts
@@ -138,4 +138,131 @@ describe('getSetupState', () => {
     await Bun.write(path, 'not json');
     expect(await getSetupState(path)).toBe('partially_configured');
   });
+
+  it('returns "ready" for TV-only feeds with tv.shows non-empty and any transmission URL', async () => {
+    const path = join(dir, 'tv-only-ready.json');
+    await Bun.write(
+      path,
+      JSON.stringify({
+        transmission: { url: 'http://mybox:9091/transmission/rpc' },
+        tv: {
+          defaults: { resolutions: ['1080p'], codecs: ['x264'] },
+          shows: ['Breaking Bad'],
+        },
+        feeds: [
+          { name: 'rss', url: 'https://example.com/rss', mediaType: 'tv' },
+        ],
+      }),
+    );
+    expect(await getSetupState(path)).toBe('ready');
+  });
+
+  it('returns "ready" for movie-only feeds with movies present and any transmission URL', async () => {
+    const path = join(dir, 'movie-only-ready.json');
+    await Bun.write(
+      path,
+      JSON.stringify({
+        transmission: { url: 'http://mybox:9091/transmission/rpc' },
+        movies: {
+          years: [2024],
+          resolutions: ['1080p'],
+          codecs: ['x264'],
+          codecPolicy: 'prefer',
+        },
+        feeds: [
+          { name: 'rss', url: 'https://example.com/rss', mediaType: 'movie' },
+        ],
+      }),
+    );
+    expect(await getSetupState(path)).toBe('ready');
+  });
+
+  it('returns "ready" for mixed feeds with both targets configured', async () => {
+    const path = join(dir, 'mixed-ready.json');
+    await Bun.write(
+      path,
+      JSON.stringify({
+        transmission: { url: 'http://mybox:9091/transmission/rpc' },
+        movies: {
+          years: [2024],
+          resolutions: ['1080p'],
+          codecs: ['x264'],
+          codecPolicy: 'prefer',
+        },
+        tv: {
+          defaults: { resolutions: ['1080p'], codecs: ['x264'] },
+          shows: ['Breaking Bad'],
+        },
+        feeds: [
+          { name: 'tv', url: 'https://example.com/tv', mediaType: 'tv' },
+          {
+            name: 'movies',
+            url: 'https://example.com/movies',
+            mediaType: 'movie',
+          },
+        ],
+      }),
+    );
+    expect(await getSetupState(path)).toBe('ready');
+  });
+
+  it('returns "ready" for bundled deployment at default transmission URL', async () => {
+    const path = join(dir, 'default-url-ready.json');
+    await Bun.write(
+      path,
+      JSON.stringify({
+        transmission: { url: 'http://localhost:9091/transmission/rpc' },
+        tv: {
+          defaults: { resolutions: ['1080p'], codecs: ['x264'] },
+          shows: ['Breaking Bad'],
+        },
+        feeds: [
+          { name: 'rss', url: 'https://example.com/rss', mediaType: 'tv' },
+        ],
+      }),
+    );
+    expect(await getSetupState(path)).toBe('ready');
+  });
+
+  it('returns "partially_configured" for TV feeds when tv.shows empty', async () => {
+    const path = join(dir, 'tv-empty-shows.json');
+    await Bun.write(
+      path,
+      JSON.stringify({
+        transmission: { url: 'http://mybox:9091/transmission/rpc' },
+        movies: {
+          years: [2024],
+          resolutions: ['1080p'],
+          codecs: ['x264'],
+          codecPolicy: 'prefer',
+        },
+        tv: {
+          defaults: { resolutions: ['1080p'], codecs: ['x264'] },
+          shows: [],
+        },
+        feeds: [
+          { name: 'rss', url: 'https://example.com/rss', mediaType: 'tv' },
+        ],
+      }),
+    );
+    expect(await getSetupState(path)).toBe('partially_configured');
+  });
+
+  it('returns "partially_configured" for movie feeds when movies absent', async () => {
+    const path = join(dir, 'movie-no-config.json');
+    await Bun.write(
+      path,
+      JSON.stringify({
+        transmission: { url: 'http://mybox:9091/transmission/rpc' },
+        tv: {
+          defaults: { resolutions: ['1080p'], codecs: ['x264'] },
+          shows: ['Breaking Bad'],
+        },
+        feeds: [
+          { name: 'rss', url: 'https://example.com/rss', mediaType: 'movie' },
+        ],
+      }),
+    );
+    expect(await getSetupState(path)).toBe('partially_configured');
+  });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -171,9 +171,9 @@ describe('validateConfig', () => {
 
     expect(config.tv[0]?.resolutions).toEqual(['1080p']);
     expect(config.tv[0]?.codecs).toEqual(['x265', 'x264']);
-    expect(config.movies.resolutions).toEqual(['2160p', '1080p']);
-    expect(config.movies.codecs).toEqual(['x265']);
-    expect(config.movies.codecPolicy).toBe('prefer');
+    expect(config.movies?.resolutions).toEqual(['2160p', '1080p']);
+    expect(config.movies?.codecs).toEqual(['x265']);
+    expect(config.movies?.codecPolicy).toBe('prefer');
   });
 
   it('parses movies.codecPolicy when set to require', () => {
@@ -187,7 +187,14 @@ describe('validateConfig', () => {
       },
     });
 
-    expect(config.movies.codecPolicy).toBe('require');
+    expect(config.movies?.codecPolicy).toBe('require');
+  });
+
+  it('accepts config without movies key; config.movies is undefined', () => {
+    const base = createMinimalConfig() as Record<string, unknown>;
+    delete base.movies;
+    const config = validateConfig(base);
+    expect(config.movies).toBeUndefined();
   });
 
   it('fails with a precise movies.codecPolicy path when the value is unsupported', () => {

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -236,6 +236,41 @@ describe('runPipeline', () => {
     ]);
   });
 
+  it('skips movie items without throwing when config.movies is absent', async () => {
+    const repository = createTestRepository(await createDatabasePath());
+    const configWithoutMovies = createConfig({
+      feeds: [
+        {
+          name: 'Movie Feed',
+          url: 'https://example.test/movie.rss',
+          mediaType: 'movie',
+        },
+      ],
+      tv: [],
+    });
+    delete (configWithoutMovies as Record<string, unknown>).movies;
+
+    const result = await runPipeline({
+      config: configWithoutMovies,
+      repository,
+      downloader: {
+        submit: async () => ({ ok: true as const, status: 'queued' as const }),
+      },
+      fetchFeed: async () => [
+        {
+          feedName: 'Movie Feed',
+          guidOrLink: 'https://example.test/releases/some-movie',
+          rawTitle: 'Some.Movie.2024.1080p.WEB.x265-GROUP',
+          publishedAt: '2026-03-30T00:00:00.000Z',
+          downloadUrl: 'https://example.test/downloads/some-movie.torrent',
+        },
+      ],
+    });
+
+    expect(result.counts.queued).toBe(0);
+    expect(result.counts.skipped_no_match).toBe(1);
+  });
+
   it('passes per-media-type downloadDir to downloader submit', async () => {
     const repository = createTestRepository(await createDatabasePath());
     const submissions: SubmitDownloadInput[] = [];


### PR DESCRIPTION
## Summary

- delivery ticket: `P22.02 getSetupState Readiness Condition Fix`
- ticket file: [docs/02-delivery/phase-22/ticket-02-setup-state-readiness-condition-fix.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-22/ticket-02-setup-state-readiness-condition-fix.md)
- stacked base branch: `agents/p22-01-starter-config-cleanup-and-movies-optional-schema`