### PR TITLE
feat: prove config restart round-trip [P25.02]

### DIFF
--- a/docs/02-delivery/phase-25/ticket-02-config-restart-round-trip-success-path.md
+++ b/docs/02-delivery/phase-25/ticket-02-config-restart-round-trip-success-path.md
@@ -30,3 +30,5 @@ An operator can trigger restart from `/config` and receive a truthful end-to-end
 ## Rationale
 
 Phase 25 needs an early visible payoff. `/config` already owns the main restart-backed settings flow, so it is the right first place to prove the contract end to end.
+
+This slice uses a same-origin SvelteKit proxy plus client polling so the browser can survive daemon downtime and verify the returned `requestId` without exposing private API base configuration to client-side code.

--- a/web/src/lib/restart-roundtrip.ts
+++ b/web/src/lib/restart-roundtrip.ts
@@ -1,0 +1,27 @@
+import type { RestartStatus } from '$lib/types';
+
+export type RestartRoundTripPhase = 'requested' | 'restarting' | 'back_online';
+
+export async function loadRestartRoundTripPhase(
+	requestId: string,
+	fetchImpl: typeof fetch = fetch
+): Promise<RestartRoundTripPhase> {
+	try {
+		const response = await fetchImpl('/api/daemon/restart-status', {
+			method: 'GET',
+			cache: 'no-store'
+		});
+		if (!response.ok) {
+			return 'restarting';
+		}
+
+		const status = (await response.json()) as RestartStatus;
+		if ('requestId' in status && status.requestId === requestId) {
+			return status.state === 'back_online' ? 'back_online' : 'requested';
+		}
+
+		return 'restarting';
+	} catch {
+		return 'restarting';
+	}
+}

--- a/web/src/routes/api/daemon/restart-status/+server.ts
+++ b/web/src/routes/api/daemon/restart-status/+server.ts
@@ -1,0 +1,17 @@
+import { json } from '@sveltejs/kit';
+import { apiRequest } from '$lib/server/api';
+
+export const GET = async () => {
+	try {
+		const response = await apiRequest('/api/daemon/restart-status');
+		return new Response(await response.text(), {
+			status: response.status,
+			headers: {
+				'content-type': response.headers.get('content-type') ?? 'application/json'
+			}
+		});
+	} catch (error) {
+		console.error('[web] restart-status proxy failed:', error);
+		return json({ error: 'Could not reach the API.' }, { status: 502 });
+	}
+};

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -6,6 +6,7 @@ import type {
 	AppConfig,
 	OnboardingStatus,
 	PlexAuthStatusResponse,
+	RestartStatus,
 	RunSummaryRecord,
 	SessionInfo,
 	TransmissionStatusResponse
@@ -506,7 +507,8 @@ export const actions: Actions = {
 				return fail(response.status, { restartError });
 			}
 
-			return { restarted: true };
+			const body = (await response.json()) as { restartStatus?: RestartStatus };
+			return { restarted: true, restartStatus: body.restartStatus ?? null };
 		} catch (error) {
 			console.error('[config] restartDaemon failed:', error);
 			return fail(502, { restartError: 'Could not reach the API to restart.' });

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
+	import { invalidateAll } from '$app/navigation';
 	import type { SubmitFunction } from '@sveltejs/kit';
-	import { tick } from 'svelte';
+	import { onDestroy, tick } from 'svelte';
 	import ApiUnavailableAlert from '$lib/components/ApiUnavailableAlert.svelte';
 	import PlexAuthCard from '$lib/components/PlexAuthCard.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import { maskConfiguredValue, parseHostPortFromUrl } from '$lib/helpers';
+	import { loadRestartRoundTripPhase } from '$lib/restart-roundtrip';
 	import { toast } from '$lib/toast';
-	import type { FeedConfig } from '$lib/types';
+	import type { FeedConfig, RestartStatus } from '$lib/types';
 	import type { ActionData, PageData } from './$types';
 	import ConfigPageHeader from './components/ConfigPageHeader.svelte';
 	import DeleteShowModal from './components/DeleteShowModal.svelte';
@@ -82,6 +84,19 @@
 	let showAddDraftInputEl = $state<HTMLInputElement | null>(null);
 	let runtimeChangesPending = $state(false);
 	let restarting = $state(false);
+	let restartPhase = $state<'idle' | 'requested' | 'restarting' | 'back_online'>('idle');
+	let restartRequestId = $state<string | null>(null);
+	let restartPollTimer = $state<number | null>(null);
+
+	const restartInProgress = $derived(
+		restarting || restartPhase === 'requested' || restartPhase === 'restarting'
+	);
+
+	onDestroy(() => {
+		if (restartPollTimer !== null) {
+			window.clearTimeout(restartPollTimer);
+		}
+	});
 
 	$effect(() => {
 		if (!showAddDraftActive) return;
@@ -261,6 +276,39 @@
 		return !!(data.config.transmission.username || data.config.transmission.password);
 	}
 
+	function clearRestartPolling() {
+		if (restartPollTimer !== null) {
+			window.clearTimeout(restartPollTimer);
+			restartPollTimer = null;
+		}
+	}
+
+	function queueRestartStatusPoll(requestId: string) {
+		clearRestartPolling();
+		restartPollTimer = window.setTimeout(() => {
+			void pollRestartStatus(requestId);
+		}, 1000);
+	}
+
+	async function pollRestartStatus(requestId: string) {
+		const phase = await loadRestartRoundTripPhase(requestId);
+		if (restartRequestId !== requestId) {
+			return;
+		}
+
+		restartPhase = phase;
+		if (phase === 'back_online') {
+			clearRestartPolling();
+			restartRequestId = null;
+			runtimeChangesPending = false;
+			toast('Daemon back online — restart proof confirmed.', 'success');
+			await invalidateAll();
+			return;
+		}
+
+		queueRestartStatusPoll(requestId);
+	}
+
 	function storagePoolTargets(): Array<{ label: string; value: string }> {
 		if (!data.config) return [{ label: 'Download', value: 'Unavailable' }];
 		const { downloadDirs, downloadDir } = data.config.transmission;
@@ -426,12 +474,24 @@
 		return async ({ result, update }) => {
 			restarting = false;
 			if (result.type === 'success') {
-				runtimeChangesPending = false;
-				toast(
-					'Restart requested — this page may go unavailable before the daemon returns',
-					'success'
-				);
+				const restartStatus =
+					(result.data as { restartStatus?: RestartStatus | null } | null)?.restartStatus ?? null;
+				if (restartStatus?.state === 'requested') {
+					runtimeChangesPending = false;
+					restartRequestId = restartStatus.requestId;
+					restartPhase = 'requested';
+					toast('Restart requested — waiting for the daemon to restart.', 'success');
+					queueRestartStatusPoll(restartStatus.requestId);
+				} else {
+					toast(
+						'Restart requested — this page may go unavailable before the daemon returns',
+						'success'
+					);
+				}
 			} else {
+				clearRestartPolling();
+				restartRequestId = null;
+				restartPhase = 'idle';
 				toast('Restart failed — try again or restart manually', 'error');
 			}
 			await update({ reset: false });
@@ -483,7 +543,8 @@
 				runtime={data.config.runtime}
 				{showRows}
 				{testingConnection}
-				{restarting}
+				restarting={restartInProgress}
+				{restartPhase}
 				{runtimeChangesPending}
 				runtimeMessage={form?.runtimeMessage}
 				compatibility={transmissionCompatibility}

--- a/web/src/routes/config/components/TransmissionCard.svelte
+++ b/web/src/routes/config/components/TransmissionCard.svelte
@@ -28,6 +28,7 @@
 		showRows: string[];
 		testingConnection: boolean;
 		restarting: boolean;
+		restartPhase: 'idle' | 'requested' | 'restarting' | 'back_online';
 		runtimeChangesPending: boolean;
 		runtimeMessage?: string;
 		compatibility?: TransmissionCompatibility | null;
@@ -56,6 +57,7 @@
 		showRows,
 		testingConnection,
 		restarting,
+		restartPhase,
 		runtimeChangesPending,
 		runtimeMessage,
 		compatibility = null,
@@ -282,7 +284,13 @@
 				{/if}
 			</Button>
 			<p class="text-muted-foreground text-xs">
-				{#if runtimeChangesPending}
+				{#if restartPhase === 'requested'}
+					Restart requested. Waiting for the daemon to go away.
+				{:else if restartPhase === 'restarting'}
+					Daemon restarting. This page will confirm when it comes back.
+				{:else if restartPhase === 'back_online'}
+					Daemon return proved. Runtime changes are live.
+				{:else if runtimeChangesPending}
 					Runtime changes are saved and waiting for restart.
 				{:else}
 					Restart stays disabled until runtime settings change.

--- a/web/test/lib/restart-roundtrip.test.ts
+++ b/web/test/lib/restart-roundtrip.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { loadRestartRoundTripPhase } from '../../src/lib/restart-roundtrip';
+
+describe('loadRestartRoundTripPhase', () => {
+	it('keeps the flow in requested while the same restart request is still pending', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					state: 'requested',
+					requestId: 'restart-123',
+					requestedAt: '2026-04-23T10:00:00.000Z',
+					requestedByStartedAt: '2026-04-23T10:00:00.000Z',
+					currentDaemonStartedAt: '2026-04-23T10:00:00.000Z'
+				}),
+				{ status: 200 }
+			)
+		);
+
+		await expect(loadRestartRoundTripPhase('restart-123', fetchMock)).resolves.toBe('requested');
+	});
+
+	it('treats API downtime as restarting after the request was accepted', async () => {
+		const fetchMock = vi.fn().mockRejectedValue(new Error('connection refused'));
+
+		await expect(loadRestartRoundTripPhase('restart-123', fetchMock)).resolves.toBe('restarting');
+	});
+
+	it('returns back_online when the restarted daemon proves the same request id', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					state: 'back_online',
+					requestId: 'restart-123',
+					requestedAt: '2026-04-23T10:00:00.000Z',
+					requestedByStartedAt: '2026-04-23T10:00:00.000Z',
+					returnedAt: '2026-04-23T10:00:05.000Z',
+					returnedStartedAt: '2026-04-23T10:00:05.000Z',
+					currentDaemonStartedAt: '2026-04-23T10:00:05.000Z'
+				}),
+				{ status: 200 }
+			)
+		);
+
+		await expect(loadRestartRoundTripPhase('restart-123', fetchMock)).resolves.toBe('back_online');
+	});
+});

--- a/web/test/routes/api/daemon/restart-status.server.test.ts
+++ b/web/test/routes/api/daemon/restart-status.server.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiRequestMock = vi.fn();
+vi.mock('$lib/server/api', () => ({
+	apiRequest: apiRequestMock
+}));
+
+describe('/api/daemon/restart-status proxy', () => {
+	beforeEach(() => {
+		apiRequestMock.mockReset();
+		vi.resetModules();
+	});
+
+	it('proxies the backend restart status payload', async () => {
+		apiRequestMock.mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					state: 'requested',
+					requestId: 'restart-123'
+				}),
+				{ status: 200, headers: { 'content-type': 'application/json' } }
+			)
+		);
+		const { GET } = await import('../../../../src/routes/api/daemon/restart-status/+server');
+
+		const response = await GET();
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			state: 'requested',
+			requestId: 'restart-123'
+		});
+	});
+
+	it('returns 502 when the backend is unavailable', async () => {
+		apiRequestMock.mockRejectedValue(new Error('connection refused'));
+		const { GET } = await import('../../../../src/routes/api/daemon/restart-status/+server');
+
+		const response = await GET();
+
+		expect(response.status).toBe(502);
+		expect(await response.json()).toEqual({ error: 'Could not reach the API.' });
+	});
+});

--- a/web/test/routes/config/page.server.test.ts
+++ b/web/test/routes/config/page.server.test.ts
@@ -478,18 +478,41 @@ describe('config page server actions', () => {
 			expect(apiRequestMock).not.toHaveBeenCalled();
 		});
 
-		it('returns restarted: true on success', async () => {
+		it('returns restarted: true with restart proof state on success', async () => {
 			vi.doMock('$env/dynamic/private', () => ({
 				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
 			}));
 			const { actions } = await import('../../../src/routes/config/+page.server');
-			apiRequestMock.mockResolvedValue(new Response(null, { status: 202 }));
+			apiRequestMock.mockResolvedValue(
+				new Response(
+					JSON.stringify({
+						ok: true,
+						restartStatus: {
+							state: 'requested',
+							requestId: 'restart-123',
+							requestedAt: '2026-04-23T10:00:00.000Z',
+							requestedByStartedAt: '2026-04-23T10:00:00.000Z',
+							currentDaemonStartedAt: '2026-04-23T10:00:00.000Z'
+						}
+					}),
+					{ status: 200 }
+				)
+			);
 
 			const result = await actions.restartDaemon({
 				request: new Request('http://localhost/config', { method: 'POST' })
 			} as never);
 
 			expect((result as { restarted?: boolean }).restarted).toBe(true);
+			expect(
+				(result as { restartStatus?: { requestId?: string; state?: string } | null }).restartStatus
+			).toEqual({
+				state: 'requested',
+				requestId: 'restart-123',
+				requestedAt: '2026-04-23T10:00:00.000Z',
+				requestedByStartedAt: '2026-04-23T10:00:00.000Z',
+				currentDaemonStartedAt: '2026-04-23T10:00:00.000Z'
+			});
 			expect(apiRequestMock).toHaveBeenCalledWith(
 				'/api/daemon/restart',
 				expect.objectContaining({ method: 'POST' })


### PR DESCRIPTION
## Summary

- delivery ticket: `P25.02 Config Restart Round-Trip Success Path`
- ticket file: [docs/02-delivery/phase-25/ticket-02-config-restart-round-trip-success-path.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-25/ticket-02-config-restart-round-trip-success-path.md)
- stacked base branch: `agents/p25-01-restart-proof-contract-and-durable-status-surface`
- self-audit: outcome `clean` completed at 2026-04-23 07:28 UTC
