### PR TITLE
feat: add durable restart proof status [P25.01]

### DIFF
--- a/docs/02-delivery/phase-25/ticket-01-restart-proof-contract-and-durable-status-surface.md
+++ b/docs/02-delivery/phase-25/ticket-01-restart-proof-contract-and-durable-status-surface.md
@@ -31,3 +31,5 @@ Pirate Claw has a durable restart-proof contract plus a read surface that a brow
 ## Rationale
 
 If the proof contract is vague, every later UI state is theater. This ticket makes restart truth observable before the browser starts narrating it.
+
+Phase 25 chooses a repo-owned runtime artifact under `.pirate-claw/runtime` as the restart proof boundary so the browser can verify return without adding a second restart-specific database contract beside the already-shipped durable surfaces.

--- a/src/api.ts
+++ b/src/api.ts
@@ -61,6 +61,7 @@ import {
   exchangePlexPinForAuthToken,
   startPlexPinAuth,
 } from './plex/auth-client';
+import { readRestartStatus, recordRestartRequested } from './restart-proof';
 
 export type CycleSnapshot = {
   status: CycleResult['status'];
@@ -400,6 +401,18 @@ export function createApiFetch(
           transmissionReachable,
           daemonLive,
         });
+      } catch {
+        return json500();
+      }
+    }
+
+    if (path === '/api/daemon/restart-status' && request.method === 'GET') {
+      try {
+        const status = await readRestartStatus(
+          activeConfig.runtime.artifactDir,
+          health.startedAt,
+        );
+        return Response.json(status);
       } catch {
         return json500();
       }
@@ -1573,10 +1586,20 @@ export function createApiFetch(
       const authError = checkWriteAuth(request, activeConfig);
       if (authError) return authError;
 
+      let restartStatus;
+      try {
+        restartStatus = await recordRestartRequested(
+          activeConfig.runtime.artifactDir,
+          health.startedAt,
+        );
+      } catch {
+        return json500();
+      }
+
       // This endpoint only requests a SIGTERM exit. The reviewed Synology
       // Docker restart policy is responsible for bringing the daemon back.
       queueMicrotask(() => process.kill(process.pid, 'SIGTERM'));
-      return Response.json({ ok: true });
+      return Response.json({ ok: true, restartStatus });
     }
 
     return Response.json({ error: 'not found' }, { status: 404 });

--- a/src/restart-proof.ts
+++ b/src/restart-proof.ts
@@ -1,0 +1,185 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+type RestartProofRecord =
+  | {
+      version: 1;
+      state: 'requested';
+      requestId: string;
+      requestedAt: string;
+      requestedByStartedAt: string;
+    }
+  | {
+      version: 1;
+      state: 'back_online';
+      requestId: string;
+      requestedAt: string;
+      requestedByStartedAt: string;
+      returnedAt: string;
+      returnedStartedAt: string;
+    };
+
+export type RestartStatus =
+  | {
+      state: 'idle';
+      currentDaemonStartedAt: string;
+    }
+  | {
+      state: 'requested';
+      requestId: string;
+      requestedAt: string;
+      requestedByStartedAt: string;
+      currentDaemonStartedAt: string;
+    }
+  | {
+      state: 'back_online';
+      requestId: string;
+      requestedAt: string;
+      requestedByStartedAt: string;
+      returnedAt: string;
+      returnedStartedAt: string;
+      currentDaemonStartedAt: string;
+    };
+
+function restartProofPath(artifactDir: string): string {
+  return join(artifactDir, 'restart-proof.json');
+}
+
+async function readRestartProofRecord(
+  artifactDir: string,
+): Promise<RestartProofRecord | null> {
+  try {
+    const raw = await readFile(restartProofPath(artifactDir), 'utf8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (
+      parsed.version !== 1 ||
+      (parsed.state !== 'requested' && parsed.state !== 'back_online') ||
+      typeof parsed.requestId !== 'string' ||
+      typeof parsed.requestedAt !== 'string' ||
+      typeof parsed.requestedByStartedAt !== 'string'
+    ) {
+      return null;
+    }
+
+    if (parsed.state === 'requested') {
+      return {
+        version: 1,
+        state: 'requested',
+        requestId: parsed.requestId,
+        requestedAt: parsed.requestedAt,
+        requestedByStartedAt: parsed.requestedByStartedAt,
+      };
+    }
+
+    if (
+      typeof parsed.returnedAt !== 'string' ||
+      typeof parsed.returnedStartedAt !== 'string'
+    ) {
+      return null;
+    }
+
+    return {
+      version: 1,
+      state: 'back_online',
+      requestId: parsed.requestId,
+      requestedAt: parsed.requestedAt,
+      requestedByStartedAt: parsed.requestedByStartedAt,
+      returnedAt: parsed.returnedAt,
+      returnedStartedAt: parsed.returnedStartedAt,
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function writeRestartProofRecord(
+  artifactDir: string,
+  record: RestartProofRecord,
+): Promise<void> {
+  await mkdir(artifactDir, { recursive: true });
+  await writeFile(
+    restartProofPath(artifactDir),
+    `${JSON.stringify(record, null, 2)}\n`,
+    'utf8',
+  );
+}
+
+export async function recordRestartRequested(
+  artifactDir: string,
+  currentDaemonStartedAt: string,
+): Promise<RestartStatus> {
+  const record: RestartProofRecord = {
+    version: 1,
+    state: 'requested',
+    requestId: randomUUID(),
+    requestedAt: new Date().toISOString(),
+    requestedByStartedAt: currentDaemonStartedAt,
+  };
+  await writeRestartProofRecord(artifactDir, record);
+  return {
+    state: 'requested',
+    requestId: record.requestId,
+    requestedAt: record.requestedAt,
+    requestedByStartedAt: record.requestedByStartedAt,
+    currentDaemonStartedAt,
+  };
+}
+
+export async function readRestartStatus(
+  artifactDir: string,
+  currentDaemonStartedAt: string,
+): Promise<RestartStatus> {
+  const record = await readRestartProofRecord(artifactDir);
+  if (!record) {
+    return {
+      state: 'idle',
+      currentDaemonStartedAt,
+    };
+  }
+
+  if (record.state === 'back_online') {
+    return {
+      state: 'back_online',
+      requestId: record.requestId,
+      requestedAt: record.requestedAt,
+      requestedByStartedAt: record.requestedByStartedAt,
+      returnedAt: record.returnedAt,
+      returnedStartedAt: record.returnedStartedAt,
+      currentDaemonStartedAt,
+    };
+  }
+
+  if (record.requestedByStartedAt === currentDaemonStartedAt) {
+    return {
+      state: 'requested',
+      requestId: record.requestId,
+      requestedAt: record.requestedAt,
+      requestedByStartedAt: record.requestedByStartedAt,
+      currentDaemonStartedAt,
+    };
+  }
+
+  const resolvedRecord: RestartProofRecord = {
+    version: 1,
+    state: 'back_online',
+    requestId: record.requestId,
+    requestedAt: record.requestedAt,
+    requestedByStartedAt: record.requestedByStartedAt,
+    returnedAt: new Date().toISOString(),
+    returnedStartedAt: currentDaemonStartedAt,
+  };
+  await writeRestartProofRecord(artifactDir, resolvedRecord);
+  return {
+    state: 'back_online',
+    requestId: resolvedRecord.requestId,
+    requestedAt: resolvedRecord.requestedAt,
+    requestedByStartedAt: resolvedRecord.requestedByStartedAt,
+    returnedAt: resolvedRecord.returnedAt,
+    returnedStartedAt: resolvedRecord.returnedStartedAt,
+    currentDaemonStartedAt,
+  };
+}

--- a/src/restart-proof.ts
+++ b/src/restart-proof.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { renameSync, writeFileSync } from 'node:fs';
+import { mkdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 type RestartProofRecord =
@@ -49,51 +50,59 @@ function restartProofPath(artifactDir: string): string {
 async function readRestartProofRecord(
   artifactDir: string,
 ): Promise<RestartProofRecord | null> {
+  let raw: string;
   try {
-    const raw = await readFile(restartProofPath(artifactDir), 'utf8');
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    if (
-      parsed.version !== 1 ||
-      (parsed.state !== 'requested' && parsed.state !== 'back_online') ||
-      typeof parsed.requestId !== 'string' ||
-      typeof parsed.requestedAt !== 'string' ||
-      typeof parsed.requestedByStartedAt !== 'string'
-    ) {
-      return null;
-    }
-
-    if (parsed.state === 'requested') {
-      return {
-        version: 1,
-        state: 'requested',
-        requestId: parsed.requestId,
-        requestedAt: parsed.requestedAt,
-        requestedByStartedAt: parsed.requestedByStartedAt,
-      };
-    }
-
-    if (
-      typeof parsed.returnedAt !== 'string' ||
-      typeof parsed.returnedStartedAt !== 'string'
-    ) {
-      return null;
-    }
-
-    return {
-      version: 1,
-      state: 'back_online',
-      requestId: parsed.requestId,
-      requestedAt: parsed.requestedAt,
-      requestedByStartedAt: parsed.requestedByStartedAt,
-      returnedAt: parsed.returnedAt,
-      returnedStartedAt: parsed.returnedStartedAt,
-    };
+    raw = await readFile(restartProofPath(artifactDir), 'utf8');
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return null;
     }
     throw error;
   }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  if (
+    parsed.version !== 1 ||
+    (parsed.state !== 'requested' && parsed.state !== 'back_online') ||
+    typeof parsed.requestId !== 'string' ||
+    typeof parsed.requestedAt !== 'string' ||
+    typeof parsed.requestedByStartedAt !== 'string'
+  ) {
+    return null;
+  }
+
+  if (parsed.state === 'requested') {
+    return {
+      version: 1,
+      state: 'requested',
+      requestId: parsed.requestId,
+      requestedAt: parsed.requestedAt,
+      requestedByStartedAt: parsed.requestedByStartedAt,
+    };
+  }
+
+  if (
+    typeof parsed.returnedAt !== 'string' ||
+    typeof parsed.returnedStartedAt !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    version: 1,
+    state: 'back_online',
+    requestId: parsed.requestId,
+    requestedAt: parsed.requestedAt,
+    requestedByStartedAt: parsed.requestedByStartedAt,
+    returnedAt: parsed.returnedAt,
+    returnedStartedAt: parsed.returnedStartedAt,
+  };
 }
 
 async function writeRestartProofRecord(
@@ -101,11 +110,13 @@ async function writeRestartProofRecord(
   record: RestartProofRecord,
 ): Promise<void> {
   await mkdir(artifactDir, { recursive: true });
-  await writeFile(
-    restartProofPath(artifactDir),
-    `${JSON.stringify(record, null, 2)}\n`,
-    'utf8',
-  );
+  const finalPath = restartProofPath(artifactDir);
+  const tempPath = `${finalPath}.${process.pid}.${randomUUID()}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(record, null, 2)}\n`, {
+    encoding: 'utf8',
+    flag: 'wx',
+  });
+  renameSync(tempPath, finalPath);
 }
 
 export async function recordRestartRequested(

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -3201,9 +3201,16 @@ describe('POST /api/daemon/restart', () => {
     );
     try {
       const deps = createDeps();
+      const artifactDir = await mkdtemp(
+        join(tmpdir(), 'pirate-claw-restart-proof-'),
+      );
       deps.config = {
         ...deps.config,
-        runtime: { ...deps.config.runtime, apiWriteToken: 'tok' },
+        runtime: {
+          ...deps.config.runtime,
+          apiWriteToken: 'tok',
+          artifactDir,
+        },
       };
       const handler = createApiFetch(deps);
       const res = await handler(
@@ -3213,7 +3220,14 @@ describe('POST /api/daemon/restart', () => {
         }),
       );
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual({ ok: true });
+      expect(await res.json()).toMatchObject({
+        ok: true,
+        restartStatus: {
+          state: 'requested',
+          requestedByStartedAt: deps.health.startedAt,
+          currentDaemonStartedAt: deps.health.startedAt,
+        },
+      });
       // Flush the microtask queue so queueMicrotask fires before we assert.
       await Promise.resolve();
       expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGTERM');
@@ -3366,7 +3380,12 @@ describe('POST /api/daemon/restart', () => {
         }),
       );
       expect(restart.status).toBe(200);
-      expect(await restart.json()).toEqual({ ok: true });
+      expect(await restart.json()).toMatchObject({
+        ok: true,
+        restartStatus: {
+          state: 'requested',
+        },
+      });
       await Promise.resolve();
       expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGTERM');
 
@@ -3399,6 +3418,109 @@ describe('POST /api/daemon/restart', () => {
       } else {
         delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
       }
+    }
+  });
+});
+
+describe('GET /api/daemon/restart-status', () => {
+  it('returns idle when no restart proof exists', async () => {
+    const artifactDir = await mkdtemp(
+      join(tmpdir(), 'pirate-claw-restart-proof-status-'),
+    );
+    const deps = createDeps();
+    deps.config = {
+      ...deps.config,
+      runtime: {
+        ...deps.config.runtime,
+        artifactDir,
+      },
+    };
+
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/daemon/restart-status'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      state: 'idle',
+      currentDaemonStartedAt: deps.health.startedAt,
+    });
+  });
+
+  it('returns requested before exit and back_online after the next daemon starts', async () => {
+    const artifactDir = await mkdtemp(
+      join(tmpdir(), 'pirate-claw-restart-proof-roundtrip-'),
+    );
+    const killSpy = spyOn(process, 'kill').mockImplementation(
+      () => undefined as never,
+    );
+
+    try {
+      const firstDeps = createDeps();
+      firstDeps.health.startedAt = '2026-04-23T10:00:00.000Z';
+      firstDeps.config = {
+        ...firstDeps.config,
+        runtime: {
+          ...firstDeps.config.runtime,
+          apiWriteToken: 'tok',
+          artifactDir,
+        },
+      };
+      const firstHandler = createApiFetch(firstDeps);
+
+      const restart = await firstHandler(
+        new Request('http://localhost/api/daemon/restart', {
+          method: 'POST',
+          headers: { Authorization: 'Bearer tok' },
+        }),
+      );
+      expect(restart.status).toBe(200);
+      const restartBody = (await restart.json()) as {
+        restartStatus: { requestId: string };
+      };
+
+      const requested = await firstHandler(
+        new Request('http://localhost/api/daemon/restart-status'),
+      );
+      expect(requested.status).toBe(200);
+      expect(await requested.json()).toEqual({
+        state: 'requested',
+        requestId: restartBody.restartStatus.requestId,
+        requestedAt: expect.any(String),
+        requestedByStartedAt: '2026-04-23T10:00:00.000Z',
+        currentDaemonStartedAt: '2026-04-23T10:00:00.000Z',
+      });
+
+      await Promise.resolve();
+      expect(killSpy).toHaveBeenCalledWith(process.pid, 'SIGTERM');
+
+      const secondDeps = createDeps();
+      secondDeps.health.startedAt = '2026-04-23T10:00:05.000Z';
+      secondDeps.config = {
+        ...secondDeps.config,
+        runtime: {
+          ...secondDeps.config.runtime,
+          artifactDir,
+        },
+      };
+      const secondHandler = createApiFetch(secondDeps);
+
+      const backOnline = await secondHandler(
+        new Request('http://localhost/api/daemon/restart-status'),
+      );
+      expect(backOnline.status).toBe(200);
+      expect(await backOnline.json()).toEqual({
+        state: 'back_online',
+        requestId: restartBody.restartStatus.requestId,
+        requestedAt: expect.any(String),
+        requestedByStartedAt: '2026-04-23T10:00:00.000Z',
+        returnedAt: expect.any(String),
+        returnedStartedAt: '2026-04-23T10:00:05.000Z',
+        currentDaemonStartedAt: '2026-04-23T10:00:05.000Z',
+      });
+    } finally {
+      killSpy.mockRestore();
     }
   });
 });

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -3448,6 +3448,33 @@ describe('GET /api/daemon/restart-status', () => {
     });
   });
 
+  it('treats a corrupt restart-proof artifact as idle instead of returning 500', async () => {
+    const artifactDir = await mkdtemp(
+      join(tmpdir(), 'pirate-claw-restart-proof-corrupt-'),
+    );
+    await writeFile(join(artifactDir, 'restart-proof.json'), '{"state":');
+
+    const deps = createDeps();
+    deps.config = {
+      ...deps.config,
+      runtime: {
+        ...deps.config.runtime,
+        artifactDir,
+      },
+    };
+
+    const handler = createApiFetch(deps);
+    const response = await handler(
+      new Request('http://localhost/api/daemon/restart-status'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      state: 'idle',
+      currentDaemonStartedAt: deps.health.startedAt,
+    });
+  });
+
   it('returns requested before exit and back_online after the next daemon starts', async () => {
     const artifactDir = await mkdtemp(
       join(tmpdir(), 'pirate-claw-restart-proof-roundtrip-'),

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -256,6 +256,27 @@ export type DaemonHealth = {
 
 export type SetupState = 'starter' | 'partially_configured' | 'ready';
 export type ReadinessState = 'not_ready' | 'ready_pending_restart' | 'ready';
+export type RestartStatus =
+	| {
+			state: 'idle';
+			currentDaemonStartedAt: string;
+	  }
+	| {
+			state: 'requested';
+			requestId: string;
+			requestedAt: string;
+			requestedByStartedAt: string;
+			currentDaemonStartedAt: string;
+	  }
+	| {
+			state: 'back_online';
+			requestId: string;
+			requestedAt: string;
+			requestedByStartedAt: string;
+			returnedAt: string;
+			returnedStartedAt: string;
+			currentDaemonStartedAt: string;
+	  };
 
 export type ReadinessResponse = {
 	state: ReadinessState;


### PR DESCRIPTION
## Summary

- delivery ticket: `P25.01 Restart Proof Contract and Durable Status Surface`
- ticket file: [docs/02-delivery/phase-25/ticket-01-restart-proof-contract-and-durable-status-surface.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-25/ticket-01-restart-proof-contract-and-durable-status-surface.md)
- stacked base branch: `main`
- self-audit: outcome `clean` completed at 2026-04-23 07:19 UTC


## AI Review Follow-up (2026-04-23)

- CodeRabbit reported 1 actionable finding in `src/restart-proof.ts`; patched in `bf1a590`.
- `readRestartProofRecord` now treats corrupt or unparseable `restart-proof.json` content as no valid record, so `GET /api/daemon/restart-status` returns `idle` instead of failing with a permanent 500.
- `writeRestartProofRecord` now uses a same-directory temp file with exclusive create plus rename, so restart-proof updates are atomic.
- Added a regression test covering a corrupt restart-proof artifact.
- Left 1 non-blocking nit unpatched in `web/src/lib/types.ts`: the duplicated `RestartStatus` type should be consolidated or explicitly sync-marked in a future shared-contract pass.
