### PR TITLE
feat: add restart CTA to ready pending restart banner

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { enhance } from '$app/forms';
+	import { invalidateAll } from '$app/navigation';
 	import MenuIcon from '@lucide/svelte/icons/menu';
 	import ClapperboardIcon from '@lucide/svelte/icons/clapperboard';
 	import TvMinimalPlayIcon from '@lucide/svelte/icons/tv-minimal-play';
@@ -15,6 +17,8 @@
 	import MobileNav from './components/MobileNav.svelte';
 	import type { NavLink } from './components/SidebarNav.svelte';
 	import { page } from '$app/stores';
+	import { toast } from '$lib/toast';
+	import type { SubmitFunction } from '@sveltejs/kit';
 
 	interface Props {
 		children: Snippet;
@@ -48,6 +52,25 @@
 	const isReadyPendingRestart = $derived(
 		readinessState === 'ready_pending_restart' && !isOnboarding
 	);
+	let restartingFromBanner = $state(false);
+
+	const enhanceRestartDaemon: SubmitFunction = () => {
+		restartingFromBanner = true;
+		return async ({ result }) => {
+			restartingFromBanner = false;
+			if (result.type === 'success') {
+				toast('Restarting… the page may become temporarily unavailable', 'success');
+				await invalidateAll();
+				return;
+			}
+
+			const restartError =
+				result.type === 'failure' && typeof result.data?.restartError === 'string'
+					? result.data.restartError
+					: 'Restart failed — try again or restart manually';
+			toast(restartError, 'error');
+		};
+	};
 </script>
 
 <svelte:head>
@@ -146,12 +169,30 @@
 						Setup incomplete — some services may be unavailable until configuration is complete.
 					</div>
 				{:else if isReadyPendingRestart}
-					<div
-						class="bg-warning/10 border-warning/30 text-warning mb-4 rounded-lg border px-4 py-2 text-sm"
+					<form
+						method="POST"
+						action="/config?/restartDaemon"
+						use:enhance={enhanceRestartDaemon}
+						class="mb-4"
 						data-testid="ready-pending-restart-banner"
 					>
-						Restart daemon to apply config changes.
-					</div>
+						<div
+							class="bg-warning/10 border-warning/30 text-warning flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3 text-sm"
+						>
+							<p>Restart daemon to apply config changes.</p>
+							<button
+								type="submit"
+								class="border-warning/40 text-warning hover:bg-warning/10 shrink-0 rounded-md border px-3 py-1.5 font-medium transition-colors"
+								disabled={restartingFromBanner}
+							>
+								{#if restartingFromBanner}
+									Restarting…
+								{:else}
+									Restart Daemon
+								{/if}
+							</button>
+						</div>
+					</form>
 				{/if}
 				{@render children()}
 			{/if}

--- a/web/src/routes/layout.test.ts
+++ b/web/src/routes/layout.test.ts
@@ -29,6 +29,18 @@ vi.mock('$lib/components/ui/sonner', () => ({
 	Toaster: vi.fn()
 }));
 
+vi.mock('$app/forms', () => ({
+	enhance: vi.fn()
+}));
+
+vi.mock('$app/navigation', () => ({
+	invalidateAll: vi.fn()
+}));
+
+vi.mock('$lib/toast', () => ({
+	toast: vi.fn()
+}));
+
 vi.mock('$app/stores', () => ({
 	page
 }));
@@ -206,6 +218,7 @@ describe('+layout.svelte', () => {
 		});
 
 		expect(screen.getByTestId('ready-pending-restart-banner')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Restart Daemon' })).toBeInTheDocument();
 		expect(screen.queryByTestId('partial-config-banner')).not.toBeInTheDocument();
 		expect(screen.queryByTestId('starter-mode-splash')).not.toBeInTheDocument();
 	});


### PR DESCRIPTION
## Summary
- wire the shared ready-pending-restart banner to the existing restart action
- show restart loading state and success/error toasts from the banner flow
- invalidate app data after successful restart initiation and cover the CTA in layout tests

## Notes
- standalone P22 follow-up PR
- no daemon lifecycle redesign included