### PR TITLE
feat: add Plex silent renewal states [P23.04]

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1700,7 +1700,14 @@ export type FeedStatus = {
 };
 
 export type PlexAuthStatusResponse = {
-  state: 'not_connected' | 'connecting' | 'connected' | 'reconnect_required';
+  state:
+    | 'not_connected'
+    | 'connecting'
+    | 'connected'
+    | 'reconnect_required'
+    | 'renewing'
+    | 'expired_reconnect_required'
+    | 'error_reconnect_required';
   plexUrl: string;
   hasToken: boolean;
   returnTo: string | null;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,10 @@ import {
 import { runPlexBackgroundRefresh } from './plex/background-refresh';
 import { PlexCache } from './plex/cache';
 import { PlexHttpClient } from './plex/client';
+import {
+  PlexCredentialManager,
+  RenewingPlexHttpClient,
+} from './plex/credential-manager';
 import type { PlexMovieEnrichDeps } from './plex/movies';
 import type { PlexShowEnrichDeps } from './plex/shows';
 import {
@@ -50,20 +54,27 @@ import { createTransmissionDownloader } from './transmission';
 
 function plexMovieEnrichDeps(
   database: Database,
-  config: AppConfig,
+  configHolder: { current: AppConfig },
   log: (message: string) => void,
+  credentialManager?: PlexCredentialManager,
 ): PlexMovieEnrichDeps | undefined {
+  const config = configHolder.current;
   if (!config.plex) {
     return undefined;
   }
 
   return {
     cache: new PlexCache(database),
-    client: new PlexHttpClient(
-      config.plex.url,
-      config.plex.token,
-      (m: string) => log(`[plex] ${m}`),
-    ),
+    client:
+      credentialManager === undefined
+        ? new PlexHttpClient(config.plex.url, config.plex.token, (m: string) =>
+            log(`[plex] ${m}`),
+          )
+        : new RenewingPlexHttpClient({
+            baseUrl: config.plex.url,
+            manager: credentialManager,
+            log: (m: string) => log(`[plex] ${m}`),
+          }),
     refreshIntervalMinutes: config.plex.refreshIntervalMinutes,
     log: (m: string) => log(`[plex] ${m}`),
   };
@@ -71,20 +82,27 @@ function plexMovieEnrichDeps(
 
 function plexShowEnrichDeps(
   database: Database,
-  config: AppConfig,
+  configHolder: { current: AppConfig },
   log: (message: string) => void,
+  credentialManager?: PlexCredentialManager,
 ): PlexShowEnrichDeps | undefined {
+  const config = configHolder.current;
   if (!config.plex) {
     return undefined;
   }
 
   return {
     cache: new PlexCache(database),
-    client: new PlexHttpClient(
-      config.plex.url,
-      config.plex.token,
-      (m: string) => log(`[plex] ${m}`),
-    ),
+    client:
+      credentialManager === undefined
+        ? new PlexHttpClient(config.plex.url, config.plex.token, (m: string) =>
+            log(`[plex] ${m}`),
+          )
+        : new RenewingPlexHttpClient({
+            baseUrl: config.plex.url,
+            manager: credentialManager,
+            log: (m: string) => log(`[plex] ${m}`),
+          }),
     refreshIntervalMinutes: config.plex.refreshIntervalMinutes,
     log: (m: string) => log(`[plex] ${m}`),
   };
@@ -230,8 +248,9 @@ export async function runCli(argv: string[]): Promise<number> {
 
       try {
         const repository = createRepository(database);
-        const plexMovies = plexMovieEnrichDeps(database, config, log);
-        const plexShows = plexShowEnrichDeps(database, config, log);
+        const configHolder = { current: config };
+        const plexMovies = plexMovieEnrichDeps(database, configHolder, log);
+        const plexShows = plexShowEnrichDeps(database, configHolder, log);
         await runPlexBackgroundRefresh({
           repository,
           plexMovies,
@@ -375,11 +394,30 @@ export async function runCli(argv: string[]): Promise<number> {
         const { artifactDir, artifactRetentionDays } = config.runtime;
 
         const health = createHealthState();
+        const configHolder = { current: config };
+        const plexCredentialManager = config.plex
+          ? new PlexCredentialManager({
+              database,
+              configPath: resolvedConfigPath,
+              configHolder,
+              log,
+            })
+          : undefined;
 
         const tmdbMovies = tmdbMovieEnrichDeps(database, config, log);
         const tmdbShows = tmdbShowsEnrichDeps(database, config, log);
-        const plexMovies = plexMovieEnrichDeps(database, config, log);
-        const plexShows = plexShowEnrichDeps(database, config, log);
+        const plexMovies = plexMovieEnrichDeps(
+          database,
+          configHolder,
+          log,
+          plexCredentialManager,
+        );
+        const plexShows = plexShowEnrichDeps(
+          database,
+          configHolder,
+          log,
+          plexCredentialManager,
+        );
         const tmdbRefreshIntervalMinutes =
           config.runtime.tmdbRefreshIntervalMinutes!;
         const scheduleTmdbRefresh =
@@ -388,7 +426,9 @@ export async function runCli(argv: string[]): Promise<number> {
           config.plex?.refreshIntervalMinutes ?? 0;
         const schedulePlexRefresh = plexRefreshIntervalMinutes > 0;
 
-        const configHolder = { current: config };
+        if (plexCredentialManager) {
+          await plexCredentialManager.startupRenew();
+        }
 
         await runDaemonLoop({
           runCycle: async () => {

--- a/src/plex/auth-client.ts
+++ b/src/plex/auth-client.ts
@@ -95,6 +95,66 @@ export async function exchangePlexPinForAuthToken(input: {
   return body.authToken ?? null;
 }
 
+export async function refreshPlexAuthToken(input: {
+  clientIdentifier: string;
+  identity: PlexAuthIdentity;
+  now?: Date;
+}): Promise<string> {
+  const nonceResponse = await fetch(`${PLEX_CLIENTS_API}/api/v2/auth/nonce`, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'X-Plex-Client-Identifier': input.clientIdentifier,
+    },
+  });
+
+  if (!nonceResponse.ok) {
+    throw new Error(
+      `Plex nonce request failed with HTTP ${nonceResponse.status}.`,
+    );
+  }
+
+  const nonceBody = (await nonceResponse.json()) as { nonce?: string };
+  if (!nonceBody.nonce) {
+    throw new Error('Plex nonce response did not include a nonce.');
+  }
+
+  const deviceJwt = createDeviceJwt({
+    clientIdentifier: input.clientIdentifier,
+    keyId: input.identity.keyId,
+    privateKeyPem: input.identity.privateKeyPem,
+    nonce: nonceBody.nonce,
+    now: input.now,
+  });
+
+  const tokenResponse = await fetch(`${PLEX_CLIENTS_API}/api/v2/auth/token`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-Plex-Client-Identifier': input.clientIdentifier,
+    },
+    body: JSON.stringify({ jwt: deviceJwt }),
+  });
+
+  if (!tokenResponse.ok) {
+    throw new Error(
+      `Plex token refresh failed with HTTP ${tokenResponse.status}.`,
+    );
+  }
+
+  const tokenBody = (await tokenResponse.json()) as {
+    auth_token?: string;
+    authToken?: string;
+  };
+  const authToken = tokenBody.auth_token ?? tokenBody.authToken;
+  if (!authToken) {
+    throw new Error('Plex token refresh response did not include auth_token.');
+  }
+
+  return authToken;
+}
+
 function buildPlexHostedAuthUrl(input: {
   clientIdentifier: string;
   pinCode: string;
@@ -113,6 +173,7 @@ function createDeviceJwt(input: {
   clientIdentifier: string;
   keyId: string;
   privateKeyPem: string;
+  nonce?: string;
   now?: Date;
 }): string {
   const now = input.now ?? new Date();
@@ -124,6 +185,7 @@ function createDeviceJwt(input: {
     typ: 'JWT',
   };
   const payload = {
+    ...(input.nonce ? { nonce: input.nonce } : {}),
     aud: 'plex.tv',
     iss: input.clientIdentifier,
     scope: PLEX_AUTH_SCOPE,

--- a/src/plex/auth.ts
+++ b/src/plex/auth.ts
@@ -6,7 +6,12 @@ export type PlexAuthState =
   | 'not_connected'
   | 'connecting'
   | 'connected'
-  | 'reconnect_required';
+  | 'reconnect_required'
+  | 'renewing'
+  | 'expired_reconnect_required'
+  | 'error_reconnect_required';
+
+export type PlexReconnectRequiredReason = 'expired' | 'error' | null;
 
 export type PlexAuthSessionStatus =
   | 'pending'
@@ -34,6 +39,8 @@ export type PlexAuthIdentity = {
   lastAuthenticatedAt: string | null;
   lastError: string | null;
   reconnectRequiredAt: string | null;
+  reconnectRequiredReason: PlexReconnectRequiredReason;
+  renewalStartedAt: string | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -106,6 +113,8 @@ export class PlexAuthStore {
       lastAuthenticatedAt: null,
       lastError: null,
       reconnectRequiredAt: null,
+      reconnectRequiredReason: null,
+      renewalStartedAt: null,
       createdAt: now,
       updatedAt: now,
     };
@@ -126,11 +135,13 @@ export class PlexAuthStore {
           last_authenticated_at,
           last_error,
           reconnect_required_at,
+          reconnect_required_reason,
+          renewal_started_at,
           created_at,
           updated_at
         ) VALUES (
           1, ?1, ?2, ?3, ?4, ?5, ?6, ?7,
-          NULL, NULL, NULL, NULL, NULL, ?8, ?8
+          NULL, NULL, NULL, NULL, NULL, NULL, NULL, ?8, ?8
         )`,
       )
       .run(
@@ -163,6 +174,8 @@ export class PlexAuthStore {
           last_authenticated_at AS lastAuthenticatedAt,
           last_error AS lastError,
           reconnect_required_at AS reconnectRequiredAt,
+          reconnect_required_reason AS reconnectRequiredReason,
+          renewal_started_at AS renewalStartedAt,
           created_at AS createdAt,
           updated_at AS updatedAt
         FROM plex_auth_identity
@@ -277,6 +290,8 @@ export class PlexAuthStore {
             last_authenticated_at = ?3,
             last_error = NULL,
             reconnect_required_at = NULL,
+            reconnect_required_reason = NULL,
+            renewal_started_at = NULL,
             updated_at = ?3
         WHERE singleton = 1`,
       )
@@ -299,6 +314,8 @@ export class PlexAuthStore {
         lastAuthenticatedAt: authenticatedAt,
         lastError: null,
         reconnectRequiredAt: null,
+        reconnectRequiredReason: null,
+        renewalStartedAt: null,
         updatedAt: authenticatedAt,
       },
       session: this.getSessionOrThrow(sessionId),
@@ -331,6 +348,8 @@ export class PlexAuthStore {
             token_expires_at = NULL,
             last_error = NULL,
             reconnect_required_at = NULL,
+            reconnect_required_reason = NULL,
+            renewal_started_at = NULL,
             updated_at = ?1
         WHERE singleton = 1`,
       )
@@ -351,6 +370,91 @@ export class PlexAuthStore {
       tokenExpiresAt: null,
       lastError: null,
       reconnectRequiredAt: null,
+      reconnectRequiredReason: null,
+      renewalStartedAt: null,
+      updatedAt: now,
+    };
+  }
+
+  beginRenewal(now = new Date().toISOString()): PlexAuthIdentity {
+    const identity = this.ensureIdentity(now);
+    this.database
+      .query(
+        `UPDATE plex_auth_identity
+        SET renewal_started_at = ?1,
+            last_error = NULL,
+            updated_at = ?1
+        WHERE singleton = 1`,
+      )
+      .run(now);
+
+    return {
+      ...identity,
+      lastError: null,
+      renewalStartedAt: now,
+      updatedAt: now,
+    };
+  }
+
+  completeRenewal(
+    refreshToken: string,
+    input: { tokenExpiresAt?: string; authenticatedAt?: string } = {},
+  ): PlexAuthIdentity {
+    const authenticatedAt = input.authenticatedAt ?? new Date().toISOString();
+    const identity = this.ensureIdentity(authenticatedAt);
+
+    this.database
+      .query(
+        `UPDATE plex_auth_identity
+        SET refresh_token = ?1,
+            token_expires_at = ?2,
+            last_authenticated_at = ?3,
+            last_error = NULL,
+            reconnect_required_at = NULL,
+            reconnect_required_reason = NULL,
+            renewal_started_at = NULL,
+            updated_at = ?3
+        WHERE singleton = 1`,
+      )
+      .run(refreshToken, input.tokenExpiresAt ?? null, authenticatedAt);
+
+    return {
+      ...identity,
+      refreshToken,
+      tokenExpiresAt: input.tokenExpiresAt ?? null,
+      lastAuthenticatedAt: authenticatedAt,
+      lastError: null,
+      reconnectRequiredAt: null,
+      reconnectRequiredReason: null,
+      renewalStartedAt: null,
+      updatedAt: authenticatedAt,
+    };
+  }
+
+  markReconnectRequired(
+    reason: Exclude<PlexReconnectRequiredReason, null>,
+    error: string,
+    now = new Date().toISOString(),
+  ): PlexAuthIdentity {
+    const identity = this.ensureIdentity(now);
+    this.database
+      .query(
+        `UPDATE plex_auth_identity
+        SET last_error = ?1,
+            reconnect_required_at = ?2,
+            reconnect_required_reason = ?3,
+            renewal_started_at = NULL,
+            updated_at = ?2
+        WHERE singleton = 1`,
+      )
+      .run(error, now, reason);
+
+    return {
+      ...identity,
+      lastError: error,
+      reconnectRequiredAt: now,
+      reconnectRequiredReason: reason,
+      renewalStartedAt: null,
       updatedAt: now,
     };
   }
@@ -446,6 +550,24 @@ function resolveAuthState(
 ): PlexAuthState {
   if (pendingSession) {
     return 'connecting';
+  }
+
+  if (identity?.renewalStartedAt) {
+    return 'renewing';
+  }
+
+  if (
+    identity?.reconnectRequiredAt &&
+    identity.reconnectRequiredReason === 'expired'
+  ) {
+    return 'expired_reconnect_required';
+  }
+
+  if (
+    identity?.reconnectRequiredAt &&
+    identity.reconnectRequiredReason === 'error'
+  ) {
+    return 'error_reconnect_required';
   }
 
   if (identity?.reconnectRequiredAt) {

--- a/src/plex/client.ts
+++ b/src/plex/client.ts
@@ -2,6 +2,8 @@ import { XMLParser } from 'fast-xml-parser';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 
+export type PlexRequestFailureKind = 'auth' | 'http' | 'network' | 'parse';
+
 export type PlexLibrarySection = {
   key: string;
   type?: string;
@@ -31,6 +33,8 @@ const parser = new XMLParser({
 });
 
 export class PlexHttpClient {
+  private lastFailureKind: PlexRequestFailureKind | null = null;
+
   constructor(
     private readonly baseUrl: string,
     private readonly token: string,
@@ -39,6 +43,7 @@ export class PlexHttpClient {
   ) {}
 
   async listLibrarySections(): Promise<PlexLibrarySection[]> {
+    this.lastFailureKind = null;
     const container = await this.getXml('/library/sections');
     if (!container) {
       return [];
@@ -52,6 +57,7 @@ export class PlexHttpClient {
   }
 
   async searchMovies(title: string): Promise<PlexSearchResult[] | null> {
+    this.lastFailureKind = null;
     const query = encodeURIComponent(title);
     const container = await this.getXml(
       `/library/search?query=${query}&type=1`,
@@ -63,6 +69,7 @@ export class PlexHttpClient {
   }
 
   async searchShows(title: string): Promise<PlexSearchResult[] | null> {
+    this.lastFailureKind = null;
     const query = encodeURIComponent(title);
     const container = await this.getXml(
       `/library/search?query=${query}&type=2`,
@@ -77,6 +84,7 @@ export class PlexHttpClient {
     sectionKey: string,
     title: string,
   ): Promise<PlexSearchResult[]> {
+    this.lastFailureKind = null;
     const query = encodeURIComponent(title);
     const container = await this.getXml(
       `/library/sections/${encodeURIComponent(sectionKey)}/search?query=${query}`,
@@ -92,6 +100,7 @@ export class PlexHttpClient {
    * fallback when global `/library/search` omits or reshapes hits.
    */
   async listAllTvShowsForMatching(): Promise<PlexSearchResult[]> {
+    this.lastFailureKind = null;
     const sections = await this.listLibrarySections();
     const out: PlexSearchResult[] = [];
     for (const section of sections) {
@@ -107,6 +116,7 @@ export class PlexHttpClient {
    * Lists every movie in movie library sections (paginated). Fallback for search.
    */
   async listAllMoviesForMatching(): Promise<PlexSearchResult[]> {
+    this.lastFailureKind = null;
     const sections = await this.listLibrarySections();
     const out: PlexSearchResult[] = [];
     for (const section of sections) {
@@ -116,6 +126,10 @@ export class PlexHttpClient {
       await this.collectPagedSectionItems(section.key, 'movie', out);
     }
     return dedupeSearchResults(out);
+  }
+
+  getLastFailureKind(): PlexRequestFailureKind | null {
+    return this.lastFailureKind;
   }
 
   private async collectPagedSectionItems(
@@ -212,24 +226,34 @@ export class PlexHttpClient {
         signal: AbortSignal.timeout(this.timeoutMs),
       });
     } catch (error) {
+      this.lastFailureKind = 'network';
       const message = error instanceof Error ? error.message : String(error);
       this.log(`plex request failed: ${path} (${message})`);
       return null;
     }
 
     if (!response.ok) {
+      this.lastFailureKind = isPlexAuthFailure(response.status)
+        ? 'auth'
+        : 'http';
       this.log(`plex HTTP ${response.status} for ${path}`);
       return null;
     }
 
     try {
+      this.lastFailureKind = null;
       return parser.parse(await response.text()) as PlexMediaContainer;
     } catch (error) {
+      this.lastFailureKind = 'parse';
       const message = error instanceof Error ? error.message : String(error);
       this.log(`plex response parse failed: ${path} (${message})`);
       return null;
     }
   }
+}
+
+function isPlexAuthFailure(status: number): boolean {
+  return status === 401 || status === 403 || status === 498;
 }
 
 /** Collects movie hits from flat `Video` nodes and from `Hub` shelves (modern PMS search). */

--- a/src/plex/credential-manager.ts
+++ b/src/plex/credential-manager.ts
@@ -1,0 +1,276 @@
+import type { Database } from 'bun:sqlite';
+import { randomUUID } from 'node:crypto';
+import { renameSync, writeFileSync } from 'node:fs';
+
+import type { AppConfig } from '../config';
+import { loadConfigEnv, validateConfig } from '../config';
+import { PlexAuthStore } from './auth';
+import { refreshPlexAuthToken } from './auth-client';
+import type { PlexLibrarySection, PlexSearchResult } from './client';
+import { PlexHttpClient } from './client';
+
+const PLEX_TOKEN_LIFETIME_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type PlexRenewReason = 'startup' | 'first_touch' | 'auth_failure';
+
+export class PlexCredentialManager {
+  private renewalInFlight: Promise<string | null> | null = null;
+  private firstTouchAttempted = false;
+
+  constructor(
+    private readonly input: {
+      database: Database;
+      configPath: string;
+      configHolder: { current: AppConfig };
+      log: (message: string) => void;
+    },
+  ) {}
+
+  async startupRenew(): Promise<void> {
+    await this.bestEffortRenew('startup');
+  }
+
+  async ensureTokenForRequest(): Promise<string | null> {
+    if (!this.firstTouchAttempted) {
+      this.firstTouchAttempted = true;
+      await this.bestEffortRenew('first_touch');
+    }
+
+    return this.input.configHolder.current.plex?.token ?? null;
+  }
+
+  async refreshAfterAuthFailure(): Promise<string | null> {
+    return this.runRenewal('auth_failure');
+  }
+
+  private async bestEffortRenew(
+    reason: Exclude<PlexRenewReason, 'auth_failure'>,
+  ): Promise<void> {
+    await this.runRenewal(reason);
+  }
+
+  private async runRenewal(reason: PlexRenewReason): Promise<string | null> {
+    if (this.renewalInFlight) {
+      return this.renewalInFlight;
+    }
+
+    const renewal = this.performRenewal(reason).finally(() => {
+      this.renewalInFlight = null;
+    });
+    this.renewalInFlight = renewal;
+    return renewal;
+  }
+
+  private async performRenewal(
+    reason: PlexRenewReason,
+  ): Promise<string | null> {
+    const currentConfig = this.input.configHolder.current;
+    if (!currentConfig.plex) {
+      return null;
+    }
+
+    const store = new PlexAuthStore(this.input.database);
+    const identity = store.getIdentity();
+    if (!identity?.privateKeyPem || !identity.keyId) {
+      if (reason === 'auth_failure') {
+        store.markReconnectRequired(
+          'expired',
+          'Plex token expired and no renewable device identity is stored.',
+        );
+        await this.persistCurrentToken('');
+        return null;
+      }
+      return currentConfig.plex.token || null;
+    }
+
+    store.beginRenewal();
+
+    try {
+      const now = new Date();
+      const authToken = await refreshPlexAuthToken({
+        clientIdentifier: identity.clientIdentifier,
+        identity,
+        now,
+      });
+      store.completeRenewal(authToken, {
+        tokenExpiresAt: new Date(
+          now.getTime() + PLEX_TOKEN_LIFETIME_MS,
+        ).toISOString(),
+        authenticatedAt: now.toISOString(),
+      });
+      await this.persistCurrentToken(authToken);
+      return authToken;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const reconnectReason = reason === 'auth_failure' ? 'expired' : 'error';
+      store.markReconnectRequired(reconnectReason, message);
+      this.input.log(`[plex-auth] ${reason} renewal failed: ${message}`);
+
+      if (reason === 'auth_failure') {
+        await this.persistCurrentToken('');
+        return null;
+      }
+
+      return this.input.configHolder.current.plex?.token ?? null;
+    }
+  }
+
+  private async persistCurrentToken(token: string): Promise<void> {
+    const baseOnDisk = await readConfigFileRecord(this.input.configPath);
+    const diskPlex =
+      typeof baseOnDisk.plex === 'object' &&
+      baseOnDisk.plex !== null &&
+      !Array.isArray(baseOnDisk.plex)
+        ? (baseOnDisk.plex as Record<string, unknown>)
+        : {};
+    const currentConfig = this.input.configHolder.current;
+    const merged = {
+      ...baseOnDisk,
+      plex: {
+        ...diskPlex,
+        url:
+          optionalStringValue(diskPlex.url) ??
+          currentConfig.plex?.url ??
+          'http://localhost:32400',
+        token,
+        refreshIntervalMinutes:
+          optionalNonNegativeNumber(diskPlex.refreshIntervalMinutes) ??
+          currentConfig.plex?.refreshIntervalMinutes ??
+          30,
+      },
+    };
+
+    const validated = validateConfig(
+      merged,
+      'config',
+      await loadConfigEnv(this.input.configPath),
+    );
+    writeConfigAtomically(this.input.configPath, merged);
+    this.input.configHolder.current = validated;
+  }
+}
+
+export class RenewingPlexHttpClient extends PlexHttpClient {
+  constructor(
+    private readonly input: {
+      baseUrl: string;
+      manager: PlexCredentialManager;
+      log: (message: string) => void;
+      timeoutMs?: number;
+    },
+  ) {
+    super(input.baseUrl, '', input.log, input.timeoutMs);
+  }
+
+  override async listLibrarySections(): Promise<PlexLibrarySection[]> {
+    return this.runWithRenewal((client) => client.listLibrarySections(), []);
+  }
+
+  override async searchMovies(
+    title: string,
+  ): Promise<PlexSearchResult[] | null> {
+    return this.runWithRenewal((client) => client.searchMovies(title), null);
+  }
+
+  override async searchShows(
+    title: string,
+  ): Promise<PlexSearchResult[] | null> {
+    return this.runWithRenewal((client) => client.searchShows(title), null);
+  }
+
+  override async searchLibrary(
+    sectionKey: string,
+    title: string,
+  ): Promise<PlexSearchResult[]> {
+    return this.runWithRenewal(
+      (client) => client.searchLibrary(sectionKey, title),
+      [],
+    );
+  }
+
+  override async listAllTvShowsForMatching(): Promise<PlexSearchResult[]> {
+    return this.runWithRenewal(
+      (client) => client.listAllTvShowsForMatching(),
+      [],
+    );
+  }
+
+  override async listAllMoviesForMatching(): Promise<PlexSearchResult[]> {
+    return this.runWithRenewal(
+      (client) => client.listAllMoviesForMatching(),
+      [],
+    );
+  }
+
+  private async runWithRenewal<T>(
+    operation: (client: PlexHttpClient) => Promise<T>,
+    fallback: T,
+  ): Promise<T> {
+    const token = await this.input.manager.ensureTokenForRequest();
+    if (!token) {
+      return fallback;
+    }
+
+    let result = await this.runWithToken(token, operation);
+    if (result.failureKind === 'auth') {
+      const renewedToken = await this.input.manager.refreshAfterAuthFailure();
+      if (!renewedToken) {
+        return fallback;
+      }
+
+      result = await this.runWithToken(renewedToken, operation);
+    }
+
+    return result.value;
+  }
+
+  private async runWithToken<T>(
+    token: string,
+    operation: (client: PlexHttpClient) => Promise<T>,
+  ): Promise<{
+    value: T;
+    failureKind: ReturnType<PlexHttpClient['getLastFailureKind']>;
+  }> {
+    const client = new PlexHttpClient(
+      this.input.baseUrl,
+      token,
+      this.input.log,
+      this.input.timeoutMs,
+    );
+    const value = await operation(client);
+    return { value, failureKind: client.getLastFailureKind() };
+  }
+}
+
+async function readConfigFileRecord(
+  path: string,
+): Promise<Record<string, unknown>> {
+  const parsed = await Bun.file(path).json();
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Config file must contain a JSON object.');
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function writeConfigAtomically(
+  path: string,
+  config: Record<string, unknown>,
+): void {
+  const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(config, null, 2)}\n`, {
+    encoding: 'utf8',
+    flag: 'wx',
+  });
+  renameSync(tempPath, path);
+}
+
+function optionalStringValue(input: unknown): string | null {
+  return typeof input === 'string' ? input : null;
+}
+
+function optionalNonNegativeNumber(input: unknown): number | null {
+  if (typeof input !== 'number' || Number.isNaN(input) || input < 0) {
+    return null;
+  }
+  return input;
+}

--- a/src/plex/schema.ts
+++ b/src/plex/schema.ts
@@ -39,6 +39,8 @@ export function ensurePlexSchema(database: Database): void {
         last_authenticated_at TEXT,
         last_error TEXT,
         reconnect_required_at TEXT,
+        reconnect_required_reason TEXT,
+        renewal_started_at TEXT,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
       );
@@ -76,6 +78,18 @@ export function ensurePlexSchema(database: Database): void {
       database,
       'plex_auth_identity',
       'private_key_pem',
+      'TEXT',
+    );
+    ensurePlexTableColumn(
+      database,
+      'plex_auth_identity',
+      'reconnect_required_reason',
+      'TEXT',
+    );
+    ensurePlexTableColumn(
+      database,
+      'plex_auth_identity',
+      'renewal_started_at',
       'TEXT',
     );
     ensurePlexTableColumn(database, 'plex_auth_sessions', 'pin_id', 'INTEGER');

--- a/test/plex-auth.test.ts
+++ b/test/plex-auth.test.ts
@@ -127,6 +127,39 @@ describe('PlexAuthStore', () => {
       },
     });
   });
+
+  it('tracks renewing and reconnect-required state transitions', async () => {
+    const store = new PlexAuthStore(createDatabase(await createDatabasePath()));
+
+    store.ensureIdentity('2026-04-22T09:00:00.000Z');
+    store.beginRenewal('2026-04-22T09:01:00.000Z');
+    expect(store.getSnapshot('2026-04-22T09:01:30.000Z').state).toBe(
+      'renewing',
+    );
+
+    store.markReconnectRequired(
+      'expired',
+      'Plex token refresh failed with HTTP 401.',
+      '2026-04-22T09:02:00.000Z',
+    );
+    expect(store.getSnapshot('2026-04-22T09:02:30.000Z')).toMatchObject({
+      state: 'expired_reconnect_required',
+      identity: {
+        lastError: 'Plex token refresh failed with HTTP 401.',
+        reconnectRequiredReason: 'expired',
+      },
+    });
+
+    store.beginRenewal('2026-04-22T09:03:00.000Z');
+    store.markReconnectRequired(
+      'error',
+      'Plex nonce request failed with HTTP 503.',
+      '2026-04-22T09:04:00.000Z',
+    );
+    expect(store.getSnapshot('2026-04-22T09:04:30.000Z').state).toBe(
+      'error_reconnect_required',
+    );
+  });
 });
 
 function createDatabase(path: string): Database {

--- a/test/plex-credential-manager.test.ts
+++ b/test/plex-credential-manager.test.ts
@@ -1,0 +1,232 @@
+import { Database } from 'bun:sqlite';
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import type { MovieBreakdown } from '../src/movie-api-types';
+import { loadConfig } from '../src/config';
+import { PlexAuthStore } from '../src/plex/auth';
+import {
+  PlexCredentialManager,
+  RenewingPlexHttpClient,
+} from '../src/plex/credential-manager';
+import { refreshMovieLibraryCache } from '../src/plex/movies';
+import { ensureSchema, openDatabase } from '../src/repository';
+
+const tempDirs: string[] = [];
+const openDatabases: Database[] = [];
+
+describe('Plex credential renewal', () => {
+  afterEach(async () => {
+    while (openDatabases.length > 0) {
+      openDatabases.pop()?.close();
+    }
+
+    while (tempDirs.length > 0) {
+      const directory = tempDirs.pop();
+      if (directory) {
+        await Bun.$`rm -rf ${directory}`;
+      }
+    }
+  });
+
+  it('rotates the stored Plex credential on successful silent renewal', async () => {
+    const { configPath, database, configHolder } = await createRenewalHarness();
+    const store = new PlexAuthStore(database);
+    const identity = store.ensureIdentity('2026-04-22T09:00:00.000Z');
+    store.completeRenewal('old-plex-token', {
+      authenticatedAt: '2026-04-22T09:00:00.000Z',
+    });
+
+    const fetchMock = spyOn(globalThis, 'fetch').mockImplementation((async (
+      input: RequestInfo | URL,
+    ) => {
+      const url = String(input);
+      if (url.endsWith('/api/v2/auth/nonce')) {
+        return new Response(JSON.stringify({ nonce: 'renewal-nonce' }), {
+          status: 200,
+        });
+      }
+      if (url.endsWith('/api/v2/auth/token')) {
+        return new Response(JSON.stringify({ auth_token: 'new-plex-token' }), {
+          status: 200,
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch);
+
+    const manager = new PlexCredentialManager({
+      database,
+      configPath,
+      configHolder,
+      log: () => {},
+    });
+
+    await manager.startupRenew();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(configHolder.current.plex?.token).toBe('new-plex-token');
+    expect(store.getSnapshot('2026-04-22T09:05:00.000Z')).toMatchObject({
+      state: 'connected',
+      identity: {
+        clientIdentifier: identity.clientIdentifier,
+        refreshToken: 'new-plex-token',
+      },
+    });
+
+    const disk = (await Bun.file(configPath).json()) as {
+      plex?: { token?: string };
+    };
+    expect(disk.plex?.token).toBe('new-plex-token');
+    fetchMock.mockRestore();
+  });
+
+  it('moves renewal failures into reconnect-required state without throwing', async () => {
+    const { configPath, database, configHolder } = await createRenewalHarness();
+    const store = new PlexAuthStore(database);
+    store.ensureIdentity('2026-04-22T09:00:00.000Z');
+    store.completeRenewal('old-plex-token', {
+      authenticatedAt: '2026-04-22T09:00:00.000Z',
+    });
+
+    const fetchMock = spyOn(globalThis, 'fetch').mockImplementation(
+      (async () =>
+        new Response(JSON.stringify({ error: 'unavailable' }), {
+          status: 503,
+        })) as unknown as typeof fetch,
+    );
+
+    const manager = new PlexCredentialManager({
+      database,
+      configPath,
+      configHolder,
+      log: () => {},
+    });
+
+    await manager.startupRenew();
+
+    fetchMock.mockRestore();
+    expect(store.getSnapshot('2026-04-22T09:05:00.000Z')).toMatchObject({
+      state: 'error_reconnect_required',
+      identity: {
+        reconnectRequiredReason: 'error',
+      },
+    });
+    expect(configHolder.current.plex?.token).toBe('old-plex-token');
+  });
+
+  it('lets Plex enrichment fail closed when renewal cannot recover auth', async () => {
+    const { configPath, database, configHolder } = await createRenewalHarness();
+    const store = new PlexAuthStore(database);
+    store.ensureIdentity('2026-04-22T09:00:00.000Z');
+    store.completeRenewal('old-plex-token', {
+      authenticatedAt: '2026-04-22T09:00:00.000Z',
+    });
+
+    let callCount = 0;
+    const fetchMock = spyOn(globalThis, 'fetch').mockImplementation((async (
+      input: RequestInfo | URL,
+    ) => {
+      callCount += 1;
+      const url = String(input);
+      if (url.endsWith('/api/v2/auth/nonce')) {
+        return new Response(JSON.stringify({ error: 'unavailable' }), {
+          status: 503,
+        });
+      }
+      return new Response('unauthorized', { status: 401 });
+    }) as unknown as typeof fetch);
+
+    const logMessages: string[] = [];
+    const manager = new PlexCredentialManager({
+      database,
+      configPath,
+      configHolder,
+      log: (message) => logMessages.push(message),
+    });
+    const client = new RenewingPlexHttpClient({
+      baseUrl: configHolder.current.plex!.url,
+      manager,
+      log: (message) => logMessages.push(message),
+    });
+
+    const cache = {
+      rows: [] as Array<{ title: string; inLibrary: boolean }>,
+      upsertMovie(row: { title: string; inLibrary: boolean }) {
+        this.rows.push(row);
+      },
+    };
+    const movie: MovieBreakdown = {
+      normalizedTitle: 'Severance',
+      year: 2022,
+      identityKey: 'movie-1',
+      status: 'queued',
+      plexStatus: 'unknown',
+      watchCount: null,
+      lastWatchedAt: null,
+    };
+
+    await refreshMovieLibraryCache([movie], {
+      cache: cache as never,
+      client,
+      refreshIntervalMinutes: 30,
+      log: (message) => logMessages.push(message),
+    });
+
+    expect(callCount).toBeGreaterThanOrEqual(5);
+    expect(cache.rows).toEqual([
+      expect.objectContaining({ title: 'Severance', inLibrary: false }),
+    ]);
+    expect(store.getSnapshot('2026-04-22T09:05:00.000Z').state).toBe(
+      'expired_reconnect_required',
+    );
+    fetchMock.mockRestore();
+  });
+});
+
+async function createRenewalHarness(): Promise<{
+  configPath: string;
+  database: Database;
+  configHolder: { current: Awaited<ReturnType<typeof loadConfig>> };
+}> {
+  const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-plex-renew-'));
+  tempDirs.push(directory);
+  const configPath = join(directory, 'pirate-claw.config.json');
+  await Bun.write(
+    configPath,
+    `${JSON.stringify(
+      {
+        feeds: [],
+        tv: [],
+        transmission: {
+          url: 'http://localhost:9091/transmission/rpc',
+          username: 'user',
+          password: 'pass',
+        },
+        runtime: {
+          runIntervalMinutes: 15,
+          reconcileIntervalSeconds: 30,
+          artifactDir: '.pirate-claw/runtime',
+          artifactRetentionDays: 7,
+          apiWriteToken: 'write-token',
+        },
+        plex: {
+          url: 'http://localhost:32400',
+          token: 'old-plex-token',
+          refreshIntervalMinutes: 30,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const config = await loadConfig(configPath);
+  const configHolder = { current: config };
+  const database = openDatabase(join(dirname(configPath), 'pirate-claw.db'));
+  openDatabases.push(database);
+  ensureSchema(database);
+
+  return { configPath, database, configHolder };
+}

--- a/test/plex-credential-manager.test.ts
+++ b/test/plex-credential-manager.test.ts
@@ -124,12 +124,12 @@ describe('Plex credential renewal', () => {
       authenticatedAt: '2026-04-22T09:00:00.000Z',
     });
 
-    let callCount = 0;
+    const requestUrls: string[] = [];
     const fetchMock = spyOn(globalThis, 'fetch').mockImplementation((async (
       input: RequestInfo | URL,
     ) => {
-      callCount += 1;
       const url = String(input);
+      requestUrls.push(url);
       if (url.endsWith('/api/v2/auth/nonce')) {
         return new Response(JSON.stringify({ error: 'unavailable' }), {
           status: 503,
@@ -167,21 +167,31 @@ describe('Plex credential renewal', () => {
       lastWatchedAt: null,
     };
 
-    await refreshMovieLibraryCache([movie], {
-      cache: cache as never,
-      client,
-      refreshIntervalMinutes: 30,
-      log: (message) => logMessages.push(message),
-    });
+    try {
+      await refreshMovieLibraryCache([movie], {
+        cache: cache as never,
+        client,
+        refreshIntervalMinutes: 30,
+        log: (message) => logMessages.push(message),
+      });
 
-    expect(callCount).toBeGreaterThanOrEqual(5);
-    expect(cache.rows).toEqual([
-      expect.objectContaining({ title: 'Severance', inLibrary: false }),
-    ]);
-    expect(store.getSnapshot('2026-04-22T09:05:00.000Z').state).toBe(
-      'expired_reconnect_required',
-    );
-    fetchMock.mockRestore();
+      expect(
+        requestUrls.filter((url) => url.includes('/api/v2/auth/nonce')).length,
+      ).toBeGreaterThanOrEqual(2);
+      expect(
+        requestUrls.some((url) =>
+          url.includes('http://localhost:32400/library'),
+        ),
+      ).toBe(true);
+      expect(cache.rows).toEqual([
+        expect.objectContaining({ title: 'Severance', inLibrary: false }),
+      ]);
+      expect(store.getSnapshot('2026-04-22T09:05:00.000Z').state).toBe(
+        'expired_reconnect_required',
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
   });
 });
 

--- a/web/src/lib/components/PlexAuthCard.svelte
+++ b/web/src/lib/components/PlexAuthCard.svelte
@@ -43,6 +43,18 @@
 		reconnect_required: {
 			label: 'Reconnect required',
 			description: 'The saved Plex credential needs to be replaced from the browser flow.'
+		},
+		renewing: {
+			label: 'Renewing',
+			description: 'Pirate Claw is attempting a silent Plex credential renewal.'
+		},
+		expired_reconnect_required: {
+			label: 'Expired, reconnect required',
+			description: 'The saved Plex credential expired and silent renewal did not recover it.'
+		},
+		error_reconnect_required: {
+			label: 'Renewal error, reconnect required',
+			description: 'Silent renewal failed before Plex could confirm the current credential.'
 		}
 	} satisfies Record<PlexAuthStatusResponse['state'], { label: string; description: string }>;
 
@@ -51,8 +63,17 @@
 		if (status.state === 'connected' || status.state === 'reconnect_required') {
 			return 'Reconnect in browser';
 		}
+		if (
+			status.state === 'expired_reconnect_required' ||
+			status.state === 'error_reconnect_required'
+		) {
+			return 'Reconnect in browser';
+		}
 		if (status.state === 'connecting') {
 			return 'Restart browser sign-in';
+		}
+		if (status.state === 'renewing') {
+			return 'Connect in browser';
 		}
 		return 'Connect in browser';
 	});
@@ -62,8 +83,13 @@
 				return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-100';
 			case 'reconnect_required':
 				return 'border-amber-500/40 bg-amber-500/10 text-amber-100';
+			case 'expired_reconnect_required':
+			case 'error_reconnect_required':
+				return 'border-amber-500/40 bg-amber-500/10 text-amber-100';
 			case 'connecting':
 				return 'border-sky-500/40 bg-sky-500/10 text-sky-100';
+			case 'renewing':
+				return 'border-cyan-500/40 bg-cyan-500/10 text-cyan-100';
 			default:
 				return 'border-white/15 bg-white/5 text-white';
 		}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -170,7 +170,14 @@ export type PlexConfig = {
 	refreshIntervalMinutes: number;
 };
 
-export type PlexAuthState = 'not_connected' | 'connecting' | 'connected' | 'reconnect_required';
+export type PlexAuthState =
+	| 'not_connected'
+	| 'connecting'
+	| 'connected'
+	| 'reconnect_required'
+	| 'renewing'
+	| 'expired_reconnect_required'
+	| 'error_reconnect_required';
 
 export type PlexAuthStatusResponse = {
 	state: PlexAuthState;


### PR DESCRIPTION
## Summary

- delivery ticket: `P23.04 Best-Effort Silent Renewal and Reconnect-Required States`
- ticket file: [docs/02-delivery/phase-23/ticket-04-silent-renewal-and-state-model.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-23/ticket-04-silent-renewal-and-state-model.md)
- stacked base branch: `agents/p23-03-onboarding-and-config-plex-connection-ux`
- self-audit: outcome `clean` completed at 2026-04-22 09:19 UTC

## External AI Review

- outcome: `clean`
- current branch head: [`7dc6ee2271dc`](https://github.com/cesarnml/Pirate-Claw/commit/7dc6ee2271dcf3cbb6c0afbc8c333549e0033230)
- no prudent follow-up changes were required.
