### PR TITLE
feat: gate onboarding on Synology install health [P27.06]

### DIFF
--- a/docs/02-delivery/phase-27/ticket-06-first-run-health-ui.md
+++ b/docs/02-delivery/phase-27/ticket-06-first-run-health-ui.md
@@ -28,4 +28,6 @@ A fresh install that fails one or more health checks shows the install health pa
 
 ## Rationale
 
-_To be completed after implementation._
+The onboarding health panel treats install health as a Synology-runtime gate only when the loaded config declares `runtime.installRoot`. That preserves the existing local and non-Synology onboarding flow while the Phase 27 Synology compose stack can require Docker image import, folder mounts, write access, generated token, and Transmission path checks to pass before the owner reaches feed and target configuration.
+
+The "Re-check" action reloads `/onboarding`, which re-runs the shared layout health fetch without adding a new route or action. Remediation text comes from the daemon health response so DSM-facing operator guidance stays centralized with the health checks.

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -288,6 +288,20 @@ export type ReadinessResponse = {
 	daemonLive: boolean;
 };
 
+export type InstallHealthStatus = 'pass' | 'fail' | 'skip';
+
+export type InstallHealthCheck = {
+	status: InstallHealthStatus;
+	remediation: string;
+	detail?: string;
+};
+
+export type InstallHealthResponse = {
+	healthy: boolean;
+	installRoot: string;
+	checks: Record<string, InstallHealthCheck>;
+};
+
 export type TransmissionCompatibility =
 	| 'recommended'
 	| 'compatible'

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -2,6 +2,7 @@ import { apiFetch } from '$lib/server/api';
 import type {
 	AppConfig,
 	DaemonHealth,
+	InstallHealthResponse,
 	ReadinessResponse,
 	ReadinessState,
 	SessionInfo,
@@ -22,12 +23,14 @@ function normalizeReadinessState(state: unknown): ReadinessState {
 }
 
 export const load: LayoutServerLoad = async () => {
-	const [healthResult, sessionResult, configResult, readinessResult] = await Promise.allSettled([
-		apiFetch<DaemonHealth>('/api/health'),
-		apiFetch<SessionInfo>('/api/transmission/session'),
-		apiFetch<AppConfig>('/api/config'),
-		apiFetch<ReadinessResponse>('/api/setup/readiness')
-	]);
+	const [healthResult, sessionResult, configResult, readinessResult, installHealthResult] =
+		await Promise.allSettled([
+			apiFetch<DaemonHealth>('/api/health'),
+			apiFetch<SessionInfo>('/api/transmission/session'),
+			apiFetch<AppConfig>('/api/config'),
+			apiFetch<ReadinessResponse>('/api/setup/readiness'),
+			apiFetch<InstallHealthResponse>('/api/setup/install-health')
+		]);
 
 	if (healthResult.status === 'rejected') {
 		console.error('[layout] failed to load /api/health:', healthResult.reason);
@@ -45,6 +48,10 @@ export const load: LayoutServerLoad = async () => {
 		console.error('[layout] failed to load /api/setup/readiness:', readinessResult.reason);
 	}
 
+	if (installHealthResult.status === 'rejected') {
+		console.error('[layout] failed to load /api/setup/install-health:', installHealthResult.reason);
+	}
+
 	const readiness = readinessResult.status === 'fulfilled' ? readinessResult.value : null;
 
 	return {
@@ -52,6 +59,8 @@ export const load: LayoutServerLoad = async () => {
 		transmissionSession: sessionResult.status === 'fulfilled' ? sessionResult.value : null,
 		plexConfigured: configResult.status === 'fulfilled' && configResult.value.plex !== undefined,
 		setupState: normalizeSetupState(readiness?.configState),
-		readinessState: normalizeReadinessState(readiness?.state)
+		readinessState: normalizeReadinessState(readiness?.state),
+		installHealthState:
+			installHealthResult.status === 'fulfilled' ? installHealthResult.value : null
 	};
 };

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -9,7 +9,7 @@
 		writeOnboardingPath
 	} from '$lib/onboarding';
 	import TransmissionCompatibilityBadge from '$lib/components/TransmissionCompatibilityBadge.svelte';
-	import type { ReadinessState, TransmissionCompatibility } from '$lib/types';
+	import type { InstallHealthCheck, ReadinessState, TransmissionCompatibility } from '$lib/types';
 	import type { ActionData, PageData } from './$types';
 
 	const ALL_RESOLUTIONS = ['2160p', '1080p', '720p', '480p'];
@@ -37,6 +37,16 @@
 	);
 	const transmissionAdvisory = $derived(
 		(form as { transmissionAdvisory?: string | null } | undefined)?.transmissionAdvisory ?? null
+	);
+	const installHealthApplies = $derived(!!data.config?.runtime?.installRoot);
+	const installHealthState = $derived(data.installHealthState ?? null);
+	const installHealthReady = $derived(
+		!installHealthApplies || installHealthState?.healthy === true
+	);
+	const installHealthFailures = $derived(
+		Object.entries(installHealthState?.checks ?? {}).filter(
+			(entry): entry is [string, InstallHealthCheck] => entry[1].status === 'fail'
+		)
 	);
 
 	const hasTvFeed = $derived((data.config?.feeds ?? []).some((feed) => feed.mediaType === 'tv'));
@@ -203,6 +213,13 @@
 		}
 		movieCodecs = [...movieCodecs, codec];
 	}
+
+	function formatHealthCheckName(name: string) {
+		return name
+			.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+			.replace(/[_-]+/g, ' ')
+			.replace(/\b\w/g, (char) => char.toUpperCase());
+	}
 </script>
 
 <section class="space-y-3">
@@ -221,7 +238,56 @@
 	/>
 {:else}
 	<section class="mt-8 space-y-6">
-		{#if !showDoneStep}
+		{#if installHealthApplies}
+			<div
+				class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
+			>
+				<div class="flex flex-wrap items-start justify-between gap-3">
+					<div class="space-y-1">
+						<h2 class="text-lg font-semibold tracking-tight">Synology install health</h2>
+						<p class="text-muted-foreground text-sm">
+							{#if installHealthState?.healthy}
+								Synology storage is ready. Continue with Pirate Claw setup.
+							{:else}
+								Finish the DSM Docker image and folder setup before continuing.
+							{/if}
+						</p>
+					</div>
+					<a
+						href="/onboarding"
+						class="border-border bg-background/55 hover:bg-muted/80 inline-flex h-10 items-center rounded-xl border px-4 text-sm transition-colors"
+					>
+						Re-check
+					</a>
+				</div>
+
+				{#if installHealthState?.healthy}
+					<p class="text-muted-foreground text-sm">
+						All required Synology folders, mounts, write access, and Transmission checks are passing
+						for {installHealthState.installRoot}.
+					</p>
+				{:else if installHealthFailures.length > 0}
+					<ul class="space-y-3">
+						{#each installHealthFailures as [name, check]}
+							<li class="border-border/80 bg-background/45 rounded-xl border p-4">
+								<p class="text-sm font-semibold">{formatHealthCheckName(name)}</p>
+								<p class="text-muted-foreground mt-1 text-sm">{check.remediation}</p>
+								{#if check.detail}
+									<p class="text-muted-foreground/80 mt-2 text-xs">{check.detail}</p>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				{:else}
+					<p class="text-muted-foreground text-sm">
+						Install health is not available yet. Open Package Center, start Pirate Claw, then
+						re-check from this page.
+					</p>
+				{/if}
+			</div>
+		{/if}
+
+		{#if installHealthReady && !showDoneStep}
 			<Alert
 				class="border-border/80 bg-card/85 rounded-2xl border shadow-lg shadow-black/20 backdrop-blur-sm"
 			>
@@ -241,713 +307,717 @@
 			</Alert>
 		{/if}
 
-		{#if showPreStepsDone}
-			<div class="space-y-3">
-				<h2 class="text-lg font-semibold tracking-tight">{plexStepLabel}</h2>
-				<PlexAuthCard
-					status={data.plexAuth ?? {
-						state: 'not_connected',
-						plexUrl: data.config?.plex?.url ?? 'http://localhost:32400',
-						hasToken: !!data.config?.plex?.token,
-						returnTo: null
-					}}
-					canWrite={data.canWrite}
-					returnTo="/onboarding"
-					mode="onboarding"
-					skipHref="#after-plex"
-				/>
-			</div>
-		{/if}
-
-		<div id="after-plex"></div>
-
-		{#if showTransmissionStep}
-			<!-- Step 1: Transmission -->
-			<div
-				class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
-			>
-				<h2 class="text-lg font-semibold tracking-tight">Step 1 — Verify Transmission</h2>
-				<p class="text-muted-foreground text-sm">
-					Transmission is not configured yet. Set the URL, username, and password in your config
-					file, then reload this page.
-				</p>
-				<dl class="grid gap-3 text-sm sm:grid-cols-2">
-					<div class="space-y-1">
-						<dt class="text-muted-foreground">URL</dt>
-						<dd class="font-mono text-xs">{transmissionUrl || '(not set)'}</dd>
-					</div>
-				</dl>
-				<form method="POST" action="?/testTransmission">
-					<button
-						type="submit"
-						class="border-border bg-background/55 hover:bg-muted/80 inline-flex h-10 items-center rounded-xl border px-4 text-sm transition-colors"
-					>
-						Test connection
-					</button>
-				</form>
-				{#if transmissionTested && transmissionCompatibility}
-					<TransmissionCompatibilityBadge
-						compatibility={transmissionCompatibility}
-						advisory={transmissionAdvisory ?? undefined}
+		{#if installHealthReady}
+			{#if showPreStepsDone}
+				<div class="space-y-3">
+					<h2 class="text-lg font-semibold tracking-tight">{plexStepLabel}</h2>
+					<PlexAuthCard
+						status={data.plexAuth ?? {
+							state: 'not_connected',
+							plexUrl: data.config?.plex?.url ?? 'http://localhost:32400',
+							hasToken: !!data.config?.plex?.token,
+							returnTo: null
+						}}
+						canWrite={data.canWrite}
+						returnTo="/onboarding"
+						mode="onboarding"
+						skipHref="#after-plex"
 					/>
-				{:else if transmissionTested && !transmissionReachable}
+				</div>
+			{/if}
+
+			<div id="after-plex"></div>
+
+			{#if showTransmissionStep}
+				<!-- Step 1: Transmission -->
+				<div
+					class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
+				>
+					<h2 class="text-lg font-semibold tracking-tight">Step 1 — Verify Transmission</h2>
 					<p class="text-muted-foreground text-sm">
-						Transmission is not reachable. Update your config and reload.
+						Transmission is not configured yet. Set the URL, username, and password in your config
+						file, then reload this page.
 					</p>
-				{/if}
-			</div>
-		{:else if showWriteKeyStep}
-			<!-- Step 2: Write-access key -->
-			<div
-				class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
-			>
-				<h2 class="text-lg font-semibold tracking-tight">Step 2 — Enable Config Writes</h2>
-				<p class="text-muted-foreground text-sm">
-					Config writes are disabled. Set <code>PIRATE_CLAW_API_WRITE_TOKEN</code> in your
-					environment or <code>.env</code> file next to the config, then restart the daemon.
-				</p>
-				<a href="/config" class="text-muted-foreground text-sm hover:underline">
-					Review existing config
-				</a>
-			</div>
-		{:else if showPreStepsDone && !hasFeeds && !(form as { downloadDirsSuccess?: boolean } | undefined)?.downloadDirsSuccess}
-			<!-- Step 3: Media directories (optional) -->
-			<div
-				class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
-			>
-				<h2 class="text-lg font-semibold tracking-tight">{mediaDirsStepLabel}</h2>
-				<p class="text-muted-foreground text-sm">
-					Set per-media-type download directories. Leave blank to use the Transmission default.
-				</p>
-				<form method="POST" action="?/saveDownloadDirs" class="space-y-4">
-					<input type="hidden" name="ifMatch" value={data.etag ?? ''} />
-					<div class="grid gap-3 sm:grid-cols-2">
+					<dl class="grid gap-3 text-sm sm:grid-cols-2">
 						<div class="space-y-1">
-							<label for="tv-dir" class="text-sm font-medium">TV download directory</label>
-							<input
-								id="tv-dir"
-								name="tvDir"
-								type="text"
-								placeholder="/data/tv"
-								value={data.config?.transmission?.downloadDirs?.tv ?? ''}
-								class="border-input bg-background/70 ring-offset-background placeholder:text-muted-foreground/70 h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-							/>
+							<dt class="text-muted-foreground">URL</dt>
+							<dd class="font-mono text-xs">{transmissionUrl || '(not set)'}</dd>
 						</div>
-						<div class="space-y-1">
-							<label for="movie-dir" class="text-sm font-medium">Movie download directory</label>
-							<input
-								id="movie-dir"
-								name="movieDir"
-								type="text"
-								placeholder="/data/movies"
-								value={data.config?.transmission?.downloadDirs?.movie ?? ''}
-								class="border-input bg-background/70 ring-offset-background placeholder:text-muted-foreground/70 h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-							/>
-						</div>
-					</div>
-					{#if (form as { downloadDirsMessage?: string } | undefined)?.downloadDirsMessage}
-						<p
-							class:text-destructive={!(form as { downloadDirsSuccess?: boolean } | undefined)
-								?.downloadDirsSuccess}
-							class="text-sm"
-						>
-							{(form as { downloadDirsMessage?: string }).downloadDirsMessage}
-						</p>
-					{/if}
-					<div class="flex flex-wrap items-center gap-3">
+					</dl>
+					<form method="POST" action="?/testTransmission">
 						<button
 							type="submit"
-							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-11 items-center rounded-xl px-5 text-sm font-semibold shadow-[0_12px_30px_rgb(20_184_166_/_0.18)] disabled:opacity-50"
-							disabled={!data.etag}
+							class="border-border bg-background/55 hover:bg-muted/80 inline-flex h-10 items-center rounded-xl border px-4 text-sm transition-colors"
 						>
-							Save directories
+							Test connection
 						</button>
-						<a href="?/skipDownloadDirs" class="text-muted-foreground text-sm hover:underline">
-							Skip for now
-						</a>
-					</div>
-				</form>
-			</div>
-
-			<!-- Step 4: Feed type + first feed -->
-			<div
-				class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
-			>
-				<h2 class="text-lg font-semibold tracking-tight">{feedTypeStepLabel}</h2>
-				<div class="flex flex-wrap gap-3">
-					<label
-						class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
-					>
-						<input type="radio" bind:group={selectedPath} value="tv" />
-						<span>TV</span>
-					</label>
-					<label
-						class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
-					>
-						<input type="radio" bind:group={selectedPath} value="movie" />
-						<span>Movie</span>
-					</label>
-					<label
-						class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
-					>
-						<input type="radio" bind:group={selectedPath} value="both" />
-						<span>Both</span>
-					</label>
+					</form>
+					{#if transmissionTested && transmissionCompatibility}
+						<TransmissionCompatibilityBadge
+							compatibility={transmissionCompatibility}
+							advisory={transmissionAdvisory ?? undefined}
+						/>
+					{:else if transmissionTested && !transmissionReachable}
+						<p class="text-muted-foreground text-sm">
+							Transmission is not reachable. Update your config and reload.
+						</p>
+					{/if}
 				</div>
-				<p class="text-muted-foreground text-sm">
-					{selectedPath === 'both'
-						? 'Both is supported. Save one feed first, then onboarding will guide TV and movie targets in order.'
-						: `Your first feed will default to ${feedMediaType.toUpperCase()}.`}
-				</p>
-			</div>
+			{:else if showWriteKeyStep}
+				<!-- Step 2: Write-access key -->
+				<div
+					class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
+				>
+					<h2 class="text-lg font-semibold tracking-tight">Step 2 — Enable Config Writes</h2>
+					<p class="text-muted-foreground text-sm">
+						Config writes are disabled. Set <code>PIRATE_CLAW_API_WRITE_TOKEN</code> in your
+						environment or <code>.env</code> file next to the config, then restart the daemon.
+					</p>
+					<a href="/config" class="text-muted-foreground text-sm hover:underline">
+						Review existing config
+					</a>
+				</div>
+			{:else if showPreStepsDone && !hasFeeds && !(form as { downloadDirsSuccess?: boolean } | undefined)?.downloadDirsSuccess}
+				<!-- Step 3: Media directories (optional) -->
+				<div
+					class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
+				>
+					<h2 class="text-lg font-semibold tracking-tight">{mediaDirsStepLabel}</h2>
+					<p class="text-muted-foreground text-sm">
+						Set per-media-type download directories. Leave blank to use the Transmission default.
+					</p>
+					<form method="POST" action="?/saveDownloadDirs" class="space-y-4">
+						<input type="hidden" name="ifMatch" value={data.etag ?? ''} />
+						<div class="grid gap-3 sm:grid-cols-2">
+							<div class="space-y-1">
+								<label for="tv-dir" class="text-sm font-medium">TV download directory</label>
+								<input
+									id="tv-dir"
+									name="tvDir"
+									type="text"
+									placeholder="/data/tv"
+									value={data.config?.transmission?.downloadDirs?.tv ?? ''}
+									class="border-input bg-background/70 ring-offset-background placeholder:text-muted-foreground/70 h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+								/>
+							</div>
+							<div class="space-y-1">
+								<label for="movie-dir" class="text-sm font-medium">Movie download directory</label>
+								<input
+									id="movie-dir"
+									name="movieDir"
+									type="text"
+									placeholder="/data/movies"
+									value={data.config?.transmission?.downloadDirs?.movie ?? ''}
+									class="border-input bg-background/70 ring-offset-background placeholder:text-muted-foreground/70 h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+								/>
+							</div>
+						</div>
+						{#if (form as { downloadDirsMessage?: string } | undefined)?.downloadDirsMessage}
+							<p
+								class:text-destructive={!(form as { downloadDirsSuccess?: boolean } | undefined)
+									?.downloadDirsSuccess}
+								class="text-sm"
+							>
+								{(form as { downloadDirsMessage?: string }).downloadDirsMessage}
+							</p>
+						{/if}
+						<div class="flex flex-wrap items-center gap-3">
+							<button
+								type="submit"
+								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-11 items-center rounded-xl px-5 text-sm font-semibold shadow-[0_12px_30px_rgb(20_184_166_/_0.18)] disabled:opacity-50"
+								disabled={!data.etag}
+							>
+								Save directories
+							</button>
+							<a href="?/skipDownloadDirs" class="text-muted-foreground text-sm hover:underline">
+								Skip for now
+							</a>
+						</div>
+					</form>
+				</div>
 
-			<div
-				class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
-			>
-				<h2 class="text-lg font-semibold tracking-tight">{firstFeedStepLabel}</h2>
-				<form method="POST" action="?/saveFeed" class="space-y-4">
+				<!-- Step 4: Feed type + first feed -->
+				<div
+					class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
+				>
+					<h2 class="text-lg font-semibold tracking-tight">{feedTypeStepLabel}</h2>
+					<div class="flex flex-wrap gap-3">
+						<label
+							class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
+						>
+							<input type="radio" bind:group={selectedPath} value="tv" />
+							<span>TV</span>
+						</label>
+						<label
+							class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
+						>
+							<input type="radio" bind:group={selectedPath} value="movie" />
+							<span>Movie</span>
+						</label>
+						<label
+							class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
+						>
+							<input type="radio" bind:group={selectedPath} value="both" />
+							<span>Both</span>
+						</label>
+					</div>
+					<p class="text-muted-foreground text-sm">
+						{selectedPath === 'both'
+							? 'Both is supported. Save one feed first, then onboarding will guide TV and movie targets in order.'
+							: `Your first feed will default to ${feedMediaType.toUpperCase()}.`}
+					</p>
+				</div>
+
+				<div
+					class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
+				>
+					<h2 class="text-lg font-semibold tracking-tight">{firstFeedStepLabel}</h2>
+					<form method="POST" action="?/saveFeed" class="space-y-4">
+						<input
+							type="hidden"
+							name="ifMatch"
+							value={(form as { feedsEtag?: string } | undefined)?.feedsEtag ??
+								(form as { downloadDirsEtag?: string } | undefined)?.downloadDirsEtag ??
+								data.etag ??
+								''}
+						/>
+						<input type="hidden" name="onboardingPath" value={selectedPath} />
+						<input
+							type="hidden"
+							name="existingFeedsJson"
+							value={JSON.stringify(data.config?.feeds ?? [])}
+						/>
+						<div class="grid gap-3 sm:grid-cols-2">
+							<div class="space-y-1">
+								<label for="feed-name" class="text-sm font-medium">Feed name</label>
+								<input
+									id="feed-name"
+									name="feedName"
+									type="text"
+									placeholder="TV Feed"
+									class="border-input bg-background/70 ring-offset-background placeholder:text-muted-foreground/70 h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+								/>
+							</div>
+							<div class="space-y-1">
+								<label for="feed-type" class="text-sm font-medium">Feed media type</label>
+								<select
+									id="feed-type"
+									name="feedMediaType"
+									bind:value={feedMediaType}
+									class="border-input bg-background/70 ring-offset-background h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+								>
+									<option value="tv">TV</option>
+									<option value="movie">Movie</option>
+								</select>
+							</div>
+						</div>
+						<div class="space-y-1">
+							<label for="feed-url" class="text-sm font-medium">Feed URL</label>
+							<input
+								id="feed-url"
+								name="feedUrl"
+								type="url"
+								placeholder="https://example.com/feed.rss"
+								class="border-input bg-background/70 ring-offset-background placeholder:text-muted-foreground/70 h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+							/>
+						</div>
+						{#if (form as { feedsMessage?: string } | undefined)?.feedsMessage}
+							<p
+								class:text-destructive={!(form as { feedsSuccess?: boolean } | undefined)
+									?.feedsSuccess}
+								class="text-sm"
+							>
+								{(form as { feedsMessage?: string }).feedsMessage}
+							</p>
+						{/if}
+						<div class="flex flex-wrap items-center gap-3">
+							<button
+								type="submit"
+								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-11 items-center rounded-xl px-5 text-sm font-semibold shadow-[0_12px_30px_rgb(20_184_166_/_0.18)] disabled:opacity-50"
+								disabled={!(
+									(form as { feedsEtag?: string } | undefined)?.feedsEtag ??
+									(form as { downloadDirsEtag?: string } | undefined)?.downloadDirsEtag ??
+									data.etag
+								)}
+							>
+								Save first feed
+							</button>
+							<button
+								type="button"
+								class="text-muted-foreground text-sm hover:underline"
+								onclick={dismissOnboarding}
+							>
+								Skip for now
+							</button>
+						</div>
+					</form>
+				</div>
+			{:else if !hasFeeds}
+				<!-- Step 4: Feed type + first feed (after dirs saved/skipped) -->
+				<div
+					class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
+				>
+					<h2 class="text-lg font-semibold tracking-tight">{feedTypeStepLabel}</h2>
+					<div class="flex flex-wrap gap-3">
+						<label
+							class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
+						>
+							<input type="radio" bind:group={selectedPath} value="tv" />
+							<span>TV</span>
+						</label>
+						<label
+							class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
+						>
+							<input type="radio" bind:group={selectedPath} value="movie" />
+							<span>Movie</span>
+						</label>
+						<label
+							class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
+						>
+							<input type="radio" bind:group={selectedPath} value="both" />
+							<span>Both</span>
+						</label>
+					</div>
+					<p class="text-muted-foreground text-sm">
+						{selectedPath === 'both'
+							? 'Both is supported. Save one feed first, then onboarding will guide TV and movie targets in order.'
+							: `Your first feed will default to ${feedMediaType.toUpperCase()}.`}
+					</p>
+				</div>
+
+				<div
+					class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
+				>
+					<h2 class="text-lg font-semibold tracking-tight">{firstFeedStepLabel}</h2>
+					<form method="POST" action="?/saveFeed" class="space-y-4">
+						<input
+							type="hidden"
+							name="ifMatch"
+							value={(form as { feedsEtag?: string } | undefined)?.feedsEtag ?? data.etag ?? ''}
+						/>
+						<input type="hidden" name="onboardingPath" value={selectedPath} />
+						<input
+							type="hidden"
+							name="existingFeedsJson"
+							value={JSON.stringify(data.config?.feeds ?? [])}
+						/>
+						<div class="grid gap-3 sm:grid-cols-2">
+							<div class="space-y-1">
+								<label for="feed-name-2" class="text-sm font-medium">Feed name</label>
+								<input
+									id="feed-name-2"
+									name="feedName"
+									type="text"
+									placeholder="TV Feed"
+									class="border-input bg-background/70 ring-offset-background placeholder:text-muted-foreground/70 h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+								/>
+							</div>
+							<div class="space-y-1">
+								<label for="feed-type-2" class="text-sm font-medium">Feed media type</label>
+								<select
+									id="feed-type-2"
+									name="feedMediaType"
+									bind:value={feedMediaType}
+									class="border-input bg-background/70 ring-offset-background h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+								>
+									<option value="tv">TV</option>
+									<option value="movie">Movie</option>
+								</select>
+							</div>
+						</div>
+						<div class="space-y-1">
+							<label for="feed-url-2" class="text-sm font-medium">Feed URL</label>
+							<input
+								id="feed-url-2"
+								name="feedUrl"
+								type="url"
+								placeholder="https://example.com/feed.rss"
+								class="border-input bg-background/70 ring-offset-background placeholder:text-muted-foreground/70 h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+							/>
+						</div>
+						{#if (form as { feedsMessage?: string } | undefined)?.feedsMessage}
+							<p
+								class:text-destructive={!(form as { feedsSuccess?: boolean } | undefined)
+									?.feedsSuccess}
+								class="text-sm"
+							>
+								{(form as { feedsMessage?: string }).feedsMessage}
+							</p>
+						{/if}
+						<div class="flex flex-wrap items-center gap-3">
+							<button
+								type="submit"
+								class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-11 items-center rounded-xl px-5 text-sm font-semibold shadow-[0_12px_30px_rgb(20_184_166_/_0.18)] disabled:opacity-50"
+								disabled={!((form as { feedsEtag?: string } | undefined)?.feedsEtag ?? data.etag)}
+							>
+								Save first feed
+							</button>
+							<button
+								type="button"
+								class="text-muted-foreground text-sm hover:underline"
+								onclick={dismissOnboarding}
+							>
+								Skip for now
+							</button>
+						</div>
+					</form>
+				</div>
+			{:else if showTvTargetStep}
+				<Alert
+					class="border-border/80 bg-card/85 rounded-2xl border shadow-lg shadow-black/20 backdrop-blur-sm"
+				>
+					<AlertTitle>{tvTargetStepLabel}</AlertTitle>
+					<AlertDescription>
+						Your first feed is saved. Add a TV show and optional defaults without replacing any
+						existing shows already in config.
+					</AlertDescription>
+				</Alert>
+
+				<form
+					method="POST"
+					action="?/saveTvTarget"
+					class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
+				>
 					<input
 						type="hidden"
 						name="ifMatch"
-						value={(form as { feedsEtag?: string } | undefined)?.feedsEtag ??
-							(form as { downloadDirsEtag?: string } | undefined)?.downloadDirsEtag ??
-							data.etag ??
-							''}
+						value={(form as { tvTargetEtag?: string } | undefined)?.tvTargetEtag ?? data.etag ?? ''}
 					/>
-					<input type="hidden" name="onboardingPath" value={selectedPath} />
+					<input type="hidden" name="onboardingPath" value={onboardingPath} />
 					<input
 						type="hidden"
-						name="existingFeedsJson"
-						value={JSON.stringify(data.config?.feeds ?? [])}
+						name="existingShowsJson"
+						value={JSON.stringify(data.config?.tv.map((rule) => rule.name) ?? [])}
 					/>
-					<div class="grid gap-3 sm:grid-cols-2">
-						<div class="space-y-1">
-							<label for="feed-name" class="text-sm font-medium">Feed name</label>
-							<input
-								id="feed-name"
-								name="feedName"
-								type="text"
-								placeholder="TV Feed"
-								class="border-input bg-background/70 ring-offset-background placeholder:text-muted-foreground/70 h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-							/>
-						</div>
-						<div class="space-y-1">
-							<label for="feed-type" class="text-sm font-medium">Feed media type</label>
-							<select
-								id="feed-type"
-								name="feedMediaType"
-								bind:value={feedMediaType}
-								class="border-input bg-background/70 ring-offset-background h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-							>
-								<option value="tv">TV</option>
-								<option value="movie">Movie</option>
-							</select>
-						</div>
-					</div>
+					{#each tvResolutions as resolution}
+						<input type="hidden" name="tvResolution" value={resolution} />
+					{/each}
+					{#each tvCodecs as codec}
+						<input type="hidden" name="tvCodec" value={codec} />
+					{/each}
+
 					<div class="space-y-1">
-						<label for="feed-url" class="text-sm font-medium">Feed URL</label>
+						<label for="show-name" class="text-sm font-medium">TV show</label>
 						<input
-							id="feed-url"
-							name="feedUrl"
-							type="url"
-							placeholder="https://example.com/feed.rss"
+							id="show-name"
+							name="showName"
+							type="text"
+							placeholder="The Example Show"
 							class="border-input bg-background/70 ring-offset-background placeholder:text-muted-foreground/70 h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
 						/>
 					</div>
-					{#if (form as { feedsMessage?: string } | undefined)?.feedsMessage}
+
+					<div class="space-y-2">
+						<p class="text-sm font-medium">TV resolutions</p>
+						<div class="flex flex-wrap gap-2">
+							{#each ALL_RESOLUTIONS as resolution}
+								<button
+									type="button"
+									class="inline-flex h-9 items-center rounded-full border px-4 text-sm font-medium transition-colors {tvResolutions.includes(
+										resolution
+									)
+										? 'border-primary bg-primary text-primary-foreground shadow-[0_8px_24px_rgb(20_184_166_/_0.2)]'
+										: 'border-border bg-background/55 hover:bg-muted/80'}"
+									aria-label={`Toggle ${resolution}`}
+									aria-pressed={tvResolutions.includes(resolution)}
+									onclick={() => toggleResolution(resolution)}
+								>
+									{resolution}
+								</button>
+							{/each}
+						</div>
+					</div>
+
+					<div class="space-y-2">
+						<p class="text-sm font-medium">TV codecs</p>
+						<div class="flex flex-wrap gap-2">
+							{#each ALL_CODECS as codec}
+								<button
+									type="button"
+									class="inline-flex h-9 items-center rounded-full border px-4 text-sm font-medium transition-colors {tvCodecs.includes(
+										codec
+									)
+										? 'border-primary bg-primary text-primary-foreground shadow-[0_8px_24px_rgb(20_184_166_/_0.2)]'
+										: 'border-border bg-background/55 hover:bg-muted/80'}"
+									aria-label={`Toggle ${codec}`}
+									aria-pressed={tvCodecs.includes(codec)}
+									onclick={() => toggleCodec(codec)}
+								>
+									{codec}
+								</button>
+							{/each}
+						</div>
+					</div>
+
+					{#if (form as { tvTargetMessage?: string } | undefined)?.tvTargetMessage}
 						<p
-							class:text-destructive={!(form as { feedsSuccess?: boolean } | undefined)
-								?.feedsSuccess}
+							class:text-destructive={!(form as { tvTargetSuccess?: boolean } | undefined)
+								?.tvTargetSuccess}
 							class="text-sm"
 						>
-							{(form as { feedsMessage?: string }).feedsMessage}
+							{(form as { tvTargetMessage?: string }).tvTargetMessage}
 						</p>
 					{/if}
+
 					<div class="flex flex-wrap items-center gap-3">
 						<button
 							type="submit"
 							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-11 items-center rounded-xl px-5 text-sm font-semibold shadow-[0_12px_30px_rgb(20_184_166_/_0.18)] disabled:opacity-50"
 							disabled={!(
-								(form as { feedsEtag?: string } | undefined)?.feedsEtag ??
-								(form as { downloadDirsEtag?: string } | undefined)?.downloadDirsEtag ??
-								data.etag
+								(form as { tvTargetEtag?: string } | undefined)?.tvTargetEtag ?? data.etag
 							)}
 						>
-							Save first feed
+							Save TV target
 						</button>
-						<button
-							type="button"
-							class="text-muted-foreground text-sm hover:underline"
-							onclick={dismissOnboarding}
+						<a href="/config" class="text-muted-foreground text-sm hover:underline"
+							>Use Config page instead</a
 						>
-							Skip for now
-						</button>
 					</div>
 				</form>
-			</div>
-		{:else if !hasFeeds}
-			<!-- Step 4: Feed type + first feed (after dirs saved/skipped) -->
-			<div
-				class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
-			>
-				<h2 class="text-lg font-semibold tracking-tight">{feedTypeStepLabel}</h2>
-				<div class="flex flex-wrap gap-3">
-					<label
-						class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
-					>
-						<input type="radio" bind:group={selectedPath} value="tv" />
-						<span>TV</span>
-					</label>
-					<label
-						class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
-					>
-						<input type="radio" bind:group={selectedPath} value="movie" />
-						<span>Movie</span>
-					</label>
-					<label
-						class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
-					>
-						<input type="radio" bind:group={selectedPath} value="both" />
-						<span>Both</span>
-					</label>
-				</div>
-				<p class="text-muted-foreground text-sm">
-					{selectedPath === 'both'
-						? 'Both is supported. Save one feed first, then onboarding will guide TV and movie targets in order.'
-						: `Your first feed will default to ${feedMediaType.toUpperCase()}.`}
-				</p>
-			</div>
+			{:else if showMovieTargetStep}
+				<Alert
+					class="border-border/80 bg-card/85 rounded-2xl border shadow-lg shadow-black/20 backdrop-blur-sm"
+				>
+					<AlertTitle>{movieStepLabel}</AlertTitle>
+					<AlertDescription>
+						{#if onboardingPath === 'both'}
+							Your TV target is saved. Finish the guided flow by adding the first movie year target.
+						{:else}
+							Your feed is saved. Add a movie year target and policy defaults.
+						{/if}
+					</AlertDescription>
+				</Alert>
 
-			<div
-				class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
-			>
-				<h2 class="text-lg font-semibold tracking-tight">{firstFeedStepLabel}</h2>
-				<form method="POST" action="?/saveFeed" class="space-y-4">
+				<form
+					method="POST"
+					action="?/saveMovieTarget"
+					class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
+				>
 					<input
 						type="hidden"
 						name="ifMatch"
-						value={(form as { feedsEtag?: string } | undefined)?.feedsEtag ?? data.etag ?? ''}
+						value={(form as { movieTargetEtag?: string } | undefined)?.movieTargetEtag ??
+							(form as { tvTargetEtag?: string } | undefined)?.tvTargetEtag ??
+							data.etag ??
+							''}
 					/>
-					<input type="hidden" name="onboardingPath" value={selectedPath} />
+					<input type="hidden" name="onboardingPath" value={onboardingPath} />
 					<input
 						type="hidden"
-						name="existingFeedsJson"
-						value={JSON.stringify(data.config?.feeds ?? [])}
+						name="existingMovieYearsJson"
+						value={JSON.stringify(data.config?.movies?.years ?? [])}
 					/>
-					<div class="grid gap-3 sm:grid-cols-2">
-						<div class="space-y-1">
-							<label for="feed-name-2" class="text-sm font-medium">Feed name</label>
-							<input
-								id="feed-name-2"
-								name="feedName"
-								type="text"
-								placeholder="TV Feed"
-								class="border-input bg-background/70 ring-offset-background placeholder:text-muted-foreground/70 h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-							/>
-						</div>
-						<div class="space-y-1">
-							<label for="feed-type-2" class="text-sm font-medium">Feed media type</label>
-							<select
-								id="feed-type-2"
-								name="feedMediaType"
-								bind:value={feedMediaType}
-								class="border-input bg-background/70 ring-offset-background h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-							>
-								<option value="tv">TV</option>
-								<option value="movie">Movie</option>
-							</select>
-						</div>
-					</div>
+					<input
+						type="hidden"
+						name="existingMovieResolutionsJson"
+						value={JSON.stringify(data.config?.movies?.resolutions ?? [])}
+					/>
+					<input
+						type="hidden"
+						name="existingMovieCodecsJson"
+						value={JSON.stringify(data.config?.movies?.codecs ?? [])}
+					/>
+					<input
+						type="hidden"
+						name="existingMovieCodecPolicy"
+						value={data.config?.movies?.codecPolicy ?? 'prefer'}
+					/>
+					{#each movieResolutions as resolution}
+						<input type="hidden" name="movieResolution" value={resolution} />
+					{/each}
+					{#each movieCodecs as codec}
+						<input type="hidden" name="movieCodec" value={codec} />
+					{/each}
+
 					<div class="space-y-1">
-						<label for="feed-url-2" class="text-sm font-medium">Feed URL</label>
+						<label for="movie-year" class="text-sm font-medium">Movie year</label>
 						<input
-							id="feed-url-2"
-							name="feedUrl"
-							type="url"
-							placeholder="https://example.com/feed.rss"
+							id="movie-year"
+							name="movieYear"
+							type="number"
+							min="1900"
+							max="2100"
+							placeholder="2024"
 							class="border-input bg-background/70 ring-offset-background placeholder:text-muted-foreground/70 h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
 						/>
 					</div>
-					{#if (form as { feedsMessage?: string } | undefined)?.feedsMessage}
-						<p
-							class:text-destructive={!(form as { feedsSuccess?: boolean } | undefined)
-								?.feedsSuccess}
-							class="text-sm"
-						>
-							{(form as { feedsMessage?: string }).feedsMessage}
+
+					<div class="space-y-2">
+						<p class="text-sm font-medium">Movie resolutions</p>
+						<div class="flex flex-wrap gap-2">
+							{#each ALL_RESOLUTIONS as resolution}
+								<button
+									type="button"
+									class="inline-flex h-9 items-center rounded-full border px-4 text-sm font-medium transition-colors {movieResolutions.includes(
+										resolution
+									)
+										? 'border-primary bg-primary text-primary-foreground shadow-[0_8px_24px_rgb(20_184_166_/_0.2)]'
+										: 'border-border bg-background/55 hover:bg-muted/80'}"
+									aria-label={`Toggle ${resolution}`}
+									aria-pressed={movieResolutions.includes(resolution)}
+									onclick={() => toggleMovieResolution(resolution)}
+								>
+									{resolution}
+								</button>
+							{/each}
+						</div>
+					</div>
+
+					<div class="space-y-2">
+						<p class="text-sm font-medium">Movie codecs</p>
+						<div class="flex flex-wrap gap-2">
+							{#each ALL_CODECS as codec}
+								<button
+									type="button"
+									class="inline-flex h-9 items-center rounded-full border px-4 text-sm font-medium transition-colors {movieCodecs.includes(
+										codec
+									)
+										? 'border-primary bg-primary text-primary-foreground shadow-[0_8px_24px_rgb(20_184_166_/_0.2)]'
+										: 'border-border bg-background/55 hover:bg-muted/80'}"
+									aria-label={`Toggle ${codec}`}
+									aria-pressed={movieCodecs.includes(codec)}
+									onclick={() => toggleMovieCodec(codec)}
+								>
+									{codec}
+								</button>
+							{/each}
+						</div>
+					</div>
+
+					<div class="space-y-2">
+						<p class="text-sm font-medium">Codec policy</p>
+						<div class="flex flex-wrap gap-3">
+							<label
+								class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
+							>
+								<input
+									type="radio"
+									name="movieCodecPolicy"
+									value="prefer"
+									bind:group={movieCodecPolicy}
+								/>
+								<span>Prefer</span>
+							</label>
+							<label
+								class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
+							>
+								<input
+									type="radio"
+									name="movieCodecPolicy"
+									value="require"
+									bind:group={movieCodecPolicy}
+								/>
+								<span>Require</span>
+							</label>
+						</div>
+					</div>
+
+					{#if hasExistingMoviePolicy}
+						<p class="text-muted-foreground text-sm">
+							Existing movie policy is already configured. Onboarding will preserve it and only add
+							the new year target.
 						</p>
 					{/if}
+
+					{#if (form as { movieTargetMessage?: string } | undefined)?.movieTargetMessage}
+						<p
+							class:text-destructive={!(form as { movieTargetSuccess?: boolean } | undefined)
+								?.movieTargetSuccess}
+							class="text-sm"
+						>
+							{(form as { movieTargetMessage?: string }).movieTargetMessage}
+						</p>
+					{/if}
+
 					<div class="flex flex-wrap items-center gap-3">
 						<button
 							type="submit"
 							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-11 items-center rounded-xl px-5 text-sm font-semibold shadow-[0_12px_30px_rgb(20_184_166_/_0.18)] disabled:opacity-50"
-							disabled={!((form as { feedsEtag?: string } | undefined)?.feedsEtag ?? data.etag)}
+							disabled={!(
+								(form as { movieTargetEtag?: string } | undefined)?.movieTargetEtag ??
+								(form as { tvTargetEtag?: string } | undefined)?.tvTargetEtag ??
+								data.etag
+							)}
 						>
-							Save first feed
+							Save movie target
 						</button>
-						<button
-							type="button"
-							class="text-muted-foreground text-sm hover:underline"
-							onclick={dismissOnboarding}
+						<a href="/config" class="text-muted-foreground text-sm hover:underline"
+							>Use Config page instead</a
 						>
-							Skip for now
-						</button>
 					</div>
 				</form>
-			</div>
-		{:else if showTvTargetStep}
-			<Alert
-				class="border-border/80 bg-card/85 rounded-2xl border shadow-lg shadow-black/20 backdrop-blur-sm"
-			>
-				<AlertTitle>{tvTargetStepLabel}</AlertTitle>
-				<AlertDescription>
-					Your first feed is saved. Add a TV show and optional defaults without replacing any
-					existing shows already in config.
-				</AlertDescription>
-			</Alert>
+			{:else if showDoneStep}
+				<Alert
+					class="border-border/80 bg-card/85 rounded-2xl border shadow-lg shadow-black/20 backdrop-blur-sm"
+				>
+					<AlertTitle>Done</AlertTitle>
+					<AlertDescription>
+						{#if readinessState === 'ready_pending_restart'}
+							Your minimum setup is complete, but the daemon is restarting. The dashboard unlocks
+							once it is back online.
+						{:else}
+							Your minimum setup is complete. Review the summary, then continue in the dashboard.
+						{/if}
+					</AlertDescription>
+				</Alert>
 
-			<form
-				method="POST"
-				action="?/saveTvTarget"
-				class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
-			>
-				<input
-					type="hidden"
-					name="ifMatch"
-					value={(form as { tvTargetEtag?: string } | undefined)?.tvTargetEtag ?? data.etag ?? ''}
-				/>
-				<input type="hidden" name="onboardingPath" value={onboardingPath} />
-				<input
-					type="hidden"
-					name="existingShowsJson"
-					value={JSON.stringify(data.config?.tv.map((rule) => rule.name) ?? [])}
-				/>
-				{#each tvResolutions as resolution}
-					<input type="hidden" name="tvResolution" value={resolution} />
-				{/each}
-				{#each tvCodecs as codec}
-					<input type="hidden" name="tvCodec" value={codec} />
-				{/each}
-
-				<div class="space-y-1">
-					<label for="show-name" class="text-sm font-medium">TV show</label>
-					<input
-						id="show-name"
-						name="showName"
-						type="text"
-						placeholder="The Example Show"
-						class="border-input bg-background/70 ring-offset-background placeholder:text-muted-foreground/70 h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-					/>
-				</div>
-
-				<div class="space-y-2">
-					<p class="text-sm font-medium">TV resolutions</p>
-					<div class="flex flex-wrap gap-2">
-						{#each ALL_RESOLUTIONS as resolution}
-							<button
-								type="button"
-								class="inline-flex h-9 items-center rounded-full border px-4 text-sm font-medium transition-colors {tvResolutions.includes(
-									resolution
-								)
-									? 'border-primary bg-primary text-primary-foreground shadow-[0_8px_24px_rgb(20_184_166_/_0.2)]'
-									: 'border-border bg-background/55 hover:bg-muted/80'}"
-								aria-label={`Toggle ${resolution}`}
-								aria-pressed={tvResolutions.includes(resolution)}
-								onclick={() => toggleResolution(resolution)}
-							>
-								{resolution}
-							</button>
-						{/each}
-					</div>
-				</div>
-
-				<div class="space-y-2">
-					<p class="text-sm font-medium">TV codecs</p>
-					<div class="flex flex-wrap gap-2">
-						{#each ALL_CODECS as codec}
-							<button
-								type="button"
-								class="inline-flex h-9 items-center rounded-full border px-4 text-sm font-medium transition-colors {tvCodecs.includes(
-									codec
-								)
-									? 'border-primary bg-primary text-primary-foreground shadow-[0_8px_24px_rgb(20_184_166_/_0.2)]'
-									: 'border-border bg-background/55 hover:bg-muted/80'}"
-								aria-label={`Toggle ${codec}`}
-								aria-pressed={tvCodecs.includes(codec)}
-								onclick={() => toggleCodec(codec)}
-							>
-								{codec}
-							</button>
-						{/each}
-					</div>
-				</div>
-
-				{#if (form as { tvTargetMessage?: string } | undefined)?.tvTargetMessage}
-					<p
-						class:text-destructive={!(form as { tvTargetSuccess?: boolean } | undefined)
-							?.tvTargetSuccess}
-						class="text-sm"
-					>
-						{(form as { tvTargetMessage?: string }).tvTargetMessage}
-					</p>
-				{/if}
-
-				<div class="flex flex-wrap items-center gap-3">
-					<button
-						type="submit"
-						class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-11 items-center rounded-xl px-5 text-sm font-semibold shadow-[0_12px_30px_rgb(20_184_166_/_0.18)] disabled:opacity-50"
-						disabled={!((form as { tvTargetEtag?: string } | undefined)?.tvTargetEtag ?? data.etag)}
-					>
-						Save TV target
-					</button>
-					<a href="/config" class="text-muted-foreground text-sm hover:underline"
-						>Use Config page instead</a
-					>
-				</div>
-			</form>
-		{:else if showMovieTargetStep}
-			<Alert
-				class="border-border/80 bg-card/85 rounded-2xl border shadow-lg shadow-black/20 backdrop-blur-sm"
-			>
-				<AlertTitle>{movieStepLabel}</AlertTitle>
-				<AlertDescription>
-					{#if onboardingPath === 'both'}
-						Your TV target is saved. Finish the guided flow by adding the first movie year target.
-					{:else}
-						Your feed is saved. Add a movie year target and policy defaults.
-					{/if}
-				</AlertDescription>
-			</Alert>
-
-			<form
-				method="POST"
-				action="?/saveMovieTarget"
-				class="border-border/80 bg-card/80 space-y-4 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
-			>
-				<input
-					type="hidden"
-					name="ifMatch"
-					value={(form as { movieTargetEtag?: string } | undefined)?.movieTargetEtag ??
-						(form as { tvTargetEtag?: string } | undefined)?.tvTargetEtag ??
-						data.etag ??
-						''}
-				/>
-				<input type="hidden" name="onboardingPath" value={onboardingPath} />
-				<input
-					type="hidden"
-					name="existingMovieYearsJson"
-					value={JSON.stringify(data.config?.movies?.years ?? [])}
-				/>
-				<input
-					type="hidden"
-					name="existingMovieResolutionsJson"
-					value={JSON.stringify(data.config?.movies?.resolutions ?? [])}
-				/>
-				<input
-					type="hidden"
-					name="existingMovieCodecsJson"
-					value={JSON.stringify(data.config?.movies?.codecs ?? [])}
-				/>
-				<input
-					type="hidden"
-					name="existingMovieCodecPolicy"
-					value={data.config?.movies?.codecPolicy ?? 'prefer'}
-				/>
-				{#each movieResolutions as resolution}
-					<input type="hidden" name="movieResolution" value={resolution} />
-				{/each}
-				{#each movieCodecs as codec}
-					<input type="hidden" name="movieCodec" value={codec} />
-				{/each}
-
-				<div class="space-y-1">
-					<label for="movie-year" class="text-sm font-medium">Movie year</label>
-					<input
-						id="movie-year"
-						name="movieYear"
-						type="number"
-						min="1900"
-						max="2100"
-						placeholder="2024"
-						class="border-input bg-background/70 ring-offset-background placeholder:text-muted-foreground/70 h-11 w-full rounded-xl border px-4 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
-					/>
-				</div>
-
-				<div class="space-y-2">
-					<p class="text-sm font-medium">Movie resolutions</p>
-					<div class="flex flex-wrap gap-2">
-						{#each ALL_RESOLUTIONS as resolution}
-							<button
-								type="button"
-								class="inline-flex h-9 items-center rounded-full border px-4 text-sm font-medium transition-colors {movieResolutions.includes(
-									resolution
-								)
-									? 'border-primary bg-primary text-primary-foreground shadow-[0_8px_24px_rgb(20_184_166_/_0.2)]'
-									: 'border-border bg-background/55 hover:bg-muted/80'}"
-								aria-label={`Toggle ${resolution}`}
-								aria-pressed={movieResolutions.includes(resolution)}
-								onclick={() => toggleMovieResolution(resolution)}
-							>
-								{resolution}
-							</button>
-						{/each}
-					</div>
-				</div>
-
-				<div class="space-y-2">
-					<p class="text-sm font-medium">Movie codecs</p>
-					<div class="flex flex-wrap gap-2">
-						{#each ALL_CODECS as codec}
-							<button
-								type="button"
-								class="inline-flex h-9 items-center rounded-full border px-4 text-sm font-medium transition-colors {movieCodecs.includes(
-									codec
-								)
-									? 'border-primary bg-primary text-primary-foreground shadow-[0_8px_24px_rgb(20_184_166_/_0.2)]'
-									: 'border-border bg-background/55 hover:bg-muted/80'}"
-								aria-label={`Toggle ${codec}`}
-								aria-pressed={movieCodecs.includes(codec)}
-								onclick={() => toggleMovieCodec(codec)}
-							>
-								{codec}
-							</button>
-						{/each}
-					</div>
-				</div>
-
-				<div class="space-y-2">
-					<p class="text-sm font-medium">Codec policy</p>
-					<div class="flex flex-wrap gap-3">
-						<label
-							class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
-						>
-							<input
-								type="radio"
-								name="movieCodecPolicy"
-								value="prefer"
-								bind:group={movieCodecPolicy}
-							/>
-							<span>Prefer</span>
-						</label>
-						<label
-							class="border-border bg-background/55 hover:bg-muted/80 flex items-center gap-2 rounded-xl border px-4 py-3 text-sm transition-colors"
-						>
-							<input
-								type="radio"
-								name="movieCodecPolicy"
-								value="require"
-								bind:group={movieCodecPolicy}
-							/>
-							<span>Require</span>
-						</label>
-					</div>
-				</div>
-
-				{#if hasExistingMoviePolicy}
-					<p class="text-muted-foreground text-sm">
-						Existing movie policy is already configured. Onboarding will preserve it and only add
-						the new year target.
-					</p>
-				{/if}
-
-				{#if (form as { movieTargetMessage?: string } | undefined)?.movieTargetMessage}
-					<p
-						class:text-destructive={!(form as { movieTargetSuccess?: boolean } | undefined)
-							?.movieTargetSuccess}
-						class="text-sm"
-					>
-						{(form as { movieTargetMessage?: string }).movieTargetMessage}
-					</p>
-				{/if}
-
-				<div class="flex flex-wrap items-center gap-3">
-					<button
-						type="submit"
-						class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-11 items-center rounded-xl px-5 text-sm font-semibold shadow-[0_12px_30px_rgb(20_184_166_/_0.18)] disabled:opacity-50"
-						disabled={!(
-							(form as { movieTargetEtag?: string } | undefined)?.movieTargetEtag ??
-							(form as { tvTargetEtag?: string } | undefined)?.tvTargetEtag ??
-							data.etag
-						)}
-					>
-						Save movie target
-					</button>
-					<a href="/config" class="text-muted-foreground text-sm hover:underline"
-						>Use Config page instead</a
-					>
-				</div>
-			</form>
-		{:else if showDoneStep}
-			<Alert
-				class="border-border/80 bg-card/85 rounded-2xl border shadow-lg shadow-black/20 backdrop-blur-sm"
-			>
-				<AlertTitle>Done</AlertTitle>
-				<AlertDescription>
-					{#if readinessState === 'ready_pending_restart'}
-						Your minimum setup is complete, but the daemon is restarting. The dashboard unlocks once
-						it is back online.
-					{:else}
-						Your minimum setup is complete. Review the summary, then continue in the dashboard.
-					{/if}
-				</AlertDescription>
-			</Alert>
-
-			<div
-				class="border-border/80 bg-card/80 space-y-5 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
-			>
-				<h2 class="text-lg font-semibold tracking-tight">Setup summary</h2>
-				<dl class="grid gap-3 text-sm sm:grid-cols-2">
-					<div class="space-y-1">
-						<dt class="text-muted-foreground">Feeds configured</dt>
-						<dd class="font-medium">{configuredFeedCount}</dd>
-					</div>
-					<div class="space-y-1">
-						<dt class="text-muted-foreground">First feed</dt>
-						<dd class="font-medium">{firstFeedLabel ?? 'None yet'}</dd>
-					</div>
-					<div class="space-y-1">
-						<dt class="text-muted-foreground">TV target</dt>
-						<dd class="font-medium">{hasTvSummary ? 'Added' : 'Not added'}</dd>
-					</div>
-					<div class="space-y-1">
-						<dt class="text-muted-foreground">Movie target</dt>
-						<dd class="font-medium">{hasMovieSummary ? 'Added' : 'Not added'}</dd>
-					</div>
-					{#if readinessState}
+				<div
+					class="border-border/80 bg-card/80 space-y-5 rounded-2xl border p-6 shadow-lg shadow-black/20 backdrop-blur-sm"
+				>
+					<h2 class="text-lg font-semibold tracking-tight">Setup summary</h2>
+					<dl class="grid gap-3 text-sm sm:grid-cols-2">
 						<div class="space-y-1">
-							<dt class="text-muted-foreground">Readiness</dt>
-							<dd class="font-medium">{readinessState}</dd>
+							<dt class="text-muted-foreground">Feeds configured</dt>
+							<dd class="font-medium">{configuredFeedCount}</dd>
 						</div>
-					{/if}
-				</dl>
+						<div class="space-y-1">
+							<dt class="text-muted-foreground">First feed</dt>
+							<dd class="font-medium">{firstFeedLabel ?? 'None yet'}</dd>
+						</div>
+						<div class="space-y-1">
+							<dt class="text-muted-foreground">TV target</dt>
+							<dd class="font-medium">{hasTvSummary ? 'Added' : 'Not added'}</dd>
+						</div>
+						<div class="space-y-1">
+							<dt class="text-muted-foreground">Movie target</dt>
+							<dd class="font-medium">{hasMovieSummary ? 'Added' : 'Not added'}</dd>
+						</div>
+						{#if readinessState}
+							<div class="space-y-1">
+								<dt class="text-muted-foreground">Readiness</dt>
+								<dd class="font-medium">{readinessState}</dd>
+							</div>
+						{/if}
+					</dl>
 
-				<div class="flex flex-wrap items-center gap-3">
-					<a
-						href="/"
-						class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-11 items-center rounded-xl px-5 text-sm font-semibold shadow-[0_12px_30px_rgb(20_184_166_/_0.18)] {readinessState !==
-						'ready'
-							? 'pointer-events-none opacity-50'
-							: ''}"
-						aria-disabled={readinessState !== 'ready'}
-					>
-						Go to Dashboard
-					</a>
-					<a href="/config" class="text-muted-foreground text-sm hover:underline">
-						Review Config
-					</a>
+					<div class="flex flex-wrap items-center gap-3">
+						<a
+							href="/"
+							class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-11 items-center rounded-xl px-5 text-sm font-semibold shadow-[0_12px_30px_rgb(20_184_166_/_0.18)] {readinessState !==
+							'ready'
+								? 'pointer-events-none opacity-50'
+								: ''}"
+							aria-disabled={readinessState !== 'ready'}
+						>
+							Go to Dashboard
+						</a>
+						<a href="/config" class="text-muted-foreground text-sm hover:underline">
+							Review Config
+						</a>
+					</div>
 				</div>
-			</div>
-		{:else if showPreStepsDone && !(data.onboarding?.hasTvTargets ?? false) && !(data.onboarding?.hasMovieTargets ?? false)}
-			<Alert
-				class="border-border/80 bg-card/85 rounded-2xl border shadow-lg shadow-black/20 backdrop-blur-sm"
-			>
-				<AlertTitle>Target setup depends on your feed path</AlertTitle>
-				<AlertDescription>
-					Your first feed is saved. Continue in the
-					<a href="/config" class="text-primary font-medium hover:underline">Config page</a>
-					to finish target setup for this feed type.
-				</AlertDescription>
-			</Alert>
+			{:else if showPreStepsDone && !(data.onboarding?.hasTvTargets ?? false) && !(data.onboarding?.hasMovieTargets ?? false)}
+				<Alert
+					class="border-border/80 bg-card/85 rounded-2xl border shadow-lg shadow-black/20 backdrop-blur-sm"
+				>
+					<AlertTitle>Target setup depends on your feed path</AlertTitle>
+					<AlertDescription>
+						Your first feed is saved. Continue in the
+						<a href="/config" class="text-primary font-medium hover:underline">Config page</a>
+						to finish target setup for this feed type.
+					</AlertDescription>
+				</Alert>
+			{/if}
 		{/if}
 	</section>
 {/if}

--- a/web/test/routes/dashboard.test.ts
+++ b/web/test/routes/dashboard.test.ts
@@ -82,6 +82,7 @@ const baseData = {
 	plexConfigured: false,
 	setupState: 'ready' as const,
 	readinessState: 'ready' as const,
+	installHealthState: null,
 	transmissionTorrents: [],
 	candidates: [],
 	runSummaries: [],

--- a/web/test/routes/layout.test.ts
+++ b/web/test/routes/layout.test.ts
@@ -61,6 +61,10 @@ const mockSession: SessionInfo = {
 	currentUploadedBytes: 0
 };
 
+const sharedLayoutData = {
+	installHealthState: null
+};
+
 function setPathname(pathname: string) {
 	page.set({ url: new URL(`http://localhost${pathname}`) });
 }
@@ -77,6 +81,7 @@ describe('+layout.svelte', () => {
 			props: {
 				children: (() => {}) as unknown as import('svelte').Snippet,
 				data: {
+					...sharedLayoutData,
 					health: mockHealth,
 					transmissionSession: mockSession,
 					plexConfigured: true,
@@ -116,6 +121,7 @@ describe('+layout.svelte', () => {
 			props: {
 				children: (() => {}) as unknown as import('svelte').Snippet,
 				data: {
+					...sharedLayoutData,
 					health: null,
 					transmissionSession: null,
 					plexConfigured: false,
@@ -141,6 +147,7 @@ describe('+layout.svelte', () => {
 			props: {
 				children: childSnippet,
 				data: {
+					...sharedLayoutData,
 					health: null,
 					transmissionSession: null,
 					plexConfigured: false,
@@ -167,6 +174,7 @@ describe('+layout.svelte', () => {
 			props: {
 				children: childSnippet,
 				data: {
+					...sharedLayoutData,
 					health: null,
 					transmissionSession: null,
 					plexConfigured: false,
@@ -188,6 +196,7 @@ describe('+layout.svelte', () => {
 			props: {
 				children: (() => {}) as unknown as import('svelte').Snippet,
 				data: {
+					...sharedLayoutData,
 					health: mockHealth,
 					transmissionSession: mockSession,
 					plexConfigured: true,
@@ -212,6 +221,7 @@ describe('+layout.svelte', () => {
 			props: {
 				children: (() => {}) as unknown as import('svelte').Snippet,
 				data: {
+					...sharedLayoutData,
 					health: mockHealth,
 					transmissionSession: mockSession,
 					plexConfigured: true,
@@ -239,6 +249,7 @@ describe('+layout.svelte', () => {
 			props: {
 				children: (() => {}) as unknown as import('svelte').Snippet,
 				data: {
+					...sharedLayoutData,
 					health: mockHealth,
 					transmissionSession: mockSession,
 					plexConfigured: true,

--- a/web/test/routes/movies/movies.test.ts
+++ b/web/test/routes/movies/movies.test.ts
@@ -6,13 +6,19 @@ import type { PageData } from '../../../src/routes/movies/$types';
 
 const sharedLayoutData: Pick<
 	PageData,
-	'health' | 'transmissionSession' | 'plexConfigured' | 'setupState' | 'readinessState'
+	| 'health'
+	| 'transmissionSession'
+	| 'plexConfigured'
+	| 'setupState'
+	| 'readinessState'
+	| 'installHealthState'
 > = {
 	health: null,
 	transmissionSession: null,
 	plexConfigured: false,
 	setupState: 'ready' as const,
-	readinessState: 'ready' as const
+	readinessState: 'ready' as const,
+	installHealthState: null
 };
 
 const mockMovie = (overrides: Partial<MovieBreakdown> = {}): MovieBreakdown => ({

--- a/web/test/routes/onboarding/onboarding.test.ts
+++ b/web/test/routes/onboarding/onboarding.test.ts
@@ -6,7 +6,7 @@ import emptyConfig from '../../../../fixtures/api/config-empty.json';
 import feedOnlyConfig from '../../../../fixtures/api/config-feed-only.json';
 import configWithMovies from '../../../../fixtures/api/config-with-movies.json';
 import configWithTvDefaults from '../../../../fixtures/api/config-with-tv-defaults.json';
-import type { AppConfig } from '$lib/types';
+import type { AppConfig, InstallHealthResponse } from '$lib/types';
 import Page from '../../../src/routes/onboarding/+page.svelte';
 
 const emptyConfigFixture = emptyConfig as AppConfig;
@@ -20,11 +20,39 @@ const sharedLayoutData = {
 	plexConfigured: false,
 	setupState: 'ready' as const,
 	readinessState: 'ready' as const,
+	installHealthState: null,
 	plexAuth: {
 		state: 'not_connected' as const,
 		plexUrl: 'http://localhost:32400',
 		hasToken: false,
 		returnTo: null
+	}
+};
+
+const failingInstallHealth: InstallHealthResponse = {
+	healthy: false,
+	installRoot: '/volume1/pirate-claw',
+	checks: {
+		installRoot: {
+			status: 'pass',
+			remediation: 'No action needed.'
+		},
+		mediaShowsWritable: {
+			status: 'fail',
+			remediation:
+				'Open File Station and create the pirate-claw media shows folder, then map it in Docker.'
+		}
+	}
+};
+
+const passingInstallHealth: InstallHealthResponse = {
+	healthy: true,
+	installRoot: '/volume1/pirate-claw',
+	checks: {
+		installRoot: {
+			status: 'pass',
+			remediation: 'No action needed.'
+		}
 	}
 };
 
@@ -36,6 +64,82 @@ function renderPage(data: Record<string, unknown>) {
 }
 
 describe('/onboarding', () => {
+	it('blocks config onboarding behind failing Synology install health', () => {
+		renderPage({
+			config: {
+				...emptyConfigFixture,
+				runtime: { ...emptyConfigFixture.runtime, installRoot: '/volume1/pirate-claw' }
+			},
+			etag: '"rev-1"',
+			canWrite: true,
+			installHealthState: failingInstallHealth,
+			onboarding: {
+				state: 'initial_empty',
+				hasFeeds: false,
+				hasTvTargets: false,
+				hasMovieTargets: false,
+				minimumComplete: false
+			},
+			error: null
+		});
+
+		expect(screen.getByText('Synology install health')).toBeInTheDocument();
+		expect(screen.getByText('Media Shows Writable')).toBeInTheDocument();
+		expect(screen.getByText(/Open File Station and create/)).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'Re-check' })).toHaveAttribute('href', '/onboarding');
+		expect(screen.queryByText('Step 1 — Verify Transmission')).not.toBeInTheDocument();
+		expect(screen.queryByText('Step 5 — Add your first feed')).not.toBeInTheDocument();
+	});
+
+	it('shows passing Synology install health before config onboarding', () => {
+		renderPage({
+			config: {
+				...emptyConfigFixture,
+				runtime: { ...emptyConfigFixture.runtime, installRoot: '/volume1/pirate-claw' }
+			},
+			etag: '"rev-1"',
+			canWrite: true,
+			installHealthState: passingInstallHealth,
+			onboarding: {
+				state: 'initial_empty',
+				hasFeeds: false,
+				hasTvTargets: false,
+				hasMovieTargets: false,
+				minimumComplete: false
+			},
+			error: null
+		});
+
+		expect(
+			screen.getByText('Synology storage is ready. Continue with Pirate Claw setup.')
+		).toBeInTheDocument();
+		expect(screen.getByText(/All required Synology folders/)).toBeInTheDocument();
+		expect(screen.getByText('Step 5 — Feed type')).toBeInTheDocument();
+	});
+
+	it('does not block non-Synology onboarding when install health is unhealthy', () => {
+		renderPage({
+			config: {
+				...emptyConfigFixture,
+				runtime: { ...emptyConfigFixture.runtime, installRoot: undefined }
+			},
+			etag: '"rev-1"',
+			canWrite: true,
+			installHealthState: failingInstallHealth,
+			onboarding: {
+				state: 'initial_empty',
+				hasFeeds: false,
+				hasTvTargets: false,
+				hasMovieTargets: false,
+				minimumComplete: false
+			},
+			error: null
+		});
+
+		expect(screen.queryByText('Synology install health')).not.toBeInTheDocument();
+		expect(screen.getByText('Step 5 — Feed type')).toBeInTheDocument();
+	});
+
 	it('suppresses the intro alert once the done summary is active', () => {
 		renderPage({
 			config: {

--- a/web/test/routes/shows/[slug]/shows.test.ts
+++ b/web/test/routes/shows/[slug]/shows.test.ts
@@ -6,13 +6,19 @@ import type { PageData } from '../../../../src/routes/shows/[slug]/$types';
 
 const sharedLayoutData: Pick<
 	PageData,
-	'health' | 'transmissionSession' | 'plexConfigured' | 'setupState' | 'readinessState'
+	| 'health'
+	| 'transmissionSession'
+	| 'plexConfigured'
+	| 'setupState'
+	| 'readinessState'
+	| 'installHealthState'
 > = {
 	health: null,
 	transmissionSession: null,
 	plexConfigured: false,
 	setupState: 'ready' as const,
-	readinessState: 'ready' as const
+	readinessState: 'ready' as const,
+	installHealthState: null
 };
 
 const detailShow: ShowBreakdown = {

--- a/web/test/routes/shows/shows.test.ts
+++ b/web/test/routes/shows/shows.test.ts
@@ -8,7 +8,8 @@ const sharedLayoutData = {
 	transmissionSession: null,
 	plexConfigured: false,
 	setupState: 'ready' as const,
-	readinessState: 'ready' as const
+	readinessState: 'ready' as const,
+	installHealthState: null
 };
 
 const exampleShow: ShowBreakdown = {


### PR DESCRIPTION
## Summary

- delivery ticket: \`P27.06 First-Run Health UI\`
- ticket file: [docs/02-delivery/phase-27/ticket-06-first-run-health-ui.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-27/ticket-06-first-run-health-ui.md)
- stacked base branch: \`agents/p27-05-install-health-daemon-endpoint\`
- self-audit: outcome \`clean\` completed at 2026-04-25 13:14 UTC

## [cursor-agent] review findings (2026-04-26, late-arriving)

| Severity | File | Finding | Resolution |
|---|---|---|---|
| ℹ️ Info | `web/src/routes/+layout.server.ts:32` | `/api/setup/install-health` fetched on every layout load; non-Synology sessions pay for work they never surface | **No action** — fetch runs in `Promise.allSettled` so it cannot block; deferred if latency becomes a concern |