### PR TITLE
feat(api): runtime readiness model and daemon liveness [P22.04]

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -369,6 +369,34 @@ export function createApiFetch(
       }
     }
 
+    if (path === '/api/setup/readiness' && request.method === 'GET') {
+      try {
+        const configState = await getSetupState(configPath);
+        const daemonLive = true;
+        let transmissionReachable = false;
+        if (configState === 'ready') {
+          const pingResult = await fetchSessionInfo(activeConfig.transmission);
+          transmissionReachable = pingResult.ok === true;
+        }
+        let state: 'not_ready' | 'ready_pending_restart' | 'ready';
+        if (configState !== 'ready') {
+          state = 'not_ready';
+        } else if (!daemonLive || !transmissionReachable) {
+          state = 'ready_pending_restart';
+        } else {
+          state = 'ready';
+        }
+        return Response.json({
+          state,
+          configState,
+          transmissionReachable,
+          daemonLive,
+        });
+      } catch {
+        return json500();
+      }
+    }
+
     if (path === '/api/status') {
       return safeJson(() => ({ runs: repository.listRecentRunSummaries() }));
     }

--- a/src/api.ts
+++ b/src/api.ts
@@ -931,12 +931,19 @@ export function createApiFetch(
         if (tvDir !== undefined) downloadDirs.tv = tvDir;
         if (movieDir !== undefined) downloadDirs.movie = movieDir;
 
+        const nextTransmission = {
+          ...existingTransmission,
+          ...(Object.keys(downloadDirs).length > 0
+            ? { downloadDirs }
+            : { downloadDirs: undefined }),
+        };
+        if (nextTransmission.downloadDirs === undefined) {
+          delete nextTransmission.downloadDirs;
+        }
+
         const merged = {
           ...baseOnDisk,
-          transmission: {
-            ...existingTransmission,
-            ...(Object.keys(downloadDirs).length > 0 ? { downloadDirs } : {}),
-          },
+          transmission: nextTransmission,
         };
 
         const validated = validateConfig(

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -246,6 +246,113 @@ describe('GET /api/setup/state', () => {
   });
 });
 
+describe('GET /api/setup/readiness', () => {
+  it('returns not_ready when configState is partially_configured', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'pirate-claw-api-test-'));
+    const configPath = join(dir, 'pirate-claw.config.json');
+    await Bun.write(
+      configPath,
+      JSON.stringify({
+        transmission: { url: 'http://localhost:9091/transmission/rpc' },
+        feeds: [],
+        tv: [],
+      }),
+    );
+
+    const deps = { ...createDeps(), configPath };
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/setup/readiness'),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.state).toBe('not_ready');
+    expect(body.configState).toBe('partially_configured');
+    expect(body.daemonLive).toBe(true);
+  });
+
+  it('returns not_ready when configState is starter', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'pirate-claw-api-test-'));
+    const configPath = join(dir, 'pirate-claw.config.json');
+    await Bun.write(
+      configPath,
+      JSON.stringify({
+        _starter: true,
+        transmission: { url: '' },
+        feeds: [],
+        tv: [],
+      }),
+    );
+
+    const deps = { ...createDeps(), configPath };
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/setup/readiness'),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.state).toBe('not_ready');
+    expect(body.configState).toBe('starter');
+  });
+
+  it('returns ready_pending_restart when config is ready but transmission unreachable', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'pirate-claw-api-test-'));
+    const configPath = join(dir, 'pirate-claw.config.json');
+    await Bun.write(
+      configPath,
+      JSON.stringify({
+        transmission: {
+          url: 'http://192.168.1.100:9091/transmission/rpc',
+          username: 'op',
+          password: 'x',
+        },
+        tv: [
+          { name: 'Breaking Bad', resolutions: ['1080p'], codecs: ['x264'] },
+        ],
+        feeds: [
+          { name: 'rss', url: 'https://example.com/rss', mediaType: 'tv' },
+        ],
+      }),
+    );
+
+    const deps = {
+      ...createDeps(),
+      configPath,
+      config: {
+        ...createDeps().config,
+        transmission: {
+          url: 'http://127.0.0.1:1/transmission/rpc',
+          username: 'u',
+          password: 'p',
+        },
+      },
+    };
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/setup/readiness'),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.state).toBe('ready_pending_restart');
+    expect(body.configState).toBe('ready');
+    expect(body.transmissionReachable).toBe(false);
+    expect(body.daemonLive).toBe(true);
+  });
+
+  it('requires no auth', async () => {
+    const deps = createDeps();
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/setup/readiness'),
+    );
+    expect(response.status).not.toBe(401);
+    expect(response.status).not.toBe(403);
+  });
+});
+
 describe('GET /api/health', () => {
   it('returns uptime and startedAt', async () => {
     const deps = createDeps();

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1883,6 +1883,88 @@ describe('PUT /api/config/movies', () => {
   });
 });
 
+describe('PUT /api/config/transmission/download-dirs', () => {
+  async function makeDownloadDirsHandler() {
+    const prevWrite = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    const directory = await mkdtemp(
+      join(tmpdir(), 'pirate-claw-download-dirs-'),
+    );
+    const configPath = join(directory, 'pirate-claw.config.json');
+    await writeCompactTvConfigFile(configPath);
+    const loaded = await loadConfig(configPath);
+    const holder = {
+      current: {
+        ...loaded,
+        transmission: {
+          ...loaded.transmission,
+          downloadDirs: { tv: '/downloads/tv', movie: '/downloads/movies' },
+        },
+        runtime: { ...loaded.runtime, apiWriteToken: 'write-token' },
+      },
+    };
+    await Bun.write(
+      configPath,
+      JSON.stringify(
+        {
+          feeds: loaded.feeds,
+          tv: {
+            defaults: loaded.tvDefaults,
+            shows: ['Example Show'],
+          },
+          movies: loaded.movies,
+          transmission: {
+            ...loaded.transmission,
+            downloadDirs: { tv: '/downloads/tv', movie: '/downloads/movies' },
+          },
+          runtime: {
+            ...loaded.runtime,
+            apiWriteToken: 'write-token',
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    const deps = createDeps();
+    deps.config = holder.current;
+    deps.configHolder = holder;
+    deps.configPath = configPath;
+    const handler = createApiFetch(deps);
+    const get = await handler(new Request('http://localhost/api/config'));
+    const etag = get.headers.get('etag')!;
+    return { handler, holder, configPath, etag, prevWrite };
+  }
+
+  it('removes transmission.downloadDirs when both values are cleared', async () => {
+    const { handler, holder, configPath, etag, prevWrite } =
+      await makeDownloadDirsHandler();
+    try {
+      const res = await handler(
+        new Request('http://localhost/api/config/transmission/download-dirs', {
+          method: 'PUT',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer write-token',
+            'if-match': etag,
+          },
+          body: JSON.stringify({}),
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(holder.current.transmission.downloadDirs).toBeUndefined();
+
+      const disk = await Bun.file(configPath).json();
+      expect(disk.transmission.downloadDirs).toBeUndefined();
+    } finally {
+      if (prevWrite !== undefined)
+        process.env.PIRATE_CLAW_API_WRITE_TOKEN = prevWrite;
+      else delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    }
+  });
+});
+
 describe('buildShowBreakdowns', () => {
   it('sorts shows by title and seasons/episodes by number', () => {
     const candidates = [

--- a/test/fixtures/readiness-not-ready.json
+++ b/test/fixtures/readiness-not-ready.json
@@ -1,0 +1,6 @@
+{
+  "state": "not_ready",
+  "configState": "partially_configured",
+  "transmissionReachable": false,
+  "daemonLive": true
+}

--- a/test/fixtures/readiness-ready-pending-restart.json
+++ b/test/fixtures/readiness-ready-pending-restart.json
@@ -1,0 +1,6 @@
+{
+  "state": "ready_pending_restart",
+  "configState": "ready",
+  "transmissionReachable": false,
+  "daemonLive": true
+}

--- a/test/fixtures/readiness-ready.json
+++ b/test/fixtures/readiness-ready.json
@@ -1,0 +1,6 @@
+{
+  "state": "ready",
+  "configState": "ready",
+  "transmissionReachable": true,
+  "daemonLive": true
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -237,3 +237,13 @@ export type DaemonHealth = {
 	lastRunCycle?: CycleSnapshot;
 	lastReconcileCycle?: CycleSnapshot;
 };
+
+export type SetupState = 'starter' | 'partially_configured' | 'ready';
+export type ReadinessState = 'not_ready' | 'ready_pending_restart' | 'ready';
+
+export type ReadinessResponse = {
+	state: ReadinessState;
+	configState: SetupState;
+	transmissionReachable: boolean;
+	daemonLive: boolean;
+};

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -3,6 +3,7 @@ import type {
 	AppConfig,
 	DaemonHealth,
 	ReadinessResponse,
+	ReadinessState,
 	SessionInfo,
 	SetupState
 } from '$lib/types';
@@ -12,6 +13,12 @@ function normalizeSetupState(state: unknown): SetupState {
 	return state === 'starter' || state === 'partially_configured' || state === 'ready'
 		? state
 		: 'partially_configured';
+}
+
+function normalizeReadinessState(state: unknown): ReadinessState {
+	return state === 'not_ready' || state === 'ready_pending_restart' || state === 'ready'
+		? state
+		: 'not_ready';
 }
 
 export const load: LayoutServerLoad = async () => {
@@ -45,6 +52,6 @@ export const load: LayoutServerLoad = async () => {
 		transmissionSession: sessionResult.status === 'fulfilled' ? sessionResult.value : null,
 		plexConfigured: configResult.status === 'fulfilled' && configResult.value.plex !== undefined,
 		setupState: normalizeSetupState(readiness?.configState),
-		readinessState: readiness?.state ?? 'not_ready'
+		readinessState: normalizeReadinessState(readiness?.state)
 	};
 };

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -1,21 +1,25 @@
 import { apiFetch } from '$lib/server/api';
-import type { AppConfig, DaemonHealth, SessionInfo } from '$lib/types';
+import type {
+	AppConfig,
+	DaemonHealth,
+	ReadinessResponse,
+	SessionInfo,
+	SetupState
+} from '$lib/types';
 import type { LayoutServerLoad } from './$types';
 
-type SetupStateResponse = { state: 'starter' | 'partially_configured' | 'ready' };
-
-function normalizeSetupState(state: unknown): SetupStateResponse['state'] {
+function normalizeSetupState(state: unknown): SetupState {
 	return state === 'starter' || state === 'partially_configured' || state === 'ready'
 		? state
 		: 'partially_configured';
 }
 
 export const load: LayoutServerLoad = async () => {
-	const [healthResult, sessionResult, configResult, setupStateResult] = await Promise.allSettled([
+	const [healthResult, sessionResult, configResult, readinessResult] = await Promise.allSettled([
 		apiFetch<DaemonHealth>('/api/health'),
 		apiFetch<SessionInfo>('/api/transmission/session'),
 		apiFetch<AppConfig>('/api/config'),
-		apiFetch<SetupStateResponse>('/api/setup/state')
+		apiFetch<ReadinessResponse>('/api/setup/readiness')
 	]);
 
 	if (healthResult.status === 'rejected') {
@@ -30,17 +34,17 @@ export const load: LayoutServerLoad = async () => {
 		console.error('[layout] failed to load /api/config:', configResult.reason);
 	}
 
-	if (setupStateResult.status === 'rejected') {
-		console.error('[layout] failed to load /api/setup/state:', setupStateResult.reason);
+	if (readinessResult.status === 'rejected') {
+		console.error('[layout] failed to load /api/setup/readiness:', readinessResult.reason);
 	}
+
+	const readiness = readinessResult.status === 'fulfilled' ? readinessResult.value : null;
 
 	return {
 		health: healthResult.status === 'fulfilled' ? healthResult.value : null,
 		transmissionSession: sessionResult.status === 'fulfilled' ? sessionResult.value : null,
 		plexConfigured: configResult.status === 'fulfilled' && configResult.value.plex !== undefined,
-		setupState:
-			setupStateResult.status === 'fulfilled'
-				? normalizeSetupState(setupStateResult.value.state)
-				: 'partially_configured'
+		setupState: normalizeSetupState(readiness?.configState),
+		readinessState: readiness?.state ?? 'not_ready'
 	};
 };

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -42,8 +42,12 @@
 	const isOnboarding = $derived($page.url.pathname === '/onboarding');
 	const showSidebar = $derived(!isOnboarding);
 	const setupState = $derived(data.setupState ?? 'partially_configured');
+	const readinessState = $derived(data.readinessState ?? 'not_ready');
 	const isStarter = $derived(setupState === 'starter' && !isOnboarding);
 	const isPartiallyConfigured = $derived(setupState === 'partially_configured');
+	const isReadyPendingRestart = $derived(
+		readinessState === 'ready_pending_restart' && !isOnboarding
+	);
 </script>
 
 <svelte:head>
@@ -140,6 +144,13 @@
 						data-testid="partial-config-banner"
 					>
 						Setup incomplete — some services may be unavailable until configuration is complete.
+					</div>
+				{:else if isReadyPendingRestart}
+					<div
+						class="bg-warning/10 border-warning/30 text-warning mb-4 rounded-lg border px-4 py-2 text-sm"
+						data-testid="ready-pending-restart-banner"
+					>
+						Restart daemon to apply config changes.
 					</div>
 				{/if}
 				{@render children()}

--- a/web/src/routes/dashboard.test.ts
+++ b/web/src/routes/dashboard.test.ts
@@ -81,6 +81,7 @@ const baseData = {
 	transmissionSession: null,
 	plexConfigured: false,
 	setupState: 'ready' as const,
+	readinessState: 'ready' as const,
 	transmissionTorrents: [],
 	candidates: [],
 	runSummaries: [],

--- a/web/src/routes/layout.server.test.ts
+++ b/web/src/routes/layout.server.test.ts
@@ -33,7 +33,12 @@ describe('layout server load', () => {
 					refreshIntervalMinutes: 30
 				}
 			})
-			.mockResolvedValueOnce({ state: 'ready' });
+			.mockResolvedValueOnce({
+				state: 'ready',
+				configState: 'ready',
+				transmissionReachable: true,
+				daemonLive: true
+			});
 
 		const result = await load({} as never);
 
@@ -50,11 +55,12 @@ describe('layout server load', () => {
 				currentUploadedBytes: 0
 			},
 			plexConfigured: true,
-			setupState: 'ready'
+			setupState: 'ready',
+			readinessState: 'ready'
 		});
 	});
 
-	it('returns setupState=starter when setup/state reports starter', async () => {
+	it('returns setupState=starter when readiness reports starter configState', async () => {
 		const { load } = await import('./+layout.server');
 
 		apiFetchMock
@@ -68,13 +74,19 @@ describe('layout server load', () => {
 			.mockResolvedValueOnce({
 				plex: { url: 'http://localhost:32400', token: '', refreshIntervalMinutes: 30 }
 			})
-			.mockResolvedValueOnce({ state: 'starter' });
+			.mockResolvedValueOnce({
+				state: 'not_ready',
+				configState: 'starter',
+				transmissionReachable: false,
+				daemonLive: true
+			});
 
-		const result = (await load({} as never)) as { setupState: string };
+		const result = (await load({} as never)) as { setupState: string; readinessState: string };
 		expect(result.setupState).toBe('starter');
+		expect(result.readinessState).toBe('not_ready');
 	});
 
-	it('normalizes unknown setup state values to partially_configured', async () => {
+	it('normalizes unknown configState values to partially_configured', async () => {
 		const { load } = await import('./+layout.server');
 
 		apiFetchMock
@@ -88,7 +100,12 @@ describe('layout server load', () => {
 			.mockResolvedValueOnce({
 				plex: { url: 'http://localhost:32400', token: '', refreshIntervalMinutes: 30 }
 			})
-			.mockResolvedValueOnce({ state: 'mystery' });
+			.mockResolvedValueOnce({
+				state: 'not_ready',
+				configState: 'mystery',
+				transmissionReachable: false,
+				daemonLive: true
+			});
 
 		const result = (await load({} as never)) as { setupState: string };
 		expect(result.setupState).toBe('partially_configured');
@@ -103,7 +120,7 @@ describe('layout server load', () => {
 				.mockRejectedValueOnce(new Error('health down'))
 				.mockRejectedValueOnce(new Error('tx down'))
 				.mockRejectedValueOnce(new Error('config down'))
-				.mockRejectedValueOnce(new Error('setup down'));
+				.mockRejectedValueOnce(new Error('readiness down'));
 
 			const result = await load({} as never);
 
@@ -111,7 +128,8 @@ describe('layout server load', () => {
 				health: null,
 				transmissionSession: null,
 				plexConfigured: false,
-				setupState: 'partially_configured'
+				setupState: 'partially_configured',
+				readinessState: 'not_ready'
 			});
 		} finally {
 			errorSpy.mockRestore();

--- a/web/src/routes/layout.server.test.ts
+++ b/web/src/routes/layout.server.test.ts
@@ -111,6 +111,31 @@ describe('layout server load', () => {
 		expect(result.setupState).toBe('partially_configured');
 	});
 
+	it('normalizes unknown readinessState values to not_ready', async () => {
+		const { load } = await import('./+layout.server');
+
+		apiFetchMock
+			.mockResolvedValueOnce({ uptime: 1, startedAt: '2024-01-01T00:00:00Z' })
+			.mockResolvedValueOnce({
+				version: '3.0',
+				downloadSpeed: 0,
+				uploadSpeed: 0,
+				activeTorrentCount: 0
+			})
+			.mockResolvedValueOnce({
+				plex: { url: 'http://localhost:32400', token: '', refreshIntervalMinutes: 30 }
+			})
+			.mockResolvedValueOnce({
+				state: 'mystery',
+				configState: 'ready',
+				transmissionReachable: true,
+				daemonLive: true
+			});
+
+		const result = (await load({} as never)) as { readinessState: string };
+		expect(result.readinessState).toBe('not_ready');
+	});
+
 	it('tolerates unavailable shared endpoints and returns nulls', async () => {
 		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 		try {

--- a/web/src/routes/layout.test.ts
+++ b/web/src/routes/layout.test.ts
@@ -68,7 +68,8 @@ describe('+layout.svelte', () => {
 					health: mockHealth,
 					transmissionSession: mockSession,
 					plexConfigured: true,
-					setupState: 'ready' as const
+					setupState: 'ready' as const,
+					readinessState: 'ready' as const
 				}
 			}
 		});
@@ -106,7 +107,8 @@ describe('+layout.svelte', () => {
 					health: null,
 					transmissionSession: null,
 					plexConfigured: false,
-					setupState: 'partially_configured' as const
+					setupState: 'partially_configured' as const,
+					readinessState: 'not_ready' as const
 				}
 			}
 		});
@@ -130,7 +132,8 @@ describe('+layout.svelte', () => {
 					health: null,
 					transmissionSession: null,
 					plexConfigured: false,
-					setupState: 'starter' as const
+					setupState: 'starter' as const,
+					readinessState: 'not_ready' as const
 				}
 			}
 		});
@@ -155,7 +158,8 @@ describe('+layout.svelte', () => {
 					health: null,
 					transmissionSession: null,
 					plexConfigured: false,
-					setupState: 'starter' as const
+					setupState: 'starter' as const,
+					readinessState: 'not_ready' as const
 				}
 			}
 		});
@@ -175,12 +179,34 @@ describe('+layout.svelte', () => {
 					health: mockHealth,
 					transmissionSession: mockSession,
 					plexConfigured: true,
-					setupState: 'partially_configured' as const
+					setupState: 'partially_configured' as const,
+					readinessState: 'not_ready' as const
 				}
 			}
 		});
 
 		expect(screen.getByTestId('partial-config-banner')).toBeInTheDocument();
+		expect(screen.queryByTestId('starter-mode-splash')).not.toBeInTheDocument();
+	});
+
+	it('renders ready-pending-restart banner when readinessState is ready_pending_restart', () => {
+		setPathname('/');
+
+		render(Layout, {
+			props: {
+				children: (() => {}) as unknown as import('svelte').Snippet,
+				data: {
+					health: mockHealth,
+					transmissionSession: mockSession,
+					plexConfigured: true,
+					setupState: 'ready' as const,
+					readinessState: 'ready_pending_restart' as const
+				}
+			}
+		});
+
+		expect(screen.getByTestId('ready-pending-restart-banner')).toBeInTheDocument();
+		expect(screen.queryByTestId('partial-config-banner')).not.toBeInTheDocument();
 		expect(screen.queryByTestId('starter-mode-splash')).not.toBeInTheDocument();
 	});
 
@@ -194,12 +220,14 @@ describe('+layout.svelte', () => {
 					health: mockHealth,
 					transmissionSession: mockSession,
 					plexConfigured: true,
-					setupState: 'ready' as const
+					setupState: 'ready' as const,
+					readinessState: 'ready' as const
 				}
 			}
 		});
 
 		expect(screen.queryByTestId('starter-mode-splash')).not.toBeInTheDocument();
 		expect(screen.queryByTestId('partial-config-banner')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('ready-pending-restart-banner')).not.toBeInTheDocument();
 	});
 });

--- a/web/src/routes/movies/movies.test.ts
+++ b/web/src/routes/movies/movies.test.ts
@@ -6,12 +6,13 @@ import type { PageData } from './$types';
 
 const sharedLayoutData: Pick<
 	PageData,
-	'health' | 'transmissionSession' | 'plexConfigured' | 'setupState'
+	'health' | 'transmissionSession' | 'plexConfigured' | 'setupState' | 'readinessState'
 > = {
 	health: null,
 	transmissionSession: null,
 	plexConfigured: false,
-	setupState: 'ready' as const
+	setupState: 'ready' as const,
+	readinessState: 'ready' as const
 };
 
 const mockMovie = (overrides: Partial<MovieBreakdown> = {}): MovieBreakdown => ({

--- a/web/src/routes/onboarding/+page.server.ts
+++ b/web/src/routes/onboarding/+page.server.ts
@@ -332,7 +332,7 @@ export const actions: Actions = {
 
 	testTransmission: async () => {
 		try {
-			const response = await apiRequest('/api/transmission/ping', { method: 'POST' });
+			const response = await apiRequest('/api/transmission/session');
 			const reachable = response.ok;
 			return { transmissionReachable: reachable };
 		} catch {

--- a/web/src/routes/onboarding/+page.server.ts
+++ b/web/src/routes/onboarding/+page.server.ts
@@ -2,16 +2,16 @@ import { env } from '$env/dynamic/private';
 import { fail } from '@sveltejs/kit';
 import { deriveOnboardingStatus } from '$lib/onboarding';
 import { apiRequest } from '$lib/server/api';
-import type { AppConfig, FeedConfig, MoviePolicy } from '$lib/types';
+import type { AppConfig, FeedConfig, MoviePolicy, ReadinessResponse } from '$lib/types';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
 	const canWrite = !!env.PIRATE_CLAW_API_WRITE_TOKEN;
 
 	try {
-		const [configResponse, setupStateResponse] = await Promise.all([
+		const [configResponse, readinessResponse] = await Promise.all([
 			apiRequest('/api/config'),
-			apiRequest('/api/setup/state')
+			apiRequest('/api/setup/readiness')
 		]);
 
 		if (!configResponse.ok) {
@@ -21,15 +21,15 @@ export const load: PageServerLoad = async () => {
 				etag: null,
 				canWrite,
 				onboarding: null,
-				setupState: null,
+				readinessState: null,
 				error: 'Could not reach the API.'
 			};
 		}
 
 		const config = (await configResponse.json()) as AppConfig;
 		const etag = configResponse.headers.get('etag');
-		const setupState = setupStateResponse.ok
-			? ((await setupStateResponse.json()) as { state: string }).state
+		const readinessState = readinessResponse.ok
+			? ((await readinessResponse.json()) as ReadinessResponse).state
 			: null;
 
 		return {
@@ -37,7 +37,7 @@ export const load: PageServerLoad = async () => {
 			etag,
 			canWrite,
 			onboarding: deriveOnboardingStatus(config, canWrite),
-			setupState,
+			readinessState,
 			error: null
 		};
 	} catch (error) {
@@ -47,7 +47,7 @@ export const load: PageServerLoad = async () => {
 			etag: null,
 			canWrite,
 			onboarding: null,
-			setupState: null,
+			readinessState: null,
 			error: 'Could not reach the API.'
 		};
 	}

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -7,6 +7,7 @@
 		writeOnboardingDismissed,
 		writeOnboardingPath
 	} from '$lib/onboarding';
+	import type { ReadinessState } from '$lib/types';
 	import type { ActionData, PageData } from './$types';
 
 	const ALL_RESOLUTIONS = ['2160p', '1080p', '720p', '480p'];
@@ -87,6 +88,38 @@
 			!!(form as { movieTargetSuccess?: boolean } | undefined)?.movieTargetSuccess
 	);
 	const showDoneStep = $derived(showPreStepsDone && minimumComplete && !showMovieTargetStep);
+
+	let readinessState = $state<ReadinessState>('not_ready');
+	let readinessInterval: ReturnType<typeof setInterval> | undefined;
+
+	$effect(() => {
+		if (!showDoneStep) return;
+		if (data.readinessState) readinessState = data.readinessState as ReadinessState;
+		if (!browser || readinessState === 'ready') return;
+		async function pollReadiness() {
+			try {
+				const res = await fetch('/api/setup/readiness');
+				if (res.ok) {
+					const json = (await res.json()) as { state: ReadinessState };
+					readinessState = json.state;
+					if (json.state === 'ready' && readinessInterval !== undefined) {
+						clearInterval(readinessInterval);
+						readinessInterval = undefined;
+					}
+				}
+			} catch {
+				// ignore transient errors
+			}
+		}
+		pollReadiness();
+		readinessInterval = setInterval(pollReadiness, 3000);
+		return () => {
+			if (readinessInterval !== undefined) {
+				clearInterval(readinessInterval);
+				readinessInterval = undefined;
+			}
+		};
+	});
 	const configuredFeedCount = $derived(data.config?.feeds.length ?? 0);
 	const firstFeedLabel = $derived(
 		configuredFeedCount > 0
@@ -842,10 +875,10 @@
 						<dt class="text-muted-foreground">Movie target</dt>
 						<dd class="font-medium">{hasMovieSummary ? 'Added' : 'Not added'}</dd>
 					</div>
-					{#if data.setupState}
+					{#if readinessState}
 						<div class="space-y-1">
-							<dt class="text-muted-foreground">Setup state</dt>
-							<dd class="font-medium">{data.setupState}</dd>
+							<dt class="text-muted-foreground">Readiness</dt>
+							<dd class="font-medium">{readinessState}</dd>
 						</div>
 					{/if}
 				</dl>
@@ -853,11 +886,11 @@
 				<div class="flex flex-wrap items-center gap-3">
 					<a
 						href="/"
-						class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-11 items-center rounded-xl px-5 text-sm font-semibold shadow-[0_12px_30px_rgb(20_184_166_/_0.18)] {data.setupState !==
+						class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-11 items-center rounded-xl px-5 text-sm font-semibold shadow-[0_12px_30px_rgb(20_184_166_/_0.18)] {readinessState !==
 						'ready'
 							? 'pointer-events-none opacity-50'
 							: ''}"
-						aria-disabled={data.setupState !== 'ready'}
+						aria-disabled={readinessState !== 'ready'}
 					>
 						Go to Dashboard
 					</a>

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -88,13 +88,16 @@
 			!!(form as { movieTargetSuccess?: boolean } | undefined)?.movieTargetSuccess
 	);
 	const showDoneStep = $derived(showPreStepsDone && minimumComplete && !showMovieTargetStep);
+	const initialReadinessState = $derived(data.readinessState ?? 'not_ready');
 
 	let readinessState = $state<ReadinessState>('not_ready');
 	let readinessInterval: ReturnType<typeof setInterval> | undefined;
 
 	$effect(() => {
 		if (!showDoneStep) return;
-		if (data.readinessState) readinessState = data.readinessState as ReadinessState;
+		if (readinessState === 'not_ready' && initialReadinessState !== 'not_ready') {
+			readinessState = initialReadinessState;
+		}
 		if (!browser || readinessState === 'ready') return;
 		async function pollReadiness() {
 			try {
@@ -885,12 +888,13 @@
 
 				<div class="flex flex-wrap items-center gap-3">
 					<a
-						href="/"
+						href={readinessState === 'ready' ? '/' : undefined}
 						class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-11 items-center rounded-xl px-5 text-sm font-semibold shadow-[0_12px_30px_rgb(20_184_166_/_0.18)] {readinessState !==
 						'ready'
 							? 'pointer-events-none opacity-50'
 							: ''}"
 						aria-disabled={readinessState !== 'ready'}
+						tabindex={readinessState !== 'ready' ? -1 : undefined}
 					>
 						Go to Dashboard
 					</a>

--- a/web/src/routes/onboarding/onboarding.test.ts
+++ b/web/src/routes/onboarding/onboarding.test.ts
@@ -18,7 +18,8 @@ const sharedLayoutData = {
 	health: null,
 	transmissionSession: null,
 	plexConfigured: false,
-	setupState: 'ready' as const
+	setupState: 'ready' as const,
+	readinessState: 'ready' as const
 };
 
 function renderPage(data: Record<string, unknown>) {

--- a/web/src/routes/onboarding/onboarding.test.ts
+++ b/web/src/routes/onboarding/onboarding.test.ts
@@ -354,4 +354,30 @@ describe('/onboarding', () => {
 		expect(screen.getByText('Movie target')).toBeInTheDocument();
 		expect(screen.getByRole('link', { name: 'Go to Dashboard' })).toHaveAttribute('href', '/');
 	});
+
+	it('keeps the dashboard action unfocusable until readiness is ready', () => {
+		renderPage({
+			config: {
+				...configWithMoviesFixture,
+				feeds: [{ name: 'TV Feed', url: 'https://example.com/tv.rss', mediaType: 'tv' }],
+				movies: { years: [], resolutions: [], codecs: [], codecPolicy: 'prefer' }
+			},
+			etag: '"rev-3"',
+			canWrite: true,
+			onboarding: {
+				state: 'ready',
+				hasFeeds: true,
+				hasTvTargets: true,
+				hasMovieTargets: false,
+				minimumComplete: true
+			},
+			readinessState: 'ready_pending_restart',
+			error: null
+		});
+
+		const dashboardLink = screen.getByText('Go to Dashboard');
+		expect(dashboardLink).not.toHaveAttribute('href');
+		expect(dashboardLink).toHaveAttribute('tabindex', '-1');
+		expect(dashboardLink).toHaveAttribute('aria-disabled', 'true');
+	});
 });

--- a/web/src/routes/onboarding/page.server.test.ts
+++ b/web/src/routes/onboarding/page.server.test.ts
@@ -20,8 +20,18 @@ describe('onboarding page server', () => {
 			}));
 			const { load } = await import('./+page.server');
 			apiRequestMock.mockImplementation((url: string) =>
-				url === '/api/setup/state'
-					? Promise.resolve(new Response(JSON.stringify({ state: 'starter' }), { status: 200 }))
+				url === '/api/setup/readiness'
+					? Promise.resolve(
+							new Response(
+								JSON.stringify({
+									state: 'not_ready',
+									configState: 'starter',
+									transmissionReachable: false,
+									daemonLive: true
+								}),
+								{ status: 200 }
+							)
+						)
 					: Promise.resolve(new Response(JSON.stringify(emptyConfig), { status: 200 }))
 			);
 
@@ -37,8 +47,18 @@ describe('onboarding page server', () => {
 			}));
 			const { load } = await import('./+page.server');
 			apiRequestMock.mockImplementation((url: string) =>
-				url === '/api/setup/state'
-					? Promise.resolve(new Response(JSON.stringify({ state: 'starter' }), { status: 200 }))
+				url === '/api/setup/readiness'
+					? Promise.resolve(
+							new Response(
+								JSON.stringify({
+									state: 'not_ready',
+									configState: 'starter',
+									transmissionReachable: false,
+									daemonLive: true
+								}),
+								{ status: 200 }
+							)
+						)
 					: Promise.resolve(
 							new Response(JSON.stringify(emptyConfig), {
 								status: 200,
@@ -59,9 +79,17 @@ describe('onboarding page server', () => {
 			}));
 			const { load } = await import('./+page.server');
 			apiRequestMock.mockImplementation((url: string) =>
-				url === '/api/setup/state'
+				url === '/api/setup/readiness'
 					? Promise.resolve(
-							new Response(JSON.stringify({ state: 'partially_configured' }), { status: 200 })
+							new Response(
+								JSON.stringify({
+									state: 'not_ready',
+									configState: 'partially_configured',
+									transmissionReachable: false,
+									daemonLive: true
+								}),
+								{ status: 200 }
+							)
 						)
 					: Promise.resolve(
 							new Response(JSON.stringify(feedOnlyConfig), {

--- a/web/src/routes/onboarding/page.server.test.ts
+++ b/web/src/routes/onboarding/page.server.test.ts
@@ -509,4 +509,91 @@ describe('onboarding page server', () => {
 			);
 		});
 	});
+
+	describe('testTransmission', () => {
+		it('uses the read-only transmission session endpoint', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: {}
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						version: '3.00',
+						downloadSpeed: 0,
+						uploadSpeed: 0,
+						activeTorrentCount: 0,
+						cumulativeDownloadedBytes: 0,
+						cumulativeUploadedBytes: 0,
+						currentDownloadedBytes: 0,
+						currentUploadedBytes: 0
+					}),
+					{ status: 200 }
+				)
+			);
+
+			const result = await actions.testTransmission({} as never);
+
+			expect((result as { transmissionReachable?: boolean }).transmissionReachable).toBe(true);
+			expect(apiRequestMock).toHaveBeenCalledWith('/api/transmission/session');
+		});
+	});
+
+	describe('saveDownloadDirs', () => {
+		it('returns fail(400) when ifMatch is missing', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+
+			const body = new URLSearchParams();
+			body.set('tvDir', '/data/tv');
+
+			const result = await actions.saveDownloadDirs({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(400);
+			expect(
+				(result as { data?: { downloadDirsMessage?: string } }).data?.downloadDirsMessage
+			).toContain('Missing config revision');
+			expect(apiRequestMock).not.toHaveBeenCalled();
+		});
+
+		it('sends an empty object when both fields are blank so existing download dirs can be cleared', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(null, { status: 200, headers: { etag: '"rev-2"' } })
+			);
+
+			const body = new URLSearchParams();
+			body.set('ifMatch', '"rev-1"');
+			body.set('tvDir', '');
+			body.set('movieDir', '');
+
+			const result = await actions.saveDownloadDirs({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { downloadDirsSuccess?: boolean }).downloadDirsSuccess).toBe(true);
+			expect(apiRequestMock).toHaveBeenCalledWith(
+				'/api/config/transmission/download-dirs',
+				expect.objectContaining({
+					method: 'PUT',
+					body: JSON.stringify({})
+				})
+			);
+		});
+	});
 });

--- a/web/src/routes/shows/[slug]/shows.test.ts
+++ b/web/src/routes/shows/[slug]/shows.test.ts
@@ -6,12 +6,13 @@ import type { PageData } from './$types';
 
 const sharedLayoutData: Pick<
 	PageData,
-	'health' | 'transmissionSession' | 'plexConfigured' | 'setupState'
+	'health' | 'transmissionSession' | 'plexConfigured' | 'setupState' | 'readinessState'
 > = {
 	health: null,
 	transmissionSession: null,
 	plexConfigured: false,
-	setupState: 'ready' as const
+	setupState: 'ready' as const,
+	readinessState: 'ready' as const
 };
 
 const detailShow: ShowBreakdown = {

--- a/web/src/routes/shows/shows.test.ts
+++ b/web/src/routes/shows/shows.test.ts
@@ -7,7 +7,8 @@ const sharedLayoutData = {
 	health: null,
 	transmissionSession: null,
 	plexConfigured: false,
-	setupState: 'ready' as const
+	setupState: 'ready' as const,
+	readinessState: 'ready' as const
 };
 
 const exampleShow: ShowBreakdown = {


### PR DESCRIPTION
## Summary

- delivery ticket: `P22.04 Runtime Readiness Model and Daemon Liveness`
- ticket file: [docs/02-delivery/phase-22/ticket-04-runtime-readiness-model.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-22/ticket-04-runtime-readiness-model.md)
- stacked base branch: `agents/p22-03-dependency-ordered-setup-wizard`

## External AI Review

- Late CodeRabbit review was triaged against the current branch and patched in `fix(onboarding): harden readiness state handling [codex]` (`4051a8f`).
- Patched findings:
  - normalize `readinessState` in [web/src/routes/+layout.server.ts](/Users/cesar/code/pirate_claw_p22_04/web/src/routes/+layout.server.ts) so malformed/version-skewed readiness payloads fall back safely to `not_ready`
  - stop onboarding readiness polling from resetting runtime-updated state back to stale server-load data in [web/src/routes/onboarding/+page.svelte](/Users/cesar/code/pirate_claw_p22_04/web/src/routes/onboarding/+page.svelte)
  - make the disabled “Go to Dashboard” control non-focusable/non-activatable for keyboard users until readiness is actually `ready`
- Verification:
  - `bun run --cwd web test src/routes/layout.server.test.ts src/routes/onboarding/onboarding.test.ts`
  - `bun run --cwd web check`
