### PR TITLE
docs: sync synology runbook with phase 25 restart proof

### DIFF
--- a/docs/synology-runbook.md
+++ b/docs/synology-runbook.md
@@ -106,17 +106,20 @@ is:
 - Docker `--restart always` is the supervisor; the browser UI is not the
   supervisor
 - `POST /api/daemon/restart` only asks the daemon process to exit with
-  `SIGTERM`; it does not prove that the browser has observed the daemon come
-  back yet
+  `SIGTERM`; Docker restart policy is what brings the daemon back
 - restart-backed operation is supported only when the writable `/config`
   directory and the writable data files (`pirate-claw.db` plus the
   `.pirate-claw/runtime/` tree, including `poll-state.json`) are mounted
   together as the durable Pirate Claw boundary
+- the daemon writes restart proof under `.pirate-claw/runtime/restart-proof.json`
+  so the browser can distinguish `requested`, `restarting`, `back_online`, and
+  bounded `failed_to_return` states instead of stopping at "request sent"
 - if the container is started without Docker restart supervision, a restart
   request leaves Pirate Claw stopped until the operator intervenes manually
 
-That browser-visible return-proof gap remains Phase 25 work. Phase 24 only
-defines the supported supervisor contract and the durable paths it relies on.
+Phase 24 defines the supported supervisor contract and durable paths. Phase 25
+adds the browser-visible round trip on top of that same boundary; the current
+product now ships both.
 
 ### `pirate-claw-web`
 

--- a/web/test/lib/restart-roundtrip.test.ts
+++ b/web/test/lib/restart-roundtrip.test.ts
@@ -5,22 +5,25 @@ import {
 } from '../../src/lib/restart-roundtrip';
 
 describe('loadRestartRoundTripPhase', () => {
+	const requestedAt = '2026-04-23T10:00:00.000Z';
+	const justAfterRequestedAt = Date.parse(requestedAt) + 1_000;
+
 	it('keeps the flow in requested while the same restart request is still pending', async () => {
 		const fetchMock = vi.fn().mockResolvedValue(
 			new Response(
 				JSON.stringify({
 					state: 'requested',
 					requestId: 'restart-123',
-					requestedAt: '2026-04-23T10:00:00.000Z',
-					requestedByStartedAt: '2026-04-23T10:00:00.000Z',
-					currentDaemonStartedAt: '2026-04-23T10:00:00.000Z'
+					requestedAt,
+					requestedByStartedAt: requestedAt,
+					currentDaemonStartedAt: requestedAt
 				}),
 				{ status: 200 }
 			)
 		);
 
 		await expect(
-			loadRestartRoundTripPhase('restart-123', '2026-04-23T10:00:00.000Z', fetchMock)
+			loadRestartRoundTripPhase('restart-123', requestedAt, fetchMock, justAfterRequestedAt)
 		).resolves.toBe('requested');
 	});
 
@@ -30,9 +33,9 @@ describe('loadRestartRoundTripPhase', () => {
 				JSON.stringify({
 					state: 'requested',
 					requestId: 'restart-123',
-					requestedAt: '2026-04-23T10:00:00.000Z',
-					requestedByStartedAt: '2026-04-23T10:00:00.000Z',
-					currentDaemonStartedAt: '2026-04-23T10:00:00.000Z'
+					requestedAt,
+					requestedByStartedAt: requestedAt,
+					currentDaemonStartedAt: requestedAt
 				}),
 				{ status: 200 }
 			)
@@ -41,9 +44,9 @@ describe('loadRestartRoundTripPhase', () => {
 		await expect(
 			loadRestartRoundTripPhase(
 				'restart-123',
-				'2026-04-23T10:00:00.000Z',
+				requestedAt,
 				fetchMock,
-				Date.parse('2026-04-23T10:00:00.000Z') + RESTART_RETURN_TIMEOUT_MS
+				Date.parse(requestedAt) + RESTART_RETURN_TIMEOUT_MS
 			)
 		).resolves.toBe('failed_to_return');
 	});
@@ -52,7 +55,7 @@ describe('loadRestartRoundTripPhase', () => {
 		const fetchMock = vi.fn().mockRejectedValue(new Error('connection refused'));
 
 		await expect(
-			loadRestartRoundTripPhase('restart-123', '2026-04-23T10:00:00.000Z', fetchMock)
+			loadRestartRoundTripPhase('restart-123', requestedAt, fetchMock, justAfterRequestedAt)
 		).resolves.toBe('restarting');
 	});
 
@@ -62,8 +65,8 @@ describe('loadRestartRoundTripPhase', () => {
 				JSON.stringify({
 					state: 'back_online',
 					requestId: 'restart-123',
-					requestedAt: '2026-04-23T10:00:00.000Z',
-					requestedByStartedAt: '2026-04-23T10:00:00.000Z',
+					requestedAt,
+					requestedByStartedAt: requestedAt,
 					returnedAt: '2026-04-23T10:00:05.000Z',
 					returnedStartedAt: '2026-04-23T10:00:05.000Z',
 					currentDaemonStartedAt: '2026-04-23T10:00:05.000Z'
@@ -73,7 +76,7 @@ describe('loadRestartRoundTripPhase', () => {
 		);
 
 		await expect(
-			loadRestartRoundTripPhase('restart-123', '2026-04-23T10:00:00.000Z', fetchMock)
+			loadRestartRoundTripPhase('restart-123', requestedAt, fetchMock, justAfterRequestedAt)
 		).resolves.toBe('back_online');
 	});
 
@@ -83,9 +86,9 @@ describe('loadRestartRoundTripPhase', () => {
 		await expect(
 			loadRestartRoundTripPhase(
 				'restart-123',
-				'2026-04-23T10:00:00.000Z',
+				requestedAt,
 				fetchMock,
-				Date.parse('2026-04-23T10:00:00.000Z') + RESTART_RETURN_TIMEOUT_MS
+				Date.parse(requestedAt) + RESTART_RETURN_TIMEOUT_MS
 			)
 		).resolves.toBe('failed_to_return');
 	});
@@ -96,9 +99,9 @@ describe('loadRestartRoundTripPhase', () => {
 		await expect(
 			loadRestartRoundTripPhase(
 				'restart-123',
-				'2026-04-23T10:00:00.000Z',
+				requestedAt,
 				fetchMock,
-				Date.parse('2026-04-23T10:00:00.000Z') + RESTART_RETURN_TIMEOUT_MS - 1
+				Date.parse(requestedAt) + RESTART_RETURN_TIMEOUT_MS - 1
 			)
 		).resolves.toBe('restarting');
 	});


### PR DESCRIPTION
## Summary
- update the Synology runbook to reflect shipped Phase 25 browser restart proof behavior
- clarify that Docker restart policy brings the daemon back while the browser reads durable restart proof from the runtime boundary
- remove the stale claim that browser-visible return proof is still future work

<!-- ai-review:start -->
## External AI Review

- outcome: `clean`
- reviewed commit: [`8258783319eb`](https://github.com/cesarnml/Pirate-Claw/commit/8258783319eb9ee7566f56fcd92cf294765bd2bd)
- current branch head: [`8258783319eb`](https://github.com/cesarnml/Pirate-Claw/commit/8258783319eb9ee7566f56fcd92cf294765bd2bd)
- vendors: `coderabbit`
<!-- ai-review:end -->
