### PR TITLE
feat: wire Plex browser auth flow [P23.02]

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,3 +1,4 @@
+import type { Database } from 'bun:sqlite';
 import { createHash, randomUUID } from 'node:crypto';
 import { getSetupState } from './bootstrap';
 import { renameSync, writeFileSync } from 'node:fs';
@@ -55,6 +56,11 @@ import type { PlexMovieEnrichDeps } from './plex/movies';
 import { enrichMovieBreakdownsFromPlexCache } from './plex/movies';
 import type { PlexShowEnrichDeps } from './plex/shows';
 import { enrichShowBreakdownsFromPlexCache } from './plex/shows';
+import { PlexAuthStore } from './plex/auth';
+import {
+  exchangePlexPinForAuthToken,
+  startPlexPinAuth,
+} from './plex/auth-client';
 
 export type CycleSnapshot = {
   status: CycleResult['status'];
@@ -96,6 +102,7 @@ export function recordCycleInHealth(
 }
 
 export type ApiFetchDeps = {
+  database?: Database;
   repository: Repository;
   health: HealthState;
   config: AppConfig;
@@ -330,6 +337,7 @@ export function createApiFetch(
   }
 
   const {
+    database,
     repository,
     health,
     config,
@@ -410,6 +418,146 @@ export function createApiFetch(
         return Response.json({ compatibility, url, reachable, advisory });
       } catch {
         return json500();
+      }
+    }
+
+    if (path === '/api/plex/auth/start' && request.method === 'POST') {
+      const authError = checkWriteAuth(request, activeConfig);
+      if (authError) return authError;
+      if (!database) {
+        return json500();
+      }
+
+      let body: unknown;
+      try {
+        body = await request.json();
+      } catch {
+        return Response.json({ error: 'invalid json body' }, { status: 400 });
+      }
+
+      try {
+        const parsed = expectRecord(body, 'request body');
+        const forwardUrl = requireNonEmptyString(
+          parsed.forwardUrl,
+          'request body forwardUrl',
+        );
+        const returnTo =
+          parsed.returnTo === undefined
+            ? undefined
+            : requireNonEmptyString(parsed.returnTo, 'request body returnTo');
+
+        const store = new PlexAuthStore(database);
+        const identity = store.ensureIdentity();
+        const started = await startPlexPinAuth({
+          clientIdentifier: identity.clientIdentifier,
+          publicJwk: identity.publicJwk,
+          productName: identity.clientName,
+          forwardUrl,
+        });
+        const created = store.createSession({
+          oauthState: started.pinCode,
+          codeVerifier: String(started.pinId),
+          pinId: started.pinId,
+          pinCode: started.pinCode,
+          redirectUri: forwardUrl,
+          returnTo,
+          expiresAt: started.expiresAt,
+        });
+
+        return Response.json({
+          sessionId: created.session.id,
+          redirectUrl: appendSessionToForwardUrl(
+            started.authUrl,
+            created.session.id,
+          ),
+          expiresAt: created.session.expiresAt,
+        });
+      } catch (error) {
+        return Response.json(
+          {
+            error:
+              error instanceof Error ? error.message : 'plex auth start failed',
+          },
+          { status: 400 },
+        );
+      }
+    }
+
+    if (path === '/api/plex/auth/finalize' && request.method === 'POST') {
+      const authError = checkWriteAuth(request, activeConfig);
+      if (authError) return authError;
+      if (!database) {
+        return json500();
+      }
+
+      let body: unknown;
+      try {
+        body = await request.json();
+      } catch {
+        return Response.json({ error: 'invalid json body' }, { status: 400 });
+      }
+
+      try {
+        const parsed = expectRecord(body, 'request body');
+        const sessionId = requireNonEmptyString(
+          parsed.sessionId,
+          'request body sessionId',
+        );
+        const store = new PlexAuthStore(database);
+        const snapshot = store.getSnapshot();
+
+        if (
+          !snapshot.pendingSession ||
+          snapshot.pendingSession.id !== sessionId ||
+          snapshot.pendingSession.pinId == null
+        ) {
+          return Response.json(
+            { error: 'plex auth session is missing or expired' },
+            { status: 409 },
+          );
+        }
+
+        const identity = store.ensureIdentity();
+        const authToken = await exchangePlexPinForAuthToken({
+          clientIdentifier: identity.clientIdentifier,
+          identity,
+          pinId: snapshot.pendingSession.pinId,
+        });
+
+        if (!authToken) {
+          return Response.json(
+            {
+              error:
+                'Plex sign-in was cancelled or has not completed yet. Try Connect again.',
+            },
+            { status: 409 },
+          );
+        }
+
+        activeConfig = await writePlexTokenToConfig({
+          authToken,
+          configPath,
+          currentConfig: activeConfig,
+          configHolder,
+        });
+        store.finalizeSession(sessionId, {
+          refreshToken: authToken,
+        });
+
+        return Response.json({
+          ok: true,
+          returnTo: snapshot.pendingSession.returnTo,
+        });
+      } catch (error) {
+        return Response.json(
+          {
+            error:
+              error instanceof Error
+                ? error.message
+                : 'plex auth finalize failed',
+          },
+          { status: 400 },
+        );
       }
     }
 
@@ -1653,9 +1801,81 @@ function mergeTvShowsPreservingDiskEntries(
   return next;
 }
 
+async function writePlexTokenToConfig(input: {
+  authToken: string;
+  configPath: string;
+  currentConfig: AppConfig;
+  configHolder?: { current: AppConfig };
+}): Promise<AppConfig> {
+  const baseOnDisk = await readConfigFileRecord(input.configPath);
+  const diskPlex = isRecord(baseOnDisk.plex) ? baseOnDisk.plex : {};
+  const merged = {
+    ...baseOnDisk,
+    plex: {
+      ...diskPlex,
+      url:
+        optionalStringValue(diskPlex.url) ??
+        input.currentConfig.plex?.url ??
+        'http://localhost:32400',
+      token: input.authToken,
+      refreshIntervalMinutes:
+        optionalNonNegativeNumber(diskPlex.refreshIntervalMinutes) ??
+        input.currentConfig.plex?.refreshIntervalMinutes ??
+        30,
+    },
+  };
+
+  const validated = validateConfig(
+    merged,
+    'config',
+    await loadConfigEnv(input.configPath),
+  );
+  writeConfigAtomically(input.configPath, merged);
+  if (input.configHolder) {
+    input.configHolder.current = validated;
+  }
+  return validated;
+}
+
+function appendSessionToForwardUrl(url: string, sessionId: string): string {
+  const marker = 'forwardUrl=';
+  const markerIndex = url.indexOf(marker);
+  if (markerIndex < 0) {
+    return url;
+  }
+
+  const encodedForwardUrl = url.slice(markerIndex + marker.length);
+  const forwardUrl = new URL(decodeURIComponent(encodedForwardUrl));
+  forwardUrl.searchParams.set('session', sessionId);
+
+  return `${url.slice(0, markerIndex + marker.length)}${encodeURIComponent(forwardUrl.toString())}`;
+}
+
 function expectRecord(input: unknown, label: string): Record<string, unknown> {
   if (!isRecord(input)) {
     throw new ConfigError(`Config file "${label}" must be an object.`);
+  }
+  return input;
+}
+
+function requireNonEmptyString(input: unknown, label: string): string {
+  if (typeof input !== 'string' || input.length === 0) {
+    throw new ConfigError(`Config file "${label}" must be a non-empty string.`);
+  }
+  return input;
+}
+
+function optionalStringValue(input: unknown): string | undefined {
+  if (typeof input !== 'string') {
+    return undefined;
+  }
+  const trimmed = input.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function optionalNonNegativeNumber(input: unknown): number | undefined {
+  if (typeof input !== 'number' || !Number.isFinite(input) || input < 0) {
+    return undefined;
   }
   return input;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -462,6 +462,7 @@ export async function runCli(argv: string[]): Promise<number> {
           fetch:
             config.runtime.apiPort != null
               ? createApiFetch({
+                  database,
                   repository,
                   health,
                   config,

--- a/src/plex/auth-client.ts
+++ b/src/plex/auth-client.ts
@@ -1,0 +1,150 @@
+import { sign } from 'node:crypto';
+
+import type { PlexAuthIdentity } from './auth';
+
+const PLEX_CLIENTS_API = 'https://clients.plex.tv';
+const PLEX_HOSTED_AUTH_BASE = 'https://app.plex.tv/auth#?';
+const PLEX_AUTH_SCOPE = 'username,email,friendly_name';
+
+export type StartPlexPinAuthInput = {
+  clientIdentifier: string;
+  publicJwk: PlexAuthIdentity['publicJwk'];
+  productName: string;
+  forwardUrl: string;
+};
+
+export type StartedPlexPinAuth = {
+  pinId: number;
+  pinCode: string;
+  expiresAt: string;
+  authUrl: string;
+};
+
+export async function startPlexPinAuth(
+  input: StartPlexPinAuthInput,
+): Promise<StartedPlexPinAuth> {
+  const response = await fetch(`${PLEX_CLIENTS_API}/api/v2/pins`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-Plex-Client-Identifier': input.clientIdentifier,
+    },
+    body: JSON.stringify({
+      jwk: input.publicJwk,
+      strong: true,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Plex PIN start failed with HTTP ${response.status}.`);
+  }
+
+  const body = (await response.json()) as {
+    id?: number;
+    code?: string;
+    expiresIn?: number;
+  };
+
+  if (!body.id || !body.code || !body.expiresIn) {
+    throw new Error('Plex PIN start returned an incomplete response.');
+  }
+
+  return {
+    pinId: body.id,
+    pinCode: body.code,
+    expiresAt: new Date(Date.now() + body.expiresIn * 1000).toISOString(),
+    authUrl: buildPlexHostedAuthUrl({
+      clientIdentifier: input.clientIdentifier,
+      pinCode: body.code,
+      productName: input.productName,
+      forwardUrl: input.forwardUrl,
+    }),
+  };
+}
+
+export async function exchangePlexPinForAuthToken(input: {
+  clientIdentifier: string;
+  identity: PlexAuthIdentity;
+  pinId: number;
+  now?: Date;
+}): Promise<string | null> {
+  const deviceJwt = createDeviceJwt({
+    clientIdentifier: input.clientIdentifier,
+    keyId: input.identity.keyId,
+    privateKeyPem: input.identity.privateKeyPem,
+    now: input.now,
+  });
+
+  const response = await fetch(
+    `${PLEX_CLIENTS_API}/api/v2/pins/${String(input.pinId)}?deviceJWT=${encodeURIComponent(deviceJwt)}`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'X-Plex-Client-Identifier': input.clientIdentifier,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Plex PIN exchange failed with HTTP ${response.status}.`);
+  }
+
+  const body = (await response.json()) as { authToken?: string | null };
+  return body.authToken ?? null;
+}
+
+function buildPlexHostedAuthUrl(input: {
+  clientIdentifier: string;
+  pinCode: string;
+  productName: string;
+  forwardUrl: string;
+}): string {
+  const params = new URLSearchParams();
+  params.set('clientID', input.clientIdentifier);
+  params.set('code', input.pinCode);
+  params.set('context[device][product]', input.productName);
+  params.set('forwardUrl', input.forwardUrl);
+  return `${PLEX_HOSTED_AUTH_BASE}${params.toString()}`;
+}
+
+function createDeviceJwt(input: {
+  clientIdentifier: string;
+  keyId: string;
+  privateKeyPem: string;
+  now?: Date;
+}): string {
+  const now = input.now ?? new Date();
+  const issuedAt = Math.floor(now.getTime() / 1000);
+  const expiresAt = issuedAt + 300;
+  const header = {
+    kid: input.keyId,
+    alg: 'EdDSA',
+    typ: 'JWT',
+  };
+  const payload = {
+    aud: 'plex.tv',
+    iss: input.clientIdentifier,
+    scope: PLEX_AUTH_SCOPE,
+    iat: issuedAt,
+    exp: expiresAt,
+  };
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signature = sign(
+    null,
+    Buffer.from(`${encodedHeader}.${encodedPayload}`),
+    input.privateKeyPem,
+  );
+
+  return `${encodedHeader}.${encodedPayload}.${base64UrlEncode(signature)}`;
+}
+
+function base64UrlEncode(input: string | Buffer): string {
+  return Buffer.from(input)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}

--- a/src/plex/auth.ts
+++ b/src/plex/auth.ts
@@ -42,6 +42,8 @@ export type PlexAuthSession = {
   id: string;
   oauthState: string;
   codeVerifier: string;
+  pinId: number | null;
+  pinCode: string | null;
   redirectUri: string;
   returnTo: string | null;
   openedAt: string;
@@ -60,6 +62,8 @@ export type PlexAuthSnapshot = {
 export type CreatePlexAuthSessionInput = {
   oauthState: string;
   codeVerifier: string;
+  pinId?: number;
+  pinCode?: string;
   redirectUri: string;
   returnTo?: string;
   expiresAt: string;
@@ -81,7 +85,15 @@ export class PlexAuthStore {
   ensureIdentity(now = new Date().toISOString()): PlexAuthIdentity {
     const existing = this.getIdentity();
     if (existing) {
-      return existing;
+      if (
+        existing.keyId &&
+        existing.privateKeyPem &&
+        existing.publicJwk.x.length > 0
+      ) {
+        return existing;
+      }
+
+      return this.repairIdentity(existing, now);
     }
 
     const created: PlexAuthIdentity = {
@@ -158,7 +170,7 @@ export class PlexAuthStore {
       )
       .get() as
       | (Omit<PlexAuthIdentity, 'publicJwk'> & {
-          publicJwkJson: string;
+          publicJwkJson: string | null;
         })
       | null;
 
@@ -168,7 +180,16 @@ export class PlexAuthStore {
 
     return {
       ...row,
-      publicJwk: JSON.parse(row.publicJwkJson) as PlexAuthIdentity['publicJwk'],
+      publicJwk: row.publicJwkJson
+        ? (JSON.parse(row.publicJwkJson) as PlexAuthIdentity['publicJwk'])
+        : {
+            kty: 'OKP',
+            crv: 'Ed25519',
+            x: '',
+            kid: row.keyId,
+            alg: 'EdDSA',
+            use: 'sig',
+          },
     };
   }
 
@@ -188,6 +209,8 @@ export class PlexAuthStore {
           id,
           oauth_state,
           code_verifier,
+          pin_id,
+          pin_code,
           redirect_uri,
           return_to,
           opened_at,
@@ -195,12 +218,14 @@ export class PlexAuthStore {
           status,
           completed_at,
           cancelled_at
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'pending', NULL, NULL)`,
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 'pending', NULL, NULL)`,
       )
       .run(
         id,
         input.oauthState,
         input.codeVerifier,
+        input.pinId ?? null,
+        input.pinCode ?? null,
         input.redirectUri,
         input.returnTo ?? null,
         openedAt,
@@ -300,6 +325,8 @@ export class PlexAuthStore {
           id,
           oauth_state AS oauthState,
           code_verifier AS codeVerifier,
+          pin_id AS pinId,
+          pin_code AS pinCode,
           redirect_uri AS redirectUri,
           return_to AS returnTo,
           opened_at AS openedAt,
@@ -324,6 +351,8 @@ export class PlexAuthStore {
           id,
           oauth_state AS oauthState,
           code_verifier AS codeVerifier,
+          pin_id AS pinId,
+          pin_code AS pinCode,
           redirect_uri AS redirectUri,
           return_to AS returnTo,
           opened_at AS openedAt,
@@ -341,6 +370,36 @@ export class PlexAuthStore {
     }
 
     return row;
+  }
+
+  private repairIdentity(
+    existing: PlexAuthIdentity,
+    now: string,
+  ): PlexAuthIdentity {
+    const material = createDeviceKeyMaterial();
+    this.database
+      .query(
+        `UPDATE plex_auth_identity
+        SET key_id = ?1,
+            key_algorithm = ?2,
+            public_jwk_json = ?3,
+            private_key_pem = ?4,
+            updated_at = ?5
+        WHERE singleton = 1`,
+      )
+      .run(
+        material.keyId,
+        material.keyAlgorithm,
+        JSON.stringify(material.publicJwk),
+        material.privateKeyPem,
+        now,
+      );
+
+    return {
+      ...existing,
+      ...material,
+      updatedAt: now,
+    };
   }
 }
 

--- a/src/plex/auth.ts
+++ b/src/plex/auth.ts
@@ -258,51 +258,68 @@ export class PlexAuthStore {
     session: PlexAuthSession;
   } {
     const authenticatedAt = input.authenticatedAt ?? new Date().toISOString();
-    this.expirePendingSessions(authenticatedAt);
+    return this.database.transaction(() => {
+      this.expirePendingSessions(authenticatedAt);
 
-    const session = this.getSessionOrThrow(sessionId);
-    if (session.status !== 'pending') {
-      throw new Error(
-        `Plex auth session "${sessionId}" is ${session.status} and cannot be finalized.`,
-      );
-    }
+      const session = this.getSessionOrThrow(sessionId);
+      if (session.status !== 'pending') {
+        throw new Error(
+          `Plex auth session "${sessionId}" is ${session.status} and cannot be finalized.`,
+        );
+      }
 
-    const identity = this.ensureIdentity(authenticatedAt);
+      const identity = this.ensureIdentity(authenticatedAt);
 
-    this.database
-      .query(
-        `UPDATE plex_auth_identity
-        SET refresh_token = ?1,
-            token_expires_at = ?2,
-            last_authenticated_at = ?3,
-            last_error = NULL,
-            reconnect_required_at = NULL,
-            updated_at = ?3
-        WHERE singleton = 1`,
-      )
-      .run(input.refreshToken, input.tokenExpiresAt ?? null, authenticatedAt);
+      this.database
+        .query(
+          `UPDATE plex_auth_identity
+          SET refresh_token = ?1,
+              token_expires_at = ?2,
+              last_authenticated_at = ?3,
+              last_error = NULL,
+              reconnect_required_at = NULL,
+              updated_at = ?3
+          WHERE singleton = 1`,
+        )
+        .run(input.refreshToken, input.tokenExpiresAt ?? null, authenticatedAt);
 
-    this.database
-      .query(
-        `UPDATE plex_auth_sessions
-        SET status = 'completed',
-            completed_at = ?2
-        WHERE id = ?1`,
-      )
-      .run(sessionId, authenticatedAt);
+      const completed = this.database
+        .query(
+          `UPDATE plex_auth_sessions
+          SET status = 'completed',
+              completed_at = ?2
+          WHERE id = ?1 AND status = 'pending'`,
+        )
+        .run(sessionId, authenticatedAt);
 
-    return {
-      identity: {
-        ...identity,
-        refreshToken: input.refreshToken,
-        tokenExpiresAt: input.tokenExpiresAt ?? null,
-        lastAuthenticatedAt: authenticatedAt,
-        lastError: null,
-        reconnectRequiredAt: null,
-        updatedAt: authenticatedAt,
-      },
-      session: this.getSessionOrThrow(sessionId),
-    };
+      if (Number(completed.changes ?? 0) !== 1) {
+        throw new Error(
+          `Plex auth session "${sessionId}" could not be finalized.`,
+        );
+      }
+
+      this.database
+        .query(
+          `UPDATE plex_auth_sessions
+          SET status = 'cancelled',
+              cancelled_at = ?2
+          WHERE id <> ?1 AND status = 'pending'`,
+        )
+        .run(sessionId, authenticatedAt);
+
+      return {
+        identity: {
+          ...identity,
+          refreshToken: input.refreshToken,
+          tokenExpiresAt: input.tokenExpiresAt ?? null,
+          lastAuthenticatedAt: authenticatedAt,
+          lastError: null,
+          reconnectRequiredAt: null,
+          updatedAt: authenticatedAt,
+        },
+        session: this.getSessionOrThrow(sessionId),
+      };
+    })();
   }
 
   getSnapshot(now = new Date().toISOString()): PlexAuthSnapshot {
@@ -384,6 +401,9 @@ export class PlexAuthStore {
             key_algorithm = ?2,
             public_jwk_json = ?3,
             private_key_pem = ?4,
+            refresh_token = NULL,
+            token_expires_at = NULL,
+            reconnect_required_at = ?5,
             updated_at = ?5
         WHERE singleton = 1`,
       )
@@ -398,6 +418,9 @@ export class PlexAuthStore {
     return {
       ...existing,
       ...material,
+      refreshToken: null,
+      tokenExpiresAt: null,
+      reconnectRequiredAt: now,
       updatedAt: now,
     };
   }

--- a/src/plex/schema.ts
+++ b/src/plex/schema.ts
@@ -30,10 +30,10 @@ export function ensurePlexSchema(database: Database): void {
         client_identifier TEXT NOT NULL,
         client_name TEXT NOT NULL,
         platform_name TEXT NOT NULL,
-        key_id TEXT NOT NULL,
-        key_algorithm TEXT NOT NULL,
-        public_jwk_json TEXT NOT NULL,
-        private_key_pem TEXT NOT NULL,
+        key_id TEXT,
+        key_algorithm TEXT,
+        public_jwk_json TEXT,
+        private_key_pem TEXT,
         refresh_token TEXT,
         token_expires_at TEXT,
         last_authenticated_at TEXT,
@@ -48,6 +48,8 @@ export function ensurePlexSchema(database: Database): void {
         id TEXT PRIMARY KEY,
         oauth_state TEXT NOT NULL UNIQUE,
         code_verifier TEXT NOT NULL,
+        pin_id INTEGER,
+        pin_code TEXT,
         redirect_uri TEXT NOT NULL,
         return_to TEXT,
         opened_at TEXT NOT NULL,
@@ -57,5 +59,44 @@ export function ensurePlexSchema(database: Database): void {
         cancelled_at TEXT
       );
     `);
+    ensurePlexTableColumn(database, 'plex_auth_identity', 'key_id', 'TEXT');
+    ensurePlexTableColumn(
+      database,
+      'plex_auth_identity',
+      'key_algorithm',
+      'TEXT',
+    );
+    ensurePlexTableColumn(
+      database,
+      'plex_auth_identity',
+      'public_jwk_json',
+      'TEXT',
+    );
+    ensurePlexTableColumn(
+      database,
+      'plex_auth_identity',
+      'private_key_pem',
+      'TEXT',
+    );
+    ensurePlexTableColumn(database, 'plex_auth_sessions', 'pin_id', 'INTEGER');
+    ensurePlexTableColumn(database, 'plex_auth_sessions', 'pin_code', 'TEXT');
   })();
+}
+
+function ensurePlexTableColumn(
+  database: Database,
+  tableName: string,
+  columnName: string,
+  columnType: string,
+): void {
+  const columns = database
+    .query(`SELECT name FROM pragma_table_info('${tableName}')`)
+    .all() as Array<{ name: string }>;
+  const hasColumn = columns.some((column) => column.name === columnName);
+
+  if (!hasColumn) {
+    database.run(
+      `ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${columnType}`,
+    );
+  }
 }

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,7 +1,7 @@
 import { Database } from 'bun:sqlite';
 import { chmod, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { describe, expect, it, spyOn } from 'bun:test';
 
 import {
@@ -19,6 +19,11 @@ import type { AppConfig } from '../src/config';
 import { loadConfig } from '../src/config';
 import type { PollState } from '../src/poll-state';
 import type { CandidateStateRecord, Repository } from '../src/repository';
+import {
+  createRepository,
+  ensureSchema,
+  openDatabase,
+} from '../src/repository';
 import type { CycleResult } from '../src/runtime-artifacts';
 import { TmdbCache } from '../src/tmdb/cache';
 import { movieMatchKey, tvMatchKey } from '../src/tmdb/keys';
@@ -90,6 +95,24 @@ function createDeps(overrides: Partial<Repository> = {}): ApiFetchDeps {
     health: createHealthState(),
     config: stubConfig(),
     configPath: '/nonexistent/pirate-claw.config.json',
+    pollStatePath: '/nonexistent/poll-state.json',
+    loadPollState: () => emptyPollState,
+  };
+}
+
+function createDatabaseBackedDeps(
+  config: AppConfig,
+  configPath: string,
+): ApiFetchDeps {
+  const database = openDatabase(join(dirname(configPath), 'pirate-claw.db'));
+  ensureSchema(database);
+  return {
+    database,
+    repository: createRepository(database),
+    health: createHealthState(),
+    config,
+    configHolder: { current: config },
+    configPath,
     pollStatePath: '/nonexistent/poll-state.json',
     loadPollState: () => emptyPollState,
   };
@@ -1081,6 +1104,155 @@ describe('GET /api/config', () => {
 
     expect(firstEtag).toBeTruthy();
     expect(firstEtag).toBe(secondEtag);
+  });
+});
+
+describe('Plex browser auth flow', () => {
+  it('starts Plex auth and returns a hosted redirect url', async () => {
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ id: 42, code: 'pin-code', expiresIn: 300 }),
+        {
+          status: 200,
+        },
+      ),
+    );
+
+    try {
+      const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-plex-auth-'));
+      const configPath = join(directory, 'pirate-claw.config.json');
+      await writeCompactTvConfigFile(configPath);
+      const loaded = await loadConfig(configPath);
+      loaded.runtime.apiWriteToken = 'write-token';
+      const deps = createDatabaseBackedDeps(loaded, configPath);
+
+      const handler = createApiFetch(deps);
+      const response = await handler(
+        new Request('http://localhost/api/plex/auth/start', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer write-token',
+          },
+          body: JSON.stringify({
+            forwardUrl: 'http://localhost:5173/plex/connect/callback',
+            returnTo: '/config',
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        sessionId: string;
+        redirectUrl: string;
+      };
+      expect(body.sessionId).toBeTruthy();
+      expect(body.redirectUrl).toContain('https://app.plex.tv/auth#?');
+      expect(body.redirectUrl).toContain('code=pin-code');
+      expect(body.redirectUrl).toContain(
+        encodeURIComponent(
+          'http://localhost:5173/plex/connect/callback?session=',
+        ),
+      );
+      deps.database?.close();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('finalizes Plex auth and writes plex.token for configs without a plex block', async () => {
+    const fetchSpy = spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ id: 99, code: 'pin-code', expiresIn: 300 }),
+          {
+            status: 200,
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ authToken: 'plex-jwt-token' }), {
+          status: 200,
+        }),
+      );
+
+    try {
+      const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-plex-auth-'));
+      const configPath = join(directory, 'pirate-claw.config.json');
+      const doc = {
+        feeds: [
+          {
+            name: 'TV Feed',
+            url: 'https://example.test/tv.rss',
+            mediaType: 'tv',
+          },
+        ],
+        tv: {
+          defaults: { resolutions: ['1080p'], codecs: ['x265'] },
+          shows: ['Example Show'],
+        },
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+        },
+        runtime: {
+          runIntervalMinutes: RUN_INTERVAL_MINUTES_DEFAULT,
+          reconcileIntervalSeconds: RECONCILE_INTERVAL_SECONDS_DEFAULT,
+          artifactDir: '.pirate-claw/runtime',
+          artifactRetentionDays: 7,
+          apiWriteToken: 'write-token',
+        },
+      };
+      await Bun.write(configPath, `${JSON.stringify(doc, null, 2)}\n`);
+      const loaded = await loadConfig(configPath);
+      loaded.runtime.apiWriteToken = 'write-token';
+      const deps = createDatabaseBackedDeps(loaded, configPath);
+      const handler = createApiFetch(deps);
+
+      const started = await handler(
+        new Request('http://localhost/api/plex/auth/start', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer write-token',
+          },
+          body: JSON.stringify({
+            forwardUrl: 'http://localhost:5173/plex/connect/callback',
+            returnTo: '/config',
+          }),
+        }),
+      );
+      const startedBody = (await started.json()) as { sessionId: string };
+
+      const finalized = await handler(
+        new Request('http://localhost/api/plex/auth/finalize', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer write-token',
+          },
+          body: JSON.stringify({ sessionId: startedBody.sessionId }),
+        }),
+      );
+
+      expect(finalized.status).toBe(200);
+      const disk = (await Bun.file(configPath).json()) as {
+        plex?: {
+          url?: string;
+          token?: string;
+          refreshIntervalMinutes?: number;
+        };
+      };
+      expect(disk.plex).toEqual({
+        url: 'http://localhost:32400',
+        token: 'plex-jwt-token',
+        refreshIntervalMinutes: 30,
+      });
+      deps.database?.close();
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 });
 

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1117,14 +1117,19 @@ describe('Plex browser auth flow', () => {
         },
       ),
     );
+    let directory: string | undefined;
+    let database:
+      | ReturnType<typeof createDatabaseBackedDeps>['database']
+      | undefined;
 
     try {
-      const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-plex-auth-'));
+      directory = await mkdtemp(join(tmpdir(), 'pirate-claw-plex-auth-'));
       const configPath = join(directory, 'pirate-claw.config.json');
       await writeCompactTvConfigFile(configPath);
       const loaded = await loadConfig(configPath);
       loaded.runtime.apiWriteToken = 'write-token';
       const deps = createDatabaseBackedDeps(loaded, configPath);
+      database = deps.database;
 
       const handler = createApiFetch(deps);
       const response = await handler(
@@ -1154,8 +1159,11 @@ describe('Plex browser auth flow', () => {
           'http://localhost:5173/plex/connect/callback?session=',
         ),
       );
-      deps.database?.close();
     } finally {
+      database?.close();
+      if (directory) {
+        await Bun.$`rm -rf ${directory}`;
+      }
       fetchSpy.mockRestore();
     }
   });
@@ -1175,9 +1183,13 @@ describe('Plex browser auth flow', () => {
           status: 200,
         }),
       );
+    let directory: string | undefined;
+    let database:
+      | ReturnType<typeof createDatabaseBackedDeps>['database']
+      | undefined;
 
     try {
-      const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-plex-auth-'));
+      directory = await mkdtemp(join(tmpdir(), 'pirate-claw-plex-auth-'));
       const configPath = join(directory, 'pirate-claw.config.json');
       const doc = {
         feeds: [
@@ -1208,6 +1220,7 @@ describe('Plex browser auth flow', () => {
       const loaded = await loadConfig(configPath);
       loaded.runtime.apiWriteToken = 'write-token';
       const deps = createDatabaseBackedDeps(loaded, configPath);
+      database = deps.database;
       const handler = createApiFetch(deps);
 
       const started = await handler(
@@ -1249,8 +1262,11 @@ describe('Plex browser auth flow', () => {
         token: 'plex-jwt-token',
         refreshIntervalMinutes: 30,
       });
-      deps.database?.close();
     } finally {
+      database?.close();
+      if (directory) {
+        await Bun.$`rm -rf ${directory}`;
+      }
       fetchSpy.mockRestore();
     }
   });

--- a/test/plex-auth.test.ts
+++ b/test/plex-auth.test.ts
@@ -127,6 +127,103 @@ describe('PlexAuthStore', () => {
       },
     });
   });
+
+  it('cancels other pending sessions after a successful finalization', async () => {
+    const path = await createDatabasePath();
+    const database = createDatabase(path);
+    const store = new PlexAuthStore(database);
+    const first = store.createSession({
+      oauthState: 'oauth-state-first',
+      codeVerifier: 'code-verifier-first',
+      redirectUri: 'http://localhost:5173/api/plex/auth/callback',
+      openedAt: '2026-04-22T09:00:00.000Z',
+      expiresAt: '2026-04-22T09:10:00.000Z',
+    });
+    const second = store.createSession({
+      oauthState: 'oauth-state-second',
+      codeVerifier: 'code-verifier-second',
+      redirectUri: 'http://localhost:5173/api/plex/auth/callback',
+      openedAt: '2026-04-22T09:01:00.000Z',
+      expiresAt: '2026-04-22T09:11:00.000Z',
+    });
+
+    const finalized = store.finalizeSession(first.session.id, {
+      refreshToken: 'refresh-token-123',
+      authenticatedAt: '2026-04-22T09:03:00.000Z',
+    });
+
+    expect(finalized.session.status).toBe('completed');
+    expect(store.getSnapshot('2026-04-22T09:04:00.000Z')).toMatchObject({
+      state: 'connected',
+      pendingSession: null,
+    });
+
+    const rows = database
+      .query(`SELECT id, status FROM plex_auth_sessions ORDER BY opened_at ASC`)
+      .all() as Array<{ id: string; status: string }>;
+    expect(rows).toEqual([
+      { id: first.session.id, status: 'completed' },
+      { id: second.session.id, status: 'cancelled' },
+    ]);
+
+    database.close();
+    openDatabases.pop();
+
+    const reloaded = new PlexAuthStore(createDatabase(path));
+    expect(reloaded.getSnapshot('2026-04-22T09:05:00.000Z')).toMatchObject({
+      state: 'connected',
+      identity: {
+        clientIdentifier: first.identity.clientIdentifier,
+        refreshToken: 'refresh-token-123',
+      },
+      pendingSession: null,
+    });
+  });
+
+  it('marks reconnect required when repairing incomplete key material', async () => {
+    const store = new PlexAuthStore(createDatabase(await createDatabasePath()));
+    const created = store.ensureIdentity('2026-04-22T09:00:00.000Z');
+
+    store.finalizeSession(
+      store.createSession({
+        oauthState: 'oauth-state-repair',
+        codeVerifier: 'code-verifier-repair',
+        redirectUri: 'http://localhost:5173/api/plex/auth/callback',
+        openedAt: '2026-04-22T09:00:30.000Z',
+        expiresAt: '2026-04-22T09:10:30.000Z',
+      }).session.id,
+      {
+        refreshToken: 'refresh-token-123',
+        tokenExpiresAt: '2026-04-22T10:00:00.000Z',
+        authenticatedAt: '2026-04-22T09:01:00.000Z',
+      },
+    );
+
+    const database = openDatabases[openDatabases.length - 1]!;
+    database
+      .query(
+        `UPDATE plex_auth_identity
+        SET public_jwk_json = NULL
+        WHERE singleton = 1`,
+      )
+      .run();
+
+    const repaired = store.ensureIdentity('2026-04-22T09:02:00.000Z');
+
+    expect(repaired.clientIdentifier).toBe(created.clientIdentifier);
+    expect(repaired.keyId).not.toBe(created.keyId);
+    expect(repaired.refreshToken).toBeNull();
+    expect(repaired.tokenExpiresAt).toBeNull();
+    expect(repaired.reconnectRequiredAt).toBe('2026-04-22T09:02:00.000Z');
+    expect(store.getSnapshot('2026-04-22T09:03:00.000Z')).toMatchObject({
+      state: 'reconnect_required',
+      identity: {
+        clientIdentifier: created.clientIdentifier,
+        refreshToken: null,
+        reconnectRequiredAt: '2026-04-22T09:02:00.000Z',
+      },
+    });
+  });
 });
 
 function createDatabase(path: string): Database {

--- a/web/src/lib/plex-auth.ts
+++ b/web/src/lib/plex-auth.ts
@@ -1,0 +1,11 @@
+export function sanitizePlexReturnTo(input: string | null | undefined): string {
+	if (typeof input !== 'string') {
+		return '/config';
+	}
+
+	if (!input.startsWith('/') || input.startsWith('//') || input.startsWith('/\\')) {
+		return '/config';
+	}
+
+	return input;
+}

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -36,6 +36,9 @@
 			null
 	);
 	const canWrite = $derived(data.canWrite);
+	const plexConnectLabel = $derived(
+		data.config?.plex?.token ? 'Reconnect Plex in browser' : 'Connect Plex in browser'
+	);
 
 	let showRows = $state<string[]>([]);
 	let tvResolutions = $state<string[]>([]);
@@ -436,6 +439,21 @@
 	{#if data.error}
 		<ApiUnavailableAlert message={data.error} />
 	{:else if data.config}
+		<section class="border-border/70 bg-card/80 rounded-3xl border p-6 shadow-sm">
+			<div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+				<div class="space-y-1">
+					<h2 class="text-foreground text-lg font-semibold">Plex Connection</h2>
+					<p class="text-muted-foreground text-sm">
+						Use Plex&apos;s hosted sign-in flow to connect Pirate Claw without manually copying a
+						token.
+					</p>
+				</div>
+				<Button href="/plex/connect?returnTo=/config" disabled={!canWrite}>
+					{plexConnectLabel}
+				</Button>
+			</div>
+		</section>
+
 		<div class="grid gap-5 xl:grid-cols-2">
 			<TransmissionCard
 				{canWrite}

--- a/web/src/routes/plex/connect/+server.ts
+++ b/web/src/routes/plex/connect/+server.ts
@@ -1,6 +1,7 @@
 import { env } from '$env/dynamic/private';
 import { redirect } from '@sveltejs/kit';
 import { apiRequest } from '$lib/server/api';
+import { sanitizePlexReturnTo } from '$lib/plex-auth';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ url }) => {
@@ -17,7 +18,7 @@ export const GET: RequestHandler = async ({ url }) => {
 		},
 		body: JSON.stringify({
 			forwardUrl: `${url.origin}/plex/connect/callback`,
-			returnTo: url.searchParams.get('returnTo') ?? '/config'
+			returnTo: sanitizePlexReturnTo(url.searchParams.get('returnTo'))
 		})
 	});
 

--- a/web/src/routes/plex/connect/+server.ts
+++ b/web/src/routes/plex/connect/+server.ts
@@ -1,0 +1,34 @@
+import { env } from '$env/dynamic/private';
+import { redirect } from '@sveltejs/kit';
+import { apiRequest } from '$lib/server/api';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ url }) => {
+	const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+	if (!writeToken) {
+		throw redirect(303, '/config?plexAuthError=Config+writes+are+disabled.');
+	}
+
+	const response = await apiRequest('/api/plex/auth/start', {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/json',
+			authorization: `Bearer ${writeToken}`
+		},
+		body: JSON.stringify({
+			forwardUrl: `${url.origin}/plex/connect/callback`,
+			returnTo: url.searchParams.get('returnTo') ?? '/config'
+		})
+	});
+
+	if (!response.ok) {
+		const body = (await response.json().catch(() => ({}))) as { error?: string };
+		throw redirect(
+			303,
+			`/config?plexAuthError=${encodeURIComponent(body.error ?? 'Could not start Plex auth.')}`
+		);
+	}
+
+	const body = (await response.json()) as { redirectUrl: string };
+	throw redirect(303, body.redirectUrl);
+};

--- a/web/src/routes/plex/connect/callback/+page.server.ts
+++ b/web/src/routes/plex/connect/callback/+page.server.ts
@@ -1,4 +1,5 @@
 import { env } from '$env/dynamic/private';
+import { sanitizePlexReturnTo } from '$lib/plex-auth';
 import { apiRequest } from '$lib/server/api';
 import type { PageServerLoad } from './$types';
 
@@ -32,10 +33,12 @@ export const load: PageServerLoad = async ({ url }) => {
 		};
 	}
 
-	const body = (await response.json()) as { returnTo?: string | null };
+	const body = (await response.json().catch(() => ({}))) as {
+		returnTo?: string | null;
+	};
 	return {
 		ok: true,
 		message: 'Plex connected successfully.',
-		returnTo: body.returnTo ?? '/config'
+		returnTo: sanitizePlexReturnTo(body.returnTo)
 	};
 };

--- a/web/src/routes/plex/connect/callback/+page.server.ts
+++ b/web/src/routes/plex/connect/callback/+page.server.ts
@@ -1,0 +1,41 @@
+import { env } from '$env/dynamic/private';
+import { apiRequest } from '$lib/server/api';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ url }) => {
+	const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+	const sessionId = url.searchParams.get('session');
+
+	if (!writeToken || !sessionId) {
+		return {
+			ok: false,
+			message: 'Missing Plex auth session. Start the connect flow again.',
+			returnTo: '/config'
+		};
+	}
+
+	const response = await apiRequest('/api/plex/auth/finalize', {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/json',
+			authorization: `Bearer ${writeToken}`
+		},
+		body: JSON.stringify({ sessionId })
+	});
+
+	if (!response.ok) {
+		const body = (await response.json().catch(() => ({}))) as { error?: string };
+		return {
+			ok: false,
+			message: body.error ?? 'Could not complete Plex auth.',
+			returnTo: '/config'
+		};
+	}
+
+	const body = (await response.json()) as { returnTo?: string | null };
+	return {
+		ok: true,
+		message: 'Plex connected successfully.',
+		returnTo: body.returnTo ?? '/config'
+	};
+};

--- a/web/src/routes/plex/connect/callback/+page.svelte
+++ b/web/src/routes/plex/connect/callback/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
+	import { sanitizePlexReturnTo } from '$lib/plex-auth';
 	import type { PageData } from './$types';
 
 	const { data }: { data: PageData } = $props();
@@ -22,5 +23,5 @@
 		<p class="text-muted-foreground text-sm">{data.message}</p>
 	</div>
 
-	<Button href={data.returnTo ?? '/config'}>Return to settings</Button>
+	<Button href={sanitizePlexReturnTo(data.returnTo)}>Return to settings</Button>
 </div>

--- a/web/src/routes/plex/connect/callback/+page.svelte
+++ b/web/src/routes/plex/connect/callback/+page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import type { PageData } from './$types';
+
+	const { data }: { data: PageData } = $props();
+</script>
+
+<svelte:head>
+	<title>Plex Connection</title>
+</svelte:head>
+
+<div
+	class="mx-auto flex min-h-[60vh] max-w-xl flex-col items-center justify-center gap-6 px-6 text-center"
+>
+	<div class="space-y-2">
+		<p
+			class={`text-sm font-semibold tracking-[0.28em] uppercase ${data.ok ? 'text-emerald-500' : 'text-rose-500'}`}
+		>
+			{data.ok ? 'Connected' : 'Connection Failed'}
+		</p>
+		<h1 class="text-foreground text-3xl font-semibold">Plex Browser Auth</h1>
+		<p class="text-muted-foreground text-sm">{data.message}</p>
+	</div>
+
+	<Button href={data.returnTo ?? '/config'}>Return to settings</Button>
+</div>


### PR DESCRIPTION
## Summary

- delivery ticket: `P23.02 Browser Redirect/Return Flow and Config Persistence`
- ticket file: [docs/02-delivery/phase-23/ticket-02-browser-flow-and-config-persistence.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-23/ticket-02-browser-flow-and-config-persistence.md)
- stacked base branch: `agents/p23-01-plex-auth-session-foundation-and-stored-identity-contract`
- self-audit: outcome `clean` completed at 2026-04-22 08:39 UTC

## External AI Review

- outcome: `patched`
- current branch head: [`6647b72`](https://github.com/cesarnml/Pirate-Claw/commit/6647b72)
- late CodeRabbit follow-up patched prudent issues: repaired identities now clear stale credentials and surface reconnect-required, Plex auth API tests always clean up DB/temp resources, and browser return targets are sanitized before reuse/rendering.
