### PR TITLE
feat: bootstrap Synology install root on daemon start [P27.02]

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ The writable `/volume1/pirate-claw/config` directory and
 `.pirate-claw/runtime/`, which contains `poll-state.json`) are one durability
 boundary for that contract.
 
+When `PIRATE_CLAW_INSTALL_ROOT` or `runtime.installRoot` is configured, daemon
+startup creates the Synology install tree if it is missing and writes generated
+app secrets under `config/generated/`. Existing directories and generated
+secret files are left untouched on later starts.
+
 **Plex prerequisite:** Plex Media Server **1.43.0 or later**. Check your
 installed version in **Package Center → Installed → Plex Media Server →
 Details**. On the reviewed `DS918+ / DSM 7.1.1-42962 Update 9` baseline,
@@ -132,7 +137,7 @@ Config file: `pirate-claw.config.json` (see [`pirate-claw.config.example.json`](
 - `tv` — compact `defaults + shows` object or legacy per-show array
 - `movies` — global year, resolution, codec, and `codecPolicy` (`"prefer"` or `"require"`)
 - `transmission` — RPC URL, credentials, optional `downloadDirs` per media type
-- `runtime` — daemon scheduling and artifacts; `apiPort` enables HTTP API; `apiWriteToken` enables config writes; `tmdbRefreshIntervalMinutes` controls background TMDB refresh (default 360, `0` disables)
+- `runtime` — daemon scheduling and artifacts; `apiPort` enables HTTP API; `apiWriteToken` enables config writes; `installRoot` or `PIRATE_CLAW_INSTALL_ROOT` enables Synology first-startup directory and secret bootstrap; `tmdbRefreshIntervalMinutes` controls background TMDB refresh (default 360, `0` disables)
 - `tmdb` — optional `apiKey` (or env `PIRATE_CLAW_TMDB_API_KEY`) and cache TTL overrides
 - `plex` — optional operator-managed `url`, the current usable `token` (normally browser-managed after Connect Plex; env override via `PIRATE_CLAW_PLEX_TOKEN` still works), and `refreshIntervalMinutes` for library/watch refresh cadence
 

--- a/docs/02-delivery/phase-27/ticket-02-daemon-first-startup-bootstrap.md
+++ b/docs/02-delivery/phase-27/ticket-02-daemon-first-startup-bootstrap.md
@@ -41,4 +41,8 @@ Daemon startup on a clean install root creates the full directory tree and write
 
 ## Rationale
 
-_To be completed after implementation._
+Implemented the first-startup bootstrap as daemon-owned runtime behavior gated by a configured install root. `PIRATE_CLAW_INSTALL_ROOT` or `runtime.installRoot` enables the Synology install tree creation; leaving both unset preserves existing local/Mac daemon behavior and avoids unexpectedly creating `/volume1/pirate-claw` on non-Synology hosts.
+
+Generated app secrets are written under the config directory at `config/generated/daemon-api-write-token` and loaded as the daemon API write token when no stronger environment override is present. This keeps `pirate-claw.config.json` non-secret while giving the web container a stable shared-file path that P27.03 can mount/read without requiring the owner to hand-enter `PIRATE_CLAW_API_WRITE_TOKEN`.
+
+Bootstrap is create-if-absent only: missing directories are created recursively, existing directories are left alone, and an existing generated token file is never overwritten.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import {
   resolveConfigPath,
 } from './config';
 import { daemonOptionsFromConfig, runDaemonLoop } from './daemon';
+import { ensureFirstStartupBootstrap } from './install-bootstrap';
 import {
   reconcileCandidates,
   retryFailedCandidates,
@@ -369,8 +370,25 @@ export async function runCli(argv: string[]): Promise<number> {
     if (command === 'daemon') {
       const configPath = parseConfigPath(rest);
       const resolvedConfigPath = resolveConfigPath(configPath);
+      await ensureFirstStartupBootstrap({
+        installRoot: process.env.PIRATE_CLAW_INSTALL_ROOT,
+        configPath: resolvedConfigPath,
+      });
       await ensureStarterConfig(resolvedConfigPath);
-      const config = await loadConfig(resolvedConfigPath);
+      let config = await loadConfig(resolvedConfigPath);
+      const configuredInstallRoot = config.runtime.installRoot;
+
+      if (
+        configuredInstallRoot &&
+        configuredInstallRoot !== process.env.PIRATE_CLAW_INSTALL_ROOT
+      ) {
+        await ensureFirstStartupBootstrap({
+          installRoot: configuredInstallRoot,
+          configPath: resolvedConfigPath,
+        });
+        config = await loadConfig(resolvedConfigPath);
+      }
+
       const database = openDatabase();
       const log = console.log;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,7 @@
 import { dirname, join } from 'node:path';
 
+import { generatedDaemonApiWriteTokenPath } from './install-bootstrap';
+
 export type FeedConfig = {
   name: string;
   url: string;
@@ -49,6 +51,7 @@ export type RuntimeConfig = {
   artifactRetentionDays: number;
   apiPort?: number;
   apiWriteToken?: string;
+  installRoot?: string;
   /**
    * How often to run TMDB cache refresh in the daemon (independent of RSS polling).
    * Zero disables the background pass; omitted uses the default (see `DEFAULT_RUNTIME_CONFIG` and `validateRuntime`).
@@ -98,6 +101,7 @@ const DEFAULT_CONFIG_PATH = 'pirate-claw.config.json';
 const TRANSMISSION_USERNAME_ENV = 'PIRATE_CLAW_TRANSMISSION_USERNAME';
 const TRANSMISSION_PASSWORD_ENV = 'PIRATE_CLAW_TRANSMISSION_PASSWORD';
 const API_WRITE_TOKEN_ENV = 'PIRATE_CLAW_API_WRITE_TOKEN';
+const INSTALL_ROOT_ENV = 'PIRATE_CLAW_INSTALL_ROOT';
 const PLEX_TOKEN_ENV = 'PIRATE_CLAW_PLEX_TOKEN';
 const DEFAULT_PLEX_REFRESH_INTERVAL_MINUTES = 30;
 
@@ -739,10 +743,35 @@ function validateRuntime(
   env: Record<string, string | undefined>,
 ): RuntimeConfig {
   if (input === undefined) {
-    return { ...DEFAULT_RUNTIME_CONFIG };
+    const apiWriteToken = resolveApiWriteToken(
+      undefined,
+      env[API_WRITE_TOKEN_ENV],
+      `${path} runtime apiWriteToken`,
+    );
+    const installRoot = resolveOptionalString(
+      undefined,
+      env[INSTALL_ROOT_ENV],
+      `${path} runtime installRoot`,
+    );
+
+    return {
+      ...DEFAULT_RUNTIME_CONFIG,
+      ...(apiWriteToken ? { apiWriteToken } : {}),
+      ...(installRoot ? { installRoot } : {}),
+    };
   }
 
   const runtime = expectRecord(input, `${path} runtime`);
+  const apiWriteToken = resolveApiWriteToken(
+    runtime.apiWriteToken,
+    env[API_WRITE_TOKEN_ENV],
+    `${path} runtime apiWriteToken`,
+  );
+  const installRoot = resolveOptionalString(
+    runtime.installRoot,
+    env[INSTALL_ROOT_ENV],
+    `${path} runtime installRoot`,
+  );
 
   return {
     runIntervalMinutes:
@@ -767,11 +796,8 @@ function validateRuntime(
       runtime.apiPort,
       `${path} runtime apiPort`,
     ),
-    apiWriteToken: resolveApiWriteToken(
-      runtime.apiWriteToken,
-      env[API_WRITE_TOKEN_ENV],
-      `${path} runtime apiWriteToken`,
-    ),
+    ...(apiWriteToken ? { apiWriteToken } : {}),
+    ...(installRoot ? { installRoot } : {}),
     tmdbRefreshIntervalMinutes:
       validateOptionalTmdbRefreshInterval(
         runtime.tmdbRefreshIntervalMinutes,
@@ -902,15 +928,69 @@ export async function loadConfigEnv(
 ): Promise<Record<string, string | undefined>> {
   const envPath = join(dirname(configPath), '.env');
   const envFile = Bun.file(envPath);
+  const generatedEnv = await loadGeneratedConfigEnv(configPath);
 
   if (!(await envFile.exists())) {
-    return process.env;
+    return {
+      ...generatedEnv,
+      ...definedEnv(process.env),
+    };
   }
 
   return {
+    ...generatedEnv,
     ...parseDotEnv(await envFile.text()),
-    ...process.env,
+    ...definedEnv(process.env),
   };
+}
+
+async function loadGeneratedConfigEnv(
+  configPath: string,
+): Promise<Record<string, string | undefined>> {
+  const tokenPath = generatedDaemonApiWriteTokenPath(configPath);
+  const tokenFile = Bun.file(tokenPath);
+
+  if (!(await tokenFile.exists())) {
+    return {};
+  }
+
+  const token = (await tokenFile.text()).trim();
+
+  return token.length > 0 ? { [API_WRITE_TOKEN_ENV]: token } : {};
+}
+
+function resolveOptionalString(
+  inlineValue: unknown,
+  envValue: string | undefined,
+  path: string,
+): string | undefined {
+  if (typeof envValue === 'string' && envValue.length > 0) {
+    return envValue;
+  }
+
+  if (inlineValue === undefined) {
+    return undefined;
+  }
+
+  if (typeof inlineValue !== 'string') {
+    throw new ConfigError(`Config file "${path}" must be a string.`);
+  }
+
+  return inlineValue.length > 0 ? inlineValue : undefined;
+}
+
+function definedEnv(
+  env: Record<string, string | undefined>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value === 'string') {
+      result[key] = value;
+    }
+  }
+
+  return result;
 }
 
 function parseDotEnv(input: string): Record<string, string> {

--- a/src/install-bootstrap.ts
+++ b/src/install-bootstrap.ts
@@ -1,0 +1,86 @@
+import { randomBytes } from 'node:crypto';
+import { mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+export const DEFAULT_SYNOLOGY_INSTALL_ROOT = '/volume1/pirate-claw';
+
+export const INSTALL_ROOT_DIRECTORIES = [
+  'config',
+  'data',
+  'downloads',
+  'downloads/incomplete',
+  'media',
+  'media/movies',
+  'media/shows',
+  'transmission/config',
+] as const;
+
+export const GENERATED_CONFIG_DIRECTORY = 'generated';
+export const DAEMON_API_WRITE_TOKEN_FILE = 'daemon-api-write-token';
+
+export type FirstStartupBootstrapResult = {
+  installRoot: string;
+  configDir: string;
+  daemonApiWriteTokenPath: string;
+  daemonApiWriteTokenCreated: boolean;
+};
+
+export async function ensureFirstStartupBootstrap(input: {
+  installRoot: string | undefined;
+  configPath: string;
+}): Promise<FirstStartupBootstrapResult | undefined> {
+  const installRoot = normalizeInstallRoot(input.installRoot);
+
+  if (!installRoot) {
+    return undefined;
+  }
+
+  for (const relativePath of INSTALL_ROOT_DIRECTORIES) {
+    await mkdir(join(installRoot, relativePath), { recursive: true });
+  }
+
+  const configDir = dirname(input.configPath);
+  await mkdir(configDir, { recursive: true });
+
+  const generatedConfigDir = join(configDir, GENERATED_CONFIG_DIRECTORY);
+  await mkdir(generatedConfigDir, { recursive: true });
+
+  const daemonApiWriteTokenPath = join(
+    generatedConfigDir,
+    DAEMON_API_WRITE_TOKEN_FILE,
+  );
+  const tokenFile = Bun.file(daemonApiWriteTokenPath);
+  const daemonApiWriteTokenCreated = !(await tokenFile.exists());
+
+  if (daemonApiWriteTokenCreated) {
+    await Bun.write(daemonApiWriteTokenPath, `${generateSecretToken()}\n`);
+  }
+
+  return {
+    installRoot,
+    configDir,
+    daemonApiWriteTokenPath,
+    daemonApiWriteTokenCreated,
+  };
+}
+
+export function generatedDaemonApiWriteTokenPath(configPath: string): string {
+  return join(
+    dirname(configPath),
+    GENERATED_CONFIG_DIRECTORY,
+    DAEMON_API_WRITE_TOKEN_FILE,
+  );
+}
+
+export function generateSecretToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+function normalizeInstallRoot(path: string | undefined): string | undefined {
+  if (path === undefined) {
+    return undefined;
+  }
+
+  const trimmed = path.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -561,14 +561,18 @@ describe('pirate-claw config show', () => {
             username: 'user',
             password: 'pass',
           },
+          runtime: {
+            apiWriteToken: '',
+          },
         },
         null,
         2,
       ),
     );
 
-    const result = await runSimpleCommand(
+    const result = await runSimpleCommandWithEnv(
       directory,
+      { PIRATE_CLAW_API_WRITE_TOKEN: '' },
       'config',
       'show',
       '--config',
@@ -1070,9 +1074,17 @@ async function runSimpleCommand(
   commandCwd: string,
   ...args: string[]
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return runSimpleCommandWithEnv(commandCwd, {}, ...args);
+}
+
+async function runSimpleCommandWithEnv(
+  commandCwd: string,
+  commandEnv: Record<string, string>,
+  ...args: string[]
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const child = Bun.spawn([cliExecutable, ...args], {
     cwd: commandCwd,
-    env,
+    env: { ...env, ...commandEnv },
     stderr: 'pipe',
     stdout: 'pipe',
   });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { mkdtemp } from 'node:fs/promises';
+import { mkdir, mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -9,6 +9,10 @@ import {
   loadConfig,
   validateConfig,
 } from '../src/config';
+import {
+  DAEMON_API_WRITE_TOKEN_FILE,
+  GENERATED_CONFIG_DIRECTORY,
+} from '../src/install-bootstrap';
 
 const RUN_INTERVAL_MINUTES_DEFAULT = 15;
 const RECONCILE_INTERVAL_SECONDS_DEFAULT = 30;
@@ -286,7 +290,11 @@ describe('validateConfig', () => {
   });
 
   it('applies default runtime config when runtime section is absent', () => {
-    const config = validateConfig(createMinimalConfig());
+    const config = validateConfig(
+      createMinimalConfig(),
+      'config',
+      envWithoutProcessWriteToken(),
+    );
 
     expect(config.runtime).toEqual(DEFAULT_RUNTIME_CONFIG);
     expect(config.runtime.runIntervalMinutes).toBe(
@@ -479,6 +487,39 @@ describe('validateConfig', () => {
         envWithoutProcessWriteToken(),
       ),
     ).toThrow(/runtime apiWriteToken.*must be a string/);
+  });
+
+  it('accepts runtime.installRoot from config', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      runtime: { installRoot: '/volume1/pirate-claw' },
+    });
+
+    expect(config.runtime.installRoot).toBe('/volume1/pirate-claw');
+  });
+
+  it('prefers PIRATE_CLAW_INSTALL_ROOT env override over config install root', () => {
+    const config = validateConfig(
+      {
+        ...createMinimalConfig(),
+        runtime: { installRoot: '/volume1/pirate-claw' },
+      },
+      'config',
+      {
+        PIRATE_CLAW_INSTALL_ROOT: '/tmp/pirate-claw',
+      },
+    );
+
+    expect(config.runtime.installRoot).toBe('/tmp/pirate-claw');
+  });
+
+  it('fails when runtime.installRoot is not a string', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        runtime: { installRoot: 12345 },
+      }),
+    ).toThrow(/runtime installRoot.*must be a string/);
   });
 
   it('fails when runtime.apiPort is zero', () => {
@@ -733,6 +774,39 @@ describe('validateConfig', () => {
       } else {
         delete process.env.PIRATE_CLAW_TRANSMISSION_PASSWORD;
       }
+      if (prevWrite !== undefined) {
+        process.env.PIRATE_CLAW_API_WRITE_TOKEN = prevWrite;
+      } else {
+        delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+      }
+    }
+  });
+
+  it('loads generated daemon write token from the config directory when env is absent', async () => {
+    const prevWrite = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+
+    const directory = await mkdtemp(join(tmpdir(), 'pirate-claw-config-'));
+    try {
+      const configPath = join(directory, 'pirate-claw.config.json');
+      await mkdir(join(directory, GENERATED_CONFIG_DIRECTORY), {
+        recursive: true,
+      });
+      await Bun.write(
+        join(
+          directory,
+          GENERATED_CONFIG_DIRECTORY,
+          DAEMON_API_WRITE_TOKEN_FILE,
+        ),
+        'generated-write-token\n',
+      );
+      await Bun.write(configPath, JSON.stringify(createMinimalConfig()));
+
+      const config = await loadConfig(configPath);
+
+      expect(config.runtime.apiWriteToken).toBe('generated-write-token');
+    } finally {
+      await Bun.$`rm -rf ${directory}`;
       if (prevWrite !== undefined) {
         process.env.PIRATE_CLAW_API_WRITE_TOKEN = prevWrite;
       } else {

--- a/test/install-bootstrap.test.ts
+++ b/test/install-bootstrap.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'bun:test';
-import { mkdtemp, stat } from 'node:fs/promises';
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -12,8 +12,17 @@ import {
 } from '../src/install-bootstrap';
 
 describe('ensureFirstStartupBootstrap', () => {
+  let installRoot: string | undefined;
+
+  afterEach(async () => {
+    if (installRoot) {
+      await rm(installRoot, { recursive: true, force: true });
+      installRoot = undefined;
+    }
+  });
+
   it('creates the Synology install root tree and generated daemon token on a clean root', async () => {
-    const installRoot = await mkdtemp(join(tmpdir(), 'pirate-claw-install-'));
+    installRoot = await mkdtemp(join(tmpdir(), 'pirate-claw-install-'));
     const configPath = join(installRoot, 'config', 'pirate-claw.config.json');
 
     const result = await ensureFirstStartupBootstrap({
@@ -40,7 +49,7 @@ describe('ensureFirstStartupBootstrap', () => {
   });
 
   it('leaves existing directories and generated secrets unchanged on second startup', async () => {
-    const installRoot = await mkdtemp(join(tmpdir(), 'pirate-claw-install-'));
+    installRoot = await mkdtemp(join(tmpdir(), 'pirate-claw-install-'));
     const configPath = join(installRoot, 'config', 'pirate-claw.config.json');
 
     const first = await ensureFirstStartupBootstrap({

--- a/test/install-bootstrap.test.ts
+++ b/test/install-bootstrap.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtemp, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  DAEMON_API_WRITE_TOKEN_FILE,
+  GENERATED_CONFIG_DIRECTORY,
+  INSTALL_ROOT_DIRECTORIES,
+  ensureFirstStartupBootstrap,
+  generateSecretToken,
+} from '../src/install-bootstrap';
+
+describe('ensureFirstStartupBootstrap', () => {
+  it('creates the Synology install root tree and generated daemon token on a clean root', async () => {
+    const installRoot = await mkdtemp(join(tmpdir(), 'pirate-claw-install-'));
+    const configPath = join(installRoot, 'config', 'pirate-claw.config.json');
+
+    const result = await ensureFirstStartupBootstrap({
+      installRoot,
+      configPath,
+    });
+
+    expect(result?.daemonApiWriteTokenCreated).toBe(true);
+
+    for (const relativePath of INSTALL_ROOT_DIRECTORIES) {
+      expect((await stat(join(installRoot, relativePath))).isDirectory()).toBe(
+        true,
+      );
+    }
+
+    const tokenPath = join(
+      installRoot,
+      'config',
+      GENERATED_CONFIG_DIRECTORY,
+      DAEMON_API_WRITE_TOKEN_FILE,
+    );
+    const token = (await Bun.file(tokenPath).text()).trim();
+    expect(token.length).toBeGreaterThanOrEqual(32);
+  });
+
+  it('leaves existing directories and generated secrets unchanged on second startup', async () => {
+    const installRoot = await mkdtemp(join(tmpdir(), 'pirate-claw-install-'));
+    const configPath = join(installRoot, 'config', 'pirate-claw.config.json');
+
+    const first = await ensureFirstStartupBootstrap({
+      installRoot,
+      configPath,
+    });
+    const firstToken = await Bun.file(first!.daemonApiWriteTokenPath).text();
+
+    const second = await ensureFirstStartupBootstrap({
+      installRoot,
+      configPath,
+    });
+    const secondToken = await Bun.file(second!.daemonApiWriteTokenPath).text();
+
+    expect(second?.daemonApiWriteTokenCreated).toBe(false);
+    expect(secondToken).toBe(firstToken);
+  });
+
+  it('generates non-empty random-looking secret values', () => {
+    const first = generateSecretToken();
+    const second = generateSecretToken();
+
+    expect(first.length).toBeGreaterThanOrEqual(32);
+    expect(second.length).toBeGreaterThanOrEqual(32);
+    expect(second).not.toBe(first);
+  });
+
+  it('does nothing when no install root is configured', async () => {
+    const result = await ensureFirstStartupBootstrap({
+      installRoot: undefined,
+      configPath: 'pirate-claw.config.json',
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -161,6 +161,8 @@ export type RuntimeConfig = {
 	artifactDir: string;
 	artifactRetentionDays: number;
 	apiPort?: number;
+	apiWriteToken?: string;
+	installRoot?: string;
 	tmdbRefreshIntervalMinutes?: number;
 };
 


### PR DESCRIPTION
## Summary

- delivery ticket: \`P27.02 Daemon First-Startup Bootstrap\`
- ticket file: [docs/02-delivery/phase-27/ticket-02-daemon-first-startup-bootstrap.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-27/ticket-02-daemon-first-startup-bootstrap.md)
- stacked base branch: \`agents/p27-01-spk-docker-orchestration-spike\`
- self-audit: outcome \`clean\` completed at 2026-04-25 12:19 UTC

## CodeRabbit review findings (2026-04-26, late-arriving)

All findings patched in commit 2b6e1ce.

| Severity | File | Finding | Resolution |
|---|---|---|---|
| 🟡 Minor | `test/install-bootstrap.test.ts:79` | `mkdtemp` dirs never cleaned up; orphaned `/tmp/pirate-claw-install-*` trees accumulate on CI | Added `afterEach` + `rm` cleanup matching pattern in `cli.test.ts` / `config.test.ts` |