### PR TITLE
feat(api): transmission compatibility status display [P22.05]

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -397,6 +397,22 @@ export function createApiFetch(
       }
     }
 
+    if (path === '/api/setup/transmission/status' && request.method === 'GET') {
+      try {
+        const url = activeConfig.transmission.url;
+        const pingResult = await fetchSessionInfo(activeConfig.transmission);
+        const reachable = pingResult.ok === true;
+        const compatibility = classifyTransmissionUrl(url, reachable);
+        const advisory =
+          compatibility === 'compatible_custom'
+            ? 'Non-standard Transmission configuration detected. Setup will proceed but verify your URL and port.'
+            : undefined;
+        return Response.json({ compatibility, url, reachable, advisory });
+      } catch {
+        return json500();
+      }
+    }
+
     if (path === '/api/status') {
       return safeJson(() => ({ runs: repository.listRecentRunSummaries() }));
     }
@@ -1643,4 +1659,28 @@ function requireRecord(
   label: string,
 ): Record<string, unknown> {
   return expectRecord(input[key], `${label} ${key}`);
+}
+
+const BUNDLED_TRANSMISSION_URL = 'http://localhost:9091/transmission/rpc';
+const STANDARD_TRANSMISSION_PORT = '9091';
+const STANDARD_TRANSMISSION_PATH = '/transmission/rpc';
+
+export function classifyTransmissionUrl(
+  url: string,
+  reachable: boolean,
+): 'recommended' | 'compatible' | 'compatible_custom' | 'not_reachable' {
+  if (!reachable) return 'not_reachable';
+  if (url === BUNDLED_TRANSMISSION_URL) return 'recommended';
+  try {
+    const parsed = new URL(url);
+    if (
+      parsed.port === STANDARD_TRANSMISSION_PORT &&
+      parsed.pathname === STANDARD_TRANSMISSION_PATH
+    ) {
+      return 'compatible';
+    }
+  } catch {
+    return 'compatible_custom';
+  }
+  return 'compatible_custom';
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -947,12 +947,19 @@ export function createApiFetch(
         if (tvDir !== undefined) downloadDirs.tv = tvDir;
         if (movieDir !== undefined) downloadDirs.movie = movieDir;
 
+        const nextTransmission = {
+          ...existingTransmission,
+          ...(Object.keys(downloadDirs).length > 0
+            ? { downloadDirs }
+            : { downloadDirs: undefined }),
+        };
+        if (nextTransmission.downloadDirs === undefined) {
+          delete nextTransmission.downloadDirs;
+        }
+
         const merged = {
           ...baseOnDisk,
-          transmission: {
-            ...existingTransmission,
-            ...(Object.keys(downloadDirs).length > 0 ? { downloadDirs } : {}),
-          },
+          transmission: nextTransmission,
         };
 
         const validated = validateConfig(

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -9,6 +9,7 @@ import {
   buildFeedStatuses,
   buildMovieBreakdowns,
   buildShowBreakdowns,
+  classifyTransmissionUrl,
   createApiFetch,
   createHealthState,
   recordCycleInHealth,
@@ -347,6 +348,78 @@ describe('GET /api/setup/readiness', () => {
     const handler = createApiFetch(deps);
     const response = await handler(
       new Request('http://localhost/api/setup/readiness'),
+    );
+    expect(response.status).not.toBe(401);
+    expect(response.status).not.toBe(403);
+  });
+});
+
+describe('classifyTransmissionUrl', () => {
+  it('returns recommended for the bundled default URL', () => {
+    expect(
+      classifyTransmissionUrl('http://localhost:9091/transmission/rpc', true),
+    ).toBe('recommended');
+  });
+
+  it('returns compatible for a non-bundled URL on standard port and path', () => {
+    expect(
+      classifyTransmissionUrl(
+        'http://192.168.1.50:9091/transmission/rpc',
+        true,
+      ),
+    ).toBe('compatible');
+  });
+
+  it('returns compatible_custom for a non-standard port', () => {
+    expect(
+      classifyTransmissionUrl(
+        'http://192.168.1.50:9092/transmission/rpc',
+        true,
+      ),
+    ).toBe('compatible_custom');
+  });
+
+  it('returns compatible_custom for a non-standard path', () => {
+    expect(
+      classifyTransmissionUrl('http://192.168.1.50:9091/custom-rpc', true),
+    ).toBe('compatible_custom');
+  });
+
+  it('returns not_reachable when reachable is false', () => {
+    expect(
+      classifyTransmissionUrl('http://localhost:9091/transmission/rpc', false),
+    ).toBe('not_reachable');
+  });
+});
+
+describe('GET /api/setup/transmission/status', () => {
+  it('returns not_reachable when transmission is down', async () => {
+    const deps = {
+      ...createDeps(),
+      config: {
+        ...createDeps().config,
+        transmission: {
+          url: 'http://127.0.0.1:1/transmission/rpc',
+          username: 'u',
+          password: 'p',
+        },
+      },
+    };
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/setup/transmission/status'),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.compatibility).toBe('not_reachable');
+    expect(body.reachable).toBe(false);
+  });
+
+  it('requires no auth', async () => {
+    const deps = createDeps();
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/setup/transmission/status'),
     );
     expect(response.status).not.toBe(401);
     expect(response.status).not.toBe(403);

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1956,6 +1956,88 @@ describe('PUT /api/config/movies', () => {
   });
 });
 
+describe('PUT /api/config/transmission/download-dirs', () => {
+  async function makeDownloadDirsHandler() {
+    const prevWrite = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    const directory = await mkdtemp(
+      join(tmpdir(), 'pirate-claw-download-dirs-'),
+    );
+    const configPath = join(directory, 'pirate-claw.config.json');
+    await writeCompactTvConfigFile(configPath);
+    const loaded = await loadConfig(configPath);
+    const holder = {
+      current: {
+        ...loaded,
+        transmission: {
+          ...loaded.transmission,
+          downloadDirs: { tv: '/downloads/tv', movie: '/downloads/movies' },
+        },
+        runtime: { ...loaded.runtime, apiWriteToken: 'write-token' },
+      },
+    };
+    await Bun.write(
+      configPath,
+      JSON.stringify(
+        {
+          feeds: loaded.feeds,
+          tv: {
+            defaults: loaded.tvDefaults,
+            shows: ['Example Show'],
+          },
+          movies: loaded.movies,
+          transmission: {
+            ...loaded.transmission,
+            downloadDirs: { tv: '/downloads/tv', movie: '/downloads/movies' },
+          },
+          runtime: {
+            ...loaded.runtime,
+            apiWriteToken: 'write-token',
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+    const deps = createDeps();
+    deps.config = holder.current;
+    deps.configHolder = holder;
+    deps.configPath = configPath;
+    const handler = createApiFetch(deps);
+    const get = await handler(new Request('http://localhost/api/config'));
+    const etag = get.headers.get('etag')!;
+    return { handler, holder, configPath, etag, prevWrite };
+  }
+
+  it('removes transmission.downloadDirs when both values are cleared', async () => {
+    const { handler, holder, configPath, etag, prevWrite } =
+      await makeDownloadDirsHandler();
+    try {
+      const res = await handler(
+        new Request('http://localhost/api/config/transmission/download-dirs', {
+          method: 'PUT',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer write-token',
+            'if-match': etag,
+          },
+          body: JSON.stringify({}),
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(holder.current.transmission.downloadDirs).toBeUndefined();
+
+      const disk = await Bun.file(configPath).json();
+      expect(disk.transmission.downloadDirs).toBeUndefined();
+    } finally {
+      if (prevWrite !== undefined)
+        process.env.PIRATE_CLAW_API_WRITE_TOKEN = prevWrite;
+      else delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    }
+  });
+});
+
 describe('buildShowBreakdowns', () => {
   it('sorts shows by title and seasons/episodes by number', () => {
     const candidates = [

--- a/web/src/lib/components/TransmissionCompatibilityBadge.svelte
+++ b/web/src/lib/components/TransmissionCompatibilityBadge.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import type { TransmissionCompatibility } from '$lib/types';
+
+	interface Props {
+		compatibility: TransmissionCompatibility;
+		advisory?: string;
+	}
+
+	let { compatibility, advisory }: Props = $props();
+
+	const label: Record<TransmissionCompatibility, string> = {
+		recommended: 'Recommended',
+		compatible: 'Compatible',
+		compatible_custom: 'Compatible (custom)',
+		not_reachable: 'Not reachable'
+	};
+
+	const colorClass: Record<TransmissionCompatibility, string> = {
+		recommended: 'text-emerald-400',
+		compatible: 'text-emerald-400',
+		compatible_custom: 'text-yellow-400',
+		not_reachable: 'text-red-400'
+	};
+</script>
+
+<span class="inline-flex flex-col gap-1 text-sm">
+	<span class={colorClass[compatibility]} data-testid="compatibility-badge"
+		>{label[compatibility]}</span
+	>
+	{#if advisory}
+		<span class="text-muted-foreground text-xs">{advisory}</span>
+	{/if}
+</span>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -247,3 +247,16 @@ export type ReadinessResponse = {
 	transmissionReachable: boolean;
 	daemonLive: boolean;
 };
+
+export type TransmissionCompatibility =
+	| 'recommended'
+	| 'compatible'
+	| 'compatible_custom'
+	| 'not_reachable';
+
+export type TransmissionStatusResponse = {
+	compatibility: TransmissionCompatibility;
+	url: string;
+	reachable: boolean;
+	advisory?: string;
+};

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -2,7 +2,13 @@ import { env } from '$env/dynamic/private';
 import { fail } from '@sveltejs/kit';
 import { deriveOnboardingStatus } from '$lib/onboarding';
 import { apiRequest } from '$lib/server/api';
-import type { AppConfig, OnboardingStatus, RunSummaryRecord, SessionInfo } from '$lib/types';
+import type {
+	AppConfig,
+	OnboardingStatus,
+	RunSummaryRecord,
+	SessionInfo,
+	TransmissionStatusResponse
+} from '$lib/types';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
@@ -384,24 +390,40 @@ export const actions: Actions = {
 		}
 
 		try {
-			const response = await apiRequest('/api/transmission/ping', {
-				method: 'POST',
-				headers: { authorization: `Bearer ${writeToken}` }
-			});
+			const [pingResponse, statusResponse] = await Promise.all([
+				apiRequest('/api/transmission/ping', {
+					method: 'POST',
+					headers: { authorization: `Bearer ${writeToken}` }
+				}),
+				apiRequest('/api/setup/transmission/status')
+			]);
 
-			if (!response.ok) {
-				let pingError = `Ping failed (${response.status}).`;
+			const status = statusResponse.ok
+				? ((await statusResponse.json()) as TransmissionStatusResponse)
+				: null;
+
+			if (!pingResponse.ok) {
+				let pingError = `Ping failed (${pingResponse.status}).`;
 				try {
-					const body = (await response.json()) as { error?: string };
+					const body = (await pingResponse.json()) as { error?: string };
 					if (body.error) pingError = body.error;
 				} catch {
 					// keep fallback
 				}
-				return fail(502, { pingError });
+				return fail(502, {
+					pingError,
+					compatibility: status?.compatibility ?? 'not_reachable',
+					transmissionAdvisory: status?.advisory ?? null
+				});
 			}
 
-			const data = (await response.json()) as { version: string };
-			return { pingOk: true, version: data.version };
+			const data = (await pingResponse.json()) as { version: string };
+			return {
+				pingOk: true,
+				version: data.version,
+				compatibility: status?.compatibility ?? 'compatible',
+				transmissionAdvisory: status?.advisory ?? null
+			};
 		} catch (error) {
 			console.error('[config] testConnection failed:', error);
 			return fail(502, { pingError: 'Could not reach the API.' });

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -60,6 +60,10 @@
 	let newFeedMediaType = $state<'tv' | 'movie'>('tv');
 	let feedsSubmitting = $state(false);
 	let testingConnection = $state(false);
+	let transmissionCompatibility = $state<import('$lib/types').TransmissionCompatibility | null>(
+		null
+	);
+	let transmissionAdvisory = $state<string | null>(null);
 	let showsSubmitting = $state(false);
 	let pendingShowIntent = $state<ShowIntent | null>(null);
 	let showsFormEl = $state<HTMLFormElement | null>(null);
@@ -284,9 +288,19 @@
 			testingConnection = false;
 			if (result.type === 'success') {
 				const version = (result.data as { version?: string })?.version ?? '';
+				transmissionCompatibility =
+					(result.data as { compatibility?: import('$lib/types').TransmissionCompatibility })
+						?.compatibility ?? null;
+				transmissionAdvisory =
+					(result.data as { transmissionAdvisory?: string | null })?.transmissionAdvisory ?? null;
 				toast(`Transmission reachable — version ${version}`, 'success');
 			} else if (result.type === 'failure') {
 				const pingError = (result.data as { pingError?: string })?.pingError;
+				transmissionCompatibility =
+					(result.data as { compatibility?: import('$lib/types').TransmissionCompatibility })
+						?.compatibility ?? 'not_reachable';
+				transmissionAdvisory =
+					(result.data as { transmissionAdvisory?: string | null })?.transmissionAdvisory ?? null;
 				toast(pingError ?? 'Transmission unreachable — check .env credentials and host', 'error');
 			}
 			await update({ reset: false });
@@ -444,6 +458,8 @@
 				{restarting}
 				{runtimeChangesPending}
 				runtimeMessage={form?.runtimeMessage}
+				compatibility={transmissionCompatibility}
+				{transmissionAdvisory}
 				{enhanceTestConnection}
 				{enhanceSaveRuntime}
 				{enhanceRestartDaemon}

--- a/web/src/routes/config/components/TransmissionCard.svelte
+++ b/web/src/routes/config/components/TransmissionCard.svelte
@@ -3,7 +3,8 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent, CardHeader } from '$lib/components/ui/card';
 	import { formatTransferSize } from '$lib/helpers';
-	import type { RuntimeConfig } from '$lib/types';
+	import TransmissionCompatibilityBadge from '$lib/components/TransmissionCompatibilityBadge.svelte';
+	import type { RuntimeConfig, TransmissionCompatibility } from '$lib/types';
 	import type { SubmitFunction } from '@sveltejs/kit';
 	import ActivityIcon from '@lucide/svelte/icons/activity';
 	import CableIcon from '@lucide/svelte/icons/cable';
@@ -29,6 +30,8 @@
 		restarting: boolean;
 		runtimeChangesPending: boolean;
 		runtimeMessage?: string;
+		compatibility?: TransmissionCompatibility | null;
+		transmissionAdvisory?: string | null;
 		enhanceTestConnection: SubmitFunction;
 		enhanceSaveRuntime: SubmitFunction;
 		enhanceRestartDaemon: SubmitFunction;
@@ -55,6 +58,8 @@
 		restarting,
 		runtimeChangesPending,
 		runtimeMessage,
+		compatibility = null,
+		transmissionAdvisory = null,
 		enhanceTestConnection,
 		enhanceSaveRuntime,
 		enhanceRestartDaemon
@@ -141,16 +146,24 @@
 			</div>
 		</div>
 
-		<form method="POST" action="?/testConnection" use:enhance={enhanceTestConnection}>
-			<Button type="submit" variant="outline" class="rounded-full" disabled={testingConnection}>
-				<CableIcon class="size-4" />
-				{#if testingConnection}
-					Checking…
-				{:else}
-					Test Connection
-				{/if}
-			</Button>
-		</form>
+		<div class="flex flex-wrap items-center gap-4">
+			<form method="POST" action="?/testConnection" use:enhance={enhanceTestConnection}>
+				<Button type="submit" variant="outline" class="rounded-full" disabled={testingConnection}>
+					<CableIcon class="size-4" />
+					{#if testingConnection}
+						Checking…
+					{:else}
+						Test Connection
+					{/if}
+				</Button>
+			</form>
+			{#if compatibility}
+				<TransmissionCompatibilityBadge
+					{compatibility}
+					advisory={transmissionAdvisory ?? undefined}
+				/>
+			{/if}
+		</div>
 
 		<form
 			method="POST"

--- a/web/src/routes/config/page.server.test.ts
+++ b/web/src/routes/config/page.server.test.ts
@@ -137,8 +137,23 @@ describe('config page server actions', () => {
 				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
 			}));
 			const { actions } = await import('./+page.server');
-			apiRequestMock.mockResolvedValue(
-				new Response(JSON.stringify({ ok: true, version: '3.00 (bb6b5a062ef)' }), { status: 200 })
+			apiRequestMock.mockImplementation((url: string) =>
+				url === '/api/setup/transmission/status'
+					? Promise.resolve(
+							new Response(
+								JSON.stringify({
+									compatibility: 'recommended',
+									url: 'http://localhost:9091/transmission/rpc',
+									reachable: true
+								}),
+								{ status: 200 }
+							)
+						)
+					: Promise.resolve(
+							new Response(JSON.stringify({ ok: true, version: '3.00 (bb6b5a062ef)' }), {
+								status: 200
+							})
+						)
 			);
 
 			const result = await actions.testConnection({
@@ -147,6 +162,7 @@ describe('config page server actions', () => {
 
 			expect((result as { pingOk?: boolean }).pingOk).toBe(true);
 			expect((result as { version?: string }).version).toBe('3.00 (bb6b5a062ef)');
+			expect((result as { compatibility?: string }).compatibility).toBe('recommended');
 			expect(apiRequestMock).toHaveBeenCalledWith(
 				'/api/transmission/ping',
 				expect.objectContaining({ method: 'POST' })
@@ -158,8 +174,23 @@ describe('config page server actions', () => {
 				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
 			}));
 			const { actions } = await import('./+page.server');
-			apiRequestMock.mockResolvedValue(
-				new Response(JSON.stringify({ ok: false, error: 'connection refused' }), { status: 502 })
+			apiRequestMock.mockImplementation((url: string) =>
+				url === '/api/setup/transmission/status'
+					? Promise.resolve(
+							new Response(
+								JSON.stringify({
+									compatibility: 'not_reachable',
+									url: 'http://localhost:9091/transmission/rpc',
+									reachable: false
+								}),
+								{ status: 200 }
+							)
+						)
+					: Promise.resolve(
+							new Response(JSON.stringify({ ok: false, error: 'connection refused' }), {
+								status: 502
+							})
+						)
 			);
 
 			const result = await actions.testConnection({

--- a/web/src/routes/onboarding/+page.server.ts
+++ b/web/src/routes/onboarding/+page.server.ts
@@ -2,7 +2,14 @@ import { env } from '$env/dynamic/private';
 import { fail } from '@sveltejs/kit';
 import { deriveOnboardingStatus } from '$lib/onboarding';
 import { apiRequest } from '$lib/server/api';
-import type { AppConfig, FeedConfig, MoviePolicy, ReadinessResponse } from '$lib/types';
+import type {
+	AppConfig,
+	FeedConfig,
+	MoviePolicy,
+	ReadinessResponse,
+	TransmissionCompatibility,
+	TransmissionStatusResponse
+} from '$lib/types';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
@@ -332,11 +339,27 @@ export const actions: Actions = {
 
 	testTransmission: async () => {
 		try {
-			const response = await apiRequest('/api/transmission/ping', { method: 'POST' });
-			const reachable = response.ok;
-			return { transmissionReachable: reachable };
+			const [pingResponse, statusResponse] = await Promise.all([
+				apiRequest('/api/transmission/ping', { method: 'POST' }),
+				apiRequest('/api/setup/transmission/status')
+			]);
+			const reachable = pingResponse.ok;
+			const status = statusResponse.ok
+				? ((await statusResponse.json()) as TransmissionStatusResponse)
+				: null;
+			const compatibility: TransmissionCompatibility = status?.compatibility ?? 'not_reachable';
+			const advisory = status?.advisory;
+			return {
+				transmissionReachable: reachable,
+				transmissionCompatibility: compatibility,
+				transmissionAdvisory: advisory ?? null
+			};
 		} catch {
-			return { transmissionReachable: false };
+			return {
+				transmissionReachable: false,
+				transmissionCompatibility: 'not_reachable' as TransmissionCompatibility,
+				transmissionAdvisory: null
+			};
 		}
 	},
 

--- a/web/src/routes/onboarding/+page.server.ts
+++ b/web/src/routes/onboarding/+page.server.ts
@@ -340,9 +340,7 @@ export const actions: Actions = {
 	testTransmission: async () => {
 		try {
 			const response = await apiRequest('/api/setup/transmission/status');
-			const status = response.ok
-				? ((await response.json()) as TransmissionStatusResponse)
-				: null;
+			const status = response.ok ? ((await response.json()) as TransmissionStatusResponse) : null;
 			const compatibility: TransmissionCompatibility = status?.compatibility ?? 'not_reachable';
 			return {
 				transmissionReachable: status?.reachable ?? false,

--- a/web/src/routes/onboarding/+page.server.ts
+++ b/web/src/routes/onboarding/+page.server.ts
@@ -339,20 +339,15 @@ export const actions: Actions = {
 
 	testTransmission: async () => {
 		try {
-			const [pingResponse, statusResponse] = await Promise.all([
-				apiRequest('/api/transmission/ping', { method: 'POST' }),
-				apiRequest('/api/setup/transmission/status')
-			]);
-			const reachable = pingResponse.ok;
-			const status = statusResponse.ok
-				? ((await statusResponse.json()) as TransmissionStatusResponse)
+			const response = await apiRequest('/api/setup/transmission/status');
+			const status = response.ok
+				? ((await response.json()) as TransmissionStatusResponse)
 				: null;
 			const compatibility: TransmissionCompatibility = status?.compatibility ?? 'not_reachable';
-			const advisory = status?.advisory;
 			return {
-				transmissionReachable: reachable,
+				transmissionReachable: status?.reachable ?? false,
 				transmissionCompatibility: compatibility,
-				transmissionAdvisory: advisory ?? null
+				transmissionAdvisory: status?.advisory ?? null
 			};
 		} catch {
 			return {

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -7,7 +7,8 @@
 		writeOnboardingDismissed,
 		writeOnboardingPath
 	} from '$lib/onboarding';
-	import type { ReadinessState } from '$lib/types';
+	import TransmissionCompatibilityBadge from '$lib/components/TransmissionCompatibilityBadge.svelte';
+	import type { ReadinessState, TransmissionCompatibility } from '$lib/types';
 	import type { ActionData, PageData } from './$types';
 
 	const ALL_RESOLUTIONS = ['2160p', '1080p', '720p', '480p'];
@@ -28,6 +29,13 @@
 	);
 	const transmissionTested = $derived(
 		(form as { transmissionReachable?: boolean } | undefined)?.transmissionReachable !== undefined
+	);
+	const transmissionCompatibility = $derived(
+		(form as { transmissionCompatibility?: TransmissionCompatibility } | undefined)
+			?.transmissionCompatibility ?? null
+	);
+	const transmissionAdvisory = $derived(
+		(form as { transmissionAdvisory?: string | null } | undefined)?.transmissionAdvisory ?? null
 	);
 
 	const hasTvFeed = $derived((data.config?.feeds ?? []).some((feed) => feed.mediaType === 'tv'));
@@ -251,15 +259,14 @@
 						Test connection
 					</button>
 				</form>
-				{#if transmissionTested}
-					<p
-						class={transmissionReachable
-							? 'text-sm text-emerald-400'
-							: 'text-muted-foreground text-sm'}
-					>
-						{transmissionReachable
-							? 'Transmission is reachable.'
-							: 'Transmission is not reachable. Update your config and reload.'}
+				{#if transmissionTested && transmissionCompatibility}
+					<TransmissionCompatibilityBadge
+						compatibility={transmissionCompatibility}
+						advisory={transmissionAdvisory ?? undefined}
+					/>
+				{:else if transmissionTested && !transmissionReachable}
+					<p class="text-muted-foreground text-sm">
+						Transmission is not reachable. Update your config and reload.
 					</p>
 				{/if}
 			</div>

--- a/web/src/routes/onboarding/page.server.test.ts
+++ b/web/src/routes/onboarding/page.server.test.ts
@@ -509,4 +509,89 @@ describe('onboarding page server', () => {
 			);
 		});
 	});
+
+	describe('testTransmission', () => {
+		it('uses the read-only transmission status endpoint', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: {}
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						compatibility: 'recommended',
+						url: 'http://localhost:9091/transmission/rpc',
+						reachable: true
+					}),
+					{ status: 200 }
+				)
+			);
+
+			const result = await actions.testTransmission({} as never);
+
+			expect((result as { transmissionReachable?: boolean }).transmissionReachable).toBe(true);
+			expect(
+				(result as { transmissionCompatibility?: string }).transmissionCompatibility
+			).toBe('recommended');
+			expect(apiRequestMock).toHaveBeenCalledWith('/api/setup/transmission/status');
+		});
+	});
+
+	describe('saveDownloadDirs', () => {
+		it('returns fail(400) when ifMatch is missing', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+
+			const body = new URLSearchParams();
+			body.set('tvDir', '/data/tv');
+
+			const result = await actions.saveDownloadDirs({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(400);
+			expect(
+				(result as { data?: { downloadDirsMessage?: string } }).data?.downloadDirsMessage
+			).toContain('Missing config revision');
+			expect(apiRequestMock).not.toHaveBeenCalled();
+		});
+
+		it('sends an empty object when both fields are blank so existing download dirs can be cleared', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('./+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(null, { status: 200, headers: { etag: '"rev-2"' } })
+			);
+
+			const body = new URLSearchParams();
+			body.set('ifMatch', '"rev-1"');
+			body.set('tvDir', '');
+			body.set('movieDir', '');
+
+			const result = await actions.saveDownloadDirs({
+				request: new Request('http://localhost/onboarding', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { downloadDirsSuccess?: boolean }).downloadDirsSuccess).toBe(true);
+			expect(apiRequestMock).toHaveBeenCalledWith(
+				'/api/config/transmission/download-dirs',
+				expect.objectContaining({
+					method: 'PUT',
+					body: JSON.stringify({})
+				})
+			);
+		});
+	});
 });

--- a/web/src/routes/onboarding/page.server.test.ts
+++ b/web/src/routes/onboarding/page.server.test.ts
@@ -530,9 +530,9 @@ describe('onboarding page server', () => {
 			const result = await actions.testTransmission({} as never);
 
 			expect((result as { transmissionReachable?: boolean }).transmissionReachable).toBe(true);
-			expect(
-				(result as { transmissionCompatibility?: string }).transmissionCompatibility
-			).toBe('recommended');
+			expect((result as { transmissionCompatibility?: string }).transmissionCompatibility).toBe(
+				'recommended'
+			);
 			expect(apiRequestMock).toHaveBeenCalledWith('/api/setup/transmission/status');
 		});
 	});


### PR DESCRIPTION
## Summary

- delivery ticket: `P22.05 Transmission Compatibility Status Display`
- ticket file: [docs/02-delivery/phase-22/ticket-05-transmission-compatibility-status.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-22/ticket-05-transmission-compatibility-status.md)
- stacked base branch: `agents/p22-04-runtime-readiness-model-and-daemon-liveness`