### PR TITLE
feat(web): add Synology Plex compatibility guidance [P24.03]

### DIFF
--- a/web/src/lib/components/PlexAuthCard.svelte
+++ b/web/src/lib/components/PlexAuthCard.svelte
@@ -176,6 +176,15 @@
 		{/if}
 	</div>
 
+	<div class="space-y-2 rounded-2xl border border-amber-500/30 bg-amber-500/8 px-4 py-3 text-sm">
+		<p class="font-medium text-amber-100">Synology compatibility note</p>
+		<p class="text-amber-50/90">
+			The reviewed Synology baseline is Pirate Claw on Docker plus an operator-managed PMS URL. If
+			the Synology Package Center Plex build is below <code>PMS 1.43.0</code>, update Plex with a
+			newer manual install through Package Center before connecting it here.
+		</p>
+	</div>
+
 	{#if status.state === 'connecting' && status.returnTo}
 		<p class="text-muted-foreground text-sm">
 			This sign-in was started from <code>{status.returnTo}</code>.

--- a/web/test/routes/config/config.test.ts
+++ b/web/test/routes/config/config.test.ts
@@ -82,6 +82,8 @@ describe('/config', () => {
 		expect(screen.getByRole('heading', { name: 'Plex Connection' })).toBeInTheDocument();
 		expect(screen.getByLabelText('Plex Media Server URL')).toHaveValue('http://localhost:32400');
 		expect(screen.getByRole('link', { name: 'Connect in browser' })).toBeInTheDocument();
+		expect(screen.getByText('Synology compatibility note')).toBeInTheDocument();
+		expect(screen.getByText(/Package Center Plex build is below/i)).toBeInTheDocument();
 		expect(screen.getByText('Write Access: Active')).toBeInTheDocument();
 		expect(screen.getByText('TestFeed')).toBeInTheDocument();
 		expect(screen.getByRole('textbox', { name: 'TV show 1' })).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- delivery ticket: `P24.03 Plex/Synology Compatibility Truthfulness Slice`
- ticket file: [docs/02-delivery/phase-24/ticket-03-plex-synology-compatibility-truthfulness.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-24/ticket-03-plex-synology-compatibility-truthfulness.md)
- stacked base branch: `agents/p24-02-restart-durability-semantics-and-persistence-proof`
- self-audit: outcome `clean` completed at 2026-04-23 06:00 UTC
