### PR TITLE
fix(web): make restart copy match the Synology contract [P24.04]

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ requests a daemon `SIGTERM`; Docker `--restart always` is what brings the
 daemon back. Browser-visible return proof is deferred to Phase 25.
 
 The writable `/volume1/pirate-claw/config` directory and
-`/volume1/pirate-claw/data` files (`pirate-claw.db`, `poll-state.json`, and
-`.pirate-claw/runtime/`) are one durability boundary for that contract.
+`/volume1/pirate-claw/data` mounts (`pirate-claw.db` plus
+`.pirate-claw/runtime/`, which contains `poll-state.json`) are one durability
+boundary for that contract.
 
 **Plex prerequisite:** Plex Media Server **1.19.0 or later**. Check your
 installed version in **Package Center → Installed → Plex Media Server →

--- a/docs/synology-reference-pirate-claw-container.sh
+++ b/docs/synology-reference-pirate-claw-container.sh
@@ -15,7 +15,7 @@ set -eu
 # - /volume1/pirate-claw/config -> /config
 # - /volume1/pirate-claw/data/pirate-claw.db -> /app/pirate-claw.db
 # - /volume1/pirate-claw/data/runtime -> /app/.pirate-claw/runtime
-# - /volume1/pirate-claw/data/poll-state.json -> /app/poll-state.json
+#   (includes runtime artifacts such as poll-state.json)
 #
 # Restart contract:
 # - Pirate Claw exits on SIGTERM.
@@ -35,6 +35,5 @@ exec "$DOCKER_BIN" run -d \
   -v "$CONFIG_DIR:/config" \
   -v "$DATA_DIR/pirate-claw.db:/app/pirate-claw.db" \
   -v "$DATA_DIR/runtime:/app/.pirate-claw/runtime" \
-  -v "$DATA_DIR/poll-state.json:/app/poll-state.json" \
   "$IMAGE" \
   daemon --config /config/pirate-claw.config.json

--- a/docs/synology-runbook.md
+++ b/docs/synology-runbook.md
@@ -51,8 +51,8 @@ Expected durable files and directories:
 - `/volume1/pirate-claw/config/pirate-claw.config.json`
 - `/volume1/pirate-claw/config/.env`
 - `/volume1/pirate-claw/data/pirate-claw.db`
-- `/volume1/pirate-claw/data/poll-state.json`
 - `/volume1/pirate-claw/data/runtime/`
+- `/volume1/pirate-claw/data/runtime/poll-state.json`
 - `/volume1/transmission/config/`
 - `/volume1/media/downloads/`
 
@@ -78,7 +78,6 @@ Required mounts:
 - `/volume1/pirate-claw/config -> /config`
 - `/volume1/pirate-claw/data/pirate-claw.db -> /app/pirate-claw.db`
 - `/volume1/pirate-claw/data/runtime -> /app/.pirate-claw/runtime`
-- `/volume1/pirate-claw/data/poll-state.json -> /app/poll-state.json`
 
 Critical rule:
 
@@ -110,9 +109,9 @@ is:
   `SIGTERM`; it does not prove that the browser has observed the daemon come
   back yet
 - restart-backed operation is supported only when the writable `/config`
-  directory and the writable data files (`pirate-claw.db`, `poll-state.json`,
-  and `.pirate-claw/runtime/`) are mounted together as the durable Pirate Claw
-  boundary
+  directory and the writable data files (`pirate-claw.db` plus the
+  `.pirate-claw/runtime/` tree, including `poll-state.json`) are mounted
+  together as the durable Pirate Claw boundary
 - if the container is started without Docker restart supervision, a restart
   request leaves Pirate Claw stopped until the operator intervenes manually
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -59,7 +59,10 @@
 		return async ({ result }) => {
 			restartingFromBanner = false;
 			if (result.type === 'success') {
-				toast('Restarting… the page may become temporarily unavailable', 'success');
+				toast(
+					'Restart requested — this page may go unavailable before the daemon returns',
+					'success'
+				);
 				await invalidateAll();
 				return;
 			}
@@ -187,7 +190,9 @@
 						<div
 							class="bg-warning/10 border-warning/30 text-warning flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3 text-sm"
 						>
-							<p>Restart daemon to apply config changes.</p>
+							<p>
+								Restart daemon to apply config changes. The browser will not confirm return yet.
+							</p>
 							<button
 								type="submit"
 								class="border-warning/40 text-warning hover:bg-warning/10 shrink-0 rounded-md border px-3 py-1.5 font-medium transition-colors"

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -427,7 +427,10 @@
 			restarting = false;
 			if (result.type === 'success') {
 				runtimeChangesPending = false;
-				toast('Restarting… the page may become temporarily unavailable', 'success');
+				toast(
+					'Restart requested — this page may go unavailable before the daemon returns',
+					'success'
+				);
 			} else {
 				toast('Restart failed — try again or restart manually', 'error');
 			}

--- a/web/src/routes/config/components/RestartDaemonBanner.svelte
+++ b/web/src/routes/config/components/RestartDaemonBanner.svelte
@@ -23,7 +23,8 @@
 			<div class="space-y-1">
 				<p class="font-semibold">Runtime changes are staged.</p>
 				<p class="text-muted-foreground text-sm">
-					Restart the daemon to apply interval and port updates.
+					Restart the daemon to apply interval and port updates. The browser will not confirm when
+					it comes back yet.
 				</p>
 			</div>
 			<Button

--- a/web/test/routes/layout.test.ts
+++ b/web/test/routes/layout.test.ts
@@ -222,6 +222,11 @@ describe('+layout.svelte', () => {
 		});
 
 		expect(screen.getByTestId('ready-pending-restart-banner')).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'Restart daemon to apply config changes. The browser will not confirm return yet.'
+			)
+		).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Restart Daemon' })).toBeInTheDocument();
 		expect(screen.queryByTestId('partial-config-banner')).not.toBeInTheDocument();
 		expect(screen.queryByTestId('starter-mode-splash')).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- delivery ticket: `P24.04 Restart Copy and Product/Runbook Alignment`
- ticket file: [docs/02-delivery/phase-24/ticket-04-restart-copy-and-runbook-alignment.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-24/ticket-04-restart-copy-and-runbook-alignment.md)
- stacked base branch: `agents/p24-03-plex-synology-compatibility-truthfulness-slice`
- self-audit: outcome `clean` completed at 2026-04-23 06:04 UTC
