### PR TITLE
docs: add Synology daemon supervision reference artifact [P24.01]

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,27 @@ bun run --cwd web dev
 
 5. Open **http://localhost:5173** — Pirate Claw will guide you through the browser-only setup flow from starter mode to an ingestion-ready config. No config file was needed.
 
-> **Note:** Mac launchd supervisor / auto-restart setup is covered in P24.
+> **Note:** Mac `launchd` first-class auto-restart is Phase 26 work. Phase 24
+> covers the reviewed Synology restart/supervision contract.
 
 ### Synology NAS (production)
 
-**Plex prerequisite:** Plex Media Server **1.19.0 or later**. Check your installed version in **Package Center → Installed → Plex Media Server → Details**. If the listed version is below 1.19.0, open **Package Center → Update** and update Plex before proceeding.
+Reviewed reference daemon supervision path:
+[`docs/synology-reference-pirate-claw-container.sh`](./docs/synology-reference-pirate-claw-container.sh)
+
+Synology restart-backed operation is supported through Docker restart
+supervision on the `pirate-claw` daemon container. The browser restart control
+requests a daemon `SIGTERM`; Docker `--restart always` is what brings the
+daemon back. Browser-visible return proof is deferred to Phase 25.
+
+The writable `/volume1/pirate-claw/config` directory and
+`/volume1/pirate-claw/data` files (`pirate-claw.db`, `poll-state.json`, and
+`.pirate-claw/runtime/`) are one durability boundary for that contract.
+
+**Plex prerequisite:** Plex Media Server **1.19.0 or later**. Check your
+installed version in **Package Center → Installed → Plex Media Server →
+Details**. If the listed version is below 1.19.0, open **Package Center →
+Update** and update Plex before proceeding.
 
 **First-boot sequence:**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ The docs are organized by purpose so later phases can be added without flattenin
 ## Top-Level Docs
 
 - `synology-runbook.md`: canonical current Synology operator runbook and live deployment contract
+- `synology-reference-pirate-claw-container.sh`: repo-owned Synology daemon supervision artifact for the reviewed Docker restart contract
 
 ## Folder Structure
 

--- a/docs/synology-reference-pirate-claw-container.sh
+++ b/docs/synology-reference-pirate-claw-container.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -eu
+
+# Repo-owned reference artifact for the Phase 24 Synology daemon supervision
+# contract. This is the reviewed daemon topology the docs refer to when they
+# say "restart-backed Synology operation".
+#
+# Assumptions:
+# - Synology Docker package on a host that exposes /usr/local/bin/docker
+# - host networking for the daemon container
+# - writable bind mounts for the config directory and the Pirate Claw data files
+# - Docker restart policy is the supervisor, not the browser UI itself
+#
+# Writable durability boundary:
+# - /volume1/pirate-claw/config -> /config
+# - /volume1/pirate-claw/data/pirate-claw.db -> /app/pirate-claw.db
+# - /volume1/pirate-claw/data/runtime -> /app/.pirate-claw/runtime
+# - /volume1/pirate-claw/data/poll-state.json -> /app/poll-state.json
+#
+# Restart contract:
+# - Pirate Claw exits on SIGTERM.
+# - Docker's restart policy must bring the container back.
+# - /api/daemon/restart requests only the SIGTERM side of that contract.
+
+DOCKER_BIN="${DOCKER_BIN:-/usr/local/bin/docker}"
+IMAGE="${IMAGE:-pirate-claw:latest}"
+NAME="${NAME:-pirate-claw}"
+CONFIG_DIR="${CONFIG_DIR:-/volume1/pirate-claw/config}"
+DATA_DIR="${DATA_DIR:-/volume1/pirate-claw/data}"
+
+exec "$DOCKER_BIN" run -d \
+  --name "$NAME" \
+  --restart always \
+  --network host \
+  -v "$CONFIG_DIR:/config" \
+  -v "$DATA_DIR/pirate-claw.db:/app/pirate-claw.db" \
+  -v "$DATA_DIR/runtime:/app/.pirate-claw/runtime" \
+  -v "$DATA_DIR/poll-state.json:/app/poll-state.json" \
+  "$IMAGE" \
+  daemon --config /config/pirate-claw.config.json

--- a/docs/synology-runbook.md
+++ b/docs/synology-runbook.md
@@ -7,6 +7,12 @@ The historical Phase 06 validation artifact still lives at
 original validated baseline and ticket rationale trail. Use this top-level
 document for current operational guidance.
 
+The Phase 24 daemon supervision reference artifact lives at
+[`docs/synology-reference-pirate-claw-container.sh`](./synology-reference-pirate-claw-container.sh).
+Treat that file as the source of truth for the reviewed `pirate-claw` container
+invocation. The prose in this runbook explains the contract around it; it does
+not replace it.
+
 ## Scope
 
 This document is for the actual NAS deployment shape that Pirate Claw now
@@ -64,6 +70,8 @@ Observed container contract:
 - network: `host`
 - command: `daemon --config /config/pirate-claw.config.json`
 - entrypoint: `bun run dist/cli.js`
+- repo-owned reference artifact:
+  [`docs/synology-reference-pirate-claw-container.sh`](./synology-reference-pirate-claw-container.sh)
 
 Required mounts:
 
@@ -88,6 +96,28 @@ The live daemon supports `PUT /api/config`, `PUT /api/config/feeds`,
 `PUT /api/config/tv/defaults`, and `PUT /api/config/movies`. Those writes are
 real file writes, not in-memory-only updates, and they use an atomic
 temp-file-plus-rename flow.
+
+### Supervision Contract
+
+Under the reviewed Synology baseline, Pirate Claw's daemon supervision contract
+is:
+
+- the daemon runs as the `pirate-claw` Docker container created from the
+  repo-owned reference artifact
+- Docker `--restart always` is the supervisor; the browser UI is not the
+  supervisor
+- `POST /api/daemon/restart` only asks the daemon process to exit with
+  `SIGTERM`; it does not prove that the browser has observed the daemon come
+  back yet
+- restart-backed operation is supported only when the writable `/config`
+  directory and the writable data files (`pirate-claw.db`, `poll-state.json`,
+  and `.pirate-claw/runtime/`) are mounted together as the durable Pirate Claw
+  boundary
+- if the container is started without Docker restart supervision, a restart
+  request leaves Pirate Claw stopped until the operator intervenes manually
+
+That browser-visible return-proof gap remains Phase 25 work. Phase 24 only
+defines the supported supervisor contract and the durable paths it relies on.
 
 ### `pirate-claw-web`
 
@@ -483,12 +513,8 @@ was rebuilt.
 ssh -p "$SSH_PORT" "$DEST" "sudo -n /usr/local/bin/docker stop pirate-claw pirate-claw-web"
 ssh -p "$SSH_PORT" "$DEST" "sudo -n /usr/local/bin/docker rm pirate-claw pirate-claw-web"
 
-ssh -p "$SSH_PORT" "$DEST" "sudo -n /usr/local/bin/docker run -d --name pirate-claw --restart always --network host \
-  -v /volume1/pirate-claw/config:/config \
-  -v /volume1/pirate-claw/data/pirate-claw.db:/app/pirate-claw.db \
-  -v /volume1/pirate-claw/data/runtime:/app/.pirate-claw/runtime \
-  -v /volume1/pirate-claw/data/poll-state.json:/app/poll-state.json \
-  pirate-claw:latest daemon --config /config/pirate-claw.config.json"
+scp -O -P "$SSH_PORT" docs/synology-reference-pirate-claw-container.sh "$DEST:/tmp/pirate-claw-reference.sh"
+ssh -p "$SSH_PORT" "$DEST" "chmod +x /tmp/pirate-claw-reference.sh && sudo -n /tmp/pirate-claw-reference.sh"
 
 ssh -p "$SSH_PORT" "$DEST" "sudo -n /usr/local/bin/docker run -d --name pirate-claw-web --restart always --network host \
   --env-file /volume1/pirate-claw/config/web.env \


### PR DESCRIPTION
## Summary

- delivery ticket: `P24.01 Synology Reference Supervision Artifact and Contract`
- ticket file: [docs/02-delivery/phase-24/ticket-01-synology-reference-supervision-artifact.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-24/ticket-01-synology-reference-supervision-artifact.md)
- stacked base branch: `main`
- self-audit: outcome `clean` completed at 2026-04-23 05:47 UTC
