### PR TITLE
feat: add Synology compose stack artifacts [P27.03]

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Config file: `pirate-claw.config.json` (see [`pirate-claw.config.example.json`](
 - `tv` — compact `defaults + shows` object or legacy per-show array
 - `movies` — global year, resolution, codec, and `codecPolicy` (`"prefer"` or `"require"`)
 - `transmission` — RPC URL, credentials, optional `downloadDirs` per media type
-- `runtime` — daemon scheduling and artifacts; `apiPort` enables HTTP API; `apiWriteToken` enables config writes; `installRoot` or `PIRATE_CLAW_INSTALL_ROOT` enables Synology first-startup directory and secret bootstrap; `tmdbRefreshIntervalMinutes` controls background TMDB refresh (default 360, `0` disables)
+- `runtime` — daemon scheduling and artifacts; `apiPort` enables HTTP API; `apiHost` controls the API bind address; `apiWriteToken` enables config writes; `installRoot` or `PIRATE_CLAW_INSTALL_ROOT` enables Synology first-startup directory and secret bootstrap; `tmdbRefreshIntervalMinutes` controls background TMDB refresh (default 360, `0` disables)
 - `tmdb` — optional `apiKey` (or env `PIRATE_CLAW_TMDB_API_KEY`) and cache TTL overrides
 - `plex` — optional operator-managed `url`, the current usable `token` (normally browser-managed after Connect Plex; env override via `PIRATE_CLAW_PLEX_TOKEN` still works), and `refreshIntervalMinutes` for library/watch refresh cadence
 

--- a/compose.synology.cm.yml
+++ b/compose.synology.cm.yml
@@ -1,0 +1,91 @@
+# DSM 7.2+ Container Manager Project artifact.
+# Validation status: pending external DSM 7.2+ tester verification.
+name: pirate-claw-synology
+
+x-install-root: &install-root ${PIRATE_CLAW_INSTALL_ROOT:-/volume1/pirate-claw}
+x-container-install-root: &container-install-root /volume1/pirate-claw
+x-daemon-token-file: &daemon-token-file /volume1/pirate-claw/config/generated/daemon-api-write-token
+
+services:
+  pirate-claw-daemon:
+    image: pirate-claw:latest
+    entrypoint: ['bun', 'run', '/app/dist/cli.js']
+    command:
+      [
+        'daemon',
+        '--config',
+        '/volume1/pirate-claw/config/pirate-claw.config.json',
+      ]
+    working_dir: /volume1/pirate-claw/data
+    restart: unless-stopped
+    environment:
+      PIRATE_CLAW_INSTALL_ROOT: *container-install-root
+      PIRATE_CLAW_API_HOST: 0.0.0.0
+      PIRATE_CLAW_API_PORT: '5555'
+      PIRATE_CLAW_TRANSMISSION_URL: http://transmission:9091/transmission/rpc
+    expose:
+      - '5555'
+    volumes:
+      - type: bind
+        source: *install-root
+        target: /volume1/pirate-claw
+    depends_on:
+      - transmission
+    networks:
+      - pirate-claw
+
+  pirate-claw-web:
+    image: pirate-claw-web:latest
+    command:
+      - sh
+      - -c
+      - |
+        while [ ! -s "$$PIRATE_CLAW_DAEMON_TOKEN_FILE" ]; do sleep 1; done
+        export PIRATE_CLAW_API_WRITE_TOKEN="$$(cat "$$PIRATE_CLAW_DAEMON_TOKEN_FILE")"
+        exec node build
+    restart: unless-stopped
+    environment:
+      HOST: 0.0.0.0
+      PORT: '8888'
+      PIRATE_CLAW_API_URL: http://pirate-claw-daemon:5555
+      PIRATE_CLAW_DAEMON_TOKEN_FILE: *daemon-token-file
+    ports:
+      - '8888:8888'
+    volumes:
+      - type: bind
+        source: *install-root
+        target: /volume1/pirate-claw
+        read_only: true
+    depends_on:
+      - pirate-claw-daemon
+    networks:
+      - pirate-claw
+
+  transmission:
+    image: lscr.io/linuxserver/transmission:latest
+    restart: unless-stopped
+    environment:
+      PUID: '1026'
+      PGID: '100'
+      TZ: UTC
+    expose:
+      - '9091'
+    volumes:
+      - type: bind
+        source: ${PIRATE_CLAW_INSTALL_ROOT:-/volume1/pirate-claw}/transmission/config
+        target: /config
+      - type: bind
+        source: ${PIRATE_CLAW_INSTALL_ROOT:-/volume1/pirate-claw}/downloads
+        target: /downloads
+      - type: bind
+        source: ${PIRATE_CLAW_INSTALL_ROOT:-/volume1/pirate-claw}/downloads/incomplete
+        target: /incomplete-downloads
+      - type: bind
+        source: ${PIRATE_CLAW_INSTALL_ROOT:-/volume1/pirate-claw}/media
+        target: /media
+    networks:
+      - pirate-claw
+
+networks:
+  pirate-claw:
+    name: pirate-claw

--- a/compose.synology.yml
+++ b/compose.synology.yml
@@ -1,0 +1,95 @@
+name: pirate-claw-synology
+
+x-install-root: &install-root ${PIRATE_CLAW_INSTALL_ROOT:-/volume1/pirate-claw}
+x-container-install-root: &container-install-root /volume1/pirate-claw
+x-daemon-token-file: &daemon-token-file /volume1/pirate-claw/config/generated/daemon-api-write-token
+
+services:
+  pirate-claw-daemon:
+    image: pirate-claw:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    entrypoint: ['bun', 'run', '/app/dist/cli.js']
+    command:
+      [
+        'daemon',
+        '--config',
+        '/volume1/pirate-claw/config/pirate-claw.config.json',
+      ]
+    working_dir: /volume1/pirate-claw/data
+    restart: unless-stopped
+    environment:
+      PIRATE_CLAW_INSTALL_ROOT: *container-install-root
+      PIRATE_CLAW_API_HOST: 0.0.0.0
+      PIRATE_CLAW_API_PORT: '5555'
+      PIRATE_CLAW_TRANSMISSION_URL: http://transmission:9091/transmission/rpc
+    expose:
+      - '5555'
+    volumes:
+      - type: bind
+        source: *install-root
+        target: /volume1/pirate-claw
+    depends_on:
+      - transmission
+    networks:
+      - pirate-claw
+
+  pirate-claw-web:
+    image: pirate-claw-web:latest
+    build:
+      context: .
+      dockerfile: web/Dockerfile
+    command:
+      - sh
+      - -c
+      - |
+        while [ ! -s "$$PIRATE_CLAW_DAEMON_TOKEN_FILE" ]; do sleep 1; done
+        export PIRATE_CLAW_API_WRITE_TOKEN="$$(cat "$$PIRATE_CLAW_DAEMON_TOKEN_FILE")"
+        exec node build
+    restart: unless-stopped
+    environment:
+      HOST: 0.0.0.0
+      PORT: '8888'
+      PIRATE_CLAW_API_URL: http://pirate-claw-daemon:5555
+      PIRATE_CLAW_DAEMON_TOKEN_FILE: *daemon-token-file
+    ports:
+      - '8888:8888'
+    volumes:
+      - type: bind
+        source: *install-root
+        target: /volume1/pirate-claw
+        read_only: true
+    depends_on:
+      - pirate-claw-daemon
+    networks:
+      - pirate-claw
+
+  transmission:
+    image: lscr.io/linuxserver/transmission:latest
+    restart: unless-stopped
+    environment:
+      PUID: '1026'
+      PGID: '100'
+      TZ: UTC
+    expose:
+      - '9091'
+    volumes:
+      - type: bind
+        source: ${PIRATE_CLAW_INSTALL_ROOT:-/volume1/pirate-claw}/transmission/config
+        target: /config
+      - type: bind
+        source: ${PIRATE_CLAW_INSTALL_ROOT:-/volume1/pirate-claw}/downloads
+        target: /downloads
+      - type: bind
+        source: ${PIRATE_CLAW_INSTALL_ROOT:-/volume1/pirate-claw}/downloads/incomplete
+        target: /incomplete-downloads
+      - type: bind
+        source: ${PIRATE_CLAW_INSTALL_ROOT:-/volume1/pirate-claw}/media
+        target: /media
+    networks:
+      - pirate-claw
+
+networks:
+  pirate-claw:
+    name: pirate-claw

--- a/compose.synology.yml
+++ b/compose.synology.yml
@@ -69,6 +69,7 @@ services:
     image: lscr.io/linuxserver/transmission:latest
     restart: unless-stopped
     environment:
+      # Common Synology admin defaults; update PUID/PGID to match your DSM user IDs if volumes show permission errors
       PUID: '1026'
       PGID: '100'
       TZ: UTC

--- a/cspell.json
+++ b/cspell.json
@@ -35,6 +35,7 @@
     "Ironman",
     "Jellyfin",
     "Kodi",
+    "lscr",
     "mktemp",
     "NEWGROUP",
     "noarch",

--- a/docs/02-delivery/phase-27/ticket-03-synology-stack-compose-contract.md
+++ b/docs/02-delivery/phase-27/ticket-03-synology-stack-compose-contract.md
@@ -32,4 +32,16 @@ Both compose files exist. `compose.synology.yml` starts the three-service stack 
 
 ## Rationale
 
-_To be completed after implementation._
+Added `compose.synology.yml` for the DSM 7.1 baseline and `compose.synology.cm.yml` for the DSM 7.2+ Container Manager artifact. Both define the same three-service stack (`pirate-claw-web`, `pirate-claw-daemon`, `transmission`), publish only `pirate-claw-web` on host port `8888`, keep daemon `5555` and Transmission `9091` internal, and use service-name URLs for web → daemon and daemon → Transmission communication.
+
+The compose files intentionally do not inline secret values. The daemon generates `config/generated/daemon-api-write-token` through the P27.02 first-startup bootstrap. The web service waits for that file, reads it at process start, and exports `PIRATE_CLAW_API_WRITE_TOKEN` internally so the owner does not hand-enter the write token in compose or DSM.
+
+Small runtime config additions were needed to make the compose contract real rather than only documented: `PIRATE_CLAW_API_HOST` lets the daemon bind `0.0.0.0` inside the private Docker network while preserving the local default of `127.0.0.1`; `PIRATE_CLAW_API_PORT` enables the daemon API without hand-editing starter JSON; and `PIRATE_CLAW_TRANSMISSION_URL` lets the bundled stack use `http://transmission:9091/transmission/rpc` while the on-disk starter config remains non-secret and operator-editable later.
+
+Local validation used:
+
+```bash
+PIRATE_CLAW_INSTALL_ROOT="$(pwd)/.pirate-claw/compose-validation" docker compose -f compose.synology.yml up --build -d
+```
+
+Result: all three containers started; Docker published only `0.0.0.0:8888->8888/tcp`; the daemon logged `api listening on 0.0.0.0:5555`; `curl http://127.0.0.1:8888/` returned `200`; the web container fetched `http://pirate-claw-daemon:5555/api/status` with `200`; and the daemon effective config reported Transmission URL `http://transmission:9091/transmission/rpc` with the API write token redacted.

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,7 @@ export type RuntimeConfig = {
   artifactDir: string;
   artifactRetentionDays: number;
   apiPort?: number;
+  apiHost?: string;
   apiWriteToken?: string;
   installRoot?: string;
   /**
@@ -98,8 +99,11 @@ export type AppConfig = {
 };
 
 const DEFAULT_CONFIG_PATH = 'pirate-claw.config.json';
+const TRANSMISSION_URL_ENV = 'PIRATE_CLAW_TRANSMISSION_URL';
 const TRANSMISSION_USERNAME_ENV = 'PIRATE_CLAW_TRANSMISSION_USERNAME';
 const TRANSMISSION_PASSWORD_ENV = 'PIRATE_CLAW_TRANSMISSION_PASSWORD';
+const API_HOST_ENV = 'PIRATE_CLAW_API_HOST';
+const API_PORT_ENV = 'PIRATE_CLAW_API_PORT';
 const API_WRITE_TOKEN_ENV = 'PIRATE_CLAW_API_WRITE_TOKEN';
 const INSTALL_ROOT_ENV = 'PIRATE_CLAW_INSTALL_ROOT';
 const PLEX_TOKEN_ENV = 'PIRATE_CLAW_PLEX_TOKEN';
@@ -393,7 +397,12 @@ function validateTransmission(
   env: Record<string, string | undefined>,
 ): TransmissionConfig {
   return {
-    url: requireString(input, 'url', `${path} transmission`),
+    url:
+      resolveOptionalString(
+        input.url,
+        env[TRANSMISSION_URL_ENV],
+        `${path} transmission url`,
+      ) ?? requireString(input, 'url', `${path} transmission`),
     username: resolveTransmissionSecret(
       input.username,
       env[TRANSMISSION_USERNAME_ENV],
@@ -743,6 +752,17 @@ function validateRuntime(
   env: Record<string, string | undefined>,
 ): RuntimeConfig {
   if (input === undefined) {
+    const apiPort = resolveOptionalPositiveInteger(
+      undefined,
+      env[API_PORT_ENV],
+      `${path} runtime apiPort`,
+      API_PORT_ENV,
+    );
+    const apiHost = resolveOptionalString(
+      undefined,
+      env[API_HOST_ENV],
+      `${path} runtime apiHost`,
+    );
     const apiWriteToken = resolveApiWriteToken(
       undefined,
       env[API_WRITE_TOKEN_ENV],
@@ -756,12 +776,25 @@ function validateRuntime(
 
     return {
       ...DEFAULT_RUNTIME_CONFIG,
+      ...(apiPort ? { apiPort } : {}),
+      ...(apiHost ? { apiHost } : {}),
       ...(apiWriteToken ? { apiWriteToken } : {}),
       ...(installRoot ? { installRoot } : {}),
     };
   }
 
   const runtime = expectRecord(input, `${path} runtime`);
+  const apiPort = resolveOptionalPositiveInteger(
+    runtime.apiPort,
+    env[API_PORT_ENV],
+    `${path} runtime apiPort`,
+    API_PORT_ENV,
+  );
+  const apiHost = resolveOptionalString(
+    runtime.apiHost,
+    env[API_HOST_ENV],
+    `${path} runtime apiHost`,
+  );
   const apiWriteToken = resolveApiWriteToken(
     runtime.apiWriteToken,
     env[API_WRITE_TOKEN_ENV],
@@ -792,10 +825,8 @@ function validateRuntime(
         runtime.artifactRetentionDays,
         `${path} runtime artifactRetentionDays`,
       ) ?? DEFAULT_RUNTIME_CONFIG.artifactRetentionDays,
-    apiPort: optionalPositiveInteger(
-      runtime.apiPort,
-      `${path} runtime apiPort`,
-    ),
+    ...(apiPort ? { apiPort } : {}),
+    ...(apiHost ? { apiHost } : {}),
     ...(apiWriteToken ? { apiWriteToken } : {}),
     ...(installRoot ? { installRoot } : {}),
     tmdbRefreshIntervalMinutes:
@@ -917,6 +948,27 @@ function optionalPositiveInteger(
   }
 
   return input;
+}
+
+function resolveOptionalPositiveInteger(
+  inlineValue: unknown,
+  envValue: string | undefined,
+  path: string,
+  envKey: string,
+): number | undefined {
+  if (typeof envValue === 'string' && envValue.length > 0) {
+    const parsed = Number(envValue);
+
+    if (!Number.isInteger(parsed)) {
+      throw new ConfigError(
+        `Config file "${path}" must be a positive integer (1–${MAX_PORT}) or come from ${envKey} as a positive integer.`,
+      );
+    }
+
+    return optionalPositiveInteger(parsed, path);
+  }
+
+  return optionalPositiveInteger(inlineValue, path);
 }
 
 function isRecord(input: unknown): input is Record<string, unknown> {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -5,6 +5,7 @@ export type DaemonOptions = {
   runIntervalMs: number;
   reconcileIntervalMs: number;
   apiPort?: number;
+  apiHost?: string;
   /** When set (TMDB configured + interval > 0), daemon schedules background refreshes. */
   tmdbRefreshIntervalMs?: number;
   /** When set (Plex configured + interval > 0), daemon schedules background refreshes. */
@@ -20,6 +21,7 @@ export function daemonOptionsFromConfig(
     runIntervalMs: runtime.runIntervalMinutes * 60 * 1000,
     reconcileIntervalMs: runtime.reconcileIntervalSeconds * 1000,
     apiPort: runtime.apiPort,
+    apiHost: runtime.apiHost,
     tmdbRefreshIntervalMs:
       tmdbMin != null && tmdbMin > 0 ? tmdbMin * 60 * 1000 : undefined,
     plexRefreshIntervalMs:
@@ -55,23 +57,25 @@ export async function runDaemonLoop(input: {
   }
 
   if (options.apiPort != null && input.fetch) {
+    const apiHost = options.apiHost ?? '127.0.0.1';
+
     try {
       server = Bun.serve({
         port: options.apiPort,
-        hostname: '127.0.0.1',
+        hostname: apiHost,
         fetch: input.fetch,
       });
     } catch (err) {
       const e = err as NodeJS.ErrnoException;
       if (e?.code === 'EADDRINUSE') {
         throw new Error(
-          `Cannot bind HTTP API on 127.0.0.1:${options.apiPort}: address already in use (EADDRINUSE). Stop the other process or set a different runtime.apiPort in pirate-claw.config.json. To list listeners: lsof -iTCP:${options.apiPort} -sTCP:LISTEN`,
+          `Cannot bind HTTP API on ${apiHost}:${options.apiPort}: address already in use (EADDRINUSE). Stop the other process or set a different runtime.apiPort in pirate-claw.config.json. To list listeners: lsof -iTCP:${options.apiPort} -sTCP:LISTEN`,
           { cause: err },
         );
       }
       throw err;
     }
-    log(`api listening on port ${server.port}`);
+    log(`api listening on ${apiHost}:${server.port}`);
   }
 
   const emitCycleResult = (result: CycleResult): void => {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -69,7 +69,7 @@ export async function runDaemonLoop(input: {
       const e = err as NodeJS.ErrnoException;
       if (e?.code === 'EADDRINUSE') {
         throw new Error(
-          `Cannot bind HTTP API on ${apiHost}:${options.apiPort}: address already in use (EADDRINUSE). Stop the other process or set a different runtime.apiPort in pirate-claw.config.json. To list listeners: lsof -iTCP:${options.apiPort} -sTCP:LISTEN`,
+          `Cannot bind HTTP API on ${apiHost}:${options.apiPort}: address already in use (EADDRINUSE). Stop the other process, or override the port via PIRATE_CLAW_API_PORT / PIRATE_CLAW_API_HOST env vars or runtime.apiPort / runtime.apiHost in pirate-claw.config.json. To list listeners: lsof -iTCP:${options.apiPort} -sTCP:LISTEN`,
           { cause: err },
         );
       }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -145,6 +145,16 @@ describe('validateConfig', () => {
     expect(config.transmission.password).toBe('pass');
   });
 
+  it('prefers PIRATE_CLAW_TRANSMISSION_URL over inline transmission URL', () => {
+    const config = validateConfig(createMinimalConfig(), 'config', {
+      PIRATE_CLAW_TRANSMISSION_URL: 'http://transmission:9091/transmission/rpc',
+    });
+
+    expect(config.transmission.url).toBe(
+      'http://transmission:9091/transmission/rpc',
+    );
+  });
+
   it('normalizes tv and movie allowlists to lowercase', () => {
     const config = validateConfig({
       feeds: [
@@ -400,6 +410,24 @@ describe('validateConfig', () => {
     });
 
     expect(config.runtime.apiPort).toBe(5555);
+  });
+
+  it('accepts runtime.apiPort and runtime.apiHost from env', () => {
+    const config = validateConfig(createMinimalConfig(), 'config', {
+      PIRATE_CLAW_API_PORT: '5555',
+      PIRATE_CLAW_API_HOST: '0.0.0.0',
+    });
+
+    expect(config.runtime.apiPort).toBe(5555);
+    expect(config.runtime.apiHost).toBe('0.0.0.0');
+  });
+
+  it('fails when PIRATE_CLAW_API_PORT is not an integer', () => {
+    expect(() =>
+      validateConfig(createMinimalConfig(), 'config', {
+        PIRATE_CLAW_API_PORT: 'not-a-port',
+      }),
+    ).toThrow(/runtime apiPort.*positive integer/);
   });
 
   it('accepts runtime.tmdbRefreshIntervalMinutes zero to disable background refresh', () => {

--- a/test/daemon.test.ts
+++ b/test/daemon.test.ts
@@ -323,9 +323,11 @@ describe('daemon', () => {
       artifactDir: '.pirate-claw/runtime',
       artifactRetentionDays: 7,
       apiPort: 8080,
+      apiHost: '0.0.0.0',
     });
 
     expect(options.apiPort).toBe(8080);
+    expect(options.apiHost).toBe('0.0.0.0');
   });
 
   it('passes plex refresh interval through daemonOptionsFromConfig', () => {
@@ -412,7 +414,9 @@ describe('daemon', () => {
       fetch: () => Response.json({ ok: true }),
     });
 
-    expect(log.some((m) => m.startsWith('api listening on port'))).toBe(true);
+    expect(log.some((m) => m.startsWith('api listening on 127.0.0.1:'))).toBe(
+      true,
+    );
     expect(log).toContain('api stopped');
     expect(log).toContain('daemon stopped');
   });
@@ -460,9 +464,13 @@ describe('daemon', () => {
     await runDaemonLoop({
       runCycle: async () => {
         // capture port from log
-        const portMsg = log.find((m) => m.startsWith('api listening on port'));
+        const portMsg = log.find((m) =>
+          m.startsWith('api listening on 127.0.0.1:'),
+        );
         if (portMsg) {
-          serverPort = Number(portMsg.replace('api listening on port ', ''));
+          serverPort = Number(
+            portMsg.replace('api listening on 127.0.0.1:', ''),
+          );
         }
         controller.abort();
       },

--- a/test/synology-compose.test.ts
+++ b/test/synology-compose.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test';
+
+const baselineCompose = await Bun.file('compose.synology.yml').text();
+const containerManagerCompose = await Bun.file(
+  'compose.synology.cm.yml',
+).text();
+
+describe('Synology compose artifacts', () => {
+  for (const [name, content] of [
+    ['compose.synology.yml', baselineCompose],
+    ['compose.synology.cm.yml', containerManagerCompose],
+  ] as const) {
+    it(`${name} defines the three-service DSM stack`, () => {
+      expect(content).toContain('pirate-claw-web:');
+      expect(content).toContain('pirate-claw-daemon:');
+      expect(content).toContain('transmission:');
+      expect(content).toContain(
+        'PIRATE_CLAW_API_URL: http://pirate-claw-daemon:5555',
+      );
+      expect(content).toContain(
+        'PIRATE_CLAW_TRANSMISSION_URL: http://transmission:9091/transmission/rpc',
+      );
+    });
+
+    it(`${name} exposes only the Pirate Claw web port`, () => {
+      expect(content).toContain("'8888:8888'");
+      expect(content).not.toContain('"5555:5555"');
+      expect(content).not.toContain('"9091:9091"');
+    });
+
+    it(`${name} sources the write token from the generated config file`, () => {
+      expect(content).toContain(
+        '/volume1/pirate-claw/config/generated/daemon-api-write-token',
+      );
+      expect(content).toContain('cat "$$PIRATE_CLAW_DAEMON_TOKEN_FILE"');
+      expect(content).not.toContain('PIRATE_CLAW_API_WRITE_TOKEN:');
+    });
+  }
+
+  it('marks the DSM 7.2+ Container Manager artifact as validation pending', () => {
+    expect(containerManagerCompose).toContain(
+      'Validation status: pending external DSM 7.2+ tester verification.',
+    );
+  });
+});

--- a/test/synology-compose.test.ts
+++ b/test/synology-compose.test.ts
@@ -25,7 +25,9 @@ describe('Synology compose artifacts', () => {
     it(`${name} exposes only the Pirate Claw web port`, () => {
       expect(content).toContain("'8888:8888'");
       expect(content).not.toContain('"5555:5555"');
+      expect(content).not.toContain("'5555:5555'");
       expect(content).not.toContain('"9091:9091"');
+      expect(content).not.toContain("'9091:9091'");
     });
 
     it(`${name} sources the write token from the generated config file`, () => {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -161,6 +161,7 @@ export type RuntimeConfig = {
 	artifactDir: string;
 	artifactRetentionDays: number;
 	apiPort?: number;
+	apiHost?: string;
 	apiWriteToken?: string;
 	installRoot?: string;
 	tmdbRefreshIntervalMinutes?: number;


### PR DESCRIPTION
## Summary

- delivery ticket: \`P27.03 Synology Stack Compose Contract\`
- ticket file: [docs/02-delivery/phase-27/ticket-03-synology-stack-compose-contract.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-27/ticket-03-synology-stack-compose-contract.md)
- stacked base branch: \`agents/p27-02-daemon-first-startup-bootstrap\`
- self-audit: outcome \`clean\` completed at 2026-04-25 12:34 UTC

## [cursor-agent] review findings (2026-04-26, late-arriving)

All findings patched in commit 942b013.

| Severity | File | Finding | Resolution |
|---|---|---|---|
| ℹ️ Info | `src/daemon.ts:72` | EADDRINUSE error only mentions config file; misses `PIRATE_CLAW_API_PORT` / `PIRATE_CLAW_API_HOST` env overrides | Error message updated to surface both env vars and config keys |
| ℹ️ Info | `compose.synology.yml:72` | `PUID`/`PGID` hard-coded to `1026`/`100` with no explanation | Added operator comment noting these are Synology admin defaults |
| ℹ️ Info | `test/synology-compose.test.ts:27` | Port guard `not.toContain('"5555:5555"')` misses single-quoted YAML format | Added parallel `not.toContain("'5555:5555'")` and `not.toContain("'9091:9091'")` guards |