### PR TITLE
feat: unify Plex auth UX [P23.03]

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -561,6 +561,21 @@ export function createApiFetch(
       }
     }
 
+    if (path === '/api/plex/auth/status' && request.method === 'GET') {
+      if (!database) {
+        return json500();
+      }
+
+      const store = new PlexAuthStore(database);
+      const snapshot = store.getSnapshot();
+      return Response.json({
+        state: snapshot.state,
+        plexUrl: activeConfig.plex?.url ?? 'http://localhost:32400',
+        hasToken: Boolean(activeConfig.plex?.token),
+        returnTo: snapshot.pendingSession?.returnTo ?? null,
+      } satisfies PlexAuthStatusResponse);
+    }
+
     if (path === '/api/status') {
       return safeJson(() => ({ runs: repository.listRecentRunSummaries() }));
     }
@@ -952,6 +967,77 @@ export function createApiFetch(
         if (configHolder) {
           configHolder.current = validated;
         }
+
+        const redacted = redactConfig(activeConfig);
+        return Response.json(redacted, {
+          headers: { ETag: buildConfigEtag(redacted) },
+        });
+      } catch (error) {
+        if (error instanceof ConfigError) {
+          return Response.json({ error: error.message }, { status: 400 });
+        }
+        if (error instanceof ConfigWriteError) {
+          return jsonConfigWriteFailure();
+        }
+        return json500();
+      }
+    }
+
+    if (path === '/api/config/plex' && request.method === 'PUT') {
+      const authError = checkWriteAuth(request, activeConfig);
+      if (authError) return authError;
+      const etagError = checkEtag(request, activeConfig);
+      if (etagError) return etagError;
+
+      let body: unknown;
+      try {
+        body = await request.json();
+      } catch {
+        return Response.json({ error: 'invalid json body' }, { status: 400 });
+      }
+
+      try {
+        const parsed = expectRecord(body, 'request body');
+        const plexUrl = requireNonEmptyString(parsed.url, 'request body url');
+        activeConfig = await writePlexConfigToDisk({
+          configPath,
+          configHolder,
+          currentConfig: activeConfig,
+          patch: { url: plexUrl },
+        });
+
+        const redacted = redactConfig(activeConfig);
+        return Response.json(redacted, {
+          headers: { ETag: buildConfigEtag(redacted) },
+        });
+      } catch (error) {
+        if (error instanceof ConfigError) {
+          return Response.json({ error: error.message }, { status: 400 });
+        }
+        if (error instanceof ConfigWriteError) {
+          return jsonConfigWriteFailure();
+        }
+        return json500();
+      }
+    }
+
+    if (path === '/api/plex/auth/disconnect' && request.method === 'POST') {
+      const authError = checkWriteAuth(request, activeConfig);
+      if (authError) return authError;
+      const etagError = checkEtag(request, activeConfig);
+      if (etagError) return etagError;
+
+      try {
+        if (database) {
+          new PlexAuthStore(database).disconnect();
+        }
+
+        activeConfig = await writePlexConfigToDisk({
+          configPath,
+          configHolder,
+          currentConfig: activeConfig,
+          patch: { token: '' },
+        });
 
         const redacted = redactConfig(activeConfig);
         return Response.json(redacted, {
@@ -1613,6 +1699,13 @@ export type FeedStatus = {
   isDue: boolean;
 };
 
+export type PlexAuthStatusResponse = {
+  state: 'not_connected' | 'connecting' | 'connected' | 'reconnect_required';
+  plexUrl: string;
+  hasToken: boolean;
+  returnTo: string | null;
+};
+
 export function buildFeedStatuses(
   feeds: FeedConfig[],
   pollState: PollState,
@@ -1807,6 +1900,24 @@ async function writePlexTokenToConfig(input: {
   currentConfig: AppConfig;
   configHolder?: { current: AppConfig };
 }): Promise<AppConfig> {
+  return writePlexConfigToDisk({
+    configPath: input.configPath,
+    currentConfig: input.currentConfig,
+    configHolder: input.configHolder,
+    patch: { token: input.authToken },
+  });
+}
+
+async function writePlexConfigToDisk(input: {
+  configPath: string;
+  currentConfig: AppConfig;
+  configHolder?: { current: AppConfig };
+  patch: {
+    url?: string;
+    token?: string;
+    refreshIntervalMinutes?: number;
+  };
+}): Promise<AppConfig> {
   const baseOnDisk = await readConfigFileRecord(input.configPath);
   const diskPlex = isRecord(baseOnDisk.plex) ? baseOnDisk.plex : {};
   const merged = {
@@ -1814,11 +1925,17 @@ async function writePlexTokenToConfig(input: {
     plex: {
       ...diskPlex,
       url:
+        input.patch.url ??
         optionalStringValue(diskPlex.url) ??
         input.currentConfig.plex?.url ??
         'http://localhost:32400',
-      token: input.authToken,
+      token:
+        input.patch.token ??
+        optionalStringValue(diskPlex.token) ??
+        input.currentConfig.plex?.token ??
+        '',
       refreshIntervalMinutes:
+        input.patch.refreshIntervalMinutes ??
         optionalNonNegativeNumber(diskPlex.refreshIntervalMinutes) ??
         input.currentConfig.plex?.refreshIntervalMinutes ??
         30,

--- a/src/plex/auth.ts
+++ b/src/plex/auth.ts
@@ -318,6 +318,43 @@ export class PlexAuthStore {
     };
   }
 
+  disconnect(now = new Date().toISOString()): PlexAuthIdentity | null {
+    const identity = this.getIdentity();
+    if (!identity) {
+      return null;
+    }
+
+    this.database
+      .query(
+        `UPDATE plex_auth_identity
+        SET refresh_token = NULL,
+            token_expires_at = NULL,
+            last_error = NULL,
+            reconnect_required_at = NULL,
+            updated_at = ?1
+        WHERE singleton = 1`,
+      )
+      .run(now);
+
+    this.database
+      .query(
+        `UPDATE plex_auth_sessions
+        SET status = 'cancelled',
+            cancelled_at = ?1
+        WHERE status = 'pending'`,
+      )
+      .run(now);
+
+    return {
+      ...identity,
+      refreshToken: null,
+      tokenExpiresAt: null,
+      lastError: null,
+      reconnectRequiredAt: null,
+      updatedAt: now,
+    };
+  }
+
   private getPendingSession(now: string): PlexAuthSession | null {
     const row = this.database
       .query(

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1254,6 +1254,185 @@ describe('Plex browser auth flow', () => {
       fetchSpy.mockRestore();
     }
   });
+
+  it('reports connecting status while a Plex browser sign-in is pending', async () => {
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ id: 42, code: 'pin-code', expiresIn: 300 }),
+        { status: 200 },
+      ),
+    );
+
+    try {
+      const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-plex-auth-'));
+      const configPath = join(directory, 'pirate-claw.config.json');
+      await writeCompactTvConfigFile(configPath);
+      const loaded = await loadConfig(configPath);
+      loaded.runtime.apiWriteToken = 'write-token';
+      const deps = createDatabaseBackedDeps(loaded, configPath);
+      const handler = createApiFetch(deps);
+
+      await handler(
+        new Request('http://localhost/api/plex/auth/start', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer write-token',
+          },
+          body: JSON.stringify({
+            forwardUrl: 'http://localhost:5173/plex/connect/callback',
+            returnTo: '/onboarding',
+          }),
+        }),
+      );
+
+      const response = await handler(
+        new Request('http://localhost/api/plex/auth/status'),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        state: 'connecting',
+        plexUrl: 'http://localhost:32400',
+        hasToken: false,
+        returnTo: '/onboarding',
+      });
+      deps.database?.close();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('persists a Plex URL patch without requiring a manual token edit flow', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-plex-auth-'));
+    const configPath = join(directory, 'pirate-claw.config.json');
+    await writeCompactTvConfigFile(configPath);
+    const loaded = await loadConfig(configPath);
+    loaded.runtime.apiWriteToken = 'write-token';
+    const deps = createDatabaseBackedDeps(loaded, configPath);
+    const handler = createApiFetch(deps);
+
+    const current = await handler(new Request('http://localhost/api/config'));
+    const etag = current.headers.get('etag');
+
+    const response = await handler(
+      new Request('http://localhost/api/config/plex', {
+        method: 'PUT',
+        headers: {
+          'content-type': 'application/json',
+          authorization: 'Bearer write-token',
+          'if-match': etag!,
+        },
+        body: JSON.stringify({ url: 'http://plex.internal:32400' }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const disk = (await Bun.file(configPath).json()) as {
+      plex?: {
+        url?: string;
+        token?: string;
+        refreshIntervalMinutes?: number;
+      };
+    };
+    expect(disk.plex).toEqual({
+      url: 'http://plex.internal:32400',
+      token: '',
+      refreshIntervalMinutes: 30,
+    });
+    deps.database?.close();
+  });
+
+  it('disconnects Plex by clearing both config token and stored auth state', async () => {
+    const prevWrite = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    process.env.PIRATE_CLAW_API_WRITE_TOKEN = 'write-token';
+    const fetchSpy = spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ id: 99, code: 'pin-code', expiresIn: 300 }),
+          {
+            status: 200,
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ authToken: 'plex-jwt-token' }), {
+          status: 200,
+        }),
+      );
+
+    try {
+      const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-plex-auth-'));
+      const configPath = join(directory, 'pirate-claw.config.json');
+      await writeCompactTvConfigFile(configPath);
+      const loaded = await loadConfig(configPath);
+      loaded.runtime.apiWriteToken = 'write-token';
+      const deps = createDatabaseBackedDeps(loaded, configPath);
+      const handler = createApiFetch(deps);
+
+      const started = await handler(
+        new Request('http://localhost/api/plex/auth/start', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer write-token',
+          },
+          body: JSON.stringify({
+            forwardUrl: 'http://localhost:5173/plex/connect/callback',
+            returnTo: '/config',
+          }),
+        }),
+      );
+      const startedBody = (await started.json()) as { sessionId: string };
+
+      await handler(
+        new Request('http://localhost/api/plex/auth/finalize', {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer write-token',
+          },
+          body: JSON.stringify({ sessionId: startedBody.sessionId }),
+        }),
+      );
+
+      const current = await handler(new Request('http://localhost/api/config'));
+      const disconnect = await handler(
+        new Request('http://localhost/api/plex/auth/disconnect', {
+          method: 'POST',
+          headers: {
+            authorization: 'Bearer write-token',
+            'if-match': current.headers.get('etag')!,
+          },
+        }),
+      );
+
+      expect(disconnect.status).toBe(200);
+      const status = await handler(
+        new Request('http://localhost/api/plex/auth/status'),
+      );
+      expect(await status.json()).toMatchObject({
+        state: 'not_connected',
+        plexUrl: 'http://localhost:32400',
+        returnTo: null,
+      });
+
+      const disk = (await Bun.file(configPath).json()) as {
+        plex?: {
+          token?: string;
+        };
+      };
+      expect(disk.plex?.token).toBe('');
+      deps.database?.close();
+    } finally {
+      if (prevWrite !== undefined) {
+        process.env.PIRATE_CLAW_API_WRITE_TOKEN = prevWrite;
+      } else {
+        delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+      }
+      fetchSpy.mockRestore();
+    }
+  });
 });
 
 describe('PUT /api/config', () => {

--- a/web/src/lib/components/PlexAuthCard.svelte
+++ b/web/src/lib/components/PlexAuthCard.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+	import type { PlexAuthStatusResponse } from '$lib/types';
+
+	type Props = {
+		status: PlexAuthStatusResponse;
+		canWrite: boolean;
+		returnTo: string;
+		currentEtag?: string | null;
+		message?: string | null;
+		messageTone?: 'neutral' | 'success' | 'error';
+		mode?: 'config' | 'onboarding';
+		saveAction?: string;
+		disconnectAction?: string;
+		skipHref?: string | null;
+	};
+
+	const {
+		status,
+		canWrite,
+		returnTo,
+		currentEtag = null,
+		message = null,
+		messageTone = 'neutral',
+		mode = 'config',
+		saveAction = '?/savePlex',
+		disconnectAction = '?/disconnectPlex',
+		skipHref = null
+	}: Props = $props();
+
+	const stateCopy = {
+		not_connected: {
+			label: 'Not connected',
+			description: 'Pirate Claw is not signed into Plex yet.'
+		},
+		connecting: {
+			label: 'Connecting in browser',
+			description: 'A Plex hosted sign-in is in progress for this server.'
+		},
+		connected: {
+			label: 'Connected',
+			description: 'Pirate Claw can call Plex using the current server-side credential.'
+		},
+		reconnect_required: {
+			label: 'Reconnect required',
+			description: 'The saved Plex credential needs to be replaced from the browser flow.'
+		}
+	} satisfies Record<PlexAuthStatusResponse['state'], { label: string; description: string }>;
+
+	const connectHref = $derived(`/plex/connect?returnTo=${encodeURIComponent(returnTo)}`);
+	const connectLabel = $derived.by(() => {
+		if (status.state === 'connected' || status.state === 'reconnect_required') {
+			return 'Reconnect in browser';
+		}
+		if (status.state === 'connecting') {
+			return 'Restart browser sign-in';
+		}
+		return 'Connect in browser';
+	});
+	const stateClass = $derived.by(() => {
+		switch (status.state) {
+			case 'connected':
+				return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100';
+			case 'reconnect_required':
+				return 'border-amber-500/40 bg-amber-500/10 text-amber-100';
+			case 'connecting':
+				return 'border-sky-500/40 bg-sky-500/10 text-sky-100';
+			default:
+				return 'border-white/15 bg-white/5 text-white';
+		}
+	});
+	const messageClass = $derived.by(() => {
+		if (messageTone === 'error') return 'text-destructive';
+		if (messageTone === 'success') return 'text-emerald-300';
+		return 'text-muted-foreground';
+	});
+</script>
+
+<div class="bg-card/75 space-y-4 rounded-[30px] border border-white/10 p-6">
+	<div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+		<div class="space-y-2">
+			<div
+				class={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-[0.25em] uppercase ${stateClass}`}
+			>
+				{stateCopy[status.state].label}
+			</div>
+			<div class="space-y-1">
+				<h3 class="text-lg font-semibold tracking-tight">Plex Connection</h3>
+				<p class="text-muted-foreground max-w-2xl text-sm leading-6">
+					{stateCopy[status.state].description} Use Plex&apos;s hosted browser flow instead of manually
+					extracting a token.
+				</p>
+			</div>
+		</div>
+
+		<a
+			class:text-muted-foreground={!canWrite}
+			class:pointer-events-none={!canWrite}
+			class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-11 items-center rounded-xl px-5 text-sm font-semibold transition disabled:opacity-50"
+			href={connectHref}
+		>
+			{connectLabel}
+		</a>
+	</div>
+
+	{#if mode === 'config'}
+		<form method="POST" action={saveAction} class="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
+			<div class="space-y-1">
+				<label class="text-sm font-medium" for="plex-url">Plex Media Server URL</label>
+				<input
+					id="plex-url"
+					name="plexUrl"
+					type="url"
+					value={status.plexUrl}
+					class="border-input bg-background/70 ring-offset-background placeholder:text-muted-foreground/70 h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+				/>
+				<p class="text-muted-foreground text-xs">
+					Operator-managed PMS URL. Keep this pointed at the server Pirate Claw should read.
+				</p>
+			</div>
+
+			<div class="flex items-end">
+				<input type="hidden" name="ifMatch" value={currentEtag ?? ''} />
+				<button
+					type="submit"
+					class="border-border bg-background/55 hover:bg-muted/80 inline-flex h-11 items-center rounded-xl border px-4 text-sm transition-colors disabled:opacity-50"
+					disabled={!canWrite || !currentEtag}
+				>
+					Save PMS URL
+				</button>
+			</div>
+		</form>
+	{/if}
+
+	<div class="flex flex-wrap items-center gap-3">
+		{#if mode === 'config' && status.hasToken}
+			<form method="POST" action={disconnectAction}>
+				<input type="hidden" name="ifMatch" value={currentEtag ?? ''} />
+				<button
+					type="submit"
+					class="border-border bg-background/55 hover:bg-muted/80 inline-flex h-11 items-center rounded-xl border px-4 text-sm transition-colors disabled:opacity-50"
+					disabled={!canWrite || !currentEtag}
+				>
+					Disconnect
+				</button>
+			</form>
+		{/if}
+
+		{#if mode === 'onboarding' && skipHref}
+			<a href={skipHref} class="text-muted-foreground text-sm hover:underline">Skip for now</a>
+		{/if}
+	</div>
+
+	{#if status.state === 'connecting' && status.returnTo}
+		<p class="text-muted-foreground text-sm">
+			This sign-in was started from <code>{status.returnTo}</code>.
+		</p>
+	{/if}
+
+	{#if !canWrite}
+		<p class="text-muted-foreground text-sm">
+			Config writes are disabled. Set <code>PIRATE_CLAW_API_WRITE_TOKEN</code> to start or update the
+			connection.
+		</p>
+	{/if}
+
+	{#if message}
+		<p class={`text-sm ${messageClass}`}>{message}</p>
+	{/if}
+</div>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -170,6 +170,15 @@ export type PlexConfig = {
 	refreshIntervalMinutes: number;
 };
 
+export type PlexAuthState = 'not_connected' | 'connecting' | 'connected' | 'reconnect_required';
+
+export type PlexAuthStatusResponse = {
+	state: PlexAuthState;
+	plexUrl: string;
+	hasToken: boolean;
+	returnTo: string | null;
+};
+
 export type AppConfig = {
 	feeds: FeedConfig[];
 	tv: TvRule[];

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -5,6 +5,7 @@ import { apiRequest } from '$lib/server/api';
 import type {
 	AppConfig,
 	OnboardingStatus,
+	PlexAuthStatusResponse,
 	RunSummaryRecord,
 	SessionInfo,
 	TransmissionStatusResponse
@@ -14,10 +15,11 @@ import type { Actions, PageServerLoad } from './$types';
 export const load: PageServerLoad = async () => {
 	const canWrite = !!env.PIRATE_CLAW_API_WRITE_TOKEN;
 
-	const [configResult, sessionResult, statusResult] = await Promise.allSettled([
+	const [configResult, sessionResult, statusResult, plexAuthResult] = await Promise.allSettled([
 		apiRequest('/api/config'),
 		apiRequest('/api/transmission/session'),
-		apiRequest('/api/status')
+		apiRequest('/api/status'),
+		apiRequest('/api/plex/auth/status')
 	]);
 
 	let config: AppConfig | null = null;
@@ -26,6 +28,7 @@ export const load: PageServerLoad = async () => {
 	let transmissionSession: SessionInfo | null = null;
 	let runSummaries: RunSummaryRecord[] | null = null;
 	let onboarding: OnboardingStatus | null = null;
+	let plexAuth: PlexAuthStatusResponse | null = null;
 
 	if (configResult.status === 'fulfilled' && configResult.value.ok) {
 		config = (await configResult.value.json()) as AppConfig;
@@ -45,7 +48,22 @@ export const load: PageServerLoad = async () => {
 		runSummaries = statusData.runs;
 	}
 
-	return { config, etag, canWrite, error, transmissionSession, runSummaries, onboarding };
+	if (plexAuthResult.status === 'fulfilled' && plexAuthResult.value.ok) {
+		plexAuth = (await plexAuthResult.value.json()) as PlexAuthStatusResponse;
+	} else {
+		console.error('[config] failed to load plex auth status');
+	}
+
+	return {
+		config,
+		etag,
+		canWrite,
+		error,
+		transmissionSession,
+		runSummaries,
+		onboarding,
+		plexAuth
+	};
 };
 
 function parseOptionalInt(input: unknown): number | undefined {
@@ -86,6 +104,118 @@ function validateRuntimeBounds(
 }
 
 export const actions: Actions = {
+	savePlex: async ({ request }) => {
+		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+		if (!writeToken) {
+			return fail(403, { plexMessage: 'Config writes are disabled.', plexMessageTone: 'error' });
+		}
+
+		const formData = await request.formData();
+		const ifMatch = String(formData.get('ifMatch') ?? '').trim();
+		const plexUrl = String(formData.get('plexUrl') ?? '').trim();
+		if (!ifMatch) {
+			return fail(400, {
+				plexMessage: 'Missing config revision. Reload and try again.',
+				plexMessageTone: 'error'
+			});
+		}
+		if (!plexUrl) {
+			return fail(400, {
+				plexMessage: 'Plex Media Server URL is required.',
+				plexMessageTone: 'error'
+			});
+		}
+
+		try {
+			const response = await apiRequest('/api/config/plex', {
+				method: 'PUT',
+				headers: {
+					'content-type': 'application/json',
+					authorization: `Bearer ${writeToken}`,
+					'if-match': ifMatch
+				},
+				body: JSON.stringify({ url: plexUrl })
+			});
+
+			if (!response.ok) {
+				let plexMessage = `Save failed (${response.status}).`;
+				try {
+					const body = (await response.json()) as { error?: string };
+					if (body.error) plexMessage = body.error;
+				} catch {
+					// keep fallback message
+				}
+				return fail(response.status, {
+					plexMessage,
+					plexMessageTone: 'error',
+					plexEtag: response.headers.get('etag')
+				});
+			}
+
+			return {
+				plexMessage: 'Plex URL saved.',
+				plexMessageTone: 'success',
+				plexEtag: response.headers.get('etag')
+			};
+		} catch (error) {
+			console.error('[config] savePlex failed:', error);
+			return fail(500, { plexMessage: 'Could not save Plex URL.', plexMessageTone: 'error' });
+		}
+	},
+
+	disconnectPlex: async ({ request }) => {
+		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+		if (!writeToken) {
+			return fail(403, { plexMessage: 'Config writes are disabled.', plexMessageTone: 'error' });
+		}
+
+		const formData = await request.formData();
+		const ifMatch = String(formData.get('ifMatch') ?? '').trim();
+		if (!ifMatch) {
+			return fail(400, {
+				plexMessage: 'Missing config revision. Reload and try again.',
+				plexMessageTone: 'error'
+			});
+		}
+
+		try {
+			const response = await apiRequest('/api/plex/auth/disconnect', {
+				method: 'POST',
+				headers: {
+					authorization: `Bearer ${writeToken}`,
+					'if-match': ifMatch
+				}
+			});
+
+			if (!response.ok) {
+				let plexMessage = `Disconnect failed (${response.status}).`;
+				try {
+					const body = (await response.json()) as { error?: string };
+					if (body.error) plexMessage = body.error;
+				} catch {
+					// keep fallback message
+				}
+				return fail(response.status, {
+					plexMessage,
+					plexMessageTone: 'error',
+					plexEtag: response.headers.get('etag')
+				});
+			}
+
+			return {
+				plexMessage: 'Plex disconnected.',
+				plexMessageTone: 'success',
+				plexEtag: response.headers.get('etag')
+			};
+		} catch (error) {
+			console.error('[config] disconnectPlex failed:', error);
+			return fail(500, {
+				plexMessage: 'Could not disconnect Plex.',
+				plexMessageTone: 'error'
+			});
+		}
+	},
+
 	saveShows: async ({ request }) => {
 		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
 		if (!writeToken) {

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -2,6 +2,7 @@
 	import type { SubmitFunction } from '@sveltejs/kit';
 	import { tick } from 'svelte';
 	import ApiUnavailableAlert from '$lib/components/ApiUnavailableAlert.svelte';
+	import PlexAuthCard from '$lib/components/PlexAuthCard.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { maskConfiguredValue, parseHostPortFromUrl } from '$lib/helpers';
 	import { toast } from '$lib/toast';
@@ -32,13 +33,17 @@
 			form?.tvDefaultsEtag ??
 			form?.showsEtag ??
 			form?.runtimeEtag ??
+			form?.plexEtag ??
 			data.etag ??
 			null
 	);
 	const canWrite = $derived(data.canWrite);
-	const plexConnectLabel = $derived(
-		data.config?.plex?.token ? 'Reconnect Plex in browser' : 'Connect Plex in browser'
-	);
+	const plexMessageTone = $derived.by<'neutral' | 'success' | 'error'>(() => {
+		if (form?.plexMessageTone === 'success' || form?.plexMessageTone === 'error') {
+			return form.plexMessageTone;
+		}
+		return 'neutral';
+	});
 
 	let showRows = $state<string[]>([]);
 	let tvResolutions = $state<string[]>([]);
@@ -440,18 +445,20 @@
 		<ApiUnavailableAlert message={data.error} />
 	{:else if data.config}
 		<section class="border-border/70 bg-card/80 rounded-3xl border p-6 shadow-sm">
-			<div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-				<div class="space-y-1">
-					<h2 class="text-foreground text-lg font-semibold">Plex Connection</h2>
-					<p class="text-muted-foreground text-sm">
-						Use Plex&apos;s hosted sign-in flow to connect Pirate Claw without manually copying a
-						token.
-					</p>
-				</div>
-				<Button href="/plex/connect?returnTo=/config" disabled={!canWrite}>
-					{plexConnectLabel}
-				</Button>
-			</div>
+			<PlexAuthCard
+				status={data.plexAuth ?? {
+					state: 'not_connected',
+					plexUrl: data.config.plex?.url ?? 'http://localhost:32400',
+					hasToken: !!data.config.plex?.token,
+					returnTo: null
+				}}
+				{canWrite}
+				{currentEtag}
+				returnTo="/config"
+				mode="config"
+				message={form?.plexMessage}
+				messageTone={plexMessageTone}
+			/>
 		</section>
 
 		<div class="grid gap-5 xl:grid-cols-2">

--- a/web/src/routes/onboarding/+page.server.ts
+++ b/web/src/routes/onboarding/+page.server.ts
@@ -6,6 +6,7 @@ import type {
 	AppConfig,
 	FeedConfig,
 	MoviePolicy,
+	PlexAuthStatusResponse,
 	ReadinessResponse,
 	TransmissionCompatibility,
 	TransmissionStatusResponse
@@ -16,9 +17,10 @@ export const load: PageServerLoad = async () => {
 	const canWrite = !!env.PIRATE_CLAW_API_WRITE_TOKEN;
 
 	try {
-		const [configResponse, readinessResponse] = await Promise.all([
+		const [configResponse, readinessResponse, plexAuthResponse] = await Promise.all([
 			apiRequest('/api/config'),
-			apiRequest('/api/setup/readiness')
+			apiRequest('/api/setup/readiness'),
+			apiRequest('/api/plex/auth/status')
 		]);
 
 		if (!configResponse.ok) {
@@ -28,6 +30,7 @@ export const load: PageServerLoad = async () => {
 				etag: null,
 				canWrite,
 				onboarding: null,
+				plexAuth: null,
 				readinessState: null,
 				error: 'Could not reach the API.'
 			};
@@ -38,12 +41,16 @@ export const load: PageServerLoad = async () => {
 		const readinessState = readinessResponse.ok
 			? ((await readinessResponse.json()) as ReadinessResponse).state
 			: null;
+		const plexAuth = plexAuthResponse.ok
+			? ((await plexAuthResponse.json()) as PlexAuthStatusResponse)
+			: null;
 
 		return {
 			config,
 			etag,
 			canWrite,
 			onboarding: deriveOnboardingStatus(config, canWrite),
+			plexAuth,
 			readinessState,
 			error: null
 		};
@@ -54,6 +61,7 @@ export const load: PageServerLoad = async () => {
 			etag: null,
 			canWrite,
 			onboarding: null,
+			plexAuth: null,
 			readinessState: null,
 			error: 'Could not reach the API.'
 		};

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
 	import ApiUnavailableAlert from '$lib/components/ApiUnavailableAlert.svelte';
+	import PlexAuthCard from '$lib/components/PlexAuthCard.svelte';
 	import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert';
 	import {
 		readOnboardingPath,
@@ -87,8 +88,13 @@
 		(data.config?.movies?.resolutions?.length ?? 0) > 0 ||
 			(data.config?.movies?.codecs?.length ?? 0) > 0
 	);
+	const plexStepLabel = 'Step 3 — Connect Plex (optional)';
+	const mediaDirsStepLabel = 'Step 4 — Media Directories (optional)';
+	const feedTypeStepLabel = 'Step 5 — Feed type';
+	const firstFeedStepLabel = 'Step 5 — Add your first feed';
+	const tvTargetStepLabel = 'Step 6 — Add a TV target';
 	const movieStepLabel = $derived(
-		onboardingPath === 'both' ? 'Step 6 — Add a movie target' : 'Step 5 — Add a movie target'
+		onboardingPath === 'both' ? 'Step 7 — Add a movie target' : 'Step 6 — Add a movie target'
 	);
 	const minimumComplete = $derived(
 		(data.onboarding?.minimumComplete ?? false) ||
@@ -235,6 +241,26 @@
 			</Alert>
 		{/if}
 
+		{#if showPreStepsDone}
+			<div class="space-y-3">
+				<h2 class="text-lg font-semibold tracking-tight">{plexStepLabel}</h2>
+				<PlexAuthCard
+					status={data.plexAuth ?? {
+						state: 'not_connected',
+						plexUrl: data.config?.plex?.url ?? 'http://localhost:32400',
+						hasToken: !!data.config?.plex?.token,
+						returnTo: null
+					}}
+					canWrite={data.canWrite}
+					returnTo="/onboarding"
+					mode="onboarding"
+					skipHref="#after-plex"
+				/>
+			</div>
+		{/if}
+
+		<div id="after-plex"></div>
+
 		{#if showTransmissionStep}
 			<!-- Step 1: Transmission -->
 			<div
@@ -289,7 +315,7 @@
 			<div
 				class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
 			>
-				<h2 class="text-lg font-semibold tracking-tight">Step 3 — Media Directories (optional)</h2>
+				<h2 class="text-lg font-semibold tracking-tight">{mediaDirsStepLabel}</h2>
 				<p class="text-muted-foreground text-sm">
 					Set per-media-type download directories. Leave blank to use the Transmission default.
 				</p>
@@ -347,7 +373,7 @@
 			<div
 				class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
 			>
-				<h2 class="text-lg font-semibold tracking-tight">Step 4 — Feed type</h2>
+				<h2 class="text-lg font-semibold tracking-tight">{feedTypeStepLabel}</h2>
 				<div class="flex flex-wrap gap-3">
 					<label
 						class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
@@ -378,7 +404,7 @@
 			<div
 				class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
 			>
-				<h2 class="text-lg font-semibold tracking-tight">Step 4 — Add your first feed</h2>
+				<h2 class="text-lg font-semibold tracking-tight">{firstFeedStepLabel}</h2>
 				<form method="POST" action="?/saveFeed" class="space-y-4">
 					<input
 						type="hidden"
@@ -464,7 +490,7 @@
 			<div
 				class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
 			>
-				<h2 class="text-lg font-semibold tracking-tight">Step 4 — Feed type</h2>
+				<h2 class="text-lg font-semibold tracking-tight">{feedTypeStepLabel}</h2>
 				<div class="flex flex-wrap gap-3">
 					<label
 						class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
@@ -495,7 +521,7 @@
 			<div
 				class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
 			>
-				<h2 class="text-lg font-semibold tracking-tight">Step 4 — Add your first feed</h2>
+				<h2 class="text-lg font-semibold tracking-tight">{firstFeedStepLabel}</h2>
 				<form method="POST" action="?/saveFeed" class="space-y-4">
 					<input
 						type="hidden"
@@ -573,7 +599,7 @@
 			<Alert
 				class="border-border/80 bg-card/85 rounded-2xl border shadow-lg shadow-black/20 backdrop-blur-sm"
 			>
-				<AlertTitle>Step 5 — Add a TV target</AlertTitle>
+				<AlertTitle>{tvTargetStepLabel}</AlertTitle>
 				<AlertDescription>
 					Your first feed is saved. Add a TV show and optional defaults without replacing any
 					existing shows already in config.

--- a/web/test/routes/config/config.test.ts
+++ b/web/test/routes/config/config.test.ts
@@ -79,6 +79,9 @@ describe('/config', () => {
 		expect(screen.getByRole('heading', { name: 'TV Configuration' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Movie Policy' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Transmission Protocol' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Plex Connection' })).toBeInTheDocument();
+		expect(screen.getByLabelText('Plex Media Server URL')).toHaveValue('http://localhost:32400');
+		expect(screen.getByRole('link', { name: 'Connect in browser' })).toBeInTheDocument();
 		expect(screen.getByText('Write Access: Active')).toBeInTheDocument();
 		expect(screen.getByText('TestFeed')).toBeInTheDocument();
 		expect(screen.getByRole('textbox', { name: 'TV show 1' })).toBeInTheDocument();

--- a/web/test/routes/config/page.server.test.ts
+++ b/web/test/routes/config/page.server.test.ts
@@ -37,7 +37,18 @@ describe('config page server actions', () => {
 					)
 				)
 				.mockRejectedValueOnce(new Error('network error'))
-				.mockResolvedValueOnce(new Response(JSON.stringify({ runs: [] }), { status: 200 }));
+				.mockResolvedValueOnce(new Response(JSON.stringify({ runs: [] }), { status: 200 }))
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							state: 'not_connected',
+							plexUrl: 'http://localhost:32400',
+							hasToken: false,
+							returnTo: null
+						}),
+						{ status: 200 }
+					)
+				);
 
 			const result = await load({} as never);
 			expect((result as { onboarding: { state: string } | null }).onboarding?.state).toBe(
@@ -70,7 +81,18 @@ describe('config page server actions', () => {
 					)
 				)
 				.mockRejectedValueOnce(new Error('network error'))
-				.mockResolvedValueOnce(new Response(JSON.stringify({ runs: [] }), { status: 200 }));
+				.mockResolvedValueOnce(new Response(JSON.stringify({ runs: [] }), { status: 200 }))
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							state: 'not_connected',
+							plexUrl: 'http://localhost:32400',
+							hasToken: false,
+							returnTo: null
+						}),
+						{ status: 200 }
+					)
+				);
 
 			const result = await load({} as never);
 			expect((result as { transmissionSession: unknown }).transmissionSession).toBeNull();
@@ -115,7 +137,18 @@ describe('config page server actions', () => {
 						{ status: 200 }
 					)
 				)
-				.mockResolvedValueOnce(new Response(JSON.stringify({ runs: [] }), { status: 200 }));
+				.mockResolvedValueOnce(new Response(JSON.stringify({ runs: [] }), { status: 200 }))
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify({
+							state: 'connected',
+							plexUrl: 'http://localhost:32400',
+							hasToken: true,
+							returnTo: null
+						}),
+						{ status: 200 }
+					)
+				);
 
 			const result = await load({} as never);
 			expect((result as { transmissionSession: unknown }).transmissionSession).toEqual({

--- a/web/test/routes/onboarding/onboarding.test.ts
+++ b/web/test/routes/onboarding/onboarding.test.ts
@@ -19,7 +19,13 @@ const sharedLayoutData = {
 	transmissionSession: null,
 	plexConfigured: false,
 	setupState: 'ready' as const,
-	readinessState: 'ready' as const
+	readinessState: 'ready' as const,
+	plexAuth: {
+		state: 'not_connected' as const,
+		plexUrl: 'http://localhost:32400',
+		hasToken: false,
+		returnTo: null
+	}
 };
 
 function renderPage(data: Record<string, unknown>) {
@@ -88,9 +94,9 @@ describe('/onboarding', () => {
 			error: null
 		});
 
-		expect(screen.getByRole('heading', { name: 'Step 4 — Feed type' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Step 5 — Feed type' })).toBeInTheDocument();
 		expect(
-			screen.getByRole('heading', { name: 'Step 4 — Add your first feed' })
+			screen.getByRole('heading', { name: 'Step 5 — Add your first feed' })
 		).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Save first feed' })).toBeInTheDocument();
 	});
@@ -129,7 +135,7 @@ describe('/onboarding', () => {
 			error: null
 		});
 
-		expect(screen.getByText('Step 5 — Add a TV target')).toBeInTheDocument();
+		expect(screen.getByText('Step 6 — Add a TV target')).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Save TV target' })).toBeInTheDocument();
 	});
 
@@ -198,8 +204,8 @@ describe('/onboarding', () => {
 			error: null
 		});
 
-		expect(screen.queryByText('Step 5 — Add a TV target')).not.toBeInTheDocument();
-		expect(screen.getByText('Step 5 — Add a movie target')).toBeInTheDocument();
+		expect(screen.queryByText('Step 6 — Add a TV target')).not.toBeInTheDocument();
+		expect(screen.getByText('Step 6 — Add a movie target')).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Save movie target' })).toBeInTheDocument();
 	});
 
@@ -249,7 +255,7 @@ describe('/onboarding', () => {
 			}
 		});
 
-		expect(screen.getByText('Step 6 — Add a movie target')).toBeInTheDocument();
+		expect(screen.getByText('Step 7 — Add a movie target')).toBeInTheDocument();
 		expect(screen.queryByText('Done')).not.toBeInTheDocument();
 	});
 
@@ -272,7 +278,7 @@ describe('/onboarding', () => {
 			error: null
 		});
 
-		expect(screen.getByText('Step 6 — Add a movie target')).toBeInTheDocument();
+		expect(screen.getByText('Step 7 — Add a movie target')).toBeInTheDocument();
 		expect(screen.queryByText('Done')).not.toBeInTheDocument();
 		writeOnboardingPath('tv');
 	});

--- a/web/test/routes/onboarding/page.server.test.ts
+++ b/web/test/routes/onboarding/page.server.test.ts
@@ -19,21 +19,35 @@ describe('onboarding page server', () => {
 				env: { PIRATE_CLAW_API_WRITE_TOKEN: '' }
 			}));
 			const { load } = await import('../../../src/routes/onboarding/+page.server');
-			apiRequestMock.mockImplementation((url: string) =>
-				url === '/api/setup/readiness'
-					? Promise.resolve(
-							new Response(
-								JSON.stringify({
-									state: 'not_ready',
-									configState: 'starter',
-									transmissionReachable: false,
-									daemonLive: true
-								}),
-								{ status: 200 }
-							)
+			apiRequestMock.mockImplementation((url: string) => {
+				if (url === '/api/setup/readiness') {
+					return Promise.resolve(
+						new Response(
+							JSON.stringify({
+								state: 'not_ready',
+								configState: 'starter',
+								transmissionReachable: false,
+								daemonLive: true
+							}),
+							{ status: 200 }
 						)
-					: Promise.resolve(new Response(JSON.stringify(emptyConfig), { status: 200 }))
-			);
+					);
+				}
+				if (url === '/api/plex/auth/status') {
+					return Promise.resolve(
+						new Response(
+							JSON.stringify({
+								state: 'not_connected',
+								plexUrl: 'http://localhost:32400',
+								hasToken: false,
+								returnTo: null
+							}),
+							{ status: 200 }
+						)
+					);
+				}
+				return Promise.resolve(new Response(JSON.stringify(emptyConfig), { status: 200 }));
+			});
 
 			const result = await load({} as never);
 			expect((result as { onboarding: { state: string } | null }).onboarding?.state).toBe(
@@ -46,26 +60,40 @@ describe('onboarding page server', () => {
 				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
 			}));
 			const { load } = await import('../../../src/routes/onboarding/+page.server');
-			apiRequestMock.mockImplementation((url: string) =>
-				url === '/api/setup/readiness'
-					? Promise.resolve(
-							new Response(
-								JSON.stringify({
-									state: 'not_ready',
-									configState: 'starter',
-									transmissionReachable: false,
-									daemonLive: true
-								}),
-								{ status: 200 }
-							)
+			apiRequestMock.mockImplementation((url: string) => {
+				if (url === '/api/setup/readiness') {
+					return Promise.resolve(
+						new Response(
+							JSON.stringify({
+								state: 'not_ready',
+								configState: 'starter',
+								transmissionReachable: false,
+								daemonLive: true
+							}),
+							{ status: 200 }
 						)
-					: Promise.resolve(
-							new Response(JSON.stringify(emptyConfig), {
-								status: 200,
-								headers: { etag: '"rev-1"' }
-							})
+					);
+				}
+				if (url === '/api/plex/auth/status') {
+					return Promise.resolve(
+						new Response(
+							JSON.stringify({
+								state: 'not_connected',
+								plexUrl: 'http://localhost:32400',
+								hasToken: false,
+								returnTo: null
+							}),
+							{ status: 200 }
 						)
-			);
+					);
+				}
+				return Promise.resolve(
+					new Response(JSON.stringify(emptyConfig), {
+						status: 200,
+						headers: { etag: '"rev-1"' }
+					})
+				);
+			});
 
 			const result = await load({} as never);
 			expect((result as { onboarding: { state: string } | null }).onboarding?.state).toBe(
@@ -78,31 +106,46 @@ describe('onboarding page server', () => {
 				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
 			}));
 			const { load } = await import('../../../src/routes/onboarding/+page.server');
-			apiRequestMock.mockImplementation((url: string) =>
-				url === '/api/setup/readiness'
-					? Promise.resolve(
-							new Response(
-								JSON.stringify({
-									state: 'not_ready',
-									configState: 'partially_configured',
-									transmissionReachable: false,
-									daemonLive: true
-								}),
-								{ status: 200 }
-							)
+			apiRequestMock.mockImplementation((url: string) => {
+				if (url === '/api/setup/readiness') {
+					return Promise.resolve(
+						new Response(
+							JSON.stringify({
+								state: 'not_ready',
+								configState: 'partially_configured',
+								transmissionReachable: false,
+								daemonLive: true
+							}),
+							{ status: 200 }
 						)
-					: Promise.resolve(
-							new Response(JSON.stringify(feedOnlyConfig), {
-								status: 200,
-								headers: { etag: '"rev-2"' }
-							})
+					);
+				}
+				if (url === '/api/plex/auth/status') {
+					return Promise.resolve(
+						new Response(
+							JSON.stringify({
+								state: 'connected',
+								plexUrl: 'http://localhost:32400',
+								hasToken: true,
+								returnTo: null
+							}),
+							{ status: 200 }
 						)
-			);
+					);
+				}
+				return Promise.resolve(
+					new Response(JSON.stringify(feedOnlyConfig), {
+						status: 200,
+						headers: { etag: '"rev-2"' }
+					})
+				);
+			});
 
 			const result = await load({} as never);
 			expect((result as { onboarding: { state: string } | null }).onboarding?.state).toBe(
 				'partial_setup'
 			);
+			expect((result as { plexAuth: { state: string } | null }).plexAuth?.state).toBe('connected');
 		});
 	});
 


### PR DESCRIPTION
## Summary

- delivery ticket: `P23.03 Onboarding and Config Plex Connection UX`
- ticket file: [docs/02-delivery/phase-23/ticket-03-plex-connection-ux.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-23/ticket-03-plex-connection-ux.md)
- stacked base branch: `agents/p23-02-browser-redirect-return-flow-and-config-persistence`
- self-audit: outcome `clean` completed at 2026-04-22 09:06 UTC

## External AI Review

- outcome: `clean`
- current branch head: [`20c470d8d32d`](https://github.com/cesarnml/Pirate-Claw/commit/20c470d8d32d54f2740c3b6107b553b8001d4714)
- no prudent follow-up changes were required.
