### PR TITLE
refactor: extract types.ts from orchestrator god module [EE10.01]

### DIFF
--- a/tools/delivery/cli.ts
+++ b/tools/delivery/cli.ts
@@ -1,5 +1,5 @@
 import { VALID_TICKET_BOUNDARY_MODES, type TicketBoundaryMode } from './config';
-import type { OrchestratorOptions } from './orchestrator';
+import type { OrchestratorOptions } from './types';
 
 export type ParsedCliArgs = {
   command: string;

--- a/tools/delivery/closeout-stack.ts
+++ b/tools/delivery/closeout-stack.ts
@@ -7,9 +7,8 @@ import {
   resolveOrchestratorConfig,
   runProcessResult,
   saveState,
-  type DeliveryState,
-  type TicketState,
 } from './orchestrator';
+import type { DeliveryState, TicketState } from './types';
 
 type CloseoutStackArgs = {
   planPath: string;

--- a/tools/delivery/notifications.ts
+++ b/tools/delivery/notifications.ts
@@ -3,12 +3,12 @@ import { resolve } from 'node:path';
 import { buildReviewPollCheckMinutes } from './review';
 import { readReviewArtifacts } from './review-artifacts';
 import type {
-  DeliveryState,
   DeliveryNotificationEvent,
+  DeliveryState,
   ReviewResult,
   StandaloneAiReviewResult,
   TicketState,
-} from './orchestrator';
+} from './types';
 
 export type DeliveryNotifier =
   | {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -11,6 +11,19 @@ import {
   type ResolvedOrchestratorConfig,
   type TicketBoundaryMode,
 } from './config';
+import type {
+  AiReviewComment,
+  AiReviewThreadResolution,
+  DeliveryState,
+  InternalReviewPatchCommit,
+  OrchestratorOptions,
+  ReviewOutcome,
+  ReviewResult,
+  StandaloneAiReviewResult,
+  StandalonePullRequest,
+  TicketDefinition,
+  TicketState,
+} from './types';
 import {
   addWorktree as addPlatformWorktree,
   bootstrapWorktreeIfNeeded as bootstrapPlatformWorktreeIfNeeded,
@@ -156,92 +169,29 @@ export {
   resolveNotifier,
 };
 
-export type TicketStatus =
-  | 'pending'
-  | 'in_progress'
-  | 'post_verify_self_audit_complete'
-  | 'codex_preflight_complete'
-  | 'in_review'
-  | 'needs_patch'
-  | 'operator_input_needed'
-  | 'reviewed'
-  | 'done';
-
-export type ReviewOutcome = 'clean' | 'patched' | 'skipped';
-export type ReviewResult =
-  | ReviewOutcome
-  | 'needs_patch'
-  | 'operator_input_needed';
-
-export type CodexPreflightOutcome = 'clean' | 'patched' | 'skipped';
-
-export type InternalReviewPatchCommit = {
-  sha: string;
-  subject: string;
-};
-
-export type TicketDefinition = {
-  id: string;
-  title: string;
-  slug: string;
-  ticketFile: string;
-};
-
-export type TicketState = TicketDefinition & {
-  status: TicketStatus;
-  branch: string;
-  baseBranch: string;
-  worktreePath: string;
-  handoffPath?: string;
-  handoffGeneratedAt?: string;
-  postVerifySelfAuditCompletedAt?: string;
-  selfAuditOutcome?: ReviewOutcome;
-  selfAuditPatchCommits?: InternalReviewPatchCommit[];
-  codexPreflightOutcome?: CodexPreflightOutcome;
-  codexPreflightCompletedAt?: string;
-  codexPreflightNote?: string;
-  codexPreflightPatchCommits?: InternalReviewPatchCommit[];
-  docOnly?: boolean;
-  prNumber?: number;
-  prUrl?: string;
-  prOpenedAt?: string;
-  reviewFetchArtifactPath?: string;
-  reviewTriageArtifactPath?: string;
-  reviewHeadSha?: string;
-  reviewRecordedAt?: string;
-  reviewOutcome?: ReviewResult;
-  // Legacy compatibility fields: current write paths do not persist these.
-  reviewArtifactJsonPath?: string;
-  reviewArtifactPath?: string;
-  reviewActionSummary?: string;
-  reviewComments?: AiReviewComment[];
-  reviewIncompleteAgents?: string[];
-  reviewNonActionSummary?: string;
-  reviewNote?: string;
-  reviewThreadResolutions?: AiReviewThreadResolution[];
-  reviewVendors?: string[];
-};
-
-export type DeliveryState = {
-  planKey: string;
-  planPath: string;
-  statePath: string;
-  reviewsDirPath: string;
-  handoffsDirPath: string;
-  reviewPollIntervalMinutes: number;
-  reviewPollMaxWaitMinutes: number;
-  tickets: TicketState[];
-};
-
-export type OrchestratorOptions = {
-  planPath: string;
-  planKey: string;
-  statePath: string;
-  reviewsDirPath: string;
-  handoffsDirPath: string;
-  reviewPollIntervalMinutes: number;
-  reviewPollMaxWaitMinutes: number;
-};
+export type {
+  AiReviewAgentResult,
+  AiReviewAgentState,
+  AiReviewComment,
+  AiReviewCommentChannel,
+  AiReviewCommentKind,
+  AiReviewFetcherResult,
+  AiReviewThreadResolution,
+  AiReviewThreadResolutionStatus,
+  AiReviewTriagerResult,
+  CodexPreflightOutcome,
+  DeliveryNotificationEvent,
+  DeliveryState,
+  InternalReviewPatchCommit,
+  OrchestratorOptions,
+  ReviewOutcome,
+  ReviewResult,
+  StandaloneAiReviewResult,
+  StandalonePullRequest,
+  TicketDefinition,
+  TicketState,
+  TicketStatus,
+} from './types';
 
 type RepairStateResult = {
   state: DeliveryState;
@@ -323,169 +273,6 @@ export function generateRunDeliverInvocation(
 
   return `${packageManager} run deliver`;
 }
-
-export type DeliveryNotificationEvent =
-  | {
-      kind: 'ticket_started';
-      planKey: string;
-      ticketId: string;
-      ticketTitle: string;
-      branch: string;
-    }
-  | {
-      kind: 'pr_opened';
-      planKey: string;
-      ticketId: string;
-      ticketTitle: string;
-      branch: string;
-      prUrl: string;
-    }
-  | {
-      kind: 'review_window_ready';
-      planKey: string;
-      ticketId: string;
-      ticketTitle: string;
-      branch: string;
-      prUrl: string;
-      reviewPollIntervalMinutes: number;
-      reviewPollMaxWaitMinutes: number;
-      firstCheckAt: string;
-      finalCheckAt: string;
-    }
-  | {
-      kind: 'review_recorded';
-      planKey: string;
-      ticketId: string;
-      ticketTitle: string;
-      branch: string;
-      outcome: ReviewResult;
-      note?: string;
-      prUrl?: string;
-    }
-  | {
-      kind: 'ticket_completed';
-      planKey: string;
-      ticketId: string;
-      ticketTitle: string;
-      branch: string;
-      prUrl?: string;
-    }
-  | {
-      kind: 'standalone_review_started';
-      prNumber: number;
-      prUrl: string;
-      reviewPollIntervalMinutes: number;
-      reviewPollMaxWaitMinutes: number;
-    }
-  | {
-      kind: 'standalone_review_recorded';
-      prNumber: number;
-      prUrl: string;
-      outcome: ReviewResult;
-      note?: string;
-    }
-  | {
-      kind: 'run_blocked';
-      planKey?: string;
-      command?: string;
-      reason: string;
-    };
-
-export type AiReviewAgentState = 'started' | 'completed' | 'findings_detected';
-
-export type AiReviewAgentResult = {
-  agent: string;
-  state: AiReviewAgentState;
-  findingsCount?: number;
-  note?: string;
-};
-
-export type AiReviewCommentChannel =
-  | 'issue_comment'
-  | 'review_summary'
-  | 'inline_review';
-
-export type AiReviewCommentKind = 'summary' | 'finding' | 'unknown';
-
-export type AiReviewComment = {
-  authorLogin: string;
-  authorType: string;
-  body: string;
-  channel: AiReviewCommentChannel;
-  databaseId?: number;
-  isOutdated?: boolean;
-  isResolved?: boolean;
-  kind: AiReviewCommentKind;
-  line?: number;
-  path?: string;
-  threadId?: string;
-  threadViewerCanResolve?: boolean;
-  updatedAt?: string;
-  url?: string;
-  vendor: string;
-};
-
-export type AiReviewThreadResolutionStatus =
-  | 'resolved'
-  | 'already_resolved'
-  | 'failed'
-  | 'unresolvable';
-
-export type AiReviewThreadResolution = {
-  message?: string;
-  status: AiReviewThreadResolutionStatus;
-  threadId: string;
-  url?: string;
-  vendor: string;
-};
-
-export type AiReviewFetcherResult = {
-  agents: AiReviewAgentResult[];
-  // Legacy compatibility field: not populated by the current fetcher contract.
-  artifactText?: string;
-  comments: AiReviewComment[];
-  detected: boolean;
-  reviewedHeadSha?: string;
-  vendors: string[];
-};
-
-export type AiReviewTriagerResult = {
-  actionSummary?: string;
-  note: string;
-  nonActionSummary?: string;
-  outcome: ReviewResult;
-  vendors: string[];
-};
-
-export type StandaloneAiReviewResult = {
-  fetchArtifactPath?: string;
-  note: string;
-  outcome: ReviewResult;
-  prNumber: number;
-  prUrl: string;
-  reviewedHeadSha?: string;
-  recordedAt?: string;
-  triageArtifactPath?: string;
-  // Legacy compatibility fields: current write paths do not persist these.
-  actionSummary?: string;
-  artifactJsonPath?: string;
-  artifactTextPath?: string;
-  comments?: AiReviewComment[];
-  incompleteAgents?: string[];
-  nonActionSummary?: string;
-  threadResolutions?: AiReviewThreadResolution[];
-  vendors?: string[];
-};
-
-export type StandalonePullRequest = {
-  body: string;
-  createdAt: string;
-  headRefName: string;
-  headRefOid: string;
-  number: number;
-  title: string;
-  url: string;
-};
 
 export async function runDeliveryOrchestrator(
   argv: string[],

--- a/tools/delivery/planning.ts
+++ b/tools/delivery/planning.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { readFile, readdir } from 'node:fs/promises';
 import { basename, dirname, join, resolve } from 'node:path';
 
-import type { OrchestratorOptions, TicketDefinition } from './orchestrator';
+import type { OrchestratorOptions, TicketDefinition } from './types';
 import { DEFAULT_REVIEW_POLLING_PROFILE } from './review-polling-profile';
 
 export function parsePlan(

--- a/tools/delivery/pr-metadata.ts
+++ b/tools/delivery/pr-metadata.ts
@@ -3,15 +3,15 @@ import { resolve } from 'node:path';
 import type {
   AiReviewComment,
   AiReviewThreadResolution,
-  DeliveryState,
   DeliveryNotificationEvent,
+  DeliveryState,
   InternalReviewPatchCommit,
   ReviewResult,
   StandaloneAiReviewResult,
   StandalonePullRequest,
   TicketState,
   TicketStatus,
-} from './orchestrator';
+} from './types';
 import { DEFAULT_REVIEW_POLLING_PROFILE } from './review-polling-profile';
 import { readReviewArtifacts } from './review-artifacts';
 

--- a/tools/delivery/review-artifacts.ts
+++ b/tools/delivery/review-artifacts.ts
@@ -8,7 +8,7 @@ import type {
   AiReviewThreadResolution,
   ReviewOutcome,
   ReviewResult,
-} from './orchestrator';
+} from './types';
 
 export type AiReviewFetchArtifact = {
   schemaVersion: 1;

--- a/tools/delivery/review.ts
+++ b/tools/delivery/review.ts
@@ -15,7 +15,7 @@ import type {
   StandaloneAiReviewResult,
   StandalonePullRequest,
   TicketState,
-} from './orchestrator';
+} from './types';
 
 import {
   buildReviewArtifactPaths,

--- a/tools/delivery/state.ts
+++ b/tools/delivery/state.ts
@@ -17,7 +17,7 @@ import type {
   TicketDefinition,
   TicketState,
   TicketStatus,
-} from './orchestrator';
+} from './types';
 
 /** Persisted tickets may use legacy status and timestamp keys until re-saved. */
 type PersistedTicketFields = Partial<TicketState> & {

--- a/tools/delivery/test/closeout-stack.test.ts
+++ b/tools/delivery/test/closeout-stack.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import type { DeliveryState, TicketState } from '../orchestrator';
+import type { DeliveryState, TicketState } from '../types';
 import {
   getCloseoutTicketChain,
   parseCloseoutStackArgs,

--- a/tools/delivery/test/orchestrator.test.ts
+++ b/tools/delivery/test/orchestrator.test.ts
@@ -35,7 +35,6 @@ import {
   VALID_REVIEW_POLICY_STAGE_VALUES,
   recordCodexPreflight,
   loadOrchestratorConfig,
-  type CodexPreflightOutcome,
   mergeStandaloneAiReviewSection,
   notifyBestEffort,
   openPullRequest,
@@ -66,8 +65,8 @@ import {
   formatStatus,
   materializeTicketContext,
   resolveEffectiveAdvanceBoundaryMode,
-  type DeliveryState,
 } from '../orchestrator';
+import type { CodexPreflightOutcome, DeliveryState } from '../types';
 
 async function readArtifactJson(cwd: string, relativePath: string) {
   return JSON.parse(await readFile(join(cwd, relativePath), 'utf8')) as Record<

--- a/tools/delivery/test/review.test.ts
+++ b/tools/delivery/test/review.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import type { AiReviewFetcherResult } from '../orchestrator';
+import type { AiReviewFetcherResult } from '../types';
 import { buildStandaloneReviewStartedEvent } from '../pr-metadata';
 import {
   DEFAULT_REVIEW_POLLING_PROFILE,

--- a/tools/delivery/ticket-flow.ts
+++ b/tools/delivery/ticket-flow.ts
@@ -4,14 +4,14 @@ import { dirname, resolve } from 'node:path';
 
 import type { PullRequestSummary } from './platform';
 import type { ReviewActionCommit } from './pr-metadata';
+import type { ReviewPolicyStageValue } from './config';
 import type {
   CodexPreflightOutcome,
   DeliveryState,
   InternalReviewPatchCommit,
   ReviewOutcome,
-  ReviewPolicyStageValue,
   TicketState,
-} from './orchestrator';
+} from './types';
 
 function validateInternalReviewPatchCommits(input: {
   outcome: ReviewOutcome | CodexPreflightOutcome;

--- a/tools/delivery/types.ts
+++ b/tools/delivery/types.ts
@@ -1,0 +1,249 @@
+export type TicketStatus =
+  | 'pending'
+  | 'in_progress'
+  | 'post_verify_self_audit_complete'
+  | 'codex_preflight_complete'
+  | 'in_review'
+  | 'needs_patch'
+  | 'operator_input_needed'
+  | 'reviewed'
+  | 'done';
+
+export type ReviewOutcome = 'clean' | 'patched' | 'skipped';
+export type ReviewResult =
+  | ReviewOutcome
+  | 'needs_patch'
+  | 'operator_input_needed';
+
+export type CodexPreflightOutcome = 'clean' | 'patched' | 'skipped';
+
+export type InternalReviewPatchCommit = {
+  sha: string;
+  subject: string;
+};
+
+export type TicketDefinition = {
+  id: string;
+  title: string;
+  slug: string;
+  ticketFile: string;
+};
+
+export type AiReviewCommentChannel =
+  | 'issue_comment'
+  | 'review_summary'
+  | 'inline_review';
+
+export type AiReviewCommentKind = 'summary' | 'finding' | 'unknown';
+
+export type AiReviewComment = {
+  authorLogin: string;
+  authorType: string;
+  body: string;
+  channel: AiReviewCommentChannel;
+  databaseId?: number;
+  isOutdated?: boolean;
+  isResolved?: boolean;
+  kind: AiReviewCommentKind;
+  line?: number;
+  path?: string;
+  threadId?: string;
+  threadViewerCanResolve?: boolean;
+  updatedAt?: string;
+  url?: string;
+  vendor: string;
+};
+
+export type AiReviewThreadResolutionStatus =
+  | 'resolved'
+  | 'already_resolved'
+  | 'failed'
+  | 'unresolvable';
+
+export type AiReviewThreadResolution = {
+  message?: string;
+  status: AiReviewThreadResolutionStatus;
+  threadId: string;
+  url?: string;
+  vendor: string;
+};
+
+export type AiReviewAgentState = 'started' | 'completed' | 'findings_detected';
+
+export type AiReviewAgentResult = {
+  agent: string;
+  state: AiReviewAgentState;
+  findingsCount?: number;
+  note?: string;
+};
+
+export type TicketState = TicketDefinition & {
+  status: TicketStatus;
+  branch: string;
+  baseBranch: string;
+  worktreePath: string;
+  handoffPath?: string;
+  handoffGeneratedAt?: string;
+  postVerifySelfAuditCompletedAt?: string;
+  selfAuditOutcome?: ReviewOutcome;
+  selfAuditPatchCommits?: InternalReviewPatchCommit[];
+  codexPreflightOutcome?: CodexPreflightOutcome;
+  codexPreflightCompletedAt?: string;
+  codexPreflightNote?: string;
+  codexPreflightPatchCommits?: InternalReviewPatchCommit[];
+  docOnly?: boolean;
+  prNumber?: number;
+  prUrl?: string;
+  prOpenedAt?: string;
+  reviewFetchArtifactPath?: string;
+  reviewTriageArtifactPath?: string;
+  reviewHeadSha?: string;
+  reviewRecordedAt?: string;
+  reviewOutcome?: ReviewResult;
+  // Legacy compatibility fields: current write paths do not persist these.
+  reviewArtifactJsonPath?: string;
+  reviewArtifactPath?: string;
+  reviewActionSummary?: string;
+  reviewComments?: AiReviewComment[];
+  reviewIncompleteAgents?: string[];
+  reviewNonActionSummary?: string;
+  reviewNote?: string;
+  reviewThreadResolutions?: AiReviewThreadResolution[];
+  reviewVendors?: string[];
+};
+
+export type DeliveryState = {
+  planKey: string;
+  planPath: string;
+  statePath: string;
+  reviewsDirPath: string;
+  handoffsDirPath: string;
+  reviewPollIntervalMinutes: number;
+  reviewPollMaxWaitMinutes: number;
+  tickets: TicketState[];
+};
+
+export type OrchestratorOptions = {
+  planPath: string;
+  planKey: string;
+  statePath: string;
+  reviewsDirPath: string;
+  handoffsDirPath: string;
+  reviewPollIntervalMinutes: number;
+  reviewPollMaxWaitMinutes: number;
+};
+
+export type DeliveryNotificationEvent =
+  | {
+      kind: 'ticket_started';
+      planKey: string;
+      ticketId: string;
+      ticketTitle: string;
+      branch: string;
+    }
+  | {
+      kind: 'pr_opened';
+      planKey: string;
+      ticketId: string;
+      ticketTitle: string;
+      branch: string;
+      prUrl: string;
+    }
+  | {
+      kind: 'review_window_ready';
+      planKey: string;
+      ticketId: string;
+      ticketTitle: string;
+      branch: string;
+      prUrl: string;
+      reviewPollIntervalMinutes: number;
+      reviewPollMaxWaitMinutes: number;
+      firstCheckAt: string;
+      finalCheckAt: string;
+    }
+  | {
+      kind: 'review_recorded';
+      planKey: string;
+      ticketId: string;
+      ticketTitle: string;
+      branch: string;
+      outcome: ReviewResult;
+      note?: string;
+      prUrl?: string;
+    }
+  | {
+      kind: 'ticket_completed';
+      planKey: string;
+      ticketId: string;
+      ticketTitle: string;
+      branch: string;
+      prUrl?: string;
+    }
+  | {
+      kind: 'standalone_review_started';
+      prNumber: number;
+      prUrl: string;
+      reviewPollIntervalMinutes: number;
+      reviewPollMaxWaitMinutes: number;
+    }
+  | {
+      kind: 'standalone_review_recorded';
+      prNumber: number;
+      prUrl: string;
+      outcome: ReviewResult;
+      note?: string;
+    }
+  | {
+      kind: 'run_blocked';
+      planKey?: string;
+      command?: string;
+      reason: string;
+    };
+
+export type AiReviewFetcherResult = {
+  agents: AiReviewAgentResult[];
+  // Legacy compatibility field: not populated by the current fetcher contract.
+  artifactText?: string;
+  comments: AiReviewComment[];
+  detected: boolean;
+  reviewedHeadSha?: string;
+  vendors: string[];
+};
+
+export type AiReviewTriagerResult = {
+  actionSummary?: string;
+  note: string;
+  nonActionSummary?: string;
+  outcome: ReviewResult;
+  vendors: string[];
+};
+
+export type StandaloneAiReviewResult = {
+  fetchArtifactPath?: string;
+  note: string;
+  outcome: ReviewResult;
+  prNumber: number;
+  prUrl: string;
+  reviewedHeadSha?: string;
+  recordedAt?: string;
+  triageArtifactPath?: string;
+  // Legacy compatibility fields: current write paths do not persist these.
+  actionSummary?: string;
+  artifactJsonPath?: string;
+  artifactTextPath?: string;
+  comments?: AiReviewComment[];
+  incompleteAgents?: string[];
+  nonActionSummary?: string;
+  threadResolutions?: AiReviewThreadResolution[];
+  vendors?: string[];
+};
+
+export type StandalonePullRequest = {
+  body: string;
+  createdAt: string;
+  headRefName: string;
+  headRefOid: string;
+  number: number;
+  title: string;
+  url: string;
+};


### PR DESCRIPTION
## Summary

- delivery ticket: `EE10.01 Extract types.ts`
- ticket file: [docs/02-delivery/engineering-epic-10/ticket-01-extract-types.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/engineering-epic-10/ticket-01-extract-types.md)
- stacked base branch: `main`
- self-audit: outcome `clean` completed at 2026-04-25 10:34 UTC
