### PR TITLE
P27.09: Onboarding UX Follow-up

### DIFF
--- a/web/src/routes/onboarding/+page.server.ts
+++ b/web/src/routes/onboarding/+page.server.ts
@@ -424,17 +424,17 @@ export const actions: Actions = {
 			return fail(403, { reapplyMessage: 'Config writes are disabled.' });
 		}
 
-		const configResponse = await apiRequest('/api/config');
-		if (!configResponse.ok) {
-			return fail(500, { reapplyMessage: 'Could not load config.' });
-		}
-		const config = (await configResponse.json()) as AppConfig;
-		const etag = configResponse.headers.get('etag');
-		if (!etag) {
-			return fail(500, { reapplyMessage: 'Missing config revision.' });
-		}
-
 		try {
+			const configResponse = await apiRequest('/api/config');
+			if (!configResponse.ok) {
+				return fail(500, { reapplyMessage: 'Could not load config.' });
+			}
+			const config = (await configResponse.json()) as AppConfig;
+			const etag = configResponse.headers.get('etag');
+			if (!etag) {
+				return fail(500, { reapplyMessage: 'Missing config revision.' });
+			}
+
 			const response = await apiRequest('/api/config/feeds', {
 				method: 'PUT',
 				headers: {
@@ -456,7 +456,7 @@ export const actions: Actions = {
 				return fail(response.status, { reapplyMessage });
 			}
 
-			return { reapplySuccess: true };
+			return { reapplySuccess: true, reapplyMessage: 'Config re-applied successfully.' };
 		} catch (error) {
 			console.error('[onboarding] reapplyConfig failed:', error);
 			return fail(500, { reapplyMessage: 'Could not re-apply config.' });

--- a/web/src/routes/onboarding/+page.server.ts
+++ b/web/src/routes/onboarding/+page.server.ts
@@ -416,5 +416,50 @@ export const actions: Actions = {
 			console.error('[onboarding] saveDownloadDirs failed:', error);
 			return fail(500, { downloadDirsMessage: 'Could not save download directories.' });
 		}
+	},
+
+	reapplyConfig: async () => {
+		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+		if (!writeToken) {
+			return fail(403, { reapplyMessage: 'Config writes are disabled.' });
+		}
+
+		const configResponse = await apiRequest('/api/config');
+		if (!configResponse.ok) {
+			return fail(500, { reapplyMessage: 'Could not load config.' });
+		}
+		const config = (await configResponse.json()) as AppConfig;
+		const etag = configResponse.headers.get('etag');
+		if (!etag) {
+			return fail(500, { reapplyMessage: 'Missing config revision.' });
+		}
+
+		try {
+			const response = await apiRequest('/api/config/feeds', {
+				method: 'PUT',
+				headers: {
+					'content-type': 'application/json',
+					authorization: `Bearer ${writeToken}`,
+					'if-match': etag
+				},
+				body: JSON.stringify(config.feeds ?? [])
+			});
+
+			if (!response.ok) {
+				let reapplyMessage = `Re-apply failed (${response.status}).`;
+				try {
+					const body = (await response.json()) as { error?: string };
+					if (body.error) reapplyMessage = body.error;
+				} catch {
+					// keep fallback
+				}
+				return fail(response.status, { reapplyMessage });
+			}
+
+			return { reapplySuccess: true };
+		} catch (error) {
+			console.error('[onboarding] reapplyConfig failed:', error);
+			return fail(500, { reapplyMessage: 'Could not re-apply config.' });
+		}
 	}
 };

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -229,6 +229,7 @@
 		Stand up Pirate Claw with the minimum viable config, then continue in the dashboard for deeper
 		tuning.
 	</p>
+	<a href="/" class="text-muted-foreground text-sm hover:underline">← Back to dashboard</a>
 </section>
 
 {#if data.error}
@@ -1005,6 +1006,28 @@
 							Review Config
 						</a>
 					</div>
+
+					{#if readinessState !== 'ready' && readinessState !== 'ready_pending_restart'}
+						<div class="border-border/60 bg-background/40 rounded-xl border p-4">
+							<p class="text-muted-foreground text-sm">
+								Setup looks complete but readiness is stuck. Re-apply your config to clear the
+								state.
+							</p>
+							<form method="POST" action="?/reapplyConfig" class="mt-3">
+								<button
+									type="submit"
+									class="border-border bg-background/55 hover:bg-muted/80 inline-flex h-9 items-center rounded-xl border px-4 text-sm transition-colors"
+								>
+									Re-apply config
+								</button>
+							</form>
+							{#if (form as { reapplyMessage?: string } | undefined)?.reapplyMessage}
+								<p class="text-muted-foreground mt-2 text-xs">
+									{(form as { reapplyMessage?: string }).reapplyMessage}
+								</p>
+							{/if}
+						</div>
+					{/if}
 				</div>
 			{:else if showPreStepsDone && !(data.onboarding?.hasTvTargets ?? false) && !(data.onboarding?.hasMovieTargets ?? false)}
 				<Alert

--- a/web/src/routes/onboarding/+page.svelte
+++ b/web/src/routes/onboarding/+page.svelte
@@ -115,6 +115,7 @@
 
 	let readinessState = $state<ReadinessState>('not_ready');
 	let readinessInterval: ReturnType<typeof setInterval> | undefined;
+	let pollCount = $state(0);
 
 	$effect(() => {
 		if (!showDoneStep) return;
@@ -126,6 +127,7 @@
 				if (res.ok) {
 					const json = (await res.json()) as { state: ReadinessState };
 					readinessState = json.state;
+					pollCount++;
 					if (json.state === 'ready' && readinessInterval !== undefined) {
 						clearInterval(readinessInterval);
 						readinessInterval = undefined;
@@ -1007,7 +1009,7 @@
 						</a>
 					</div>
 
-					{#if readinessState !== 'ready' && readinessState !== 'ready_pending_restart'}
+					{#if pollCount > 0 && readinessState !== 'ready' && readinessState !== 'ready_pending_restart'}
 						<div class="border-border/60 bg-background/40 rounded-xl border p-4">
 							<p class="text-muted-foreground text-sm">
 								Setup looks complete but readiness is stuck. Re-apply your config to clear the
@@ -1021,7 +1023,12 @@
 									Re-apply config
 								</button>
 							</form>
-							{#if (form as { reapplyMessage?: string } | undefined)?.reapplyMessage}
+							{#if (form as { reapplySuccess?: boolean; reapplyMessage?: string } | undefined)?.reapplySuccess}
+								<p class="text-muted-foreground mt-2 text-xs">
+									{(form as { reapplyMessage?: string }).reapplyMessage ??
+										'Config re-applied successfully.'}
+								</p>
+							{:else if (form as { reapplyMessage?: string } | undefined)?.reapplyMessage}
 								<p class="text-muted-foreground mt-2 text-xs">
 									{(form as { reapplyMessage?: string }).reapplyMessage}
 								</p>

--- a/web/src/routes/plex/connect/callback/+page.svelte
+++ b/web/src/routes/plex/connect/callback/+page.svelte
@@ -1,8 +1,17 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import { Button } from '$lib/components/ui/button';
 	import type { PageData } from './$types';
 
 	const { data }: { data: PageData } = $props();
+
+	$effect(() => {
+		if (!browser || !data.ok) return;
+		const timer = setTimeout(() => {
+			window.location.href = data.returnTo ?? '/config';
+		}, 2000);
+		return () => clearTimeout(timer);
+	});
 </script>
 
 <svelte:head>
@@ -20,7 +29,12 @@
 		</p>
 		<h1 class="text-foreground text-3xl font-semibold">Plex Browser Auth</h1>
 		<p class="text-muted-foreground text-sm">{data.message}</p>
+		{#if data.ok}
+			<p class="text-muted-foreground text-xs">Redirecting automatically…</p>
+		{/if}
 	</div>
 
-	<Button href={data.returnTo ?? '/config'}>Return to settings</Button>
+	<Button href={data.returnTo ?? '/config'}
+		>{data.returnTo === '/onboarding' ? 'Continue setup' : 'Return to settings'}</Button
+	>
 </div>


### PR DESCRIPTION
## Summary

- delivery ticket: `P27.09 Onboarding UX Follow-up`
- ticket file: [docs/02-delivery/phase-27/ticket-09-onboarding-ux-followup.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-27/ticket-09-onboarding-ux-followup.md)
- stacked base branch: `agents/p27-08-exit-validation-and-screenshots`

## External AI Review

- outcome: `clean` (post CodeRabbit late findings — patched)
- current branch head: [`9ce5453`](https://github.com/cesarnml/Pirate-Claw/commit/9ce5453)
- CodeRabbit findings triaged and applied (2 issues fixed, 2 threads resolved)

### CodeRabbit Findings Applied

| Severity | Issue | Fix |
|----------|-------|-----|
| 🟠 Major | `reapplyConfig` config fetch outside `try/catch` — unhandled 500 on network hiccup | Moved `apiRequest('/api/config')`, `.json()`, and etag check inside the existing `try` block; added `reapplyMessage` on success path |
| 🟡 Minor | Stuck-readiness panel flashes on first paint; reapply success is silent | Gated panel on `pollCount > 0` (first poll complete); added success branch that renders `reapplyMessage` when `reapplySuccess` is true |