### PR TITLE
refactor: add delivery context foundation [EE11.01]

### DIFF
--- a/docs/02-delivery/engineering-epic-11/ticket-01-context-foundation.md
+++ b/docs/02-delivery/engineering-epic-11/ticket-01-context-foundation.md
@@ -52,10 +52,18 @@ the resolved config. Use existing config fixtures where practical.
 
 ## Rationale
 
-Red first:
+Red first: `bun test ./tools/delivery/test/context.test.ts` initially failed
+before the path was passed with `./`; after adding the context module, the
+focused context tests prove the new factory derives invocation text and exposes
+only the intended top-level context keys.
 
-Why this path:
+Why this path: a focused `context.ts` keeps EE11.01 additive and reviewable
+without migrating existing singleton-backed call sites before the factory shape
+is settled.
 
-Alternative considered:
+Alternative considered: placing the context type in `runtime-config.ts`, but
+that would blur config loading with runtime dependency assembly and make later
+singleton removal harder to review.
 
-Deferred:
+Deferred: broad caller migration, platform adapter factory changes, formatter
+config threading, and singleton removal remain in later EE11 tickets.

--- a/tools/delivery/context.ts
+++ b/tools/delivery/context.ts
@@ -1,0 +1,21 @@
+import * as platformAdapters from './platform-adapters';
+import { generateRunDeliverInvocation } from './runtime-config';
+import type { ResolvedOrchestratorConfig } from './runtime-config';
+
+export type PlatformAdapters = typeof platformAdapters;
+
+export type DeliveryOrchestratorContext = {
+  config: ResolvedOrchestratorConfig;
+  invocation: string;
+  platform: PlatformAdapters;
+};
+
+export function createDeliveryOrchestratorContext(
+  config: ResolvedOrchestratorConfig,
+): DeliveryOrchestratorContext {
+  return {
+    config,
+    invocation: generateRunDeliverInvocation(config.packageManager),
+    platform: platformAdapters,
+  };
+}

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -1,4 +1,6 @@
 export { parseGitWorktreeList } from './platform';
+export { createDeliveryOrchestratorContext } from './context';
+export type { DeliveryOrchestratorContext, PlatformAdapters } from './context';
 export {
   assertReviewerFacingMarkdown,
   buildExternalAiReviewSection,

--- a/tools/delivery/test/context.test.ts
+++ b/tools/delivery/test/context.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  createDeliveryOrchestratorContext,
+  type DeliveryOrchestratorContext,
+} from '../context';
+import type { ResolvedOrchestratorConfig } from '../runtime-config';
+
+const baseConfig: ResolvedOrchestratorConfig = {
+  defaultBranch: 'main',
+  planRoot: 'docs',
+  runtime: 'bun',
+  packageManager: 'bun',
+  ticketBoundaryMode: 'cook',
+  reviewPolicy: {
+    selfAudit: 'skip_doc_only',
+    codexPreflight: 'disabled',
+    externalReview: 'disabled',
+  },
+};
+
+describe('delivery orchestrator context', () => {
+  it('carries only resolved config, invocation, and platform adapters', () => {
+    const context = createDeliveryOrchestratorContext(baseConfig);
+
+    expect(Object.keys(context).sort()).toEqual([
+      'config',
+      'invocation',
+      'platform',
+    ]);
+    expect(context.config).toBe(baseConfig);
+    expect(context.invocation).toBe('bun run deliver');
+    expect(context.platform.runProcessResult).toBeFunction();
+  });
+
+  it('derives npm invocation with the script argument separator', () => {
+    const context = createDeliveryOrchestratorContext({
+      ...baseConfig,
+      packageManager: 'npm',
+    });
+
+    expect(context.invocation).toBe('npm run deliver --');
+  });
+
+  it('exposes the canonical context type', () => {
+    const context: DeliveryOrchestratorContext =
+      createDeliveryOrchestratorContext(baseConfig);
+
+    expect(context.config.packageManager).toBe('bun');
+  });
+});


### PR DESCRIPTION
## Summary

- delivery ticket: `EE11.01 Context foundation`
- ticket file: [docs/02-delivery/engineering-epic-11/ticket-01-context-foundation.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/engineering-epic-11/ticket-01-context-foundation.md)
- stacked base branch: `main`
- self-audit: outcome `clean` completed at 2026-04-27 06:26 UTC
