### PR TITLE
fix: add onboarding CTA to partial setup banner

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -143,7 +143,9 @@
 						class="bg-warning/10 border-warning/30 text-warning mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3 text-sm"
 						data-testid="partial-config-banner"
 					>
-						<p>Setup incomplete — some services may be unavailable until configuration is complete.</p>
+						<p>
+							Setup incomplete — some services may be unavailable until configuration is complete.
+						</p>
 						<a
 							href="/onboarding"
 							class="text-primary hover:text-primary/80 shrink-0 font-medium underline-offset-4 hover:underline"

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -140,10 +140,16 @@
 			{:else}
 				{#if isPartiallyConfigured}
 					<div
-						class="bg-warning/10 border-warning/30 text-warning mb-4 rounded-lg border px-4 py-2 text-sm"
+						class="bg-warning/10 border-warning/30 text-warning mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3 text-sm"
 						data-testid="partial-config-banner"
 					>
-						Setup incomplete — some services may be unavailable until configuration is complete.
+						<p>Setup incomplete — some services may be unavailable until configuration is complete.</p>
+						<a
+							href="/onboarding"
+							class="text-primary hover:text-primary/80 shrink-0 font-medium underline-offset-4 hover:underline"
+						>
+							Resume onboarding
+						</a>
 					</div>
 				{:else if isReadyPendingRestart}
 					<div

--- a/web/src/routes/layout.test.ts
+++ b/web/src/routes/layout.test.ts
@@ -186,6 +186,10 @@ describe('+layout.svelte', () => {
 		});
 
 		expect(screen.getByTestId('partial-config-banner')).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'Resume onboarding' })).toHaveAttribute(
+			'href',
+			'/onboarding'
+		);
 		expect(screen.queryByTestId('starter-mode-splash')).not.toBeInTheDocument();
 	});
 


### PR DESCRIPTION
## Summary
- add a real Resume onboarding CTA to the shared partially-configured layout banner
- keep the setup-state contract unchanged and limit the change to continuity polish
- cover the banner CTA in the layout test

## Notes
- standalone P21 follow-up PR
- no broader onboarding flow redesign included