### PR TITLE
feat: validate Mac launchd restart truthfulness [P26.02]

### DIFF
--- a/docs/02-delivery/phase-26/validation-evidence.md
+++ b/docs/02-delivery/phase-26/validation-evidence.md
@@ -1,0 +1,93 @@
+# Phase 26 Mac Validation Evidence
+
+This artifact records the real-machine validation run for `P26.02 Mac Restart
+Truthfulness and Real-Machine Validation`.
+
+## Reference Environment
+
+Validated on `2026-04-23` on the active developer Mac:
+
+- Model: `MacBook Pro` (`MacBookPro18,3`, 14-inch 2021 class hardware)
+- Chip: `Apple M1 Pro`
+- Architecture: `arm64`
+- Memory: `16 GB`
+- OS: `macOS 26.4.1 (25E253)`
+- Kernel: `Darwin 25.4.0`
+
+System facts were captured from `system_profiler SPHardwareDataType SPSoftwareDataType`,
+`sw_vers`, and `uname -m`.
+
+## Validation Method
+
+The repo-owned validator is:
+
+- `bun run validate:mac:launchd`
+
+What it does:
+
+1. Creates a clean temporary install directory that acts as the Pirate Claw
+   durable boundary for the run.
+2. Symlinks the repo `src/` and `node_modules/` into that install directory so
+   the daemon runs from a Mac-style install boundary rather than from the main
+   working tree root.
+3. Writes a validation config with a dedicated local API port and write token.
+4. Installs the repo-owned `launchd` agent via
+   `docs/mac-reference-pirate-claw-launch-agent.sh`.
+5. Waits for daemon health on the configured port.
+6. Seeds durable Plex auth identity state in SQLite.
+7. Requests daemon restart through the authenticated restart API.
+8. Polls restart proof until the same request resolves to `back_online`.
+9. Verifies that config, SQLite, restart-proof, and seeded Plex auth state all
+   survive the `launchd`-managed restart.
+10. Optionally starts the SvelteKit dev server and verifies that the browser
+    restart-status proxy reflects the same `back_online` proof.
+
+## Successful Real-Machine Runs
+
+### Daemon + launchd proof
+
+- Install dir: temporary validator-created install boundary under macOS `TMPDIR`
+- Launch agent label: temporary `dev.pirate-claw.phase26.validation.<suffix>`
+- API port: `65270`
+- Daemon `startedAt` before restart: `2026-04-23T11:44:14.739Z`
+- Daemon `startedAt` after restart: `2026-04-23T11:44:25.354Z`
+- Restart request id: `54d27296-0cee-4838-a025-a44d8b0bc509`
+- Restart proof resolved to `back_online`
+- Config survived restart inside the temporary install boundary at
+  `pirate-claw.config.json`
+- SQLite survived restart inside the temporary install boundary at
+  `pirate-claw.db`
+- Restart proof artifact survived restart inside the temporary install boundary
+  at `.pirate-claw/runtime/restart-proof.json`
+- Seeded Plex auth refresh token `phase-26-refresh-token` remained present after
+  restart
+
+### Daemon + launchd + browser proxy proof
+
+- Install dir: temporary validator-created install boundary under macOS `TMPDIR`
+- Launch agent label: temporary `dev.pirate-claw.phase26.validation.<suffix>`
+- API port: `49192`
+- Web port: `49193`
+- Daemon `startedAt` before restart: `2026-04-23T11:45:11.596Z`
+- Daemon `startedAt` after restart: `2026-04-23T11:45:22.306Z`
+- Restart request id: `1a72f0f6-7cc7-4c72-bee1-1b3064eea8b6`
+- Restart proof resolved to `back_online`
+- Browser-facing `/api/daemon/restart-status` proxy returned the same
+  `back_online` request id after the daemon returned
+
+## Conclusion
+
+On the validated Apple Silicon Mac reference environment, Pirate Claw can run
+under the repo-owned per-user `launchd` contract, accept a restart request, and
+return online with:
+
+- a new daemon `startedAt`
+- the same durable config file
+- the same SQLite database
+- the same seeded Plex auth identity state
+- a resolved `.pirate-claw/runtime/restart-proof.json`
+- a browser-facing restart-status proxy that reflects the returned daemon proof
+
+That is sufficient evidence for the bounded Phase 26 support claim: Mac
+`launchd` handoff and return are truthful on Apple Silicon under the supported
+per-user supervisor contract.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test": "bun test",
     "test:coverage": "bun test --coverage",
     "test:web": "bun install --cwd web --frozen-lockfile && bun run --cwd web test",
+    "validate:mac:launchd": "bun run ./scripts/validate-mac-launchd.ts",
     "typecheck": "tsc --noEmit",
     "verify": "bun run format:check && bun run typecheck && bun run lint && bun run spellcheck && bun run verify:web",
     "verify:quiet": "bun run ./scripts/verify-quiet.ts",

--- a/scripts/validate-mac-launchd.ts
+++ b/scripts/validate-mac-launchd.ts
@@ -1,0 +1,429 @@
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { createServer } from 'node:net';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import { loadConfig } from '../src/config';
+import { PlexAuthStore } from '../src/plex/auth';
+import { openDatabase } from '../src/repository';
+import type { RestartStatus } from '../src/restart-proof';
+
+type ValidationSummary = {
+  installDir: string;
+  label: string;
+  apiPort: number;
+  webPort?: number;
+  healthStartedAtBeforeRestart: string;
+  healthStartedAtAfterRestart: string;
+  restartStatus: RestartStatus;
+  configPath: string;
+  databasePath: string;
+  restartProofPath: string;
+  plexRefreshToken: string;
+  validatedAt: string;
+  browserProxyValidated: boolean;
+};
+
+type RunningProcess = {
+  process: Bun.Subprocess<'ignore', 'pipe', 'pipe'>;
+  stop: () => Promise<void>;
+};
+
+const WRITE_TOKEN = 'phase-26-mac-write-token';
+const PLEX_REFRESH_TOKEN = 'phase-26-refresh-token';
+const RESTART_TIMEOUT_MS = 60_000;
+const HEALTH_TIMEOUT_MS = 30_000;
+
+function parseArg(name: string): string | undefined {
+  const index = Bun.argv.indexOf(name);
+  if (index === -1) {
+    return undefined;
+  }
+  return Bun.argv[index + 1];
+}
+
+function hasFlag(name: string): boolean {
+  return Bun.argv.includes(name);
+}
+
+async function findFreePort(): Promise<number> {
+  return await new Promise<number>((resolvePort, reject) => {
+    const server = createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Could not determine free TCP port.'));
+        return;
+      }
+      const { port } = address;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolvePort(port);
+      });
+    });
+  });
+}
+
+async function ensureSymlink(target: string, path: string): Promise<void> {
+  try {
+    await symlink(target, path);
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code !== 'EEXIST') {
+      throw error;
+    }
+  }
+}
+
+async function createValidationInstallDir(repoRoot: string): Promise<string> {
+  const installDir = await mkdtemp(join(tmpdir(), 'pirate-claw-mac-launchd-'));
+  await ensureSymlink(join(repoRoot, 'src'), join(installDir, 'src'));
+  await ensureSymlink(
+    join(repoRoot, 'node_modules'),
+    join(installDir, 'node_modules'),
+  );
+  await ensureSymlink(
+    join(repoRoot, 'package.json'),
+    join(installDir, 'package.json'),
+  );
+  return installDir;
+}
+
+function buildValidationConfig(apiPort: number) {
+  return {
+    feeds: [],
+    tv: {
+      defaults: { resolutions: ['1080p'], codecs: ['x265'] },
+      shows: [],
+    },
+    transmission: {
+      url: 'http://127.0.0.1:9091/transmission/rpc',
+      username: 'validation-user',
+      password: 'validation-pass',
+    },
+    runtime: {
+      runIntervalMinutes: 31,
+      reconcileIntervalSeconds: 61,
+      artifactDir: '.pirate-claw/runtime',
+      artifactRetentionDays: 7,
+      apiPort,
+      apiWriteToken: WRITE_TOKEN,
+      tmdbRefreshIntervalMinutes: 0,
+    },
+  };
+}
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    throw new Error(
+      `Request failed for ${url}: ${response.status} ${response.statusText}`,
+    );
+  }
+  return (await response.json()) as T;
+}
+
+async function waitForJson<T>(
+  load: () => Promise<T>,
+  timeoutMs: number,
+  description: string,
+): Promise<T> {
+  const startedAt = Date.now();
+  let lastError: unknown = null;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      return await load();
+    } catch (error) {
+      lastError = error;
+      await delay(500);
+    }
+  }
+
+  throw new Error(
+    `${description} did not succeed within ${timeoutMs}ms: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`,
+  );
+}
+
+async function installLaunchAgent(
+  repoRoot: string,
+  installDir: string,
+  label: string,
+): Promise<void> {
+  const scriptPath = join(
+    repoRoot,
+    'docs',
+    'mac-reference-pirate-claw-launch-agent.sh',
+  );
+  const proc = Bun.spawnSync({
+    cmd: [
+      'sh',
+      scriptPath,
+      'install',
+      '--install-dir',
+      installDir,
+      '--label',
+      label,
+    ],
+    cwd: repoRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  if (proc.exitCode !== 0) {
+    throw new Error(
+      new TextDecoder().decode(proc.stderr) || 'launch agent install failed',
+    );
+  }
+}
+
+async function uninstallLaunchAgent(
+  repoRoot: string,
+  label: string,
+): Promise<void> {
+  const scriptPath = join(
+    repoRoot,
+    'docs',
+    'mac-reference-pirate-claw-launch-agent.sh',
+  );
+  Bun.spawnSync({
+    cmd: ['sh', scriptPath, 'uninstall', '--label', label],
+    cwd: repoRoot,
+    stdout: 'ignore',
+    stderr: 'ignore',
+  });
+}
+
+async function startWebProxy(
+  repoRoot: string,
+  apiPort: number,
+  webPort: number,
+): Promise<RunningProcess> {
+  const webServer = Bun.spawn({
+    cmd: [
+      'bun',
+      'run',
+      '--cwd',
+      'web',
+      'dev',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      String(webPort),
+    ],
+    cwd: repoRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...process.env,
+      PIRATE_CLAW_API_URL: `http://127.0.0.1:${apiPort}`,
+      PIRATE_CLAW_API_WRITE_TOKEN: WRITE_TOKEN,
+    },
+  });
+
+  await waitForJson(
+    async () =>
+      await fetchJson<{ currentDaemonStartedAt: string }>(
+        `http://127.0.0.1:${webPort}/api/daemon/restart-status`,
+      ),
+    HEALTH_TIMEOUT_MS,
+    'web restart-status proxy',
+  );
+
+  return {
+    process: webServer,
+    stop: async () => {
+      webServer.kill('SIGTERM');
+      await webServer.exited;
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  const repoRoot = resolve(import.meta.dir, '..');
+  const keepInstallDir = hasFlag('--keep-install-dir');
+  const validateBrowserProxy = hasFlag('--validate-browser-proxy');
+  const requestedInstallDir = parseArg('--install-dir');
+  const installDir = requestedInstallDir
+    ? resolve(requestedInstallDir)
+    : await createValidationInstallDir(repoRoot);
+  const apiPort =
+    Number.parseInt(parseArg('--api-port') ?? '', 10) || (await findFreePort());
+  const webPort = validateBrowserProxy
+    ? Number.parseInt(parseArg('--web-port') ?? '', 10) ||
+      (await findFreePort())
+    : undefined;
+  const label =
+    parseArg('--label') ??
+    `dev.pirate-claw.phase26.validation.${Date.now().toString(36)}`;
+  const configPath = join(installDir, 'pirate-claw.config.json');
+  const databasePath = join(installDir, 'pirate-claw.db');
+  const artifactDir = join(installDir, '.pirate-claw', 'runtime');
+  const restartProofPath = join(artifactDir, 'restart-proof.json');
+  let webProcess: RunningProcess | undefined;
+
+  try {
+    await mkdir(join(installDir, '.pirate-claw', 'runtime'), {
+      recursive: true,
+    });
+    await writeFile(
+      configPath,
+      `${JSON.stringify(buildValidationConfig(apiPort), null, 2)}\n`,
+    );
+
+    await installLaunchAgent(repoRoot, installDir, label);
+
+    const healthBeforeRestart = await waitForJson<{ startedAt: string }>(
+      () => fetchJson(`http://127.0.0.1:${apiPort}/api/health`),
+      HEALTH_TIMEOUT_MS,
+      'daemon health check',
+    );
+
+    if (webPort != null) {
+      webProcess = await startWebProxy(repoRoot, apiPort, webPort);
+    }
+
+    const database = openDatabase(databasePath);
+    try {
+      const store = new PlexAuthStore(database);
+      store.completeRenewal(PLEX_REFRESH_TOKEN, {
+        authenticatedAt: '2026-04-23T10:00:00.000Z',
+        tokenExpiresAt: '2026-05-23T10:00:00.000Z',
+      });
+    } finally {
+      database.close();
+    }
+
+    const restart = await fetchJson<{ restartStatus: RestartStatus }>(
+      `http://127.0.0.1:${apiPort}/api/daemon/restart`,
+      {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${WRITE_TOKEN}`,
+        },
+      },
+    );
+
+    if (restart.restartStatus.state !== 'requested') {
+      throw new Error(
+        `Expected requested restart state, received ${restart.restartStatus.state}.`,
+      );
+    }
+    const requestId = restart.restartStatus.requestId;
+
+    const restartStatus = await waitForJson<RestartStatus>(
+      async () => {
+        const status = await fetchJson<RestartStatus>(
+          `http://127.0.0.1:${apiPort}/api/daemon/restart-status`,
+        );
+        if (status.state === 'back_online' && status.requestId === requestId) {
+          return status;
+        }
+        throw new Error(`Restart still pending: ${JSON.stringify(status)}`);
+      },
+      RESTART_TIMEOUT_MS,
+      'restart round-trip proof',
+    );
+
+    const healthAfterRestart = await waitForJson<{ startedAt: string }>(
+      () => fetchJson(`http://127.0.0.1:${apiPort}/api/health`),
+      HEALTH_TIMEOUT_MS,
+      'post-restart daemon health check',
+    );
+
+    if (healthAfterRestart.startedAt === healthBeforeRestart.startedAt) {
+      throw new Error(
+        'Daemon startedAt did not change across launchd-managed restart.',
+      );
+    }
+
+    const persistedConfig = await loadConfig(configPath);
+    if (persistedConfig.runtime.runIntervalMinutes !== 31) {
+      throw new Error(
+        'Config did not survive restart with the expected runtime marker.',
+      );
+    }
+
+    const reopenedDatabase = openDatabase(databasePath);
+    try {
+      const identity = new PlexAuthStore(reopenedDatabase).getIdentity();
+      if (!identity || identity.refreshToken !== PLEX_REFRESH_TOKEN) {
+        throw new Error(
+          'Persisted Plex auth identity did not survive restart.',
+        );
+      }
+    } finally {
+      reopenedDatabase.close();
+    }
+
+    const restartProof = JSON.parse(
+      await readFile(restartProofPath, 'utf8'),
+    ) as {
+      state?: string;
+      requestId?: string;
+    };
+    if (
+      restartProof.state !== 'back_online' ||
+      restartProof.requestId !== requestId
+    ) {
+      throw new Error(
+        'restart-proof.json did not resolve to the expected back_online record.',
+      );
+    }
+
+    if (webPort != null) {
+      const proxiedStatus = await fetchJson<RestartStatus>(
+        `http://127.0.0.1:${webPort}/api/daemon/restart-status`,
+      );
+      if (
+        proxiedStatus.state !== 'back_online' ||
+        proxiedStatus.requestId !== requestId
+      ) {
+        throw new Error(
+          'Web restart-status proxy did not reflect the same back_online proof.',
+        );
+      }
+    }
+
+    const summary: ValidationSummary = {
+      installDir,
+      label,
+      apiPort,
+      webPort,
+      healthStartedAtBeforeRestart: healthBeforeRestart.startedAt,
+      healthStartedAtAfterRestart: healthAfterRestart.startedAt,
+      restartStatus,
+      configPath,
+      databasePath,
+      restartProofPath,
+      plexRefreshToken: PLEX_REFRESH_TOKEN,
+      validatedAt: new Date().toISOString(),
+      browserProxyValidated: webPort != null,
+    };
+
+    console.log(JSON.stringify(summary, null, 2));
+  } finally {
+    if (webProcess) {
+      await webProcess.stop();
+    }
+    await uninstallLaunchAgent(repoRoot, label);
+    if (!keepInstallDir && !requestedInstallDir) {
+      await rm(installDir, { recursive: true, force: true });
+    }
+  }
+}
+
+await main();

--- a/scripts/validate-mac-launchd.ts
+++ b/scripts/validate-mac-launchd.ts
@@ -13,7 +13,7 @@ import { setTimeout as delay } from 'node:timers/promises';
 
 import { loadConfig } from '../src/config';
 import { PlexAuthStore } from '../src/plex/auth';
-import { openDatabase } from '../src/repository';
+import { ensureSchema, openDatabase } from '../src/repository';
 import type { RestartStatus } from '../src/restart-proof';
 
 type ValidationSummary = {
@@ -33,7 +33,7 @@ type ValidationSummary = {
 };
 
 type RunningProcess = {
-  process: Bun.Subprocess<'ignore', 'pipe', 'pipe'>;
+  process: Bun.Subprocess<'ignore', 'ignore', 'ignore'>;
   stop: () => Promise<void>;
 };
 
@@ -225,8 +225,8 @@ async function startWebProxy(
       String(webPort),
     ],
     cwd: repoRoot,
-    stdout: 'pipe',
-    stderr: 'pipe',
+    stdout: 'ignore',
+    stderr: 'ignore',
     env: {
       ...process.env,
       PIRATE_CLAW_API_URL: `http://127.0.0.1:${apiPort}`,
@@ -284,6 +284,18 @@ async function main(): Promise<void> {
       `${JSON.stringify(buildValidationConfig(apiPort), null, 2)}\n`,
     );
 
+    const seededDatabase = openDatabase(databasePath);
+    try {
+      ensureSchema(seededDatabase);
+      const store = new PlexAuthStore(seededDatabase);
+      store.completeRenewal(PLEX_REFRESH_TOKEN, {
+        authenticatedAt: '2026-04-23T10:00:00.000Z',
+        tokenExpiresAt: '2026-05-23T10:00:00.000Z',
+      });
+    } finally {
+      seededDatabase.close();
+    }
+
     await installLaunchAgent(repoRoot, installDir, label);
 
     const healthBeforeRestart = await waitForJson<{ startedAt: string }>(
@@ -294,17 +306,6 @@ async function main(): Promise<void> {
 
     if (webPort != null) {
       webProcess = await startWebProxy(repoRoot, apiPort, webPort);
-    }
-
-    const database = openDatabase(databasePath);
-    try {
-      const store = new PlexAuthStore(database);
-      store.completeRenewal(PLEX_REFRESH_TOKEN, {
-        authenticatedAt: '2026-04-23T10:00:00.000Z',
-        tokenExpiresAt: '2026-05-23T10:00:00.000Z',
-      });
-    } finally {
-      database.close();
     }
 
     const restart = await fetchJson<{ restartStatus: RestartStatus }>(


### PR DESCRIPTION
## Summary

- delivery ticket: `P26.02 Mac Restart Truthfulness and Real-Machine Validation`
- ticket file: [docs/02-delivery/phase-26/ticket-02-mac-restart-truthfulness-and-real-machine-validation.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-26/ticket-02-mac-restart-truthfulness-and-real-machine-validation.md)
- stacked base branch: `agents/p26-01-mac-reference-launchd-artifact-and-contract`
- self-audit: outcome `clean` completed at 2026-04-23 11:48 UTC


## Late AI Review Follow-up

- Patched CodeRabbit's actionable subprocess finding by changing the validator's browser proxy `Bun.spawn` call to ignore `stdout` and `stderr`, and updated the `RunningProcess` subprocess typing to match.
- Rejected the broad `openDatabase()` WAL / `busy_timeout` suggestion for this ticket because it would widen repo-wide SQLite behavior beyond the late-review scope.
- Addressed the validator-side risk instead by making the validation script initialize schema explicitly and seed Plex auth state before the `launchd` agent starts, which removes the pre-restart write overlap the comment was worried about.
- Re-verified with `bun run verify:quiet` and `bun run validate:mac:launchd --validate-browser-proxy` on the Apple Silicon Mac validation target.

Patched inline review threads were resolved on GitHub after the follow-up commit.
