### PR TITLE
feat: materialize started ticket worktree context

### DIFF
--- a/.agents/skills/son-of-anton-ethos/SKILL.md
+++ b/.agents/skills/son-of-anton-ethos/SKILL.md
@@ -44,7 +44,7 @@ Commit the delivery plan and all ticket docs to the default branch before creati
 
 ### Required Behavior
 
-1. Re-read required repo docs at each ticket boundary. For ticket `01`, use the implementation plan, the ticket doc, and current repo state as the initial handoff context; for later tickets, re-read the generated handoff artifact as the source of truth.
+1. Re-read required repo docs at each ticket boundary. For ticket `01`, use the implementation plan, the ticket doc, and current repo state as the initial handoff context; for later tickets, re-read the handoff artifact materialized into the started ticket worktree as the source of truth.
 2. Use the supported orchestrator path, not ad hoc manual substitutes.
 3. Move one ticket at a time in order.
 4. For each ticket:
@@ -68,13 +68,13 @@ Commit the delivery plan and all ticket docs to the default branch before creati
 
 Treat `ticketBoundaryMode` in `orchestrator.config.json` as the contract for ticket-boundary behavior.
 
-- `cook`: default Son-of-Anton path. `advance` immediately starts the next ticket. Read the generated handoff and continue.
+- `cook`: default Son-of-Anton path. `advance` immediately starts the next ticket. Read the handoff materialized into the started worktree and continue.
 - `gated`: `advance` stops, tells the operator to reset context, and prints the canonical resume prompt for the next agent session. Prefer `/clear`; use `/compact` only when compressed carry-forward context is intentional.
 - `glide`: reserved/unimplemented — currently falls back to `gated` in repo-local code. Do not assume self-reset capability.
 
 Canonical `gated` resume prompt:
 
-`Immediately execute \`bun run deliver --plan <plan> start\`, read the generated handoff artifact as the source of truth for context, and implement <next-ticket-id>.`
+`Immediately execute \`bun run deliver --plan <plan> start\`, read the locally materialized handoff artifact in the started worktree as the source of truth for context, and implement <next-ticket-id>.`
 
 ### Codex Preflight
 

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -88,8 +88,9 @@ The orchestrator owns process mechanics:
 - durable local state under `.agents/delivery/<plan-key>/`
 - per-ticket handoff artifacts under `.agents/delivery/<plan-key>/handoffs/`
 - deterministic branch and worktree naming
-- copying a local `.env` into fresh ticket worktrees when the invoking worktree has one
+- copying a fixed repo-root ignored-file bootstrap allowlist into fresh ticket worktrees when those files exist in the invoking worktree and are missing in the target worktree (`.env`, `.env.local`, `.env.development`, `.env.test`, `.gitignore`)
 - bootstrapping fresh ticket worktrees using lockfile-aware package-manager defaults before implementation starts
+- materializing bounded delivery artifacts into started ticket worktrees so local continuation does not depend on manual artifact copying or rediscovery
 - stacked PR base chaining
 - idempotent PR open/update behavior for already-pushed ticket branches
 - a 6/12-minute AI-review polling loop after PR open (two checkpoints: 6 minutes and 12 minutes)
@@ -162,7 +163,15 @@ When a ticket starts, the orchestrator writes a handoff artifact under:
 
 That handoff is the narrow context that the next ticket worker should begin from alongside the current repo state and required docs.
 
-For the **first ticket in a new phase**, there may be no prior-ticket handoff context beyond the implementation plan, the ticket doc, and current repo state. That is expected, not a blocker.
+`start` must also leave the started ticket worktree locally self-sufficient for active-ticket continuation. In practice that means the target worktree receives:
+
+- `.agents/delivery/<plan-key>/state.json`
+- the current ticket handoff artifact
+- handoff and review artifacts for the current ticket and immediate predecessor only
+
+This is intentionally bounded context, not whole-phase mirroring.
+
+For the **first ticket in a new phase**, there may be no prior-ticket handoff or review artifacts beyond the implementation plan, the ticket doc, and current repo state. That is expected, not a blocker.
 
 The handoff includes:
 
@@ -174,7 +183,7 @@ The handoff includes:
 
 This does not automatically create a brand-new agent session, but it is the current repo mechanism for reducing reasoning carryover between tickets while preserving stacked branch continuity.
 
-For ticket `01`, `start` is the command that initializes the first ticket context for the phase. After `start`, use the generated handoff artifact if present; before that, do not treat the absence of a prior-ticket handoff as missing workflow state.
+For ticket `01`, `start` is the command that initializes the first ticket context for the phase. After `start`, read the locally materialized handoff artifact from the started ticket worktree; before that, do not treat the absence of a prior-ticket handoff as missing workflow state.
 
 **No read-ahead during the review window.** The agent does nothing while waiting on external AI review. The wait is free (LLM idle during subprocess sleep). Read-ahead during the window burns context that is dead weight at the next ticket boundary. Be sabaai sabaai.
 
@@ -421,9 +430,11 @@ State is written under:
 
 ### State file and primary checkout (multi-worktree)
 
-The orchestrator writes `state.json` **only in the repo directory where you run `deliver`** (the current working directory). If you use **one ticket worktree per ticket** and a **separate `main` clone** for `closeout-stack` or other commands, the `main` checkout’s delivery tree does **not** update automatically.
+For active ticket continuation, `start` writes the authoritative bounded continuation set into the started ticket worktree. That means the started worktree is the local source of truth for continuing that ticket.
 
-Fetched review artifacts under `reviews/` and generated handoff artifacts under `handoffs/` are written under the **same** path relative to the worktree where each command ran. Across a stacked phase, that means files are often **spread across multiple ticket worktrees** — the final worktree is **not** guaranteed to contain every `reviews/<ticket>-*.json` or `handoffs/<ticket>-handoff.md` produced earlier.
+The orchestrator also writes `state.json` in the repo directory where you run `deliver` (the current working directory). If you use **one ticket worktree per ticket** and a **separate `main` clone** for `closeout-stack` or other commands, the `main` checkout’s delivery tree does **not** update automatically.
+
+Fetched review artifacts under `reviews/` and generated handoff artifacts under `handoffs/` are still written under the **same** path relative to the worktree where each command ran. Across a stacked phase, full history is therefore often **spread across multiple ticket worktrees** — the final worktree is **not** guaranteed to contain every `reviews/<ticket>-*.json` or `handoffs/<ticket>-handoff.md` produced earlier.
 
 **Recommendation:**
 
@@ -448,7 +459,7 @@ for wt in /path/to/phase-wt-01 /path/to/phase-wt-02 /path/to/phase-wt-NN; do
 done
 ```
 
-**Stance:** Treat each **ticket worktree** as authoritative for the commands you run inside it; treat the **primary `main` copy** as the **aggregate mirror** — especially for `reviews/` and `handoffs/`, which must be **reconciled across all worktrees**, not only copied from the latest one. Until the orchestrator gains an explicit “mirror delivery artifacts to path” option, this manual merge is the reliable fix for stale or incomplete delivery state on `main`.
+**Stance:** Treat each **started ticket worktree** as authoritative for continuing its active ticket; treat the **primary `main` copy** as the **aggregate mirror** for full-phase history and closeout. Active-ticket continuation should not require scavenging across older worktrees, but aggregate `reviews/` and `handoffs/` still must be **reconciled across all worktrees**, not only copied from the latest one.
 
 ## PR Body Maintenance
 

--- a/notes/public/pr-213-retrospective.md
+++ b/notes/public/pr-213-retrospective.md
@@ -1,0 +1,31 @@
+## Scope delivered
+
+PR #213 on `agents/standalone-orchestrator-worktree-handoff-materialization` makes `bun run deliver --plan <plan> start` leave the started ticket worktree locally self-sufficient for active-ticket continuation. It adds bounded worktree materialization for delivery artifacts, expands fresh-worktree bootstrap from `.env` alone to a fixed ignored-file allowlist, adds orchestrator regression coverage for first-ticket and middle-ticket materialization behavior, and updates the delivery tooling docs/SoA skill to match the new contract.
+
+## What went well
+
+The change stayed bounded because the contract was defined in terms of active-ticket continuation rather than “mirror everything.” That made the implementation testable: current ticket plus immediate predecessor, overwrite orchestrator-owned delivery artifacts, never overwrite user-owned ignored bootstrap files. The existing `startTicket` seam in `ticket-flow` also made it straightforward to inject deterministic materialization behavior without redesigning the whole state model.
+
+## Pain points
+
+The main friction was that the old workflow mixed two different concerns under “fresh worktree setup”: repo usability inputs like `.env`, and orchestrator-owned workflow state like `state.json` and handoffs. That ambiguity was avoidable waste because it pushed critical continuation behavior into agent initiative instead of code. A second pain point was that the previous docs described artifact spreading across worktrees in a way that was true for aggregate history but misleading for active-ticket continuation.
+
+## Surprises
+
+The biggest surprise was how small the code change needed to be once the boundary was phrased correctly. The real fix was not a global multi-worktree sync feature; it was “`start` must materialize the bounded continuation set into the started worktree.” Another useful surprise was that `.gitignore` belongs in the bootstrap allowlist for new worktrees because delivery artifacts are gitignored and the fresh worktree should behave like the invoking checkout immediately.
+
+## What we'd do differently
+
+We should have made active-ticket continuation a tool-enforced invariant earlier instead of documenting a workflow that quietly relied on agents rediscovering artifacts. The previous design looked acceptable because the orchestrator already generated handoffs and state, but the missing step was materializing that state into the new worktree that was supposed to continue the ticket. In hindsight, “generate” without “make locally usable” was an incomplete contract.
+
+## Net assessment
+
+This PR achieves the intended tooling boundary change. The orchestrator now owns fresh-ticket continuation state instead of leaving it to agent initiative, while still keeping full-phase aggregate mirroring explicitly out of scope. That is the right level of determinism for the delivery path.
+
+## Follow-up
+
+- Watch whether `current + immediate predecessor` remains sufficient as handoff content evolves; if handoffs start referencing broader history, change the handoff contract before widening the copy scope.
+- If closeout and aggregate reporting remain painful, solve that as a separate explicit mirror/aggregation feature rather than quietly expanding `start`.
+- Consider adding a configurable allowlist for fresh-worktree ignored bootstrap files only if real repo usage outgrows the fixed list shipped here.
+
+_Created: 2026-04-22. PR #213 open._

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -1200,8 +1200,10 @@ export async function materializeTicketContext(
     ...(previous ? [ticketHandoffFileName(previous.id)] : []),
   ]);
   const reviewNames = new Set<string>();
-  for (const scopedTicket of [target, previous].filter(Boolean)) {
-    const ticket = scopedTicket!;
+  const scopedTickets = [target, previous].filter(
+    (ticket): ticket is TicketState => ticket !== undefined,
+  );
+  for (const ticket of scopedTickets) {
     for (const fileName of [
       `${ticket.id}-ai-review.fetch.json`,
       `${ticket.id}-ai-review.triage.json`,
@@ -1878,7 +1880,7 @@ export function formatAdvanceBoundaryGuidance(
     _config.ticketBoundaryMode,
   );
   const invocation = `${generateRunDeliverInvocation(_config.packageManager)} --plan ${state.planPath} start`;
-  const resumePrompt = `Immediately execute \`${invocation}\`, read the generated handoff artifact as the source of truth for context, and implement ${nextPending.id}.`;
+  const resumePrompt = `Immediately execute \`${invocation}\`, read the locally materialized handoff artifact in the started worktree as the source of truth for context, and implement ${nextPending.id}.`;
 
   if (effectiveMode === 'cook') {
     const startedTicket = nextState.tickets.find(
@@ -1901,7 +1903,7 @@ export function formatAdvanceBoundaryGuidance(
       nextHandoffAbsolutePath
         ? `next_handoff_absolute=${nextHandoffAbsolutePath}`
         : undefined,
-      'Read the generated handoff artifact from `next_handoff_absolute` and continue implementation in the started ticket worktree.',
+      'Read the locally materialized handoff artifact from `next_handoff_absolute` and continue implementation in the started ticket worktree.',
     ]
       .filter((line): line is string => line !== undefined)
       .join('\n');

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
+import { copyFile, mkdir, readFile, readdir } from 'node:fs/promises';
 import { basename, dirname, join, resolve } from 'node:path';
 
 import { getUsage, parseCliArgs, resolveOptionsForCommand } from './cli';
@@ -14,6 +14,7 @@ import {
 import {
   addWorktree as addPlatformWorktree,
   bootstrapWorktreeIfNeeded as bootstrapPlatformWorktreeIfNeeded,
+  copyLocalBootstrapFilesIfPresent as copyPlatformBootstrapFilesIfPresent,
   copyLocalEnvIfPresent as copyPlatformEnvIfPresent,
   createPullRequest as createPlatformPullRequest,
   editPullRequest as editPlatformPullRequest,
@@ -1115,9 +1116,20 @@ async function startTicket(
   return startTicketImpl(state, cwd, ticketId, {
     addWorktree,
     bootstrapWorktreeIfNeeded,
-    copyLocalEnvIfPresent,
+    copyLocalBootstrapFilesIfPresent,
+    materializeTicketContext,
     relativeToRepo,
   });
+}
+
+export async function copyLocalBootstrapFilesIfPresent(
+  sourceWorktreePath: string,
+  targetWorktreePath: string,
+): Promise<void> {
+  await copyPlatformBootstrapFilesIfPresent(
+    sourceWorktreePath,
+    targetWorktreePath,
+  );
 }
 
 export async function copyLocalEnvIfPresent(
@@ -1125,6 +1137,91 @@ export async function copyLocalEnvIfPresent(
   targetWorktreePath: string,
 ): Promise<void> {
   await copyPlatformEnvIfPresent(sourceWorktreePath, targetWorktreePath);
+}
+
+function ticketHandoffFileName(ticketId: string): string {
+  return `${ticketId.toLowerCase().replace('.', '-')}-handoff.md`;
+}
+
+async function copyFileIntoWorktree(
+  sourcePath: string,
+  targetPath: string,
+): Promise<void> {
+  if (!existsSync(sourcePath) || resolve(sourcePath) === resolve(targetPath)) {
+    return;
+  }
+
+  await mkdir(dirname(targetPath), { recursive: true });
+  await copyFile(sourcePath, targetPath);
+}
+
+async function copyTicketScopedArtifacts(input: {
+  artifactDirPath: string;
+  artifactNames: Set<string>;
+  sourceWorktreePath: string;
+  targetWorktreePath: string;
+}): Promise<void> {
+  const sourceDir = resolve(input.sourceWorktreePath, input.artifactDirPath);
+  if (!existsSync(sourceDir) || input.artifactNames.size === 0) {
+    return;
+  }
+
+  for (const fileName of await readdir(sourceDir)) {
+    if (!input.artifactNames.has(fileName)) {
+      continue;
+    }
+
+    await copyFileIntoWorktree(
+      resolve(sourceDir, fileName),
+      resolve(input.targetWorktreePath, input.artifactDirPath, fileName),
+    );
+  }
+}
+
+export async function materializeTicketContext(
+  state: DeliveryState,
+  sourceWorktreePath: string,
+  ticketId: string,
+): Promise<void> {
+  const targetIndex = state.tickets.findIndex(
+    (ticket) => ticket.id === ticketId,
+  );
+  const target = targetIndex >= 0 ? state.tickets[targetIndex] : undefined;
+
+  if (!target) {
+    throw new Error(`Unknown ticket ${ticketId}.`);
+  }
+
+  const previous = targetIndex > 0 ? state.tickets[targetIndex - 1] : undefined;
+  await saveStateImpl(target.worktreePath, state);
+
+  const handoffNames = new Set<string>([
+    ticketHandoffFileName(target.id),
+    ...(previous ? [ticketHandoffFileName(previous.id)] : []),
+  ]);
+  const reviewNames = new Set<string>();
+  for (const scopedTicket of [target, previous].filter(Boolean)) {
+    const ticket = scopedTicket!;
+    for (const fileName of [
+      `${ticket.id}-ai-review.fetch.json`,
+      `${ticket.id}-ai-review.triage.json`,
+    ]) {
+      reviewNames.add(fileName);
+    }
+  }
+
+  await copyTicketScopedArtifacts({
+    artifactDirPath: state.handoffsDirPath,
+    artifactNames: handoffNames,
+    sourceWorktreePath,
+    targetWorktreePath: target.worktreePath,
+  });
+  await copyTicketScopedArtifacts({
+    artifactDirPath: state.reviewsDirPath,
+    artifactNames: reviewNames,
+    sourceWorktreePath,
+    targetWorktreePath: target.worktreePath,
+  });
 }
 
 export async function recordPostVerifySelfAudit(

--- a/tools/delivery/platform.ts
+++ b/tools/delivery/platform.ts
@@ -40,6 +40,14 @@ const LOCK_FILES = [
   'package-lock.json',
 ] as const;
 
+const WORKTREE_BOOTSTRAP_FILES = [
+  '.env',
+  '.env.local',
+  '.env.development',
+  '.env.test',
+  '.gitignore',
+] as const;
+
 export function parseGitWorktreeList(output: string): GitWorktreeEntry[] {
   const entries: GitWorktreeEntry[] = [];
   let current: GitWorktreeEntry | undefined;
@@ -164,18 +172,30 @@ export function findPrimaryWorktreePath(
   )?.path;
 }
 
+export async function copyLocalBootstrapFilesIfPresent(
+  sourceWorktreePath: string,
+  targetWorktreePath: string,
+): Promise<void> {
+  for (const file of WORKTREE_BOOTSTRAP_FILES) {
+    const sourceFilePath = resolve(sourceWorktreePath, file);
+    const targetFilePath = resolve(targetWorktreePath, file);
+
+    if (!existsSync(sourceFilePath) || existsSync(targetFilePath)) {
+      continue;
+    }
+
+    await copyFile(sourceFilePath, targetFilePath);
+  }
+}
+
 export async function copyLocalEnvIfPresent(
   sourceWorktreePath: string,
   targetWorktreePath: string,
 ): Promise<void> {
-  const sourceEnvPath = resolve(sourceWorktreePath, '.env');
-  const targetEnvPath = resolve(targetWorktreePath, '.env');
-
-  if (!existsSync(sourceEnvPath) || existsSync(targetEnvPath)) {
-    return;
-  }
-
-  await copyFile(sourceEnvPath, targetEnvPath);
+  await copyLocalBootstrapFilesIfPresent(
+    sourceWorktreePath,
+    targetWorktreePath,
+  );
 }
 
 export async function bootstrapWorktreeIfNeeded(

--- a/tools/delivery/test/orchestrator.test.ts
+++ b/tools/delivery/test/orchestrator.test.ts
@@ -1891,6 +1891,15 @@ describe('delivery orchestrator', () => {
         await readFile(
           join(
             targetDir,
+            '.agents/delivery/phase-03/reviews/P3.02-ai-review.triage.json',
+          ),
+          'utf8',
+        ),
+      ).toBe('{"triage":true}\n');
+      expect(
+        await readFile(
+          join(
+            targetDir,
             '.agents/delivery/phase-03/reviews/P3.03-ai-review.fetch.json',
           ),
           'utf8',
@@ -4518,7 +4527,7 @@ describe('delivery orchestrator', () => {
       expect(output).toContain('GATED BOUNDARY before starting EE7.02.');
       expect(output).toContain('Prefer /clear for minimum token use');
       expect(output).toContain(
-        'resume_prompt=Immediately execute `bun run deliver --plan docs/02-delivery/engineering-epic-07/implementation-plan.md start`, read the generated handoff artifact as the source of truth for context, and implement EE7.02.',
+        'resume_prompt=Immediately execute `bun run deliver --plan docs/02-delivery/engineering-epic-07/implementation-plan.md start`, read the locally materialized handoff artifact in the started worktree as the source of truth for context, and implement EE7.02.',
       );
     });
 

--- a/tools/delivery/test/orchestrator.test.ts
+++ b/tools/delivery/test/orchestrator.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'bun:test';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import {
   assertReviewerFacingMarkdown,
@@ -13,7 +14,7 @@ import {
   buildPullRequestTitle,
   buildTicketHandoff,
   canAdvanceTicket,
-  copyLocalEnvIfPresent,
+  copyLocalBootstrapFilesIfPresent,
   createOptions,
   deriveBranchName,
   derivePlanKey,
@@ -63,6 +64,7 @@ import {
   formatAdvanceBoundaryGuidance,
   applyAdvanceBoundaryMode,
   formatStatus,
+  materializeTicketContext,
   resolveEffectiveAdvanceBoundaryMode,
   type DeliveryState,
 } from '../orchestrator';
@@ -72,6 +74,11 @@ async function readArtifactJson(cwd: string, relativePath: string) {
     string,
     unknown
   >;
+}
+
+async function writeFixture(path: string, content: string) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content, 'utf8');
 }
 import { getUsage, parseCliArgs } from '../cli';
 import { advanceToNextTicket } from '../ticket-flow';
@@ -1625,7 +1632,7 @@ describe('delivery orchestrator', () => {
     expect(changes).toContain('P3.01: pr https://example.test/pull/20 -> none');
   });
 
-  it('copies a local .env into a fresh ticket worktree when missing', async () => {
+  it('copies allowed ignored bootstrap files into a fresh ticket worktree when missing', async () => {
     const sourceDir = await mkdtemp(join(tmpdir(), 'orchestrator-source-'));
     const targetDir = await mkdtemp(join(tmpdir(), 'orchestrator-target-'));
 
@@ -1635,12 +1642,260 @@ describe('delivery orchestrator', () => {
         'TELEGRAM_CHAT_ID=123\n',
         'utf8',
       );
+      await writeFile(join(sourceDir, '.env.local'), 'LOCAL_ONLY=1\n', 'utf8');
+      await writeFile(join(sourceDir, '.gitignore'), '.agents/\n', 'utf8');
 
-      await copyLocalEnvIfPresent(sourceDir, targetDir);
+      await copyLocalBootstrapFilesIfPresent(sourceDir, targetDir);
 
       expect(await readFile(join(targetDir, '.env'), 'utf8')).toBe(
         'TELEGRAM_CHAT_ID=123\n',
       );
+      expect(await readFile(join(targetDir, '.env.local'), 'utf8')).toBe(
+        'LOCAL_ONLY=1\n',
+      );
+      expect(await readFile(join(targetDir, '.gitignore'), 'utf8')).toBe(
+        '.agents/\n',
+      );
+    } finally {
+      await rm(sourceDir, { recursive: true, force: true });
+      await rm(targetDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not overwrite existing ignored bootstrap files in the target worktree', async () => {
+    const sourceDir = await mkdtemp(join(tmpdir(), 'orchestrator-source-'));
+    const targetDir = await mkdtemp(join(tmpdir(), 'orchestrator-target-'));
+
+    try {
+      await writeFile(join(sourceDir, '.env'), 'SOURCE=1\n', 'utf8');
+      await writeFile(join(sourceDir, '.gitignore'), '.agents/\n', 'utf8');
+      await writeFile(join(targetDir, '.env'), 'TARGET=1\n', 'utf8');
+      await writeFile(join(targetDir, '.gitignore'), 'node_modules/\n', 'utf8');
+
+      await copyLocalBootstrapFilesIfPresent(sourceDir, targetDir);
+
+      expect(await readFile(join(targetDir, '.env'), 'utf8')).toBe(
+        'TARGET=1\n',
+      );
+      expect(await readFile(join(targetDir, '.gitignore'), 'utf8')).toBe(
+        'node_modules/\n',
+      );
+    } finally {
+      await rm(sourceDir, { recursive: true, force: true });
+      await rm(targetDir, { recursive: true, force: true });
+    }
+  });
+
+  it('materializes first-ticket continuation artifacts into the target worktree', async () => {
+    const sourceDir = await mkdtemp(join(tmpdir(), 'orchestrator-source-'));
+    const targetDir = await mkdtemp(join(tmpdir(), 'orchestrator-target-'));
+
+    try {
+      await writeFixture(
+        join(sourceDir, '.agents/delivery/phase-03/handoffs/p3-01-handoff.md'),
+        '# Ticket Handoff\n',
+      );
+
+      const state: DeliveryState = {
+        planKey: 'phase-03',
+        planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+        statePath: '.agents/delivery/phase-03/state.json',
+        reviewsDirPath: '.agents/delivery/phase-03/reviews',
+        handoffsDirPath: '.agents/delivery/phase-03/handoffs',
+        reviewPollIntervalMinutes: 6,
+        reviewPollMaxWaitMinutes: 12,
+        tickets: [
+          {
+            id: 'P3.01',
+            title: 'First ticket',
+            slug: 'first-ticket',
+            ticketFile: 'docs/ticket-01.md',
+            status: 'in_progress',
+            branch: 'agents/p3-01-first-ticket',
+            baseBranch: 'main',
+            worktreePath: targetDir,
+            handoffPath: '.agents/delivery/phase-03/handoffs/p3-01-handoff.md',
+          },
+        ],
+      };
+
+      await materializeTicketContext(state, sourceDir, 'P3.01');
+
+      expect(
+        await readFile(
+          join(
+            targetDir,
+            '.agents/delivery/phase-03/handoffs/p3-01-handoff.md',
+          ),
+          'utf8',
+        ),
+      ).toBe('# Ticket Handoff\n');
+      expect(
+        JSON.parse(
+          await readFile(
+            join(targetDir, '.agents/delivery/phase-03/state.json'),
+            'utf8',
+          ),
+        ),
+      ).toMatchObject({
+        planKey: 'phase-03',
+        tickets: [{ id: 'P3.01', worktreePath: targetDir }],
+      });
+    } finally {
+      await rm(sourceDir, { recursive: true, force: true });
+      await rm(targetDir, { recursive: true, force: true });
+    }
+  });
+
+  it('materializes only current and predecessor handoff/review artifacts into a started worktree', async () => {
+    const sourceDir = await mkdtemp(join(tmpdir(), 'orchestrator-source-'));
+    const targetDir = await mkdtemp(join(tmpdir(), 'orchestrator-target-'));
+
+    try {
+      await writeFixture(
+        join(sourceDir, '.agents/delivery/phase-03/handoffs/p3-01-handoff.md'),
+        'old\n',
+      );
+      await writeFixture(
+        join(sourceDir, '.agents/delivery/phase-03/handoffs/p3-02-handoff.md'),
+        'prev\n',
+      );
+      await writeFixture(
+        join(sourceDir, '.agents/delivery/phase-03/handoffs/p3-03-handoff.md'),
+        'current\n',
+      );
+      await writeFixture(
+        join(
+          sourceDir,
+          '.agents/delivery/phase-03/reviews/P3.01-ai-review.fetch.json',
+        ),
+        '{"old":true}\n',
+      );
+      await writeFixture(
+        join(
+          sourceDir,
+          '.agents/delivery/phase-03/reviews/P3.02-ai-review.fetch.json',
+        ),
+        '{"prev":true}\n',
+      );
+      await writeFixture(
+        join(
+          sourceDir,
+          '.agents/delivery/phase-03/reviews/P3.02-ai-review.triage.json',
+        ),
+        '{"triage":true}\n',
+      );
+      await writeFixture(
+        join(
+          sourceDir,
+          '.agents/delivery/phase-03/reviews/P3.03-ai-review.fetch.json',
+        ),
+        '{"current":true}\n',
+      );
+      await writeFixture(
+        join(targetDir, '.agents/delivery/phase-03/handoffs/p3-03-handoff.md'),
+        'stale\n',
+      );
+
+      const state: DeliveryState = {
+        planKey: 'phase-03',
+        planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+        statePath: '.agents/delivery/phase-03/state.json',
+        reviewsDirPath: '.agents/delivery/phase-03/reviews',
+        handoffsDirPath: '.agents/delivery/phase-03/handoffs',
+        reviewPollIntervalMinutes: 6,
+        reviewPollMaxWaitMinutes: 12,
+        tickets: [
+          {
+            id: 'P3.01',
+            title: 'Old ticket',
+            slug: 'old-ticket',
+            ticketFile: 'docs/ticket-01.md',
+            status: 'done',
+            branch: 'agents/p3-01-old-ticket',
+            baseBranch: 'main',
+            worktreePath: '/tmp/p3_01',
+            handoffPath: '.agents/delivery/phase-03/handoffs/p3-01-handoff.md',
+          },
+          {
+            id: 'P3.02',
+            title: 'Previous ticket',
+            slug: 'previous-ticket',
+            ticketFile: 'docs/ticket-02.md',
+            status: 'done',
+            branch: 'agents/p3-02-previous-ticket',
+            baseBranch: 'agents/p3-01-old-ticket',
+            worktreePath: '/tmp/p3_02',
+            handoffPath: '.agents/delivery/phase-03/handoffs/p3-02-handoff.md',
+          },
+          {
+            id: 'P3.03',
+            title: 'Current ticket',
+            slug: 'current-ticket',
+            ticketFile: 'docs/ticket-03.md',
+            status: 'in_progress',
+            branch: 'agents/p3-03-current-ticket',
+            baseBranch: 'agents/p3-02-previous-ticket',
+            worktreePath: targetDir,
+            handoffPath: '.agents/delivery/phase-03/handoffs/p3-03-handoff.md',
+          },
+        ],
+      };
+
+      await materializeTicketContext(state, sourceDir, 'P3.03');
+
+      expect(
+        await readFile(
+          join(
+            targetDir,
+            '.agents/delivery/phase-03/handoffs/p3-02-handoff.md',
+          ),
+          'utf8',
+        ),
+      ).toBe('prev\n');
+      expect(
+        await readFile(
+          join(
+            targetDir,
+            '.agents/delivery/phase-03/handoffs/p3-03-handoff.md',
+          ),
+          'utf8',
+        ),
+      ).toBe('current\n');
+      expect(
+        existsSync(
+          join(
+            targetDir,
+            '.agents/delivery/phase-03/handoffs/p3-01-handoff.md',
+          ),
+        ),
+      ).toBe(false);
+      expect(
+        existsSync(
+          join(
+            targetDir,
+            '.agents/delivery/phase-03/reviews/P3.01-ai-review.fetch.json',
+          ),
+        ),
+      ).toBe(false);
+      expect(
+        await readFile(
+          join(
+            targetDir,
+            '.agents/delivery/phase-03/reviews/P3.02-ai-review.fetch.json',
+          ),
+          'utf8',
+        ),
+      ).toBe('{"prev":true}\n');
+      expect(
+        await readFile(
+          join(
+            targetDir,
+            '.agents/delivery/phase-03/reviews/P3.03-ai-review.fetch.json',
+          ),
+          'utf8',
+        ),
+      ).toBe('{"current":true}\n');
     } finally {
       await rm(sourceDir, { recursive: true, force: true });
       await rm(targetDir, { recursive: true, force: true });

--- a/tools/delivery/ticket-flow.ts
+++ b/tools/delivery/ticket-flow.ts
@@ -237,7 +237,7 @@ export async function startTicket(
     (ticket) => ticket.status === 'in_progress',
   );
 
-  if (active && active.id !== ticketId) {
+  if (active && ticketId && active.id !== ticketId) {
     throw new Error(`Ticket ${active.id} is already in progress.`);
   }
 

--- a/tools/delivery/ticket-flow.ts
+++ b/tools/delivery/ticket-flow.ts
@@ -221,9 +221,14 @@ export async function startTicket(
       baseBranch: string,
     ) => void;
     bootstrapWorktreeIfNeeded: (worktreePath: string) => Promise<void>;
-    copyLocalEnvIfPresent: (
+    copyLocalBootstrapFilesIfPresent: (
       sourceWorktreePath: string,
       targetWorktreePath: string,
+    ) => Promise<void>;
+    materializeTicketContext?: (
+      state: DeliveryState,
+      sourceWorktreePath: string,
+      ticketId: string,
     ) => Promise<void>;
     relativeToRepo: (cwd: string, absolutePath: string) => string;
   },
@@ -257,6 +262,7 @@ export async function startTicket(
   }
 
   if (target.status === 'in_progress') {
+    await dependencies.materializeTicketContext?.(state, cwd, target.id);
     return state;
   }
 
@@ -269,26 +275,30 @@ export async function startTicket(
     );
   }
 
-  await dependencies.copyLocalEnvIfPresent(cwd, target.worktreePath);
+  await dependencies.copyLocalBootstrapFilesIfPresent(cwd, target.worktreePath);
   await dependencies.bootstrapWorktreeIfNeeded(target.worktreePath);
 
   const handoff = await writeTicketHandoff(state, cwd, target.id, {
     relativeToRepo: dependencies.relativeToRepo,
   });
 
-  return {
+  const nextState: DeliveryState = {
     ...state,
     tickets: state.tickets.map((ticket) =>
       ticket.id === target.id
         ? {
             ...ticket,
-            status: 'in_progress',
+            status: 'in_progress' as const,
             handoffPath: handoff.relativePath,
             handoffGeneratedAt: handoff.generatedAt,
           }
         : ticket,
     ),
   };
+
+  await dependencies.materializeTicketContext?.(nextState, cwd, target.id);
+
+  return nextState;
 }
 
 export function recordPostVerifySelfAudit(


### PR DESCRIPTION
## Summary

- make `deliver start` leave the started ticket worktree self-sufficient for active-ticket continuation
- copy a fixed repo-root ignored bootstrap allowlist into fresh worktrees when files are missing
- materialize bounded delivery artifacts (`state.json`, current handoff, current+predecessor handoff/review artifacts) into the started worktree
- align delivery-orchestrator docs and the Son-of-Anton skill with the new contract

<!-- ai-review:start -->
## External AI Review

- outcome: `operator_input_needed`
- reviewed commit: [`28d3a783499c`](https://github.com/cesarnml/Pirate-Claw/commit/28d3a783499c746f162aa9031a8eb7fbd9a21a28)
- current branch head: [`28d3a783499c`](https://github.com/cesarnml/Pirate-Claw/commit/28d3a783499c746f162aa9031a8eb7fbd9a21a28)
- vendors: `coderabbit`

### Resolved Review Findings

- [coderabbit] Align the emitted gated prompt with this new canonical wording. `.agents/skills/son-of-anton-ethos/SKILL.md:77` [thread](https://github.com/cesarnml/Pirate-Claw/pull/213#discussion_r3123289575)
<!-- ai-review:end -->
