### PR TITLE
feat: extract platform-adapters.ts [EE10.05]

### DIFF
--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -1,7 +1,3 @@
-import { existsSync } from 'node:fs';
-import { copyFile, mkdir, readdir } from 'node:fs/promises';
-import { basename, dirname, join, resolve } from 'node:path';
-
 import { getUsage, parseCliArgs, resolveOptionsForCommand } from './cli';
 import { ensureEnvReady as ensureEnvReadyImpl } from './env';
 import {
@@ -19,46 +15,50 @@ import type {
   ReviewOutcome,
   ReviewResult,
   StandaloneAiReviewResult,
-  StandalonePullRequest,
   TicketDefinition,
   TicketState,
 } from './types';
 import {
-  addWorktree as addPlatformWorktree,
-  bootstrapWorktreeIfNeeded as bootstrapPlatformWorktreeIfNeeded,
   copyLocalBootstrapFilesIfPresent as copyPlatformBootstrapFilesIfPresent,
   copyLocalEnvIfPresent as copyPlatformEnvIfPresent,
-  createPullRequest as createPlatformPullRequest,
-  editPullRequest as editPlatformPullRequest,
-  ensureBranchPushed as ensurePlatformBranchPushed,
-  ensureCleanWorktree as ensurePlatformCleanWorktree,
-  fetchOrigin as fetchPlatformOrigin,
-  findOpenPullRequest as findPlatformOpenPullRequest,
   findPrimaryWorktreePath as findPlatformPrimaryWorktreePath,
-  hasMergedPullRequestForBranch as hasPlatformMergedPullRequestForBranch,
   isLocalBranchDocOnly as isPlatformLocalBranchDocOnly,
-  listCommitSubjectsBetween as listPlatformCommitSubjectsBetween,
-  readCommitSubject as readPlatformCommitSubject,
-  readCurrentBranch as readPlatformCurrentBranch,
-  readHeadSha as readPlatformHeadSha,
-  readLatestCommitSubject as readPlatformLatestCommitSubject,
-  readMergeBase as readPlatformMergeBase,
-  rebaseOnto as rebasePlatformOnto,
-  rebaseOntoDefaultBranch as rebasePlatformOntoDefaultBranch,
-  replyToReviewComment as replyPlatformToReviewComment,
-  resolveGitHubRepo as resolvePlatformGitHubRepo,
-  resolveReviewThread as resolvePlatformReviewThread,
-  resolveStandalonePullRequest as resolvePlatformStandalonePullRequest,
-  runProcess as runPlatformProcess,
-  runProcessResult as runPlatformProcessResult,
-  type PullRequestSummary,
   type Runtime,
 } from './platform';
 import {
+  addWorktree,
+  bootstrapWorktreeIfNeeded,
+  createPullRequest,
+  editPullRequest,
+  ensureBranchPushed,
+  ensureCleanWorktree,
+  fetchOrigin,
+  findOpenPullRequest,
+  hasMergedPullRequestForBranch,
+  parsePullRequestNumber,
+  readCommitSubject,
+  readCurrentBranch,
+  readLatestCommitSubject,
+  readMergeBase,
+  rebaseOnto,
+  rebaseOntoDefaultBranch,
+  replyToReviewThreadForOrchestrator,
+  resolveGitHubRepoForOrchestrator,
+  resolveReviewThread,
+  resolveStandalonePullRequest,
+  runProcess,
+  updatePullRequestBody,
+  updateStandalonePullRequestBody,
+} from './platform-adapters';
+import {
   createOptions as createOptionsImpl,
+  deriveBranchName,
   derivePlanKey as derivePlanKeyImpl,
+  deriveWorktreePath,
+  findExistingBranch,
   inferPlanPathFromBranch as inferPlanPathFromBranchImpl,
   parsePlan as parsePlanImpl,
+  relativeToRepo,
   resolvePlanPathForBranch as resolvePlanPathForBranchImpl,
 } from './planning';
 import {
@@ -94,8 +94,6 @@ import {
   buildStandaloneAiReviewSection,
   buildStandaloneReviewStartedEvent,
   mergeStandaloneAiReviewSection,
-  updatePullRequestBody as updatePrMetadataPullRequestBody,
-  updateStandalonePullRequestBody as updateStandalonePrMetadataPullRequestBody,
 } from './pr-metadata';
 import {
   formatAdvanceBoundaryGuidance,
@@ -125,6 +123,7 @@ import {
   canAdvanceTicket,
   findNextPendingTicket,
   findTicketByBranch,
+  materializeTicketContext,
   openPullRequest as openPullRequestImpl,
   recordCodexPreflight as recordCodexPreflightImpl,
   recordPostVerifySelfAudit as recordPostVerifySelfAuditImpl,
@@ -200,11 +199,6 @@ export type {
   TicketStatus,
 } from './types';
 
-type BranchMatch = {
-  branch: string;
-  source: 'ticket-id' | 'derived';
-};
-
 export {
   generateRunDeliverInvocation,
   getOrchestratorConfig,
@@ -227,6 +221,13 @@ export {
   formatStatus,
   resolveEffectiveAdvanceBoundaryMode,
 } from './format';
+export {
+  deriveBranchName,
+  deriveWorktreePath,
+  findExistingBranch,
+} from './planning';
+export { materializeTicketContext } from './ticket-flow';
+export { runProcessResult } from './platform-adapters';
 
 export async function runDeliveryOrchestrator(
   argv: string[],
@@ -645,21 +646,6 @@ export function syncStateFromExisting(
   );
 }
 
-export function deriveBranchName(
-  definition: Pick<TicketDefinition, 'id' | 'slug'>,
-): string {
-  return `agents/${definition.id.toLowerCase().replace('.', '-')}-${definition.slug}`;
-}
-
-export function deriveWorktreePath(cwd: string, ticketId: string): string {
-  const parent = dirname(resolve(cwd));
-  const repoBaseName = basename(resolve(cwd)).replace(/_p\d+(_\d+)?$/, '');
-  return join(
-    parent,
-    `${repoBaseName}_${ticketId.toLowerCase().replace('.', '_')}`,
-  );
-}
-
 export function resolveReviewFetcher(): string {
   if (process.env.AI_CODE_REVIEW_FETCHER) {
     return process.env.AI_CODE_REVIEW_FETCHER;
@@ -743,46 +729,6 @@ export function summarizeStateDifferences(
   return summarizeStateDifferencesImpl(existing, repaired);
 }
 
-export function findExistingBranch(
-  branches: string[],
-  definition: Pick<TicketDefinition, 'id' | 'slug'>,
-): BranchMatch | undefined {
-  const ticketIdToken = definition.id.toLowerCase().replace('.', '-');
-  const ticketIdMatches = branches.filter((branch) => {
-    const normalized = branch.toLowerCase();
-    return (
-      normalized.includes(`/${ticketIdToken}`) ||
-      normalized.includes(`-${ticketIdToken}`) ||
-      normalized.endsWith(ticketIdToken)
-    );
-  });
-
-  if (ticketIdMatches.length > 0) {
-    return {
-      branch: preferDeliveryBranch(ticketIdMatches),
-      source: 'ticket-id',
-    };
-  }
-
-  const derived = deriveBranchName(definition);
-
-  if (branches.includes(derived)) {
-    return {
-      branch: derived,
-      source: 'derived',
-    };
-  }
-
-  return undefined;
-}
-
-function resolveStandalonePullRequest(
-  cwd: string,
-  prNumber?: number,
-): StandalonePullRequest {
-  return resolvePlatformStandalonePullRequest(cwd, _config.runtime, prNumber);
-}
-
 async function startTicket(
   state: DeliveryState,
   cwd: string,
@@ -812,93 +758,6 @@ export async function copyLocalEnvIfPresent(
   targetWorktreePath: string,
 ): Promise<void> {
   await copyPlatformEnvIfPresent(sourceWorktreePath, targetWorktreePath);
-}
-
-function ticketHandoffFileName(ticketId: string): string {
-  return `${ticketId.toLowerCase().replace('.', '-')}-handoff.md`;
-}
-
-async function copyFileIntoWorktree(
-  sourcePath: string,
-  targetPath: string,
-): Promise<void> {
-  if (!existsSync(sourcePath) || resolve(sourcePath) === resolve(targetPath)) {
-    return;
-  }
-
-  await mkdir(dirname(targetPath), { recursive: true });
-  await copyFile(sourcePath, targetPath);
-}
-
-async function copyTicketScopedArtifacts(input: {
-  artifactDirPath: string;
-  artifactNames: Set<string>;
-  sourceWorktreePath: string;
-  targetWorktreePath: string;
-}): Promise<void> {
-  const sourceDir = resolve(input.sourceWorktreePath, input.artifactDirPath);
-  if (!existsSync(sourceDir) || input.artifactNames.size === 0) {
-    return;
-  }
-
-  for (const fileName of await readdir(sourceDir)) {
-    if (!input.artifactNames.has(fileName)) {
-      continue;
-    }
-
-    await copyFileIntoWorktree(
-      resolve(sourceDir, fileName),
-      resolve(input.targetWorktreePath, input.artifactDirPath, fileName),
-    );
-  }
-}
-
-export async function materializeTicketContext(
-  state: DeliveryState,
-  sourceWorktreePath: string,
-  ticketId: string,
-): Promise<void> {
-  const targetIndex = state.tickets.findIndex(
-    (ticket) => ticket.id === ticketId,
-  );
-  const target = targetIndex >= 0 ? state.tickets[targetIndex] : undefined;
-
-  if (!target) {
-    throw new Error(`Unknown ticket ${ticketId}.`);
-  }
-
-  const previous = targetIndex > 0 ? state.tickets[targetIndex - 1] : undefined;
-  await saveStateImpl(target.worktreePath, state);
-
-  const handoffNames = new Set<string>([
-    ticketHandoffFileName(target.id),
-    ...(previous ? [ticketHandoffFileName(previous.id)] : []),
-  ]);
-  const reviewNames = new Set<string>();
-  const scopedTickets = [target, previous].filter(
-    (ticket): ticket is TicketState => ticket !== undefined,
-  );
-  for (const ticket of scopedTickets) {
-    for (const fileName of [
-      `${ticket.id}-ai-review.fetch.json`,
-      `${ticket.id}-ai-review.triage.json`,
-    ]) {
-      reviewNames.add(fileName);
-    }
-  }
-
-  await copyTicketScopedArtifacts({
-    artifactDirPath: state.handoffsDirPath,
-    artifactNames: handoffNames,
-    sourceWorktreePath,
-    targetWorktreePath: target.worktreePath,
-  });
-  await copyTicketScopedArtifacts({
-    artifactDirPath: state.reviewsDirPath,
-    artifactNames: reviewNames,
-    sourceWorktreePath,
-    targetWorktreePath: target.worktreePath,
-  });
 }
 
 export async function recordPostVerifySelfAudit(
@@ -1227,220 +1086,8 @@ async function restackTicket(
   });
 }
 
-function preferDeliveryBranch(branches: string[]): string {
-  return (
-    branches.find((branch) => branch.startsWith('agents/')) ?? branches[0]!
-  );
-}
-
-function updatePullRequestBody(
-  state: DeliveryState,
-  ticket: TicketState,
-): void {
-  return updatePrMetadataPullRequestBody(state, ticket, {
-    editPullRequest,
-    listCommitSubjectsBetween,
-    readHeadSha,
-    resolveGitHubRepo: resolveGitHubRepoForOrchestrator,
-  });
-}
-
-function updateStandalonePullRequestBody(
-  cwd: string,
-  pullRequest: StandalonePullRequest,
-  result: StandaloneAiReviewResult,
-): void {
-  return updateStandalonePrMetadataPullRequestBody(cwd, pullRequest, result, {
-    editPullRequest,
-    listCommitSubjectsBetween,
-    resolveGitHubRepo: resolveGitHubRepoForOrchestrator,
-  });
-}
-
-function resolveGitHubRepoForOrchestrator(cwd: string) {
-  return resolvePlatformGitHubRepo(cwd, _config.runtime);
-}
-
-const REPO_CACHE_BY_WORKTREE = new Map<
-  string,
-  ReturnType<typeof resolveGitHubRepoForOrchestrator>
->();
-
-function replyToReviewThreadForOrchestrator(
-  worktreePath: string,
-  databaseId: number,
-  body: string,
-): void {
-  const cached = REPO_CACHE_BY_WORKTREE.get(worktreePath);
-  const repo =
-    cached ?? resolvePlatformGitHubRepo(worktreePath, _config.runtime);
-  if (!cached) {
-    REPO_CACHE_BY_WORKTREE.set(worktreePath, repo);
-  }
-  if (!repo) {
-    return;
-  }
-
-  try {
-    replyPlatformToReviewComment(
-      worktreePath,
-      repo.owner,
-      repo.name,
-      databaseId,
-      body,
-      _config.runtime,
-    );
-  } catch {
-    // Best-effort; thread resolution still proceeds.
-  }
-}
-
-function findOpenPullRequest(
-  cwd: string,
-  branch: string,
-): PullRequestSummary | undefined {
-  return findPlatformOpenPullRequest(cwd, branch, _config.runtime);
-}
-
-function hasMergedPullRequestForBranch(cwd: string, branch: string): boolean {
-  return hasPlatformMergedPullRequestForBranch(cwd, branch, _config.runtime);
-}
-
-function readLatestCommitSubject(cwd: string): string {
-  return readPlatformLatestCommitSubject(cwd, _config.runtime);
-}
-
-function readCommitSubject(cwd: string, sha: string): string {
-  return readPlatformCommitSubject(cwd, sha, _config.runtime);
-}
-
-function readHeadSha(cwd: string): string {
-  return readPlatformHeadSha(cwd, _config.runtime);
-}
-
-function readCurrentBranch(cwd: string): string {
-  return readPlatformCurrentBranch(cwd, _config.runtime);
-}
-
-function ensureCleanWorktree(cwd: string): void {
-  ensurePlatformCleanWorktree(cwd, _config.runtime);
-}
-
-function ensureBranchPushed(cwd: string, branch: string): void {
-  ensurePlatformBranchPushed(cwd, branch, _config.runtime);
-}
-
-function addWorktree(
-  cwd: string,
-  worktreePath: string,
-  branch: string,
-  baseBranch: string,
-): void {
-  addPlatformWorktree(cwd, worktreePath, branch, baseBranch, _config.runtime);
-}
-
-function createPullRequest(
-  cwd: string,
-  options: {
-    base: string;
-    body: string;
-    head: string;
-    title: string;
-  },
-): string {
-  return createPlatformPullRequest(cwd, options, _config.runtime);
-}
-
-function editPullRequest(
-  cwd: string,
-  prNumber: number,
-  options: {
-    base?: string;
-    body?: string;
-    title?: string;
-  },
-): void {
-  editPlatformPullRequest(cwd, prNumber, options, _config.runtime);
-}
-
-function resolveReviewThread(worktreePath: string, threadId: string): string {
-  return resolvePlatformReviewThread(worktreePath, threadId, _config.runtime);
-}
-
-function fetchOrigin(cwd: string): void {
-  fetchPlatformOrigin(cwd, _config.runtime);
-}
-
-function readMergeBase(
-  cwd: string,
-  branch: string,
-  previousBranch: string,
-): string {
-  return readPlatformMergeBase(cwd, branch, previousBranch, _config.runtime);
-}
-
-function rebaseOnto(cwd: string, rebaseTarget: string, oldBase: string): void {
-  rebasePlatformOnto(cwd, rebaseTarget, oldBase, _config.runtime);
-}
-
-function rebaseOntoDefaultBranch(cwd: string, defaultBranch: string): void {
-  rebasePlatformOntoDefaultBranch(cwd, defaultBranch, _config.runtime);
-}
-
-function listCommitSubjectsBetween(
-  cwd: string,
-  reviewedHeadSha: string,
-  currentHeadSha: string,
-  maxCount: number,
-): string[] {
-  return listPlatformCommitSubjectsBetween(
-    cwd,
-    reviewedHeadSha,
-    currentHeadSha,
-    maxCount,
-    _config.runtime,
-  );
-}
-
-function parsePullRequestNumber(prUrl: string): number {
-  const match = prUrl.match(/\/pull\/(\d+)$/);
-
-  if (!match?.[1]) {
-    throw new Error(`Could not parse PR number from ${prUrl}.`);
-  }
-
-  return Number(match[1]);
-}
-
-function runProcess(cwd: string, cmd: string[]): string {
-  return runPlatformProcess(cwd, cmd, _config.runtime);
-}
-
-export function runProcessResult(
-  cwd: string,
-  cmd: string[],
-): {
-  exitCode: number;
-  stderr: string;
-  stdout: string;
-} {
-  return runPlatformProcessResult(cwd, cmd, _config.runtime);
-}
-
 export function derivePlanKey(planPath: string): string {
   return derivePlanKeyImpl(planPath);
-}
-
-function relativeToRepo(cwd: string, absolutePath: string): string {
-  return resolve(absolutePath).replace(`${resolve(cwd)}/`, '');
-}
-
-async function bootstrapWorktreeIfNeeded(worktreePath: string): Promise<void> {
-  await bootstrapPlatformWorktreeIfNeeded(
-    worktreePath,
-    _config.packageManager,
-    _config.runtime,
-  );
 }
 
 function formatError(error: unknown): string {

--- a/tools/delivery/planning.ts
+++ b/tools/delivery/planning.ts
@@ -188,7 +188,10 @@ export function deriveBranchName(
 
 export function deriveWorktreePath(cwd: string, ticketId: string): string {
   const parent = dirname(resolve(cwd));
-  const repoBaseName = basename(resolve(cwd)).replace(/_(?:p\d+(?:_\d+)?|ee\d+_\d+)$/, '');
+  const repoBaseName = basename(resolve(cwd)).replace(
+    /_(?:p\d+(?:_\d+)?|ee\d+_\d+)$/,
+    '',
+  );
   return join(
     parent,
     `${repoBaseName}_${ticketId.toLowerCase().replace('.', '_')}`,

--- a/tools/delivery/planning.ts
+++ b/tools/delivery/planning.ts
@@ -188,7 +188,7 @@ export function deriveBranchName(
 
 export function deriveWorktreePath(cwd: string, ticketId: string): string {
   const parent = dirname(resolve(cwd));
-  const repoBaseName = basename(resolve(cwd)).replace(/_p\d+(_\d+)?$/, '');
+  const repoBaseName = basename(resolve(cwd)).replace(/_(?:p\d+(?:_\d+)?|ee\d+_\d+)$/, '');
   return join(
     parent,
     `${repoBaseName}_${ticketId.toLowerCase().replace('.', '_')}`,

--- a/tools/delivery/planning.ts
+++ b/tools/delivery/planning.ts
@@ -164,7 +164,7 @@ function normalizeRepoPath(value: string): string {
   return value.replace(/^\.?\//, '');
 }
 
-function relativeToRepo(cwd: string, absolutePath: string): string {
+export function relativeToRepo(cwd: string, absolutePath: string): string {
   return resolve(absolutePath).replace(`${resolve(cwd)}/`, '');
 }
 
@@ -173,4 +173,63 @@ function slugify(value: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
+}
+
+export type BranchMatch = {
+  branch: string;
+  source: 'ticket-id' | 'derived';
+};
+
+export function deriveBranchName(
+  definition: Pick<TicketDefinition, 'id' | 'slug'>,
+): string {
+  return `agents/${definition.id.toLowerCase().replace('.', '-')}-${definition.slug}`;
+}
+
+export function deriveWorktreePath(cwd: string, ticketId: string): string {
+  const parent = dirname(resolve(cwd));
+  const repoBaseName = basename(resolve(cwd)).replace(/_p\d+(_\d+)?$/, '');
+  return join(
+    parent,
+    `${repoBaseName}_${ticketId.toLowerCase().replace('.', '_')}`,
+  );
+}
+
+function preferDeliveryBranch(branches: string[]): string {
+  return (
+    branches.find((branch) => branch.startsWith('agents/')) ?? branches[0]!
+  );
+}
+
+export function findExistingBranch(
+  branches: string[],
+  definition: Pick<TicketDefinition, 'id' | 'slug'>,
+): BranchMatch | undefined {
+  const ticketIdToken = definition.id.toLowerCase().replace('.', '-');
+  const ticketIdMatches = branches.filter((branch) => {
+    const normalized = branch.toLowerCase();
+    return (
+      normalized.includes(`/${ticketIdToken}`) ||
+      normalized.includes(`-${ticketIdToken}`) ||
+      normalized.endsWith(ticketIdToken)
+    );
+  });
+
+  if (ticketIdMatches.length > 0) {
+    return {
+      branch: preferDeliveryBranch(ticketIdMatches),
+      source: 'ticket-id',
+    };
+  }
+
+  const derived = deriveBranchName(definition);
+
+  if (branches.includes(derived)) {
+    return {
+      branch: derived,
+      source: 'derived',
+    };
+  }
+
+  return undefined;
 }

--- a/tools/delivery/platform-adapters.ts
+++ b/tools/delivery/platform-adapters.ts
@@ -186,11 +186,11 @@ export function replyToReviewThreadForOrchestrator(
   const cached = REPO_CACHE_BY_WORKTREE.get(worktreePath);
   const repo =
     cached ?? resolvePlatformGitHubRepo(worktreePath, _config.runtime);
-  if (!cached) {
-    REPO_CACHE_BY_WORKTREE.set(worktreePath, repo);
-  }
   if (!repo) {
     return;
+  }
+  if (!cached) {
+    REPO_CACHE_BY_WORKTREE.set(worktreePath, repo);
   }
 
   try {

--- a/tools/delivery/platform-adapters.ts
+++ b/tools/delivery/platform-adapters.ts
@@ -1,0 +1,261 @@
+import {
+  addWorktree as addPlatformWorktree,
+  bootstrapWorktreeIfNeeded as bootstrapPlatformWorktreeIfNeeded,
+  createPullRequest as createPlatformPullRequest,
+  editPullRequest as editPlatformPullRequest,
+  ensureBranchPushed as ensurePlatformBranchPushed,
+  ensureCleanWorktree as ensurePlatformCleanWorktree,
+  fetchOrigin as fetchPlatformOrigin,
+  findOpenPullRequest as findPlatformOpenPullRequest,
+  hasMergedPullRequestForBranch as hasPlatformMergedPullRequestForBranch,
+  listCommitSubjectsBetween as listPlatformCommitSubjectsBetween,
+  readCommitSubject as readPlatformCommitSubject,
+  readCurrentBranch as readPlatformCurrentBranch,
+  readHeadSha as readPlatformHeadSha,
+  readLatestCommitSubject as readPlatformLatestCommitSubject,
+  readMergeBase as readPlatformMergeBase,
+  rebaseOnto as rebasePlatformOnto,
+  rebaseOntoDefaultBranch as rebasePlatformOntoDefaultBranch,
+  replyToReviewComment as replyPlatformToReviewComment,
+  resolveGitHubRepo as resolvePlatformGitHubRepo,
+  resolveReviewThread as resolvePlatformReviewThread,
+  resolveStandalonePullRequest as resolvePlatformStandalonePullRequest,
+  runProcess as runPlatformProcess,
+  runProcessResult as runPlatformProcessResult,
+  type PullRequestSummary,
+} from './platform';
+import {
+  updatePullRequestBody as updatePrMetadataPullRequestBody,
+  updateStandalonePullRequestBody as updateStandalonePrMetadataPullRequestBody,
+} from './pr-metadata';
+import { _config } from './runtime-config';
+import type {
+  DeliveryState,
+  StandaloneAiReviewResult,
+  StandalonePullRequest,
+  TicketState,
+} from './types';
+
+export function addWorktree(
+  cwd: string,
+  worktreePath: string,
+  branch: string,
+  baseBranch: string,
+): void {
+  addPlatformWorktree(cwd, worktreePath, branch, baseBranch, _config.runtime);
+}
+
+export async function bootstrapWorktreeIfNeeded(
+  worktreePath: string,
+): Promise<void> {
+  await bootstrapPlatformWorktreeIfNeeded(
+    worktreePath,
+    _config.packageManager,
+    _config.runtime,
+  );
+}
+
+export function createPullRequest(
+  cwd: string,
+  options: {
+    base: string;
+    body: string;
+    head: string;
+    title: string;
+  },
+): string {
+  return createPlatformPullRequest(cwd, options, _config.runtime);
+}
+
+export function editPullRequest(
+  cwd: string,
+  prNumber: number,
+  options: {
+    base?: string;
+    body?: string;
+    title?: string;
+  },
+): void {
+  editPlatformPullRequest(cwd, prNumber, options, _config.runtime);
+}
+
+export function ensureBranchPushed(cwd: string, branch: string): void {
+  ensurePlatformBranchPushed(cwd, branch, _config.runtime);
+}
+
+export function ensureCleanWorktree(cwd: string): void {
+  ensurePlatformCleanWorktree(cwd, _config.runtime);
+}
+
+export function fetchOrigin(cwd: string): void {
+  fetchPlatformOrigin(cwd, _config.runtime);
+}
+
+export function findOpenPullRequest(
+  cwd: string,
+  branch: string,
+): PullRequestSummary | undefined {
+  return findPlatformOpenPullRequest(cwd, branch, _config.runtime);
+}
+
+export function hasMergedPullRequestForBranch(
+  cwd: string,
+  branch: string,
+): boolean {
+  return hasPlatformMergedPullRequestForBranch(cwd, branch, _config.runtime);
+}
+
+export function listCommitSubjectsBetween(
+  cwd: string,
+  reviewedHeadSha: string,
+  currentHeadSha: string,
+  maxCount: number,
+): string[] {
+  return listPlatformCommitSubjectsBetween(
+    cwd,
+    reviewedHeadSha,
+    currentHeadSha,
+    maxCount,
+    _config.runtime,
+  );
+}
+
+export function parsePullRequestNumber(prUrl: string): number {
+  const match = prUrl.match(/\/pull\/(\d+)$/);
+
+  if (!match?.[1]) {
+    throw new Error(`Could not parse PR number from ${prUrl}.`);
+  }
+
+  return Number(match[1]);
+}
+
+export function readCommitSubject(cwd: string, sha: string): string {
+  return readPlatformCommitSubject(cwd, sha, _config.runtime);
+}
+
+export function readCurrentBranch(cwd: string): string {
+  return readPlatformCurrentBranch(cwd, _config.runtime);
+}
+
+export function readHeadSha(cwd: string): string {
+  return readPlatformHeadSha(cwd, _config.runtime);
+}
+
+export function readLatestCommitSubject(cwd: string): string {
+  return readPlatformLatestCommitSubject(cwd, _config.runtime);
+}
+
+export function readMergeBase(
+  cwd: string,
+  branch: string,
+  previousBranch: string,
+): string {
+  return readPlatformMergeBase(cwd, branch, previousBranch, _config.runtime);
+}
+
+export function rebaseOnto(
+  cwd: string,
+  rebaseTarget: string,
+  oldBase: string,
+): void {
+  rebasePlatformOnto(cwd, rebaseTarget, oldBase, _config.runtime);
+}
+
+export function rebaseOntoDefaultBranch(
+  cwd: string,
+  defaultBranch: string,
+): void {
+  rebasePlatformOntoDefaultBranch(cwd, defaultBranch, _config.runtime);
+}
+
+export function resolveGitHubRepoForOrchestrator(cwd: string) {
+  return resolvePlatformGitHubRepo(cwd, _config.runtime);
+}
+
+const REPO_CACHE_BY_WORKTREE = new Map<
+  string,
+  ReturnType<typeof resolveGitHubRepoForOrchestrator>
+>();
+
+export function replyToReviewThreadForOrchestrator(
+  worktreePath: string,
+  databaseId: number,
+  body: string,
+): void {
+  const cached = REPO_CACHE_BY_WORKTREE.get(worktreePath);
+  const repo =
+    cached ?? resolvePlatformGitHubRepo(worktreePath, _config.runtime);
+  if (!cached) {
+    REPO_CACHE_BY_WORKTREE.set(worktreePath, repo);
+  }
+  if (!repo) {
+    return;
+  }
+
+  try {
+    replyPlatformToReviewComment(
+      worktreePath,
+      repo.owner,
+      repo.name,
+      databaseId,
+      body,
+      _config.runtime,
+    );
+  } catch {
+    // Best-effort; thread resolution still proceeds.
+  }
+}
+
+export function resolveReviewThread(
+  worktreePath: string,
+  threadId: string,
+): string {
+  return resolvePlatformReviewThread(worktreePath, threadId, _config.runtime);
+}
+
+export function resolveStandalonePullRequest(
+  cwd: string,
+  prNumber?: number,
+): StandalonePullRequest {
+  return resolvePlatformStandalonePullRequest(cwd, _config.runtime, prNumber);
+}
+
+export function runProcess(cwd: string, cmd: string[]): string {
+  return runPlatformProcess(cwd, cmd, _config.runtime);
+}
+
+export function runProcessResult(
+  cwd: string,
+  cmd: string[],
+): {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+} {
+  return runPlatformProcessResult(cwd, cmd, _config.runtime);
+}
+
+export function updatePullRequestBody(
+  state: DeliveryState,
+  ticket: TicketState,
+): void {
+  return updatePrMetadataPullRequestBody(state, ticket, {
+    editPullRequest,
+    listCommitSubjectsBetween,
+    readHeadSha,
+    resolveGitHubRepo: resolveGitHubRepoForOrchestrator,
+  });
+}
+
+export function updateStandalonePullRequestBody(
+  cwd: string,
+  pullRequest: StandalonePullRequest,
+  result: StandaloneAiReviewResult,
+): void {
+  return updateStandalonePrMetadataPullRequestBody(cwd, pullRequest, result, {
+    editPullRequest,
+    listCommitSubjectsBetween,
+    resolveGitHubRepo: resolveGitHubRepoForOrchestrator,
+  });
+}

--- a/tools/delivery/test/orchestrator.test.ts
+++ b/tools/delivery/test/orchestrator.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'bun:test';
-import { existsSync } from 'node:fs';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
 import {
   assertReviewerFacingMarkdown,
@@ -16,16 +15,13 @@ import {
   canAdvanceTicket,
   copyLocalBootstrapFilesIfPresent,
   createOptions,
-  deriveBranchName,
   derivePlanKey,
-  deriveWorktreePath,
   eventsForAdvanceCommand,
   eventsForOpenPrCommand,
   eventsForPollReviewCommand,
   eventsForReconcileLateReviewCommand,
   eventsForRecordReviewCommand,
   eventsForStartCommand,
-  findExistingBranch,
   findTicketByBranch,
   formatNotificationMessage,
   formatReviewWindowMessage,
@@ -58,7 +54,6 @@ import {
   runProcessResult,
   applyAdvanceBoundaryMode,
   formatStatus,
-  materializeTicketContext,
 } from '../orchestrator';
 import type { CodexPreflightOutcome, DeliveryState } from '../types';
 
@@ -69,10 +64,6 @@ async function readArtifactJson(cwd: string, relativePath: string) {
   >;
 }
 
-async function writeFixture(path: string, content: string) {
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, content, 'utf8');
-}
 import { getUsage, parseCliArgs } from '../cli';
 import {
   advanceToNextTicket,
@@ -333,18 +324,6 @@ describe('delivery orchestrator', () => {
     );
   });
 
-  it('derives deterministic branch and worktree names', () => {
-    expect(
-      deriveBranchName({
-        id: 'P2.03',
-        slug: 'readme-and-real-world-config-example',
-      }),
-    ).toBe('agents/p2-03-readme-and-real-world-config-example');
-    expect(deriveWorktreePath('/tmp/pirate_claw', 'P2.03')).toBe(
-      '/tmp/pirate_claw_p2_03',
-    );
-  });
-
   it('derives plan keys from implementation plan directories', () => {
     expect(
       derivePlanKey('docs/02-delivery/phase-03/implementation-plan.md'),
@@ -378,25 +357,6 @@ describe('delivery orchestrator', () => {
         branch: 'refs/heads/agents/ai-code-review-template-boundary',
       },
     ]);
-  });
-
-  it('prefers existing ticket-id branch matches over title-derived names', () => {
-    expect(
-      findExistingBranch(
-        [
-          'agents/p2-02-movie-matcher-missing-codec',
-          'agents/p2-03-readme-config-live-verification',
-          'agents/p2-04-rename-cli-config',
-        ],
-        {
-          id: 'P2.02',
-          slug: 'movie-matcher-allows-missing-codec',
-        },
-      ),
-    ).toEqual({
-      branch: 'agents/p2-02-movie-matcher-missing-codec',
-      source: 'ticket-id',
-    });
   });
 
   it('finds the tracked ticket for the current branch', () => {
@@ -1660,231 +1620,6 @@ describe('delivery orchestrator', () => {
       expect(await readFile(join(targetDir, '.gitignore'), 'utf8')).toBe(
         'node_modules/\n',
       );
-    } finally {
-      await rm(sourceDir, { recursive: true, force: true });
-      await rm(targetDir, { recursive: true, force: true });
-    }
-  });
-
-  it('materializes first-ticket continuation artifacts into the target worktree', async () => {
-    const sourceDir = await mkdtemp(join(tmpdir(), 'orchestrator-source-'));
-    const targetDir = await mkdtemp(join(tmpdir(), 'orchestrator-target-'));
-
-    try {
-      await writeFixture(
-        join(sourceDir, '.agents/delivery/phase-03/handoffs/p3-01-handoff.md'),
-        '# Ticket Handoff\n',
-      );
-
-      const state: DeliveryState = {
-        planKey: 'phase-03',
-        planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
-        statePath: '.agents/delivery/phase-03/state.json',
-        reviewsDirPath: '.agents/delivery/phase-03/reviews',
-        handoffsDirPath: '.agents/delivery/phase-03/handoffs',
-        reviewPollIntervalMinutes: 6,
-        reviewPollMaxWaitMinutes: 12,
-        tickets: [
-          {
-            id: 'P3.01',
-            title: 'First ticket',
-            slug: 'first-ticket',
-            ticketFile: 'docs/ticket-01.md',
-            status: 'in_progress',
-            branch: 'agents/p3-01-first-ticket',
-            baseBranch: 'main',
-            worktreePath: targetDir,
-            handoffPath: '.agents/delivery/phase-03/handoffs/p3-01-handoff.md',
-          },
-        ],
-      };
-
-      await materializeTicketContext(state, sourceDir, 'P3.01');
-
-      expect(
-        await readFile(
-          join(
-            targetDir,
-            '.agents/delivery/phase-03/handoffs/p3-01-handoff.md',
-          ),
-          'utf8',
-        ),
-      ).toBe('# Ticket Handoff\n');
-      expect(
-        JSON.parse(
-          await readFile(
-            join(targetDir, '.agents/delivery/phase-03/state.json'),
-            'utf8',
-          ),
-        ),
-      ).toMatchObject({
-        planKey: 'phase-03',
-        tickets: [{ id: 'P3.01', worktreePath: targetDir }],
-      });
-    } finally {
-      await rm(sourceDir, { recursive: true, force: true });
-      await rm(targetDir, { recursive: true, force: true });
-    }
-  });
-
-  it('materializes only current and predecessor handoff/review artifacts into a started worktree', async () => {
-    const sourceDir = await mkdtemp(join(tmpdir(), 'orchestrator-source-'));
-    const targetDir = await mkdtemp(join(tmpdir(), 'orchestrator-target-'));
-
-    try {
-      await writeFixture(
-        join(sourceDir, '.agents/delivery/phase-03/handoffs/p3-01-handoff.md'),
-        'old\n',
-      );
-      await writeFixture(
-        join(sourceDir, '.agents/delivery/phase-03/handoffs/p3-02-handoff.md'),
-        'prev\n',
-      );
-      await writeFixture(
-        join(sourceDir, '.agents/delivery/phase-03/handoffs/p3-03-handoff.md'),
-        'current\n',
-      );
-      await writeFixture(
-        join(
-          sourceDir,
-          '.agents/delivery/phase-03/reviews/P3.01-ai-review.fetch.json',
-        ),
-        '{"old":true}\n',
-      );
-      await writeFixture(
-        join(
-          sourceDir,
-          '.agents/delivery/phase-03/reviews/P3.02-ai-review.fetch.json',
-        ),
-        '{"prev":true}\n',
-      );
-      await writeFixture(
-        join(
-          sourceDir,
-          '.agents/delivery/phase-03/reviews/P3.02-ai-review.triage.json',
-        ),
-        '{"triage":true}\n',
-      );
-      await writeFixture(
-        join(
-          sourceDir,
-          '.agents/delivery/phase-03/reviews/P3.03-ai-review.fetch.json',
-        ),
-        '{"current":true}\n',
-      );
-      await writeFixture(
-        join(targetDir, '.agents/delivery/phase-03/handoffs/p3-03-handoff.md'),
-        'stale\n',
-      );
-
-      const state: DeliveryState = {
-        planKey: 'phase-03',
-        planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
-        statePath: '.agents/delivery/phase-03/state.json',
-        reviewsDirPath: '.agents/delivery/phase-03/reviews',
-        handoffsDirPath: '.agents/delivery/phase-03/handoffs',
-        reviewPollIntervalMinutes: 6,
-        reviewPollMaxWaitMinutes: 12,
-        tickets: [
-          {
-            id: 'P3.01',
-            title: 'Old ticket',
-            slug: 'old-ticket',
-            ticketFile: 'docs/ticket-01.md',
-            status: 'done',
-            branch: 'agents/p3-01-old-ticket',
-            baseBranch: 'main',
-            worktreePath: '/tmp/p3_01',
-            handoffPath: '.agents/delivery/phase-03/handoffs/p3-01-handoff.md',
-          },
-          {
-            id: 'P3.02',
-            title: 'Previous ticket',
-            slug: 'previous-ticket',
-            ticketFile: 'docs/ticket-02.md',
-            status: 'done',
-            branch: 'agents/p3-02-previous-ticket',
-            baseBranch: 'agents/p3-01-old-ticket',
-            worktreePath: '/tmp/p3_02',
-            handoffPath: '.agents/delivery/phase-03/handoffs/p3-02-handoff.md',
-          },
-          {
-            id: 'P3.03',
-            title: 'Current ticket',
-            slug: 'current-ticket',
-            ticketFile: 'docs/ticket-03.md',
-            status: 'in_progress',
-            branch: 'agents/p3-03-current-ticket',
-            baseBranch: 'agents/p3-02-previous-ticket',
-            worktreePath: targetDir,
-            handoffPath: '.agents/delivery/phase-03/handoffs/p3-03-handoff.md',
-          },
-        ],
-      };
-
-      await materializeTicketContext(state, sourceDir, 'P3.03');
-
-      expect(
-        await readFile(
-          join(
-            targetDir,
-            '.agents/delivery/phase-03/handoffs/p3-02-handoff.md',
-          ),
-          'utf8',
-        ),
-      ).toBe('prev\n');
-      expect(
-        await readFile(
-          join(
-            targetDir,
-            '.agents/delivery/phase-03/handoffs/p3-03-handoff.md',
-          ),
-          'utf8',
-        ),
-      ).toBe('current\n');
-      expect(
-        existsSync(
-          join(
-            targetDir,
-            '.agents/delivery/phase-03/handoffs/p3-01-handoff.md',
-          ),
-        ),
-      ).toBe(false);
-      expect(
-        existsSync(
-          join(
-            targetDir,
-            '.agents/delivery/phase-03/reviews/P3.01-ai-review.fetch.json',
-          ),
-        ),
-      ).toBe(false);
-      expect(
-        await readFile(
-          join(
-            targetDir,
-            '.agents/delivery/phase-03/reviews/P3.02-ai-review.fetch.json',
-          ),
-          'utf8',
-        ),
-      ).toBe('{"prev":true}\n');
-      expect(
-        await readFile(
-          join(
-            targetDir,
-            '.agents/delivery/phase-03/reviews/P3.02-ai-review.triage.json',
-          ),
-          'utf8',
-        ),
-      ).toBe('{"triage":true}\n');
-      expect(
-        await readFile(
-          join(
-            targetDir,
-            '.agents/delivery/phase-03/reviews/P3.03-ai-review.fetch.json',
-          ),
-          'utf8',
-        ),
-      ).toBe('{"current":true}\n');
     } finally {
       await rm(sourceDir, { recursive: true, force: true });
       await rm(targetDir, { recursive: true, force: true });

--- a/tools/delivery/test/planning.test.ts
+++ b/tools/delivery/test/planning.test.ts
@@ -17,6 +17,12 @@ describe('planning', () => {
     expect(deriveWorktreePath('/tmp/pirate_claw', 'P2.03')).toBe(
       '/tmp/pirate_claw_p2_03',
     );
+    expect(deriveWorktreePath('/tmp/pirate_claw_ee10_04', 'EE10.05')).toBe(
+      '/tmp/pirate_claw_ee10_05',
+    );
+    expect(deriveWorktreePath('/tmp/pirate_claw_p2_03', 'P2.04')).toBe(
+      '/tmp/pirate_claw_p2_04',
+    );
   });
 
   it('prefers existing ticket-id branch matches over title-derived names', () => {

--- a/tools/delivery/test/planning.test.ts
+++ b/tools/delivery/test/planning.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  deriveBranchName,
+  deriveWorktreePath,
+  findExistingBranch,
+} from '../planning';
+
+describe('planning', () => {
+  it('derives deterministic branch and worktree names', () => {
+    expect(
+      deriveBranchName({
+        id: 'P2.03',
+        slug: 'readme-and-real-world-config-example',
+      }),
+    ).toBe('agents/p2-03-readme-and-real-world-config-example');
+    expect(deriveWorktreePath('/tmp/pirate_claw', 'P2.03')).toBe(
+      '/tmp/pirate_claw_p2_03',
+    );
+  });
+
+  it('prefers existing ticket-id branch matches over title-derived names', () => {
+    expect(
+      findExistingBranch(
+        [
+          'agents/p2-02-movie-matcher-missing-codec',
+          'agents/p2-03-readme-config-live-verification',
+          'agents/p2-04-rename-cli-config',
+        ],
+        {
+          id: 'P2.02',
+          slug: 'movie-matcher-allows-missing-codec',
+        },
+      ),
+    ).toEqual({
+      branch: 'agents/p2-02-movie-matcher-missing-codec',
+      source: 'ticket-id',
+    });
+  });
+});

--- a/tools/delivery/test/ticket-flow.test.ts
+++ b/tools/delivery/test/ticket-flow.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import type { DeliveryState } from '../types';
+import { materializeTicketContext } from '../ticket-flow';
+
+async function writeFixture(path: string, content: string) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content, 'utf8');
+}
+
+describe('ticket-flow', () => {
+  it('materializes first-ticket continuation artifacts into the target worktree', async () => {
+    const sourceDir = await mkdtemp(join(tmpdir(), 'orchestrator-source-'));
+    const targetDir = await mkdtemp(join(tmpdir(), 'orchestrator-target-'));
+
+    try {
+      await writeFixture(
+        join(sourceDir, '.agents/delivery/phase-03/handoffs/p3-01-handoff.md'),
+        '# Ticket Handoff\n',
+      );
+
+      const state: DeliveryState = {
+        planKey: 'phase-03',
+        planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+        statePath: '.agents/delivery/phase-03/state.json',
+        reviewsDirPath: '.agents/delivery/phase-03/reviews',
+        handoffsDirPath: '.agents/delivery/phase-03/handoffs',
+        reviewPollIntervalMinutes: 6,
+        reviewPollMaxWaitMinutes: 12,
+        tickets: [
+          {
+            id: 'P3.01',
+            title: 'First ticket',
+            slug: 'first-ticket',
+            ticketFile: 'docs/ticket-01.md',
+            status: 'in_progress',
+            branch: 'agents/p3-01-first-ticket',
+            baseBranch: 'main',
+            worktreePath: targetDir,
+            handoffPath: '.agents/delivery/phase-03/handoffs/p3-01-handoff.md',
+          },
+        ],
+      };
+
+      await materializeTicketContext(state, sourceDir, 'P3.01');
+
+      expect(
+        await readFile(
+          join(
+            targetDir,
+            '.agents/delivery/phase-03/handoffs/p3-01-handoff.md',
+          ),
+          'utf8',
+        ),
+      ).toBe('# Ticket Handoff\n');
+      expect(
+        JSON.parse(
+          await readFile(
+            join(targetDir, '.agents/delivery/phase-03/state.json'),
+            'utf8',
+          ),
+        ),
+      ).toMatchObject({
+        planKey: 'phase-03',
+        tickets: [{ id: 'P3.01', worktreePath: targetDir }],
+      });
+    } finally {
+      await rm(sourceDir, { recursive: true, force: true });
+      await rm(targetDir, { recursive: true, force: true });
+    }
+  });
+
+  it('materializes only current and predecessor handoff/review artifacts into a started worktree', async () => {
+    const sourceDir = await mkdtemp(join(tmpdir(), 'orchestrator-source-'));
+    const targetDir = await mkdtemp(join(tmpdir(), 'orchestrator-target-'));
+
+    try {
+      await writeFixture(
+        join(sourceDir, '.agents/delivery/phase-03/handoffs/p3-01-handoff.md'),
+        'old\n',
+      );
+      await writeFixture(
+        join(sourceDir, '.agents/delivery/phase-03/handoffs/p3-02-handoff.md'),
+        'prev\n',
+      );
+      await writeFixture(
+        join(sourceDir, '.agents/delivery/phase-03/handoffs/p3-03-handoff.md'),
+        'current\n',
+      );
+      await writeFixture(
+        join(
+          sourceDir,
+          '.agents/delivery/phase-03/reviews/P3.01-ai-review.fetch.json',
+        ),
+        '{"old":true}\n',
+      );
+      await writeFixture(
+        join(
+          sourceDir,
+          '.agents/delivery/phase-03/reviews/P3.02-ai-review.fetch.json',
+        ),
+        '{"prev":true}\n',
+      );
+      await writeFixture(
+        join(
+          sourceDir,
+          '.agents/delivery/phase-03/reviews/P3.02-ai-review.triage.json',
+        ),
+        '{"triage":true}\n',
+      );
+      await writeFixture(
+        join(
+          sourceDir,
+          '.agents/delivery/phase-03/reviews/P3.03-ai-review.fetch.json',
+        ),
+        '{"current":true}\n',
+      );
+      await writeFixture(
+        join(targetDir, '.agents/delivery/phase-03/handoffs/p3-03-handoff.md'),
+        'stale\n',
+      );
+
+      const state: DeliveryState = {
+        planKey: 'phase-03',
+        planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
+        statePath: '.agents/delivery/phase-03/state.json',
+        reviewsDirPath: '.agents/delivery/phase-03/reviews',
+        handoffsDirPath: '.agents/delivery/phase-03/handoffs',
+        reviewPollIntervalMinutes: 6,
+        reviewPollMaxWaitMinutes: 12,
+        tickets: [
+          {
+            id: 'P3.01',
+            title: 'Old ticket',
+            slug: 'old-ticket',
+            ticketFile: 'docs/ticket-01.md',
+            status: 'done',
+            branch: 'agents/p3-01-old-ticket',
+            baseBranch: 'main',
+            worktreePath: '/tmp/p3_01',
+            handoffPath: '.agents/delivery/phase-03/handoffs/p3-01-handoff.md',
+          },
+          {
+            id: 'P3.02',
+            title: 'Previous ticket',
+            slug: 'previous-ticket',
+            ticketFile: 'docs/ticket-02.md',
+            status: 'done',
+            branch: 'agents/p3-02-previous-ticket',
+            baseBranch: 'agents/p3-01-old-ticket',
+            worktreePath: '/tmp/p3_02',
+            handoffPath: '.agents/delivery/phase-03/handoffs/p3-02-handoff.md',
+          },
+          {
+            id: 'P3.03',
+            title: 'Current ticket',
+            slug: 'current-ticket',
+            ticketFile: 'docs/ticket-03.md',
+            status: 'in_progress',
+            branch: 'agents/p3-03-current-ticket',
+            baseBranch: 'agents/p3-02-previous-ticket',
+            worktreePath: targetDir,
+            handoffPath: '.agents/delivery/phase-03/handoffs/p3-03-handoff.md',
+          },
+        ],
+      };
+
+      await materializeTicketContext(state, sourceDir, 'P3.03');
+
+      expect(
+        await readFile(
+          join(
+            targetDir,
+            '.agents/delivery/phase-03/handoffs/p3-02-handoff.md',
+          ),
+          'utf8',
+        ),
+      ).toBe('prev\n');
+      expect(
+        await readFile(
+          join(
+            targetDir,
+            '.agents/delivery/phase-03/handoffs/p3-03-handoff.md',
+          ),
+          'utf8',
+        ),
+      ).toBe('current\n');
+      expect(
+        existsSync(
+          join(
+            targetDir,
+            '.agents/delivery/phase-03/handoffs/p3-01-handoff.md',
+          ),
+        ),
+      ).toBe(false);
+      expect(
+        existsSync(
+          join(
+            targetDir,
+            '.agents/delivery/phase-03/reviews/P3.01-ai-review.fetch.json',
+          ),
+        ),
+      ).toBe(false);
+      expect(
+        await readFile(
+          join(
+            targetDir,
+            '.agents/delivery/phase-03/reviews/P3.02-ai-review.fetch.json',
+          ),
+          'utf8',
+        ),
+      ).toBe('{"prev":true}\n');
+      expect(
+        await readFile(
+          join(
+            targetDir,
+            '.agents/delivery/phase-03/reviews/P3.02-ai-review.triage.json',
+          ),
+          'utf8',
+        ),
+      ).toBe('{"triage":true}\n');
+      expect(
+        await readFile(
+          join(
+            targetDir,
+            '.agents/delivery/phase-03/reviews/P3.03-ai-review.fetch.json',
+          ),
+          'utf8',
+        ),
+      ).toBe('{"current":true}\n');
+    } finally {
+      await rm(sourceDir, { recursive: true, force: true });
+      await rm(targetDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tools/delivery/ticket-flow.ts
+++ b/tools/delivery/ticket-flow.ts
@@ -4,6 +4,7 @@ import {
   mkdir,
   readFile,
   readdir,
+  unlink,
   writeFile,
 } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
@@ -632,6 +633,15 @@ async function copyTicketScopedArtifacts(input: {
   const sourceDir = resolve(input.sourceWorktreePath, input.artifactDirPath);
   if (!existsSync(sourceDir) || input.artifactNames.size === 0) {
     return;
+  }
+
+  const targetDir = resolve(input.targetWorktreePath, input.artifactDirPath);
+  if (existsSync(targetDir)) {
+    for (const fileName of await readdir(targetDir)) {
+      if (!input.artifactNames.has(fileName)) {
+        await unlink(resolve(targetDir, fileName));
+      }
+    }
   }
 
   for (const fileName of await readdir(sourceDir)) {

--- a/tools/delivery/ticket-flow.ts
+++ b/tools/delivery/ticket-flow.ts
@@ -1,9 +1,16 @@
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import {
+  copyFile,
+  mkdir,
+  readFile,
+  readdir,
+  writeFile,
+} from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
 import type { PullRequestSummary } from './platform';
 import type { ReviewActionCommit } from './pr-metadata';
+import { saveState as saveStateImpl } from './state';
 import type { ReviewPolicyStageValue } from './config';
 import type {
   CodexPreflightOutcome,
@@ -598,6 +605,93 @@ export async function advanceToNextTicket(
       ticket.id === current.id ? { ...ticket, status: 'done' } : ticket,
     ),
   };
+}
+
+function ticketHandoffFileName(ticketId: string): string {
+  return `${ticketId.toLowerCase().replace('.', '-')}-handoff.md`;
+}
+
+async function copyFileIntoWorktree(
+  sourcePath: string,
+  targetPath: string,
+): Promise<void> {
+  if (!existsSync(sourcePath) || resolve(sourcePath) === resolve(targetPath)) {
+    return;
+  }
+
+  await mkdir(dirname(targetPath), { recursive: true });
+  await copyFile(sourcePath, targetPath);
+}
+
+async function copyTicketScopedArtifacts(input: {
+  artifactDirPath: string;
+  artifactNames: Set<string>;
+  sourceWorktreePath: string;
+  targetWorktreePath: string;
+}): Promise<void> {
+  const sourceDir = resolve(input.sourceWorktreePath, input.artifactDirPath);
+  if (!existsSync(sourceDir) || input.artifactNames.size === 0) {
+    return;
+  }
+
+  for (const fileName of await readdir(sourceDir)) {
+    if (!input.artifactNames.has(fileName)) {
+      continue;
+    }
+
+    await copyFileIntoWorktree(
+      resolve(sourceDir, fileName),
+      resolve(input.targetWorktreePath, input.artifactDirPath, fileName),
+    );
+  }
+}
+
+export async function materializeTicketContext(
+  state: DeliveryState,
+  sourceWorktreePath: string,
+  ticketId: string,
+): Promise<void> {
+  const targetIndex = state.tickets.findIndex(
+    (ticket) => ticket.id === ticketId,
+  );
+  const target = targetIndex >= 0 ? state.tickets[targetIndex] : undefined;
+
+  if (!target) {
+    throw new Error(`Unknown ticket ${ticketId}.`);
+  }
+
+  const previous = targetIndex > 0 ? state.tickets[targetIndex - 1] : undefined;
+  await saveStateImpl(target.worktreePath, state);
+
+  const handoffNames = new Set<string>([
+    ticketHandoffFileName(target.id),
+    ...(previous ? [ticketHandoffFileName(previous.id)] : []),
+  ]);
+  const reviewNames = new Set<string>();
+  const scopedTickets = [target, previous].filter(
+    (ticket): ticket is TicketState => ticket !== undefined,
+  );
+  for (const ticket of scopedTickets) {
+    for (const fileName of [
+      `${ticket.id}-ai-review.fetch.json`,
+      `${ticket.id}-ai-review.triage.json`,
+    ]) {
+      reviewNames.add(fileName);
+    }
+  }
+
+  await copyTicketScopedArtifacts({
+    artifactDirPath: state.handoffsDirPath,
+    artifactNames: handoffNames,
+    sourceWorktreePath,
+    targetWorktreePath: target.worktreePath,
+  });
+  await copyTicketScopedArtifacts({
+    artifactDirPath: state.reviewsDirPath,
+    artifactNames: reviewNames,
+    sourceWorktreePath,
+    targetWorktreePath: target.worktreePath,
+  });
 }
 
 export function restackTicket(


### PR DESCRIPTION
## Summary

- delivery ticket: \`EE10.05 Extract platform-adapters.ts\`
- ticket file: [docs/02-delivery/engineering-epic-10/ticket-05-extract-platform-adapters.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/engineering-epic-10/ticket-05-extract-platform-adapters.md)
- stacked base branch: \`agents/ee10-04-extract-format-ts\`
- self-audit: outcome \`clean\` completed at 2026-04-26 07:19 UTC

## CodeRabbit review findings (2026-04-26, late-arriving)

All three findings were patched in commit 94e17b0 / 948d1b2.

| Severity | File | Finding | Resolution |
|---|---|---|---|
| 🟠 Major | `planning.ts:191` | `deriveWorktreePath` only stripped `_p*` suffixes; EE worktrees accumulated prior ticket IDs | Regex updated to also strip `_ee\d+_\d+` suffix; test cases added |
| 🟡 Minor | `platform-adapters.ts:189` | Failed repo lookups (`undefined`) were cached, permanently silencing retries | Cache write moved after the `!repo` guard |
| 🟠 Major | `ticket-flow.ts:632` | `copyTicketScopedArtifacts` left stale handoff/review files in a reused worktree | Added pre-copy purge of non-allowlisted files from target dir |