### PR TITLE
feat: add Synology install health endpoint [P27.05]

### DIFF
--- a/docs/02-delivery/phase-27/ticket-05-install-health-daemon-endpoint.md
+++ b/docs/02-delivery/phase-27/ticket-05-install-health-daemon-endpoint.md
@@ -41,4 +41,8 @@ Add a daemon endpoint that checks and reports install health for the Synology ap
 
 ## Rationale
 
-_To be completed after implementation._
+Added unauthenticated `GET /api/setup/install-health` to the daemon API for the Phase 27 first-run surface. The response is a structured record of named checks plus top-level `healthy` and `installRoot`.
+
+The endpoint is diagnostic rather than mutating. P27.02 owns create-if-absent bootstrapping; this endpoint reports missing or not-writable paths with DSM-language remediation so the browser can block first-run setup without silently changing filesystem state during a health read.
+
+Transmission checks use the existing RPC session negotiation path for reachability/authentication and a new `free-space` RPC helper for the bundled container path checks. That proves Transmission can inspect the mounted downloads/media paths from inside its own container boundary without exposing the daemon or Transmission ports to the LAN and without shelling into DSM.

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,6 +2,7 @@ import type { Database } from 'bun:sqlite';
 import { createHash, randomUUID } from 'node:crypto';
 import { getSetupState } from './bootstrap';
 import { renameSync, writeFileSync } from 'node:fs';
+import { getInstallHealth } from './install-health';
 import {
   fetchSessionInfo,
   fetchTorrentStats,
@@ -401,6 +402,14 @@ export function createApiFetch(
           transmissionReachable,
           daemonLive,
         });
+      } catch {
+        return json500();
+      }
+    }
+
+    if (path === '/api/setup/install-health' && request.method === 'GET') {
+      try {
+        return Response.json(await getInstallHealth(activeConfig));
       } catch {
         return json500();
       }

--- a/src/api.ts
+++ b/src/api.ts
@@ -410,7 +410,8 @@ export function createApiFetch(
     if (path === '/api/setup/install-health' && request.method === 'GET') {
       try {
         return Response.json(await getInstallHealth(activeConfig));
-      } catch {
+      } catch (err) {
+        console.error('[api] /api/setup/install-health failed:', err);
         return json500();
       }
     }

--- a/src/install-health.ts
+++ b/src/install-health.ts
@@ -39,13 +39,13 @@ export async function getInstallHealth(
 
   checks.installRoot = await checkDirectoryExists(
     installRoot,
-    'Open File Station and create the shared folder path /volume1/pirate-claw, then rerun the package or restart the Pirate Claw containers.',
+    `Open File Station and create the shared folder path ${installRoot}, then rerun the package or restart the Pirate Claw containers.`,
   );
 
   for (const relativePath of INSTALL_ROOT_DIRECTORIES) {
     checks[directoryCheckName(relativePath)] = await checkDirectoryExists(
       join(installRoot, relativePath),
-      `Open File Station and create /volume1/pirate-claw/${relativePath} through the DSM interface.`,
+      `Open File Station and create ${installRoot}/${relativePath} through the DSM interface.`,
     );
   }
 
@@ -59,7 +59,7 @@ export async function getInstallHealth(
   ] as const) {
     checks[name] = await checkWritableDirectory(
       join(installRoot, relativePath),
-      `In DSM File Station, give the Pirate Claw and Docker package users read/write access to /volume1/pirate-claw/${relativePath}.`,
+      `In DSM File Station, give the Pirate Claw and Docker package users read/write access to ${installRoot}/${relativePath}.`,
     );
   }
 

--- a/src/install-health.ts
+++ b/src/install-health.ts
@@ -1,0 +1,226 @@
+import { randomUUID } from 'node:crypto';
+import { constants } from 'node:fs';
+import { access, stat, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import type { AppConfig } from './config';
+import {
+  DAEMON_API_WRITE_TOKEN_FILE,
+  DEFAULT_SYNOLOGY_INSTALL_ROOT,
+  GENERATED_CONFIG_DIRECTORY,
+  INSTALL_ROOT_DIRECTORIES,
+} from './install-bootstrap';
+import { fetchFreeSpace, fetchSessionInfo } from './transmission';
+
+export type InstallHealthStatus = 'pass' | 'fail' | 'skip';
+
+export type InstallHealthCheck = {
+  status: InstallHealthStatus;
+  remediation: string;
+  detail?: string;
+};
+
+export type InstallHealthResponse = {
+  healthy: boolean;
+  installRoot: string;
+  checks: Record<string, InstallHealthCheck>;
+};
+
+const DEFAULT_TRANSMISSION_DOWNLOADS_PATH = '/downloads';
+const DEFAULT_TRANSMISSION_MOVIES_PATH = '/media/movies';
+const DEFAULT_TRANSMISSION_SHOWS_PATH = '/media/shows';
+
+export async function getInstallHealth(
+  config: AppConfig,
+): Promise<InstallHealthResponse> {
+  const installRoot =
+    config.runtime.installRoot ?? DEFAULT_SYNOLOGY_INSTALL_ROOT;
+  const checks: Record<string, InstallHealthCheck> = {};
+
+  checks.installRoot = await checkDirectoryExists(
+    installRoot,
+    'Open File Station and create the shared folder path /volume1/pirate-claw, then rerun the package or restart the Pirate Claw containers.',
+  );
+
+  for (const relativePath of INSTALL_ROOT_DIRECTORIES) {
+    checks[directoryCheckName(relativePath)] = await checkDirectoryExists(
+      join(installRoot, relativePath),
+      `Open File Station and create /volume1/pirate-claw/${relativePath} through the DSM interface.`,
+    );
+  }
+
+  for (const [name, relativePath] of [
+    ['writableConfig', 'config'],
+    ['writableData', 'data'],
+    ['writableDownloads', 'downloads'],
+    ['writableDownloadsIncomplete', 'downloads/incomplete'],
+    ['writableMediaMovies', 'media/movies'],
+    ['writableMediaShows', 'media/shows'],
+  ] as const) {
+    checks[name] = await checkWritableDirectory(
+      join(installRoot, relativePath),
+      `In DSM File Station, give the Pirate Claw and Docker package users read/write access to /volume1/pirate-claw/${relativePath}.`,
+    );
+  }
+
+  checks.daemonWriteToken = checkDaemonWriteToken(config);
+
+  const session = await fetchSessionInfo(config.transmission);
+  if (session.ok) {
+    checks.transmissionRpcReachable = pass(
+      'Bundled Transmission RPC answered.',
+    );
+    checks.transmissionAuthenticated = pass(
+      'Bundled Transmission RPC session opened.',
+    );
+  } else if (
+    session.code === 'http_error' &&
+    /HTTP (401|403)/.test(session.message)
+  ) {
+    checks.transmissionRpcReachable = pass(
+      'Bundled Transmission RPC answered.',
+    );
+    checks.transmissionAuthenticated = fail(
+      'Open Docker, inspect the Transmission container settings, and verify Pirate Claw uses the bundled Transmission service without hand-entered credentials.',
+      session.message,
+    );
+  } else {
+    checks.transmissionRpcReachable = fail(
+      'Open Docker and confirm the transmission container is running on the Pirate Claw network.',
+      session.message,
+    );
+    checks.transmissionAuthenticated = skip(
+      'Fix bundled Transmission reachability first, then reload the Pirate Claw first-run page.',
+    );
+  }
+
+  const transmissionReady = checks.transmissionAuthenticated.status === 'pass';
+  await addTransmissionPathCheck({
+    checks,
+    key: 'transmissionDownloadsWritable',
+    config,
+    path:
+      config.transmission.downloadDir ??
+      config.transmission.downloadDirs?.movie ??
+      config.transmission.downloadDirs?.tv ??
+      DEFAULT_TRANSMISSION_DOWNLOADS_PATH,
+    transmissionReady,
+    remediation:
+      'Open Docker and confirm the Transmission container has the Pirate Claw downloads folder mounted at /downloads with read/write access.',
+  });
+  await addTransmissionPathCheck({
+    checks,
+    key: 'transmissionMoviesWritable',
+    config,
+    path:
+      config.transmission.downloadDirs?.movie ??
+      DEFAULT_TRANSMISSION_MOVIES_PATH,
+    transmissionReady,
+    remediation:
+      'Open Docker and confirm the Transmission container has the Pirate Claw movie media folder mounted at /media/movies with read/write access.',
+  });
+  await addTransmissionPathCheck({
+    checks,
+    key: 'transmissionShowsWritable',
+    config,
+    path:
+      config.transmission.downloadDirs?.tv ?? DEFAULT_TRANSMISSION_SHOWS_PATH,
+    transmissionReady,
+    remediation:
+      'Open Docker and confirm the Transmission container has the Pirate Claw show media folder mounted at /media/shows with read/write access.',
+  });
+
+  return {
+    healthy: Object.values(checks).every((check) => check.status === 'pass'),
+    installRoot,
+    checks,
+  };
+}
+
+function directoryCheckName(relativePath: string): string {
+  return `directory${relativePath
+    .split('/')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('')}`;
+}
+
+async function checkDirectoryExists(
+  path: string,
+  remediation: string,
+): Promise<InstallHealthCheck> {
+  try {
+    const info = await stat(path);
+    if (!info.isDirectory()) {
+      return fail(remediation, `${path} exists but is not a directory.`);
+    }
+    return pass(`${path} exists.`);
+  } catch (error) {
+    return fail(remediation, formatError(error));
+  }
+}
+
+async function checkWritableDirectory(
+  path: string,
+  remediation: string,
+): Promise<InstallHealthCheck> {
+  try {
+    await access(path, constants.W_OK);
+    const probePath = join(path, `.pirate-claw-health-${randomUUID()}`);
+    await writeFile(probePath, 'ok', { flag: 'wx' });
+    await unlink(probePath);
+    return pass(`${path} is writable.`);
+  } catch (error) {
+    return fail(remediation, formatError(error));
+  }
+}
+
+function checkDaemonWriteToken(config: AppConfig): InstallHealthCheck {
+  const token = config.runtime.apiWriteToken?.trim();
+  if (token) {
+    return pass('Daemon write token is loaded.');
+  }
+
+  return fail(
+    `Restart the Pirate Claw daemon container so it can generate ${GENERATED_CONFIG_DIRECTORY}/${DAEMON_API_WRITE_TOKEN_FILE}, then reload the first-run page.`,
+  );
+}
+
+async function addTransmissionPathCheck(input: {
+  checks: Record<string, InstallHealthCheck>;
+  key: string;
+  config: AppConfig;
+  path: string;
+  transmissionReady: boolean;
+  remediation: string;
+}): Promise<void> {
+  if (!input.transmissionReady) {
+    input.checks[input.key] = skip(
+      'Fix bundled Transmission reachability first, then reload the Pirate Claw first-run page.',
+    );
+    return;
+  }
+
+  const result = await fetchFreeSpace(input.config.transmission, input.path);
+  input.checks[input.key] = result.ok
+    ? pass(`Transmission can inspect ${input.path}.`)
+    : fail(input.remediation, result.message);
+}
+
+function pass(detail: string): InstallHealthCheck {
+  return { status: 'pass', remediation: '', detail };
+}
+
+function fail(remediation: string, detail?: string): InstallHealthCheck {
+  return { status: 'fail', remediation, ...(detail ? { detail } : {}) };
+}
+
+function skip(remediation: string): InstallHealthCheck {
+  return { status: 'skip', remediation };
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/src/transmission.ts
+++ b/src/transmission.ts
@@ -88,6 +88,10 @@ export type FetchSessionInfoResult =
   | { ok: true; session: SessionInfo }
   | SubmissionFailure;
 
+export type FetchFreeSpaceResult =
+  | { ok: true; path: string; sizeBytes: number }
+  | SubmissionFailure;
+
 export type DownloaderOptions = {
   warn?: (message: string) => void;
 };
@@ -521,6 +525,58 @@ export async function fetchSessionInfo(
   );
 }
 
+export async function fetchFreeSpace(
+  config: TransmissionConfig,
+  path: string,
+): Promise<FetchFreeSpaceResult> {
+  const body = { method: 'free-space', arguments: { path } };
+  const firstResponse = await sendRpcRequest(config, body);
+
+  if (!firstResponse.ok) {
+    return firstResponse.error;
+  }
+
+  let response = firstResponse.response;
+
+  if (response.status === 409) {
+    const sessionId = response.headers.get('x-transmission-session-id');
+    if (!sessionId) {
+      return {
+        ok: false,
+        code: 'session_error',
+        message:
+          'Transmission session negotiation failed: missing X-Transmission-Session-Id header.',
+      };
+    }
+    const retryResponse = await sendRpcRequest(config, body, sessionId);
+    if (!retryResponse.ok) {
+      return retryResponse.error;
+    }
+    response = retryResponse.response;
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      code: 'http_error',
+      message: `Transmission RPC request failed with HTTP ${response.status}.`,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await response.json();
+  } catch {
+    return {
+      ok: false,
+      code: 'invalid_response',
+      message: 'Transmission RPC response was not valid JSON.',
+    };
+  }
+
+  return parseFreeSpaceResult(parsed);
+}
+
 async function sendRpcRequest(
   config: TransmissionConfig,
   body: unknown,
@@ -912,6 +968,14 @@ type TransmissionTorrentGetResponse = {
   };
 };
 
+type TransmissionFreeSpaceResponse = {
+  result: string;
+  arguments: {
+    path?: string;
+    'size-bytes'?: number;
+  };
+};
+
 type TransmissionStatTorrent = {
   id?: number;
   name?: string;
@@ -1137,5 +1201,48 @@ function parseSessionInfoResult(
         'uploaded',
       ),
     },
+  };
+}
+
+function parseFreeSpaceResult(parsed: unknown): FetchFreeSpaceResult {
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    !('result' in parsed) ||
+    !('arguments' in parsed)
+  ) {
+    return {
+      ok: false,
+      code: 'invalid_response',
+      message: 'Transmission free-space response was malformed.',
+    };
+  }
+
+  const response = parsed as TransmissionFreeSpaceResponse;
+
+  if (response.result !== 'success') {
+    return {
+      ok: false,
+      code: 'rpc_error',
+      message: `Transmission free-space failed: ${response.result}.`,
+      rpcResult: response.result,
+    };
+  }
+
+  if (
+    typeof response.arguments.path !== 'string' ||
+    typeof response.arguments['size-bytes'] !== 'number'
+  ) {
+    return {
+      ok: false,
+      code: 'invalid_response',
+      message: 'Transmission free-space response was missing path details.',
+    };
+  }
+
+  return {
+    ok: true,
+    path: response.arguments.path,
+    sizeBytes: response.arguments['size-bytes'],
   };
 }

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -24,6 +24,7 @@ import {
   ensureSchema,
   openDatabase,
 } from '../src/repository';
+import { INSTALL_ROOT_DIRECTORIES } from '../src/install-bootstrap';
 import type { CycleResult } from '../src/runtime-artifacts';
 import { PlexAuthStore } from '../src/plex/auth';
 import { TmdbCache } from '../src/tmdb/cache';
@@ -152,6 +153,63 @@ async function writeCompactTvConfigFile(path: string): Promise<void> {
     },
   };
   await Bun.write(path, `${JSON.stringify(doc, null, 2)}\n`);
+}
+
+async function createInstallRoot(omit: string[] = []): Promise<string> {
+  const installRoot = await mkdtemp(join(tmpdir(), 'pirate-claw-install-'));
+  for (const directory of INSTALL_ROOT_DIRECTORIES) {
+    if (!omit.includes(directory)) {
+      await mkdir(join(installRoot, directory), { recursive: true });
+    }
+  }
+  return installRoot;
+}
+
+function mockHealthyTransmission() {
+  return spyOn(globalThis, 'fetch').mockImplementation((async (
+    _input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => {
+    const body = JSON.parse(String(init?.body ?? '{}')) as {
+      method?: string;
+      arguments?: { path?: string };
+    };
+
+    if (body.method === 'session-get') {
+      return Response.json({
+        result: 'success',
+        arguments: { version: '4.0.0' },
+      });
+    }
+
+    if (body.method === 'session-stats') {
+      return Response.json({
+        result: 'success',
+        arguments: {
+          'download-speed': 0,
+          'upload-speed': 0,
+          'active-torrent-count': 0,
+          'cumulative-stats': { downloadedBytes: 0, uploadedBytes: 0 },
+          'current-stats': { downloadedBytes: 0, uploadedBytes: 0 },
+        },
+      });
+    }
+
+    if (body.method === 'free-space') {
+      return Response.json({
+        result: 'success',
+        arguments: {
+          path: body.arguments?.path ?? '/downloads',
+          'size-bytes': 1024,
+        },
+      });
+    }
+
+    return Response.json(
+      { result: 'unknown method', arguments: {} },
+      { status: 500 },
+    );
+  }) as typeof fetch);
 }
 
 describe('createApiFetch', () => {
@@ -457,6 +515,120 @@ describe('GET /api/setup/transmission/status', () => {
     );
     expect(response.status).not.toBe(401);
     expect(response.status).not.toBe(403);
+  });
+});
+
+describe('GET /api/setup/install-health', () => {
+  it('returns healthy true with all checks passing for a complete install', async () => {
+    const installRoot = await createInstallRoot();
+    const fetchSpy = mockHealthyTransmission();
+
+    try {
+      const deps = {
+        ...createDeps(),
+        config: {
+          ...createDeps().config,
+          runtime: {
+            ...createDeps().config.runtime,
+            installRoot,
+            apiWriteToken: 'write-token',
+          },
+        },
+      };
+      const handler = createApiFetch(deps);
+      const response = await handler(
+        new Request('http://localhost/api/setup/install-health'),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.healthy).toBe(true);
+      expect(body.installRoot).toBe(installRoot);
+      expect(
+        Object.values(body.checks).every(
+          (check) => (check as { status: string }).status === 'pass',
+        ),
+      ).toBe(true);
+      expect(body.checks.daemonWriteToken.status).toBe('pass');
+      expect(body.checks.transmissionDownloadsWritable.status).toBe('pass');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('reports a missing directory with DSM-language remediation', async () => {
+    const installRoot = await createInstallRoot(['media/shows']);
+    const fetchSpy = mockHealthyTransmission();
+
+    try {
+      const deps = {
+        ...createDeps(),
+        config: {
+          ...createDeps().config,
+          runtime: {
+            ...createDeps().config.runtime,
+            installRoot,
+            apiWriteToken: 'write-token',
+          },
+        },
+      };
+      const handler = createApiFetch(deps);
+      const response = await handler(
+        new Request('http://localhost/api/setup/install-health'),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.healthy).toBe(false);
+      expect(body.checks.directoryMediaShows.status).toBe('fail');
+      expect(body.checks.directoryMediaShows.remediation).toContain(
+        'File Station',
+      );
+      expect(body.checks.directoryMediaShows.remediation).not.toMatch(
+        /ssh|terminal|chmod|chown/i,
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('reports Transmission unreachable without requiring auth', async () => {
+    const installRoot = await createInstallRoot();
+    const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(
+      (async () => {
+        throw new Error('connection refused');
+      }) as unknown as typeof fetch,
+    );
+
+    try {
+      const deps = {
+        ...createDeps(),
+        config: {
+          ...createDeps().config,
+          runtime: {
+            ...createDeps().config.runtime,
+            installRoot,
+            apiWriteToken: 'write-token',
+          },
+        },
+      };
+      const handler = createApiFetch(deps);
+      const response = await handler(
+        new Request('http://localhost/api/setup/install-health'),
+      );
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.healthy).toBe(false);
+      expect(body.checks.transmissionRpcReachable.status).toBe('fail');
+      expect(body.checks.transmissionRpcReachable.remediation).toContain(
+        'Open Docker',
+      );
+      expect(body.checks.transmissionAuthenticated.status).toBe('skip');
+      expect(body.checks.transmissionDownloadsWritable.status).toBe('skip');
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- delivery ticket: \`P27.05 Install Health Daemon Endpoint\`
- ticket file: [docs/02-delivery/phase-27/ticket-05-install-health-daemon-endpoint.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-27/ticket-05-install-health-daemon-endpoint.md)
- stacked base branch: \`agents/p27-04-spk-installer-and-dsm-icon\`
- self-audit: outcome \`clean\` completed at 2026-04-25 13:02 UTC

## [cursor-agent] review findings (2026-04-26, late-arriving)

Both findings patched in commit fed8a16.

| Severity | File | Finding | Resolution |
|---|---|---|---|
| 🟡 Minor | `src/install-health.ts:62` | Remediation strings hard-code `/volume1/pirate-claw/...`; wrong when `installRoot` is relocated | All three remediation strings now interpolate `${installRoot}` |
| ℹ️ Info | `src/api.ts:414` | `/api/setup/install-health` swallows all errors as a generic 500 with no server log | Added `console.error` before `json500()` to surface the exception for triage |