### PR TITLE
feat: add shared restart failure states [P25.03]

### DIFF
--- a/docs/02-delivery/phase-25/ticket-03-shared-restart-state-model-and-failed-return-ux.md
+++ b/docs/02-delivery/phase-25/ticket-03-shared-restart-state-model-and-failed-return-ux.md
@@ -30,3 +30,5 @@ Pirate Claw uses one restart vocabulary across its existing surfaces and reports
 ## Rationale
 
 The success path alone is not enough. Without a shared failure model, Pirate Claw would still overclaim certainty the moment the happy path breaks.
+
+This ticket sets one browser-side timeout of 45 seconds for `failed_to_return`, which is long enough for the supported Synology restart path to hand control back on a normal restart without leaving the UI in an indefinite `restarting` state when the daemon never returns.

--- a/web/src/lib/restart-roundtrip.ts
+++ b/web/src/lib/restart-roundtrip.ts
@@ -1,18 +1,36 @@
 import type { RestartStatus } from '$lib/types';
 
-export type RestartRoundTripPhase = 'requested' | 'restarting' | 'back_online';
+export const RESTART_RETURN_TIMEOUT_MS = 45_000;
+
+export type RestartRoundTripPhase = 'requested' | 'restarting' | 'back_online' | 'failed_to_return';
+
+export function hasRestartTimedOut(
+	requestedAt: string,
+	nowMs: number = Date.now(),
+	timeoutMs: number = RESTART_RETURN_TIMEOUT_MS
+): boolean {
+	const requestedAtMs = Date.parse(requestedAt);
+	if (Number.isNaN(requestedAtMs)) {
+		return false;
+	}
+	return nowMs - requestedAtMs >= timeoutMs;
+}
 
 export async function loadRestartRoundTripPhase(
 	requestId: string,
-	fetchImpl: typeof fetch = fetch
+	requestedAt: string,
+	fetchImpl: typeof fetch = fetch,
+	nowMs: number = Date.now()
 ): Promise<RestartRoundTripPhase> {
+	const timedOut = hasRestartTimedOut(requestedAt, nowMs);
+
 	try {
 		const response = await fetchImpl('/api/daemon/restart-status', {
 			method: 'GET',
 			cache: 'no-store'
 		});
 		if (!response.ok) {
-			return 'restarting';
+			return timedOut ? 'failed_to_return' : 'restarting';
 		}
 
 		const status = (await response.json()) as RestartStatus;
@@ -20,8 +38,8 @@ export async function loadRestartRoundTripPhase(
 			return status.state === 'back_online' ? 'back_online' : 'requested';
 		}
 
-		return 'restarting';
+		return timedOut ? 'failed_to_return' : 'restarting';
 	} catch {
-		return 'restarting';
+		return timedOut ? 'failed_to_return' : 'restarting';
 	}
 }

--- a/web/src/lib/restart-roundtrip.ts
+++ b/web/src/lib/restart-roundtrip.ts
@@ -1,6 +1,7 @@
 import type { RestartStatus } from '$lib/types';
 
 export const RESTART_RETURN_TIMEOUT_MS = 45_000;
+export const RESTART_RETURN_TIMEOUT_SECONDS = RESTART_RETURN_TIMEOUT_MS / 1000;
 
 export type RestartRoundTripPhase = 'requested' | 'restarting' | 'back_online' | 'failed_to_return';
 
@@ -11,7 +12,7 @@ export function hasRestartTimedOut(
 ): boolean {
 	const requestedAtMs = Date.parse(requestedAt);
 	if (Number.isNaN(requestedAtMs)) {
-		return false;
+		return true;
 	}
 	return nowMs - requestedAtMs >= timeoutMs;
 }
@@ -35,7 +36,10 @@ export async function loadRestartRoundTripPhase(
 
 		const status = (await response.json()) as RestartStatus;
 		if ('requestId' in status && status.requestId === requestId) {
-			return status.state === 'back_online' ? 'back_online' : 'requested';
+			if (status.state === 'back_online') {
+				return 'back_online';
+			}
+			return timedOut ? 'failed_to_return' : 'requested';
 		}
 
 		return timedOut ? 'failed_to_return' : 'restarting';

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -19,6 +19,7 @@
 	import { page } from '$app/stores';
 	import { toast } from '$lib/toast';
 	import type { SubmitFunction } from '@sveltejs/kit';
+	import { loadRestartRoundTripPhase } from '$lib/restart-roundtrip';
 
 	interface Props {
 		children: Snippet;
@@ -53,20 +54,83 @@
 		readinessState === 'ready_pending_restart' && !isOnboarding
 	);
 	let restartingFromBanner = $state(false);
+	let restartBannerPhase = $state<
+		'idle' | 'requested' | 'restarting' | 'back_online' | 'failed_to_return'
+	>('idle');
+	let restartBannerRequestId = $state<string | null>(null);
+	let restartBannerRequestedAt = $state<string | null>(null);
+	let restartBannerPollTimer = $state<number | null>(null);
+
+	function clearRestartBannerPolling() {
+		if (restartBannerPollTimer !== null) {
+			window.clearTimeout(restartBannerPollTimer);
+			restartBannerPollTimer = null;
+		}
+	}
+
+	function queueRestartBannerPoll(requestId: string) {
+		clearRestartBannerPolling();
+		restartBannerPollTimer = window.setTimeout(() => {
+			void pollRestartBannerStatus(requestId);
+		}, 1000);
+	}
+
+	async function pollRestartBannerStatus(requestId: string) {
+		if (!restartBannerRequestedAt) return;
+		const phase = await loadRestartRoundTripPhase(requestId, restartBannerRequestedAt);
+		if (restartBannerRequestId !== requestId) return;
+
+		restartBannerPhase = phase;
+		if (phase === 'back_online') {
+			clearRestartBannerPolling();
+			restartBannerRequestId = null;
+			restartBannerRequestedAt = null;
+			toast('Daemon back online — restart proof confirmed.', 'success');
+			await invalidateAll();
+			return;
+		}
+		if (phase === 'failed_to_return') {
+			clearRestartBannerPolling();
+			restartBannerRequestId = null;
+			restartBannerRequestedAt = null;
+			toast(
+				'Daemon failed to return within 45 seconds — check the host, then retry or restart manually.',
+				'error'
+			);
+			return;
+		}
+
+		queueRestartBannerPoll(requestId);
+	}
 
 	const enhanceRestartDaemon: SubmitFunction = () => {
 		restartingFromBanner = true;
 		return async ({ result }) => {
 			restartingFromBanner = false;
 			if (result.type === 'success') {
-				toast(
-					'Restart requested — this page may go unavailable before the daemon returns',
-					'success'
-				);
-				await invalidateAll();
+				const restartStatus = (
+					result.data as { restartStatus?: { requestId?: string; requestedAt?: string } } | null
+				)?.restartStatus;
+				if (restartStatus?.requestId && restartStatus.requestedAt) {
+					restartBannerRequestId = restartStatus.requestId;
+					restartBannerRequestedAt = restartStatus.requestedAt;
+					restartBannerPhase = 'requested';
+					toast('Restart requested — waiting for the daemon to restart.', 'success');
+					queueRestartBannerPoll(restartStatus.requestId);
+				} else {
+					toast(
+						'Restart requested — this page may go unavailable before the daemon returns',
+						'success'
+					);
+					await invalidateAll();
+				}
 				return;
 			}
 
+			clearRestartBannerPolling();
+			restartBannerRequestId = null;
+			restartBannerRequestedAt = null;
+			restartBannerPhase = 'idle';
 			const restartError =
 				result.type === 'failure' && typeof result.data?.restartError === 'string'
 					? result.data.restartError
@@ -191,7 +255,19 @@
 							class="bg-warning/10 border-warning/30 text-warning flex flex-wrap items-center justify-between gap-3 rounded-lg border px-4 py-3 text-sm"
 						>
 							<p>
-								Restart daemon to apply config changes. The browser will not confirm return yet.
+								{#if restartBannerPhase === 'requested'}
+									Restart requested. Waiting for the daemon to go away.
+								{:else if restartBannerPhase === 'restarting'}
+									Daemon restarting. This page will confirm when it comes back.
+								{:else if restartBannerPhase === 'back_online'}
+									Daemon back_online. Return proof is recorded.
+								{:else if restartBannerPhase === 'failed_to_return'}
+									Daemon failed_to_return within 45 seconds. Check the host, then retry or restart
+									manually.
+								{:else}
+									Restart daemon to apply config changes. The browser will confirm whether it comes
+									back.
+								{/if}
 							</p>
 							<button
 								type="submit"

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -19,7 +19,10 @@
 	import { page } from '$app/stores';
 	import { toast } from '$lib/toast';
 	import type { SubmitFunction } from '@sveltejs/kit';
-	import { loadRestartRoundTripPhase } from '$lib/restart-roundtrip';
+	import {
+		loadRestartRoundTripPhase,
+		RESTART_RETURN_TIMEOUT_SECONDS
+	} from '$lib/restart-roundtrip';
 
 	interface Props {
 		children: Snippet;
@@ -60,6 +63,12 @@
 	let restartBannerRequestId = $state<string | null>(null);
 	let restartBannerRequestedAt = $state<string | null>(null);
 	let restartBannerPollTimer = $state<number | null>(null);
+	const restartBannerActionDisabled = $derived(
+		restartingFromBanner ||
+			restartBannerPhase === 'requested' ||
+			restartBannerPhase === 'restarting' ||
+			restartBannerPhase === 'back_online'
+	);
 
 	function clearRestartBannerPolling() {
 		if (restartBannerPollTimer !== null) {
@@ -260,10 +269,10 @@
 								{:else if restartBannerPhase === 'restarting'}
 									Daemon restarting. This page will confirm when it comes back.
 								{:else if restartBannerPhase === 'back_online'}
-									Daemon back_online. Return proof is recorded.
+									Daemon back online. Return proof is recorded.
 								{:else if restartBannerPhase === 'failed_to_return'}
-									Daemon failed_to_return within 45 seconds. Check the host, then retry or restart
-									manually.
+									Daemon failed to return within {RESTART_RETURN_TIMEOUT_SECONDS} seconds. Check the host,
+									then retry or restart manually.
 								{:else}
 									Restart daemon to apply config changes. The browser will confirm whether it comes
 									back.
@@ -272,7 +281,7 @@
 							<button
 								type="submit"
 								class="border-warning/40 text-warning hover:bg-warning/10 shrink-0 rounded-md border px-3 py-1.5 font-medium transition-colors"
-								disabled={restartingFromBanner}
+								disabled={restartBannerActionDisabled}
 							>
 								{#if restartingFromBanner}
 									Restarting…

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -84,8 +84,11 @@
 	let showAddDraftInputEl = $state<HTMLInputElement | null>(null);
 	let runtimeChangesPending = $state(false);
 	let restarting = $state(false);
-	let restartPhase = $state<'idle' | 'requested' | 'restarting' | 'back_online'>('idle');
+	let restartPhase = $state<
+		'idle' | 'requested' | 'restarting' | 'back_online' | 'failed_to_return'
+	>('idle');
 	let restartRequestId = $state<string | null>(null);
+	let restartRequestedAt = $state<string | null>(null);
 	let restartPollTimer = $state<number | null>(null);
 
 	const restartInProgress = $derived(
@@ -291,7 +294,11 @@
 	}
 
 	async function pollRestartStatus(requestId: string) {
-		const phase = await loadRestartRoundTripPhase(requestId);
+		if (!restartRequestedAt) {
+			return;
+		}
+
+		const phase = await loadRestartRoundTripPhase(requestId, restartRequestedAt);
 		if (restartRequestId !== requestId) {
 			return;
 		}
@@ -300,9 +307,21 @@
 		if (phase === 'back_online') {
 			clearRestartPolling();
 			restartRequestId = null;
+			restartRequestedAt = null;
 			runtimeChangesPending = false;
 			toast('Daemon back online — restart proof confirmed.', 'success');
 			await invalidateAll();
+			return;
+		}
+
+		if (phase === 'failed_to_return') {
+			clearRestartPolling();
+			restartRequestId = null;
+			restartRequestedAt = null;
+			toast(
+				'Daemon failed to return within 45 seconds — check the host, then retry or restart manually.',
+				'error'
+			);
 			return;
 		}
 
@@ -479,6 +498,7 @@
 				if (restartStatus?.state === 'requested') {
 					runtimeChangesPending = false;
 					restartRequestId = restartStatus.requestId;
+					restartRequestedAt = restartStatus.requestedAt;
 					restartPhase = 'requested';
 					toast('Restart requested — waiting for the daemon to restart.', 'success');
 					queueRestartStatusPoll(restartStatus.requestId);
@@ -491,6 +511,7 @@
 			} else {
 				clearRestartPolling();
 				restartRequestId = null;
+				restartRequestedAt = null;
 				restartPhase = 'idle';
 				toast('Restart failed — try again or restart manually', 'error');
 			}

--- a/web/src/routes/config/components/TransmissionCard.svelte
+++ b/web/src/routes/config/components/TransmissionCard.svelte
@@ -28,7 +28,7 @@
 		showRows: string[];
 		testingConnection: boolean;
 		restarting: boolean;
-		restartPhase: 'idle' | 'requested' | 'restarting' | 'back_online';
+		restartPhase: 'idle' | 'requested' | 'restarting' | 'back_online' | 'failed_to_return';
 		runtimeChangesPending: boolean;
 		runtimeMessage?: string;
 		compatibility?: TransmissionCompatibility | null;
@@ -289,7 +289,9 @@
 				{:else if restartPhase === 'restarting'}
 					Daemon restarting. This page will confirm when it comes back.
 				{:else if restartPhase === 'back_online'}
-					Daemon return proved. Runtime changes are live.
+					Daemon back_online. Return proof is recorded and runtime changes are live.
+				{:else if restartPhase === 'failed_to_return'}
+					Daemon failed_to_return within 45 seconds. Check the host, then retry or restart manually.
 				{:else if runtimeChangesPending}
 					Runtime changes are saved and waiting for restart.
 				{:else}

--- a/web/src/routes/config/components/TransmissionCard.svelte
+++ b/web/src/routes/config/components/TransmissionCard.svelte
@@ -3,6 +3,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Card, CardContent, CardHeader } from '$lib/components/ui/card';
 	import { formatTransferSize } from '$lib/helpers';
+	import { RESTART_RETURN_TIMEOUT_SECONDS } from '$lib/restart-roundtrip';
 	import TransmissionCompatibilityBadge from '$lib/components/TransmissionCompatibilityBadge.svelte';
 	import type { RuntimeConfig, TransmissionCompatibility } from '$lib/types';
 	import type { SubmitFunction } from '@sveltejs/kit';
@@ -289,9 +290,10 @@
 				{:else if restartPhase === 'restarting'}
 					Daemon restarting. This page will confirm when it comes back.
 				{:else if restartPhase === 'back_online'}
-					Daemon back_online. Return proof is recorded and runtime changes are live.
+					Daemon back online. Return proof is recorded and runtime changes are live.
 				{:else if restartPhase === 'failed_to_return'}
-					Daemon failed_to_return within 45 seconds. Check the host, then retry or restart manually.
+					Daemon failed to return within {RESTART_RETURN_TIMEOUT_SECONDS} seconds. Check the host, then
+					retry or restart manually.
 				{:else if runtimeChangesPending}
 					Runtime changes are saved and waiting for restart.
 				{:else}

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -883,7 +883,12 @@
 			>
 				<AlertTitle>Done</AlertTitle>
 				<AlertDescription>
-					Your minimum setup is complete. Review the summary, then continue in the dashboard.
+					{#if readinessState === 'ready_pending_restart'}
+						Your minimum setup is complete, but the daemon is restarting. The dashboard unlocks once
+						it is back_online.
+					{:else}
+						Your minimum setup is complete. Review the summary, then continue in the dashboard.
+					{/if}
 				</AlertDescription>
 			</Alert>
 

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -885,7 +885,7 @@
 				<AlertDescription>
 					{#if readinessState === 'ready_pending_restart'}
 						Your minimum setup is complete, but the daemon is restarting. The dashboard unlocks once
-						it is back_online.
+						it is back online.
 					{:else}
 						Your minimum setup is complete. Review the summary, then continue in the dashboard.
 					{/if}

--- a/web/test/lib/restart-roundtrip.test.ts
+++ b/web/test/lib/restart-roundtrip.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { loadRestartRoundTripPhase } from '../../src/lib/restart-roundtrip';
+import {
+	RESTART_RETURN_TIMEOUT_MS,
+	loadRestartRoundTripPhase
+} from '../../src/lib/restart-roundtrip';
 
 describe('loadRestartRoundTripPhase', () => {
 	it('keeps the flow in requested while the same restart request is still pending', async () => {
@@ -16,13 +19,17 @@ describe('loadRestartRoundTripPhase', () => {
 			)
 		);
 
-		await expect(loadRestartRoundTripPhase('restart-123', fetchMock)).resolves.toBe('requested');
+		await expect(
+			loadRestartRoundTripPhase('restart-123', '2026-04-23T10:00:00.000Z', fetchMock)
+		).resolves.toBe('requested');
 	});
 
 	it('treats API downtime as restarting after the request was accepted', async () => {
 		const fetchMock = vi.fn().mockRejectedValue(new Error('connection refused'));
 
-		await expect(loadRestartRoundTripPhase('restart-123', fetchMock)).resolves.toBe('restarting');
+		await expect(
+			loadRestartRoundTripPhase('restart-123', '2026-04-23T10:00:00.000Z', fetchMock)
+		).resolves.toBe('restarting');
 	});
 
 	it('returns back_online when the restarted daemon proves the same request id', async () => {
@@ -41,6 +48,21 @@ describe('loadRestartRoundTripPhase', () => {
 			)
 		);
 
-		await expect(loadRestartRoundTripPhase('restart-123', fetchMock)).resolves.toBe('back_online');
+		await expect(
+			loadRestartRoundTripPhase('restart-123', '2026-04-23T10:00:00.000Z', fetchMock)
+		).resolves.toBe('back_online');
+	});
+
+	it('returns failed_to_return after the timeout expires while the daemon stays unavailable', async () => {
+		const fetchMock = vi.fn().mockRejectedValue(new Error('connection refused'));
+
+		await expect(
+			loadRestartRoundTripPhase(
+				'restart-123',
+				'2026-04-23T10:00:00.000Z',
+				fetchMock,
+				Date.parse('2026-04-23T10:00:00.000Z') + RESTART_RETURN_TIMEOUT_MS
+			)
+		).resolves.toBe('failed_to_return');
 	});
 });

--- a/web/test/lib/restart-roundtrip.test.ts
+++ b/web/test/lib/restart-roundtrip.test.ts
@@ -24,6 +24,30 @@ describe('loadRestartRoundTripPhase', () => {
 		).resolves.toBe('requested');
 	});
 
+	it('returns failed_to_return when the same request id is still pending after the timeout', async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					state: 'requested',
+					requestId: 'restart-123',
+					requestedAt: '2026-04-23T10:00:00.000Z',
+					requestedByStartedAt: '2026-04-23T10:00:00.000Z',
+					currentDaemonStartedAt: '2026-04-23T10:00:00.000Z'
+				}),
+				{ status: 200 }
+			)
+		);
+
+		await expect(
+			loadRestartRoundTripPhase(
+				'restart-123',
+				'2026-04-23T10:00:00.000Z',
+				fetchMock,
+				Date.parse('2026-04-23T10:00:00.000Z') + RESTART_RETURN_TIMEOUT_MS
+			)
+		).resolves.toBe('failed_to_return');
+	});
+
 	it('treats API downtime as restarting after the request was accepted', async () => {
 		const fetchMock = vi.fn().mockRejectedValue(new Error('connection refused'));
 
@@ -63,6 +87,27 @@ describe('loadRestartRoundTripPhase', () => {
 				fetchMock,
 				Date.parse('2026-04-23T10:00:00.000Z') + RESTART_RETURN_TIMEOUT_MS
 			)
+		).resolves.toBe('failed_to_return');
+	});
+
+	it('stays restarting just below the timeout threshold', async () => {
+		const fetchMock = vi.fn().mockRejectedValue(new Error('connection refused'));
+
+		await expect(
+			loadRestartRoundTripPhase(
+				'restart-123',
+				'2026-04-23T10:00:00.000Z',
+				fetchMock,
+				Date.parse('2026-04-23T10:00:00.000Z') + RESTART_RETURN_TIMEOUT_MS - 1
+			)
+		).resolves.toBe('restarting');
+	});
+
+	it('treats an invalid requestedAt timestamp as timed out', async () => {
+		const fetchMock = vi.fn().mockRejectedValue(new Error('connection refused'));
+
+		await expect(
+			loadRestartRoundTripPhase('restart-123', 'not-a-timestamp', fetchMock)
 		).resolves.toBe('failed_to_return');
 	});
 });

--- a/web/test/routes/config/config.test.ts
+++ b/web/test/routes/config/config.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import Page from '../../../src/routes/config/+page.svelte';
+import TransmissionCard from '../../../src/routes/config/components/TransmissionCard.svelte';
 import type { AppConfig } from '$lib/types';
 
 vi.mock('svelte-sonner', () => ({
@@ -346,5 +347,39 @@ describe('/config', () => {
 		expect(screen.getByRole('textbox', { name: 'TV show 1' })).toBeDisabled();
 		expect(screen.getByRole('spinbutton', { name: 'Run interval (minutes)' })).toBeDisabled();
 		expect(screen.getByRole('button', { name: 'Test Connection' })).toBeEnabled();
+	});
+
+	it('renders failed_to_return guidance when restart proof times out', () => {
+		render(TransmissionCard, {
+			canWrite: true,
+			currentEtag: '"rev-1"',
+			writeDisabledTooltip: '',
+			connected: true,
+			host: 'localhost',
+			port: '9091',
+			version: '3.00',
+			totalDownloadedBytes: 0,
+			totalUploadedBytes: 0,
+			sessionDownloadedBytes: 0,
+			sessionUploadedBytes: 0,
+			authToken: '[redacted]',
+			url: 'http://localhost:9091',
+			downloadTargets: [{ label: 'Download', value: '/tmp' }],
+			runtime: mockConfig.runtime,
+			showRows: ['The Show'],
+			testingConnection: false,
+			restarting: false,
+			restartPhase: 'failed_to_return',
+			runtimeChangesPending: false,
+			enhanceTestConnection: vi.fn(),
+			enhanceSaveRuntime: vi.fn(),
+			enhanceRestartDaemon: vi.fn()
+		});
+
+		expect(
+			screen.getByText(
+				'Daemon failed_to_return within 45 seconds. Check the host, then retry or restart manually.'
+			)
+		).toBeInTheDocument();
 	});
 });

--- a/web/test/routes/config/config.test.ts
+++ b/web/test/routes/config/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
+import { RESTART_RETURN_TIMEOUT_SECONDS } from '../../../src/lib/restart-roundtrip';
 import Page from '../../../src/routes/config/+page.svelte';
 import TransmissionCard from '../../../src/routes/config/components/TransmissionCard.svelte';
 import type { AppConfig } from '$lib/types';
@@ -378,8 +379,59 @@ describe('/config', () => {
 
 		expect(
 			screen.getByText(
-				'Daemon failed_to_return within 45 seconds. Check the host, then retry or restart manually.'
+				`Daemon failed to return within ${RESTART_RETURN_TIMEOUT_SECONDS} seconds. Check the host, then retry or restart manually.`
 			)
+		).toBeInTheDocument();
+	});
+
+	it('renders requested, restarting, and back online guidance with human-readable copy', async () => {
+		const baseProps = {
+			canWrite: true,
+			currentEtag: '"rev-1"',
+			writeDisabledTooltip: '',
+			connected: true,
+			host: 'localhost',
+			port: '9091',
+			version: '3.00',
+			totalDownloadedBytes: 0,
+			totalUploadedBytes: 0,
+			sessionDownloadedBytes: 0,
+			sessionUploadedBytes: 0,
+			authToken: '[redacted]',
+			url: 'http://localhost:9091',
+			downloadTargets: [{ label: 'Download', value: '/tmp' }],
+			runtime: mockConfig.runtime,
+			showRows: ['The Show'],
+			testingConnection: false,
+			restarting: false,
+			runtimeChangesPending: false,
+			enhanceTestConnection: vi.fn(),
+			enhanceSaveRuntime: vi.fn(),
+			enhanceRestartDaemon: vi.fn()
+		};
+
+		const rendered = render(TransmissionCard, {
+			...baseProps,
+			restartPhase: 'requested'
+		});
+		expect(
+			screen.getByText('Restart requested. Waiting for the daemon to go away.')
+		).toBeInTheDocument();
+
+		await rendered.rerender({
+			...baseProps,
+			restartPhase: 'restarting'
+		});
+		expect(
+			screen.getByText('Daemon restarting. This page will confirm when it comes back.')
+		).toBeInTheDocument();
+
+		await rendered.rerender({
+			...baseProps,
+			restartPhase: 'back_online'
+		});
+		expect(
+			screen.getByText('Daemon back online. Return proof is recorded and runtime changes are live.')
 		).toBeInTheDocument();
 	});
 });

--- a/web/test/routes/layout.test.ts
+++ b/web/test/routes/layout.test.ts
@@ -224,7 +224,7 @@ describe('+layout.svelte', () => {
 		expect(screen.getByTestId('ready-pending-restart-banner')).toBeInTheDocument();
 		expect(
 			screen.getByText(
-				'Restart daemon to apply config changes. The browser will not confirm return yet.'
+				'Restart daemon to apply config changes. The browser will confirm whether it comes back.'
 			)
 		).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Restart Daemon' })).toBeInTheDocument();

--- a/web/test/routes/onboarding/onboarding.test.ts
+++ b/web/test/routes/onboarding/onboarding.test.ts
@@ -385,5 +385,10 @@ describe('/onboarding', () => {
 		expect(dashboardLink).toHaveAttribute('href', '/');
 		expect(dashboardLink).toHaveAttribute('aria-disabled', 'true');
 		expect(dashboardLink).toHaveClass('pointer-events-none');
+		expect(
+			screen.getByText(
+				'Your minimum setup is complete, but the daemon is restarting. The dashboard unlocks once it is back_online.'
+			)
+		).toBeInTheDocument();
 	});
 });

--- a/web/test/routes/onboarding/onboarding.test.ts
+++ b/web/test/routes/onboarding/onboarding.test.ts
@@ -387,7 +387,7 @@ describe('/onboarding', () => {
 		expect(dashboardLink).toHaveClass('pointer-events-none');
 		expect(
 			screen.getByText(
-				'Your minimum setup is complete, but the daemon is restarting. The dashboard unlocks once it is back_online.'
+				'Your minimum setup is complete, but the daemon is restarting. The dashboard unlocks once it is back online.'
 			)
 		).toBeInTheDocument();
 	});


### PR DESCRIPTION
## Summary

- delivery ticket: `P25.03 Shared Restart State Model and Failed-Return UX`
- ticket file: [docs/02-delivery/phase-25/ticket-03-shared-restart-state-model-and-failed-return-ux.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-25/ticket-03-shared-restart-state-model-and-failed-return-ux.md)
- stacked base branch: `agents/p25-02-config-restart-round-trip-success-path`
- self-audit: outcome `clean` completed at 2026-04-23 09:33 UTC


## AI Review Follow-up (2026-04-23)

- CodeRabbit reported 4 inline findings plus 1 outside-diff banner-state issue.
- Patched in `da96652`: the shared restart round-trip helper now treats invalid timestamps as timed out, honors the timeout even when the matched `requestId` still reports `requested`, and has boundary coverage for the timeout window.
- Patched the shared UI copy to use human-readable restart messaging in the shell banner, config card, and onboarding done state.
- Patched the shell banner action guard so the restart button stays disabled while the restart round trip is still active.
- Added/updated web tests covering timeout semantics and human-readable restart messaging.
- Left 1 broader follow-up unpatched in onboarding: surfacing a full failed-restart retry path there needs additional route data/action plumbing beyond this late review pass.
