### PR TITLE
refactor: pass formatter config explicitly [EE11.03]

### DIFF
--- a/docs/02-delivery/engineering-epic-11/ticket-03-explicit-formatter-config.md
+++ b/docs/02-delivery/engineering-epic-11/ticket-03-explicit-formatter-config.md
@@ -49,10 +49,17 @@ output unchanged unless a test only encoded previous singleton setup mechanics.
 
 ## Rationale
 
-Red first:
+Red first: direct formatter, ticket-flow, and orchestrator tests were updated to
+pass explicit config values before the full `verify:quiet` gate. The formatter
+module now has no `_config` import to satisfy the ticket's hidden-state check.
 
-Why this path:
+Why this path: passing `ResolvedOrchestratorConfig` directly keeps formatter
+functions as pure string renderers while preserving existing terminal output and
+avoiding a broader CLI command-context migration before EE11.04.
 
-Alternative considered:
+Alternative considered: passing the full delivery context everywhere, but the
+formatters only need config values today, so taking the narrower dependency
+keeps this ticket smaller and makes future context threading mechanical.
 
-Deferred:
+Deferred: command helper splitting and full context ownership remain in EE11.04;
+final singleton export removal remains in EE11.05.

--- a/tools/delivery/cli-runner.ts
+++ b/tools/delivery/cli-runner.ts
@@ -163,7 +163,7 @@ export async function runDeliveryOrchestrator(
     if (parsed.command === 'repair-state') {
       const repaired = await repairState(cwd, options);
       console.log(
-        [formatStatus(repaired.state), formatRepairSummary(repaired)]
+        [formatStatus(repaired.state, _config), formatRepairSummary(repaired)]
           .filter(Boolean)
           .join('\n\n'),
       );
@@ -175,17 +175,17 @@ export async function runDeliveryOrchestrator(
     switch (parsed.command) {
       case 'sync': {
         await saveState(cwd, state);
-        console.log(formatStatus(state));
+        console.log(formatStatus(state, _config));
         return 0;
       }
       case 'status': {
-        console.log(formatStatus(state));
+        console.log(formatStatus(state, _config));
         return 0;
       }
       case 'start': {
         const nextState = await startTicket(state, cwd, parsed.positionals[0]);
         await saveState(cwd, nextState);
-        console.log(formatStatus(nextState));
+        console.log(formatStatus(nextState, _config));
         await emitNotificationWarnings(
           notifier,
           cwd,
@@ -230,7 +230,7 @@ export async function runDeliveryOrchestrator(
           auditPatchCommits,
         );
         await saveState(cwd, nextState);
-        console.log(formatStatus(nextState));
+        console.log(formatStatus(nextState, _config));
         return 0;
       }
       case 'codex-preflight': {
@@ -286,7 +286,7 @@ export async function runDeliveryOrchestrator(
           console.log('Doc-only ticket — Codex preflight auto-skipped.');
         }
         await saveState(cwd, nextState);
-        console.log(formatStatus(nextState));
+        console.log(formatStatus(nextState, _config));
         return 0;
       }
       case 'open-pr': {
@@ -298,7 +298,7 @@ export async function runDeliveryOrchestrator(
         await saveState(cwd, nextState);
         console.log(
           [
-            formatStatus(nextState),
+            formatStatus(nextState, _config),
             formatReviewWindowMessage(nextState, parsed.positionals[0]),
           ]
             .filter(Boolean)
@@ -341,7 +341,9 @@ export async function runDeliveryOrchestrator(
             skipNote,
           );
           await saveState(cwd, docOnlyState);
-          console.log(formatCurrentTicketStatus(docOnlyState, pollTicketId));
+          console.log(
+            formatCurrentTicketStatus(docOnlyState, _config, pollTicketId),
+          );
           await emitNotificationWarnings(
             notifier,
             cwd,
@@ -352,7 +354,9 @@ export async function runDeliveryOrchestrator(
 
         const nextState = await pollReview(state, cwd, pollTicketId);
         await saveState(cwd, nextState);
-        console.log(formatCurrentTicketStatus(nextState, pollTicketId));
+        console.log(
+          formatCurrentTicketStatus(nextState, _config, pollTicketId),
+        );
         await emitNotificationWarnings(
           notifier,
           cwd,
@@ -371,7 +375,7 @@ export async function runDeliveryOrchestrator(
 
         const nextState = await reconcileLateReview(state, cwd, ticketId);
         await saveState(cwd, nextState);
-        console.log(formatStatus(nextState));
+        console.log(formatStatus(nextState, _config));
         await emitNotificationWarnings(
           notifier,
           cwd,
@@ -401,7 +405,7 @@ export async function runDeliveryOrchestrator(
           noteParts.join(' ').trim() || undefined,
         );
         await saveState(cwd, nextState);
-        console.log(formatStatus(nextState));
+        console.log(formatStatus(nextState, _config));
         await emitNotificationWarnings(
           notifier,
           cwd,
@@ -417,11 +421,12 @@ export async function runDeliveryOrchestrator(
           cwd,
         );
         await saveState(cwd, nextState);
-        console.log(formatStatus(nextState));
+        console.log(formatStatus(nextState, _config));
         const boundaryGuidance = formatAdvanceBoundaryGuidance(
           state,
           advancedState,
           nextState,
+          _config,
         );
 
         if (boundaryGuidance) {
@@ -443,7 +448,7 @@ export async function runDeliveryOrchestrator(
           parsed.positionals[0],
         );
         await saveState(cwd, nextState);
-        console.log(formatStatus(nextState));
+        console.log(formatStatus(nextState, _config));
         return 0;
       }
       default: {

--- a/tools/delivery/closeout-stack.ts
+++ b/tools/delivery/closeout-stack.ts
@@ -9,6 +9,7 @@ import {
   resolveOrchestratorConfig,
   saveState,
 } from './orchestrator';
+import type { ResolvedOrchestratorConfig } from './runtime-config';
 import type { DeliveryState, TicketState } from './types';
 
 type CloseoutStackArgs = {
@@ -294,8 +295,9 @@ function closePullRequest(
 function formatCloseoutSummary(
   summary: CloseoutSummary,
   state: DeliveryState,
+  config: ResolvedOrchestratorConfig,
 ): string {
-  const lines = [formatStatus(state), '', 'Stacked Closeout Summary'];
+  const lines = [formatStatus(state, config), '', 'Stacked Closeout Summary'];
 
   for (const merged of summary.merged) {
     const via =
@@ -430,7 +432,7 @@ export async function runCloseoutStack(
     }
 
     await saveState(cwd, state);
-    console.log(formatCloseoutSummary(summary, state));
+    console.log(formatCloseoutSummary(summary, state, config));
     return 0;
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));

--- a/tools/delivery/format.ts
+++ b/tools/delivery/format.ts
@@ -1,8 +1,9 @@
 import { resolve } from 'node:path';
 
 import { readReviewArtifacts } from './review-artifacts';
-import { _config, generateRunDeliverInvocation } from './runtime-config';
+import { generateRunDeliverInvocation } from './runtime-config';
 import type { TicketBoundaryMode } from './config';
+import type { ResolvedOrchestratorConfig } from './runtime-config';
 import type {
   AiReviewComment,
   AiReviewThreadResolution,
@@ -63,7 +64,10 @@ function loadTicketReviewSnapshot(ticket: TicketState): {
   };
 }
 
-export function formatStatus(state: DeliveryState): string {
+export function formatStatus(
+  state: DeliveryState,
+  config: ResolvedOrchestratorConfig,
+): string {
   return [
     'Delivery Orchestrator',
     `plan_key=${state.planKey}`,
@@ -72,8 +76,8 @@ export function formatStatus(state: DeliveryState): string {
     `handoffs=${state.handoffsDirPath}`,
     `review_poll_interval_minutes=${state.reviewPollIntervalMinutes}`,
     `review_poll_max_wait_minutes=${state.reviewPollMaxWaitMinutes}`,
-    `boundary_mode=${_config.ticketBoundaryMode}`,
-    `review_policy=selfAudit:${_config.reviewPolicy.selfAudit} codexPreflight:${_config.reviewPolicy.codexPreflight} externalReview:${_config.reviewPolicy.externalReview}`,
+    `boundary_mode=${config.ticketBoundaryMode}`,
+    `review_policy=selfAudit:${config.reviewPolicy.selfAudit} codexPreflight:${config.reviewPolicy.codexPreflight} externalReview:${config.reviewPolicy.externalReview}`,
     '',
     ...state.tickets.map((ticket) =>
       [
@@ -111,6 +115,7 @@ export function formatAdvanceBoundaryGuidance(
   state: DeliveryState,
   advancedState: DeliveryState,
   nextState: DeliveryState,
+  config: ResolvedOrchestratorConfig,
 ): string | undefined {
   const nextPending = advancedState.tickets.find(
     (t) =>
@@ -128,9 +133,9 @@ export function formatAdvanceBoundaryGuidance(
   }
 
   const effectiveMode = resolveEffectiveAdvanceBoundaryMode(
-    _config.ticketBoundaryMode,
+    config.ticketBoundaryMode,
   );
-  const invocation = `${generateRunDeliverInvocation(_config.packageManager)} --plan ${state.planPath} start`;
+  const invocation = `${generateRunDeliverInvocation(config.packageManager)} --plan ${state.planPath} start`;
   const resumePrompt = `Immediately execute \`${invocation}\`, read the locally materialized handoff artifact in the started worktree as the source of truth for context, and implement ${nextPending.id}.`;
 
   if (effectiveMode === 'cook') {
@@ -162,11 +167,11 @@ export function formatAdvanceBoundaryGuidance(
 
   return [
     'context_reset_required=true',
-    _config.ticketBoundaryMode === 'glide' ? 'glide_fallback=gated' : undefined,
-    _config.ticketBoundaryMode === 'glide'
+    config.ticketBoundaryMode === 'glide' ? 'glide_fallback=gated' : undefined,
+    config.ticketBoundaryMode === 'glide'
       ? `GLIDE FALLBACK before starting ${nextPending.id}.`
       : `GATED BOUNDARY before starting ${nextPending.id}.`,
-    _config.ticketBoundaryMode === 'glide'
+    config.ticketBoundaryMode === 'glide'
       ? 'Host/runtime self-reset is not supported here, so Son-of-Anton is using gated boundary behavior instead.'
       : undefined,
     'Reset context now. Prefer /clear for minimum token use; use /compact only if you intentionally want compressed carry-forward context.',
@@ -178,6 +183,7 @@ export function formatAdvanceBoundaryGuidance(
 
 export function formatCurrentTicketStatus(
   state: DeliveryState,
+  config: ResolvedOrchestratorConfig,
   ticketId?: string,
 ): string {
   const ticket =
@@ -192,7 +198,7 @@ export function formatCurrentTicketStatus(
     'Delivery Orchestrator',
     `plan_key=${state.planKey}`,
     `plan=${state.planPath}`,
-    `boundary_mode=${_config.ticketBoundaryMode}`,
+    `boundary_mode=${config.ticketBoundaryMode}`,
   ].join('\n');
 
   if (!ticket) {

--- a/tools/delivery/test/format.test.ts
+++ b/tools/delivery/test/format.test.ts
@@ -1,12 +1,25 @@
 import { describe, expect, it } from 'bun:test';
 
-import { initOrchestratorConfig } from '../orchestrator';
 import {
   formatAdvanceBoundaryGuidance,
   formatCurrentTicketStatus,
   resolveEffectiveAdvanceBoundaryMode,
 } from '../format';
+import type { ResolvedOrchestratorConfig } from '../runtime-config';
 import type { DeliveryState } from '../types';
+
+const baseConfig: ResolvedOrchestratorConfig = {
+  defaultBranch: 'main',
+  planRoot: 'docs',
+  runtime: 'bun',
+  packageManager: 'bun',
+  ticketBoundaryMode: 'cook',
+  reviewPolicy: {
+    selfAudit: 'skip_doc_only',
+    codexPreflight: 'skip_doc_only',
+    externalReview: 'skip_doc_only',
+  },
+};
 
 describe('formatAdvanceBoundaryGuidance (EE7 boundary output)', () => {
   const baseState: DeliveryState = {
@@ -52,18 +65,16 @@ describe('formatAdvanceBoundaryGuidance (EE7 boundary output)', () => {
   };
 
   it('emits gated reset guidance and the canonical resume prompt', () => {
-    initOrchestratorConfig({
-      defaultBranch: 'main',
-      planRoot: 'docs',
-      runtime: 'bun',
-      packageManager: 'bun',
+    const config: ResolvedOrchestratorConfig = {
+      ...baseConfig,
       ticketBoundaryMode: 'gated',
-    });
+    };
 
     const output = formatAdvanceBoundaryGuidance(
       baseState,
       advancedState,
       advancedState,
+      config,
     );
 
     expect(output).toContain('context_reset_required=true');
@@ -75,13 +86,10 @@ describe('formatAdvanceBoundaryGuidance (EE7 boundary output)', () => {
   });
 
   it('emits cook continuation guidance with the next worktree and absolute handoff path', () => {
-    initOrchestratorConfig({
-      defaultBranch: 'main',
-      planRoot: 'docs',
-      runtime: 'bun',
-      packageManager: 'bun',
+    const config: ResolvedOrchestratorConfig = {
+      ...baseConfig,
       ticketBoundaryMode: 'cook',
-    });
+    };
 
     const nextState: DeliveryState = {
       ...advancedState,
@@ -101,6 +109,7 @@ describe('formatAdvanceBoundaryGuidance (EE7 boundary output)', () => {
       baseState,
       advancedState,
       nextState,
+      config,
     );
 
     expect(output).toContain('continuation_mode=cook');
@@ -115,18 +124,16 @@ describe('formatAdvanceBoundaryGuidance (EE7 boundary output)', () => {
   });
 
   it('emits explicit glide fallback guidance', () => {
-    initOrchestratorConfig({
-      defaultBranch: 'main',
-      planRoot: 'docs',
-      runtime: 'bun',
-      packageManager: 'bun',
+    const config: ResolvedOrchestratorConfig = {
+      ...baseConfig,
       ticketBoundaryMode: 'glide',
-    });
+    };
 
     const output = formatAdvanceBoundaryGuidance(
       baseState,
       advancedState,
       advancedState,
+      config,
     );
 
     expect(output).toContain('context_reset_required=true');
@@ -191,7 +198,7 @@ describe('formatCurrentTicketStatus (EE6: findings block)', () => {
   };
 
   it('emits a findings block for actionable finding comments', () => {
-    const output = formatCurrentTicketStatus(baseState, 'P15.06');
+    const output = formatCurrentTicketStatus(baseState, baseConfig, 'P15.06');
 
     expect(output).toContain('findings (2):');
     expect(output).toContain(
@@ -213,7 +220,11 @@ describe('formatCurrentTicketStatus (EE6: findings block)', () => {
       })),
     };
 
-    const output = formatCurrentTicketStatus(stateWithStale, 'P15.06');
+    const output = formatCurrentTicketStatus(
+      stateWithStale,
+      baseConfig,
+      'P15.06',
+    );
 
     expect(output).not.toContain('findings (');
     expect(output).not.toContain('[coderabbit]');
@@ -225,7 +236,11 @@ describe('formatCurrentTicketStatus (EE6: findings block)', () => {
       tickets: baseState.tickets.map((t) => ({ ...t, reviewComments: [] })),
     };
 
-    const output = formatCurrentTicketStatus(stateNoComments, 'P15.06');
+    const output = formatCurrentTicketStatus(
+      stateNoComments,
+      baseConfig,
+      'P15.06',
+    );
 
     expect(output).not.toContain('findings (');
   });
@@ -252,7 +267,7 @@ describe('formatCurrentTicketStatus (EE6: findings block)', () => {
       })),
     };
 
-    const output = formatCurrentTicketStatus(stateNoBold, 'P15.06');
+    const output = formatCurrentTicketStatus(stateNoBold, baseConfig, 'P15.06');
 
     expect(output).toContain('findings (1):');
     expect(output).toContain(
@@ -282,7 +297,11 @@ describe('formatCurrentTicketStatus (EE6: findings block)', () => {
       })),
     };
 
-    const output = formatCurrentTicketStatus(stateUnknown, 'P15.06');
+    const output = formatCurrentTicketStatus(
+      stateUnknown,
+      baseConfig,
+      'P15.06',
+    );
 
     expect(output).toContain('findings (1):');
     expect(output).toContain(
@@ -300,7 +319,7 @@ describe('formatCurrentTicketStatus (EE6: findings block)', () => {
     };
 
     // no ticketId — selector must find needs_patch ticket
-    const output = formatCurrentTicketStatus(stateNeedsPatch);
+    const output = formatCurrentTicketStatus(stateNeedsPatch, baseConfig);
 
     expect(output).toContain('findings (2):');
     expect(output).toContain('[coderabbit]');

--- a/tools/delivery/test/orchestrator.test.ts
+++ b/tools/delivery/test/orchestrator.test.ts
@@ -179,25 +179,32 @@ describe('delivery orchestrator', () => {
   });
 
   it('formats status with the effective boundary mode', () => {
-    initOrchestratorConfig({
-      defaultBranch: 'main',
-      planRoot: 'docs',
-      runtime: 'bun',
-      packageManager: 'bun',
-      ticketBoundaryMode: 'glide',
-    });
-
     expect(
-      formatStatus({
-        planKey: 'engineering-epic-07',
-        planPath: 'docs/02-delivery/engineering-epic-07/implementation-plan.md',
-        statePath: '.agents/delivery/engineering-epic-07/state.json',
-        reviewsDirPath: '.agents/delivery/engineering-epic-07/reviews',
-        handoffsDirPath: '.agents/delivery/engineering-epic-07/handoffs',
-        reviewPollIntervalMinutes: 6,
-        reviewPollMaxWaitMinutes: 12,
-        tickets: [],
-      }),
+      formatStatus(
+        {
+          planKey: 'engineering-epic-07',
+          planPath:
+            'docs/02-delivery/engineering-epic-07/implementation-plan.md',
+          statePath: '.agents/delivery/engineering-epic-07/state.json',
+          reviewsDirPath: '.agents/delivery/engineering-epic-07/reviews',
+          handoffsDirPath: '.agents/delivery/engineering-epic-07/handoffs',
+          reviewPollIntervalMinutes: 6,
+          reviewPollMaxWaitMinutes: 12,
+          tickets: [],
+        },
+        {
+          defaultBranch: 'main',
+          planRoot: 'docs',
+          runtime: 'bun',
+          packageManager: 'bun',
+          ticketBoundaryMode: 'glide',
+          reviewPolicy: {
+            selfAudit: 'skip_doc_only',
+            codexPreflight: 'skip_doc_only',
+            externalReview: 'skip_doc_only',
+          },
+        },
+      ),
     ).toContain('boundary_mode=glide');
   });
 

--- a/tools/delivery/test/ticket-flow.test.ts
+++ b/tools/delivery/test/ticket-flow.test.ts
@@ -18,6 +18,7 @@ import {
   initOrchestratorConfig,
   loadOrchestratorConfig,
   resolveOrchestratorConfig,
+  type ResolvedOrchestratorConfig,
   VALID_REVIEW_POLICY_STAGE_VALUES,
 } from '../runtime-config';
 import {
@@ -29,6 +30,19 @@ async function writeFixture(path: string, content: string) {
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, content, 'utf8');
 }
+
+const baseConfig: ResolvedOrchestratorConfig = {
+  defaultBranch: 'main',
+  planRoot: 'docs',
+  runtime: 'bun',
+  packageManager: 'bun',
+  ticketBoundaryMode: 'cook',
+  reviewPolicy: {
+    selfAudit: 'skip_doc_only',
+    codexPreflight: 'skip_doc_only',
+    externalReview: 'skip_doc_only',
+  },
+};
 
 describe('ticket-flow', () => {
   it('materializes first-ticket continuation artifacts into the target worktree', async () => {
@@ -364,14 +378,7 @@ describe('EE8.01 — self-audit observability and reviewPolicy config', () => {
         },
       ],
     );
-    initOrchestratorConfig({
-      defaultBranch: 'main',
-      planRoot: 'docs',
-      runtime: 'bun',
-      packageManager: 'bun',
-      ticketBoundaryMode: 'cook',
-    });
-    const output = formatStatus(state);
+    const output = formatStatus(state, baseConfig);
     expect(output).toMatch(
       /post_verify_self_audit=completed at .+ \(patched\)/,
     );
@@ -386,19 +393,15 @@ describe('EE8.01 — self-audit observability and reviewPolicy config', () => {
   });
 
   it('renders effective reviewPolicy in formatStatus', () => {
-    initOrchestratorConfig({
-      defaultBranch: 'main',
-      planRoot: 'docs',
-      runtime: 'bun',
-      packageManager: 'bun',
-      ticketBoundaryMode: 'cook',
+    const config: ResolvedOrchestratorConfig = {
+      ...baseConfig,
       reviewPolicy: {
         selfAudit: 'required',
         codexPreflight: 'disabled',
         externalReview: 'required',
       },
-    });
-    const output = formatStatus(baseInProgressState);
+    };
+    const output = formatStatus(baseInProgressState, config);
     expect(output).toContain(
       'review_policy=selfAudit:required codexPreflight:disabled externalReview:required',
     );
@@ -830,13 +833,6 @@ describe('EE8.02 — codex preflight command, status, and gate', () => {
   });
 
   it('formats codex_preflight outcome in formatStatus', () => {
-    initOrchestratorConfig({
-      defaultBranch: 'main',
-      planRoot: 'docs',
-      runtime: 'bun',
-      packageManager: 'bun',
-      ticketBoundaryMode: 'cook',
-    });
     const state: DeliveryState = {
       ...basePostAuditState,
       tickets: basePostAuditState.tickets.map((t) => ({
@@ -846,20 +842,13 @@ describe('EE8.02 — codex preflight command, status, and gate', () => {
         codexPreflightCompletedAt: '2026-04-14T10:00:00.000Z',
       })),
     };
-    const output = formatStatus(state);
+    const output = formatStatus(state, baseConfig);
     expect(output).toContain(
       'codex_preflight=completed at 2026-04-14T10:00:00.000Z (clean)',
     );
   });
 
   it('formats skipped codex_preflight outcome in formatStatus', () => {
-    initOrchestratorConfig({
-      defaultBranch: 'main',
-      planRoot: 'docs',
-      runtime: 'bun',
-      packageManager: 'bun',
-      ticketBoundaryMode: 'cook',
-    });
     const state: DeliveryState = {
       ...basePostAuditState,
       tickets: basePostAuditState.tickets.map((t) => ({
@@ -869,7 +858,7 @@ describe('EE8.02 — codex preflight command, status, and gate', () => {
         codexPreflightCompletedAt: '2026-04-14T10:00:00.000Z',
       })),
     };
-    const output = formatStatus(state);
+    const output = formatStatus(state, baseConfig);
     expect(output).toContain(
       'codex_preflight=completed at 2026-04-14T10:00:00.000Z (skipped)',
     );


### PR DESCRIPTION
## Summary

- delivery ticket: `EE11.03 Explicit formatter config`
- ticket file: [docs/02-delivery/engineering-epic-11/ticket-03-explicit-formatter-config.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/engineering-epic-11/ticket-03-explicit-formatter-config.md)
- stacked base branch: `agents/ee11-02-platform-adapter-factory-and-pr-contract`
- self-audit: outcome `clean` completed at 2026-04-27 06:57 UTC
