### PR TITLE
refactor: remove delivery config singleton [EE11.05]

### DIFF
--- a/docs/02-delivery/engineering-epic-11/ticket-05-clean-singleton-removal-and-test-isolation.md
+++ b/docs/02-delivery/engineering-epic-11/ticket-05-clean-singleton-removal-and-test-isolation.md
@@ -47,9 +47,26 @@ builders only when they reduce repeated object boilerplate.
 ## Rationale
 
 Red first:
+Focused delivery tests initially encoded the hidden singleton contract: helpers
+could be called after mutating module-level config. The removal work made those
+dependencies explicit, so tests now build local resolved config/context values
+and pass them through the same helper surfaces used by the CLI.
 
 Why this path:
+Deleting `_config`, `initOrchestratorConfig`, and `getOrchestratorConfig`
+directly from `runtime-config.ts` forced every remaining source and test caller
+to choose a config source at the call site. `runDeliveryOrchestrator` resolves
+config once, builds a `DeliveryOrchestratorContext`, and passes config/context
+through state, review, PR, and boundary helpers. This keeps runtime config
+visible without adding a replacement global.
 
 Alternative considered:
+Keeping optional helper fallbacks with hard-coded defaults would reduce test
+churn, but it would preserve a second implicit runtime path. The ticket is the
+cleanup gate for EE11, so the exported helper signatures now require explicit
+config or context where runtime behavior depends on it.
 
 Deferred:
+Durable documentation cleanup for the final EE11 architecture summary remains
+with the docs/retrospective ticket; this ticket only updates the active cleanup
+ticket rationale and code/test surfaces.

--- a/tools/delivery/cli-runner.ts
+++ b/tools/delivery/cli-runner.ts
@@ -1,13 +1,15 @@
 import { getUsage, parseCliArgs, resolveOptionsForCommand } from './cli';
 import { ensureEnvReady as ensureEnvReadyImpl } from './env';
 import {
-  _config,
   generateRunDeliverInvocation,
-  initOrchestratorConfig,
   loadOrchestratorConfig,
   resolveOrchestratorConfig,
 } from './runtime-config';
-import type { ReviewPolicyStageValue, TicketBoundaryMode } from './config';
+import type {
+  ResolvedOrchestratorConfig,
+  ReviewPolicyStageValue,
+  TicketBoundaryMode,
+} from './config';
 import type {
   DeliveryState,
   InternalReviewPatchCommit,
@@ -95,10 +97,6 @@ import {
   startTicket as startTicketImpl,
 } from './ticket-flow';
 
-function defaultContext(): DeliveryOrchestratorContext {
-  return createDeliveryOrchestratorContext(_config);
-}
-
 export async function runDeliveryOrchestrator(
   argv: string[],
   cwd: string,
@@ -116,11 +114,12 @@ export async function runDeliveryOrchestrator(
 
   try {
     const rawConfig = await loadOrchestratorConfig(cwd);
-    await ensureEnvReadyImpl(cwd, findPrimaryWorktreePath);
+    const initialConfig = resolveOrchestratorConfig(rawConfig, cwd);
+    await ensureEnvReadyImpl(cwd, (worktreePath) =>
+      findPrimaryWorktreePath(worktreePath, initialConfig),
+    );
     const usage = getUsage(
-      generateRunDeliverInvocation(
-        resolveOrchestratorConfig(rawConfig, cwd).packageManager,
-      ),
+      generateRunDeliverInvocation(initialConfig.packageManager),
     );
     parsed = parseCliArgs(argv, usage);
     const resolvedConfig = resolveOrchestratorConfig(
@@ -130,7 +129,6 @@ export async function runDeliveryOrchestrator(
       },
       cwd,
     );
-    initOrchestratorConfig(resolvedConfig);
     const context = createDeliveryOrchestratorContext(resolvedConfig);
     const platform = context.platform;
     const notifier = resolveNotifier();
@@ -151,7 +149,8 @@ export async function runDeliveryOrchestrator(
       command: parsed.command,
       createOptions,
       cwd,
-      inferPlanPathFromBranch,
+      inferPlanPathFromBranch: (worktreePath, branch) =>
+        inferPlanPathFromBranch(worktreePath, branch, context.config),
       planPath: parsed.planPath,
       readCurrentBranch: platform.readCurrentBranch,
     });
@@ -161,7 +160,7 @@ export async function runDeliveryOrchestrator(
     };
 
     if (parsed.command === 'repair-state') {
-      const repaired = await repairState(cwd, options);
+      const repaired = await repairState(cwd, options, context.config);
       console.log(
         [
           formatStatus(repaired.state, context.config),
@@ -173,7 +172,7 @@ export async function runDeliveryOrchestrator(
       return 0;
     }
 
-    const state = await loadState(cwd, options);
+    const state = await loadState(cwd, options, context.config);
 
     switch (parsed.command) {
       case 'sync': {
@@ -235,6 +234,7 @@ export async function runDeliveryOrchestrator(
           state,
           auditTicketId,
           auditOutcome,
+          context.config,
           {},
           auditPatchCommits,
         );
@@ -498,11 +498,14 @@ export async function runDeliveryOrchestrator(
   }
 }
 
-export function findPrimaryWorktreePath(cwd: string): string | undefined {
+export function findPrimaryWorktreePath(
+  cwd: string,
+  config: ResolvedOrchestratorConfig,
+): string | undefined {
   return findPlatformPrimaryWorktreePath(
     cwd,
-    _config.defaultBranch,
-    _config.runtime,
+    config.defaultBranch,
+    config.runtime,
   );
 }
 
@@ -517,11 +520,12 @@ export function syncStateFromScratch(
   ticketDefinitions: TicketDefinition[],
   cwd: string,
   options: OrchestratorOptions,
+  config: ResolvedOrchestratorConfig,
   inferred?: DeliveryState,
 ): DeliveryState {
   return syncStateFromScratchImpl(ticketDefinitions, options, inferred, {
     cwd,
-    defaultBranch: _config.defaultBranch,
+    defaultBranch: config.defaultBranch,
     deriveBranchName,
     deriveWorktreePath,
   });
@@ -532,6 +536,7 @@ export function syncStateFromExisting(
   ticketDefinitions: TicketDefinition[],
   cwd: string,
   options: OrchestratorOptions,
+  config: ResolvedOrchestratorConfig,
   inferred?: DeliveryState,
 ): DeliveryState {
   return syncStateFromExistingImpl(
@@ -541,7 +546,7 @@ export function syncStateFromExisting(
     inferred,
     {
       cwd,
-      defaultBranch: _config.defaultBranch,
+      defaultBranch: config.defaultBranch,
       deriveBranchName,
       deriveWorktreePath,
     },
@@ -573,11 +578,12 @@ export function createOptions(input: {
 export async function loadState(
   cwd: string,
   options: OrchestratorOptions,
+  config: ResolvedOrchestratorConfig,
 ): Promise<DeliveryState> {
   return loadStateImpl(cwd, options, {
     cwd,
-    defaultBranch: _config.defaultBranch,
-    runtime: _config.runtime,
+    defaultBranch: config.defaultBranch,
+    runtime: config.runtime,
     deriveBranchName,
     deriveWorktreePath,
     findExistingBranch,
@@ -587,11 +593,12 @@ export async function loadState(
 async function repairState(
   cwd: string,
   options: OrchestratorOptions,
+  config: ResolvedOrchestratorConfig,
 ): Promise<RepairStateResult> {
   return repairStateImpl(cwd, options, {
     cwd,
-    defaultBranch: _config.defaultBranch,
-    runtime: _config.runtime,
+    defaultBranch: config.defaultBranch,
+    runtime: config.runtime,
     deriveBranchName,
     deriveWorktreePath,
     findExistingBranch,
@@ -601,11 +608,12 @@ async function repairState(
 export async function inferPlanPathFromBranch(
   cwd: string,
   branch: string,
+  config: ResolvedOrchestratorConfig,
 ): Promise<string> {
   return inferPlanPathFromBranchImpl(
     cwd,
     branch,
-    _config.planRoot,
+    config.planRoot,
     findExistingBranch,
   );
 }
@@ -668,6 +676,7 @@ export async function recordPostVerifySelfAudit(
   state: DeliveryState,
   ticketId?: string,
   outcome?: ReviewOutcome,
+  config?: ResolvedOrchestratorConfig,
   dependencies: {
     isLocalBranchDocOnly?: (
       cwd: string,
@@ -678,21 +687,24 @@ export async function recordPostVerifySelfAudit(
   } = {},
   patchCommits?: InternalReviewPatchCommit[],
 ): Promise<DeliveryState> {
-  const context = defaultContext();
+  if (!config) {
+    throw new Error('recordPostVerifySelfAudit requires explicit config.');
+  }
+
   const target =
     (ticketId
       ? state.tickets.find((ticket) => ticket.id === ticketId)
       : state.tickets.find((ticket) => ticket.status === 'in_progress')) ??
     undefined;
   const selfAuditPolicy =
-    dependencies.selfAuditPolicy ?? context.config.reviewPolicy.selfAudit;
+    dependencies.selfAuditPolicy ?? config.reviewPolicy.selfAudit;
   const isDocOnly =
     target &&
     selfAuditPolicy !== 'disabled' &&
     (dependencies.isLocalBranchDocOnly ?? isPlatformLocalBranchDocOnly)(
       target.worktreePath,
       target.baseBranch,
-      context.config.runtime,
+      config.runtime,
     );
 
   if (selfAuditPolicy === 'skip_doc_only' && isDocOnly) {
@@ -712,11 +724,14 @@ export function recordCodexPreflight(
   state: DeliveryState,
   outcome?: 'clean' | 'patched',
   isDocOnly?: boolean,
-  policy: ReviewPolicyStageValue = defaultContext().config.reviewPolicy
-    .codexPreflight,
+  policy?: ReviewPolicyStageValue,
   patchCommits?: InternalReviewPatchCommit[],
   note?: string,
 ): DeliveryState {
+  if (!policy) {
+    throw new Error('recordCodexPreflight requires an explicit policy.');
+  }
+
   return recordCodexPreflightImpl(
     state,
     outcome,
@@ -786,15 +801,10 @@ function resolveInternalReviewPatchCommits(
 export async function openPullRequest(
   state: DeliveryState,
   cwd: string,
-  contextOrTicketId?: DeliveryOrchestratorContext | string,
+  context: DeliveryOrchestratorContext,
   ticketId?: string,
 ): Promise<DeliveryState> {
-  const context =
-    typeof contextOrTicketId === 'object'
-      ? contextOrTicketId
-      : defaultContext();
-  const resolvedTicketId =
-    typeof contextOrTicketId === 'string' ? contextOrTicketId : ticketId;
+  const resolvedTicketId = ticketId;
   const platform = context.platform;
   const nextState = openPullRequestImpl(state, cwd, resolvedTicketId, {
     assertReviewerFacingMarkdown,
@@ -839,24 +849,13 @@ export async function openPullRequest(
 export async function pollReview(
   state: DeliveryState,
   cwd: string,
-  contextOrTicketId?: DeliveryOrchestratorContext | string,
-  maybeTicketIdOrDependencies?: string | Partial<TicketReviewDependencies>,
+  context: DeliveryOrchestratorContext,
+  ticketId?: string,
+  maybeDependencies?: Partial<TicketReviewDependencies>,
   dependencies: Partial<TicketReviewDependencies> = {},
 ): Promise<DeliveryState> {
-  const context =
-    typeof contextOrTicketId === 'object'
-      ? contextOrTicketId
-      : defaultContext();
-  const ticketId =
-    typeof contextOrTicketId === 'string'
-      ? contextOrTicketId
-      : typeof maybeTicketIdOrDependencies === 'string'
-        ? maybeTicketIdOrDependencies
-        : undefined;
   const resolvedDependencies =
-    typeof maybeTicketIdOrDependencies === 'object'
-      ? maybeTicketIdOrDependencies
-      : dependencies;
+    typeof maybeDependencies === 'object' ? maybeDependencies : dependencies;
   const platform = context.platform;
   return runTicketReviewLifecycle(state, cwd, ticketId, {
     ...resolvedDependencies,
@@ -877,23 +876,13 @@ export async function pollReview(
 export async function reconcileLateReview(
   state: DeliveryState,
   cwd: string,
-  contextOrTicketId: DeliveryOrchestratorContext | string,
-  maybeTicketIdOrDependencies?: string | Partial<TicketReviewDependencies>,
+  context: DeliveryOrchestratorContext,
+  ticketId: string,
+  maybeDependencies?: Partial<TicketReviewDependencies>,
   dependencies: Partial<TicketReviewDependencies> = {},
 ): Promise<DeliveryState> {
-  const context =
-    typeof contextOrTicketId === 'object'
-      ? contextOrTicketId
-      : defaultContext();
-  const ticketId =
-    typeof contextOrTicketId === 'string'
-      ? contextOrTicketId
-      : (maybeTicketIdOrDependencies as string | undefined);
   const resolvedDependencies =
-    typeof contextOrTicketId === 'string' &&
-    typeof maybeTicketIdOrDependencies === 'object'
-      ? maybeTicketIdOrDependencies
-      : dependencies;
+    typeof maybeDependencies === 'object' ? maybeDependencies : dependencies;
   if (!ticketId) {
     throw new Error('Missing ticket id for reconcile-late-review.');
   }
@@ -917,26 +906,13 @@ export async function reconcileLateReview(
 export async function runStandaloneAiReview(
   cwd: string,
   notifier: DeliveryNotifier,
-  contextOrPrNumber?: DeliveryOrchestratorContext | number,
-  maybePrNumberOrDependencies?:
-    | number
-    | Partial<StandaloneAiReviewDependencies>,
+  context: DeliveryOrchestratorContext,
+  prNumber?: number,
+  maybeDependencies?: Partial<StandaloneAiReviewDependencies>,
   dependencies: Partial<StandaloneAiReviewDependencies> = {},
 ): Promise<StandaloneAiReviewResult> {
-  const context =
-    typeof contextOrPrNumber === 'object'
-      ? contextOrPrNumber
-      : defaultContext();
-  const prNumber =
-    typeof contextOrPrNumber === 'number'
-      ? contextOrPrNumber
-      : typeof maybePrNumberOrDependencies === 'number'
-        ? maybePrNumberOrDependencies
-        : undefined;
   const resolvedDependencies =
-    typeof maybePrNumberOrDependencies === 'object'
-      ? maybePrNumberOrDependencies
-      : dependencies;
+    typeof maybeDependencies === 'object' ? maybeDependencies : dependencies;
   const platform = context.platform;
   const pullRequest =
     resolvedDependencies.pullRequest ??
@@ -967,62 +943,30 @@ export async function runStandaloneAiReview(
 export async function recordReview(
   state: DeliveryState,
   cwd: string,
-  contextOrTicketId: DeliveryOrchestratorContext | string,
-  ticketIdOrOutcome: string | ReviewResult,
-  outcomeOrNote?: ReviewResult | string,
-  noteOrDependencies?: string | Partial<TicketReviewDependencies>,
+  context: DeliveryOrchestratorContext,
+  ticketId: string,
+  outcome: ReviewResult,
+  note?: string,
+  maybeDependencies?: Partial<TicketReviewDependencies>,
   dependencies: Partial<TicketReviewDependencies> = {},
 ): Promise<DeliveryState> {
-  const context =
-    typeof contextOrTicketId === 'object'
-      ? contextOrTicketId
-      : defaultContext();
-  const ticketId =
-    typeof contextOrTicketId === 'string'
-      ? contextOrTicketId
-      : ticketIdOrOutcome;
-  const resolvedOutcome =
-    typeof contextOrTicketId === 'string'
-      ? (ticketIdOrOutcome as ReviewResult)
-      : (outcomeOrNote as ReviewResult);
-  const resolvedNote =
-    typeof contextOrTicketId === 'string'
-      ? typeof outcomeOrNote === 'string'
-        ? outcomeOrNote
-        : undefined
-      : typeof noteOrDependencies === 'string'
-        ? noteOrDependencies
-        : undefined;
   const resolvedDependencies =
-    typeof contextOrTicketId === 'string'
-      ? typeof noteOrDependencies === 'object'
-        ? noteOrDependencies
-        : dependencies
-      : typeof noteOrDependencies === 'object'
-        ? noteOrDependencies
-        : dependencies;
+    typeof maybeDependencies === 'object' ? maybeDependencies : dependencies;
   const platform = context.platform;
-  return recordTicketReview(
-    state,
-    cwd,
-    ticketId,
-    resolvedOutcome,
-    resolvedNote,
-    {
-      ...(resolvedDependencies as Partial<TicketReviewDependencies>),
-      relativeToRepo,
-      replyToReviewThread:
-        resolvedDependencies.replyToReviewThread ??
-        platform.replyToReviewThreadForOrchestrator,
-      resolveReviewFetcher,
-      resolveReviewThread: platform.resolveReviewThread,
-      resolveReviewTriager,
-      runProcess: platform.runProcess,
-      updatePullRequestBody:
-        resolvedDependencies.updatePullRequestBody ??
-        platform.updatePullRequestBody,
-    },
-  );
+  return recordTicketReview(state, cwd, ticketId, outcome, note, {
+    ...(resolvedDependencies as Partial<TicketReviewDependencies>),
+    relativeToRepo,
+    replyToReviewThread:
+      resolvedDependencies.replyToReviewThread ??
+      platform.replyToReviewThreadForOrchestrator,
+    resolveReviewFetcher,
+    resolveReviewThread: platform.resolveReviewThread,
+    resolveReviewTriager,
+    runProcess: platform.runProcess,
+    updatePullRequestBody:
+      resolvedDependencies.updatePullRequestBody ??
+      platform.updatePullRequestBody,
+  });
 }
 
 async function advanceToNextTicketImpl(
@@ -1040,41 +984,18 @@ export async function applyAdvanceBoundaryMode(
   state: DeliveryState,
   advancedState: DeliveryState,
   cwd: string,
-  contextOrDependencies?:
-    | DeliveryOrchestratorContext
-    | {
-        startTicket: (
-          state: DeliveryState,
-          cwd: string,
-          ticketId?: string,
-        ) => Promise<DeliveryState>;
-      },
+  context: DeliveryOrchestratorContext,
   dependencies: {
     startTicket: (
       state: DeliveryState,
       cwd: string,
       ticketId?: string,
     ) => Promise<DeliveryState>;
-  } = typeof contextOrDependencies === 'object' &&
-  'startTicket' in contextOrDependencies
-    ? contextOrDependencies
-    : {
-        startTicket: (state, cwd, ticketId) =>
-          startTicket(
-            state,
-            cwd,
-            typeof contextOrDependencies === 'object'
-              ? contextOrDependencies
-              : defaultContext(),
-            ticketId,
-          ),
-      },
+  } = {
+    startTicket: (state, cwd, ticketId) =>
+      startTicket(state, cwd, context, ticketId),
+  },
 ): Promise<DeliveryState> {
-  const context =
-    typeof contextOrDependencies === 'object' &&
-    !('startTicket' in contextOrDependencies)
-      ? contextOrDependencies
-      : defaultContext();
   const nextPending = advancedState.tickets.find(
     (ticket) =>
       ticket.status === 'pending' &&

--- a/tools/delivery/closeout-stack.ts
+++ b/tools/delivery/closeout-stack.ts
@@ -3,7 +3,6 @@ import {
   createPlatformAdapters,
   type DeliveryPlatformAdapters,
   formatStatus,
-  initOrchestratorConfig,
   loadOrchestratorConfig,
   loadState,
   resolveOrchestratorConfig,
@@ -324,10 +323,9 @@ export async function runCloseoutStack(
     const parsed = parseCloseoutStackArgs(argv);
     const rawConfig = await loadOrchestratorConfig(cwd);
     const config = resolveOrchestratorConfig(rawConfig, cwd);
-    initOrchestratorConfig(config);
     closeoutPlatform = createPlatformAdapters(config);
     const options = createOptions({ planPath: parsed.planPath });
-    const state = await loadState(cwd, options);
+    const state = await loadState(cwd, options, config);
     const tickets = getCloseoutTicketChain(state);
     const repo = resolveRepoSlug(cwd);
     const summary: CloseoutSummary = {

--- a/tools/delivery/orchestrator.ts
+++ b/tools/delivery/orchestrator.ts
@@ -70,9 +70,7 @@ export type {
 } from './types';
 export {
   generateRunDeliverInvocation,
-  getOrchestratorConfig,
   inferPackageManager,
-  initOrchestratorConfig,
   loadOrchestratorConfig,
   resolveOrchestratorConfig,
   VALID_REVIEW_POLICY_STAGE_VALUES,

--- a/tools/delivery/runtime-config.ts
+++ b/tools/delivery/runtime-config.ts
@@ -20,39 +20,6 @@ export type {
 
 export { inferPackageManager, VALID_REVIEW_POLICY_STAGE_VALUES };
 
-export let _config: ResolvedOrchestratorConfig = {
-  defaultBranch: 'main',
-  planRoot: 'docs',
-  runtime: 'bun',
-  packageManager: 'npm',
-  ticketBoundaryMode: 'cook',
-  reviewPolicy: {
-    selfAudit: 'skip_doc_only',
-    codexPreflight: 'skip_doc_only',
-    externalReview: 'skip_doc_only',
-  },
-};
-
-export function initOrchestratorConfig(
-  config: Omit<ResolvedOrchestratorConfig, 'reviewPolicy'> & {
-    reviewPolicy?: ResolvedOrchestratorConfig['reviewPolicy'];
-  },
-): void {
-  _config = {
-    ..._config,
-    ...config,
-    reviewPolicy: config.reviewPolicy ?? {
-      selfAudit: 'skip_doc_only',
-      codexPreflight: 'skip_doc_only',
-      externalReview: 'skip_doc_only',
-    },
-  };
-}
-
-export function getOrchestratorConfig(): ResolvedOrchestratorConfig {
-  return _config;
-}
-
 export async function loadOrchestratorConfig(
   cwd: string,
 ): Promise<OrchestratorConfig> {

--- a/tools/delivery/test/orchestrator.test.ts
+++ b/tools/delivery/test/orchestrator.test.ts
@@ -56,7 +56,7 @@ import {
 } from '../review';
 import {
   generateRunDeliverInvocation,
-  initOrchestratorConfig,
+  type ResolvedOrchestratorConfig,
 } from '../runtime-config';
 import { normalizeDeliveryStateFromPersisted } from '../state';
 import {
@@ -65,12 +65,40 @@ import {
   canAdvanceTicket,
   findTicketByBranch,
 } from '../ticket-flow';
+import { createDeliveryOrchestratorContext } from '../context';
 
 async function readArtifactJson(cwd: string, relativePath: string) {
   return JSON.parse(await readFile(join(cwd, relativePath), 'utf8')) as Record<
     string,
     unknown
   >;
+}
+
+const baseConfig: ResolvedOrchestratorConfig = {
+  defaultBranch: 'main',
+  planRoot: 'docs',
+  runtime: 'bun',
+  packageManager: 'bun',
+  ticketBoundaryMode: 'cook',
+  reviewPolicy: {
+    selfAudit: 'skip_doc_only',
+    codexPreflight: 'skip_doc_only',
+    externalReview: 'skip_doc_only',
+  },
+};
+
+function testConfig(
+  overrides: Partial<ResolvedOrchestratorConfig> = {},
+): ResolvedOrchestratorConfig {
+  return {
+    ...baseConfig,
+    ...overrides,
+    reviewPolicy: overrides.reviewPolicy ?? baseConfig.reviewPolicy,
+  };
+}
+
+function testContext(overrides: Partial<ResolvedOrchestratorConfig> = {}) {
+  return createDeliveryOrchestratorContext(testConfig(overrides));
 }
 
 describe('delivery orchestrator', () => {
@@ -259,6 +287,7 @@ describe('delivery orchestrator', () => {
       ],
       '/workspace/pirate_claw',
       options,
+      baseConfig,
     );
 
     expect(synced.tickets[0]?.status).toBe('done');
@@ -1826,7 +1855,12 @@ describe('delivery orchestrator', () => {
       ],
     };
 
-    const nextState = await recordPostVerifySelfAudit(state, 'P3.01');
+    const nextState = await recordPostVerifySelfAudit(
+      state,
+      'P3.01',
+      undefined,
+      baseConfig,
+    );
 
     expect(nextState.tickets[0]?.status).toBe(
       'post_verify_self_audit_complete',
@@ -1960,7 +1994,7 @@ describe('delivery orchestrator', () => {
     };
 
     await expect(
-      openPullRequest(state, '/tmp/pirate_claw', 'P3.01'),
+      openPullRequest(state, '/tmp/pirate_claw', testContext(), 'P3.01'),
     ).rejects.toThrow(
       'Ticket P3.01 must complete post-verify self-audit before opening a PR.',
     );
@@ -2026,7 +2060,7 @@ describe('delivery orchestrator', () => {
     let fetchCount = 0;
 
     try {
-      const nextState = await pollReview(state, cwd, 'P3.01', {
+      const nextState = await pollReview(state, cwd, testContext(), 'P3.01', {
         now: () => Date.parse('2026-04-01T10:00:00.000Z'),
         sleep: async (milliseconds) => {
           sleeps.push(milliseconds);
@@ -2176,54 +2210,60 @@ describe('delivery orchestrator', () => {
     };
     const prBodyUpdates: string[] = [];
 
-    const nextState = await pollReview(state, '/tmp/pirate_claw', 'P3.01', {
-      now: () => Date.parse('2026-04-01T10:00:00.000Z'),
-      sleep: async () => {},
-      fetcher: () => ({
-        agents: [
+    const nextState = await pollReview(
+      state,
+      '/tmp/pirate_claw',
+      testContext(),
+      'P3.01',
+      {
+        now: () => Date.parse('2026-04-01T10:00:00.000Z'),
+        sleep: async () => {},
+        fetcher: () => ({
+          agents: [
+            {
+              agent: 'coderabbit',
+              state: 'findings_detected',
+              findingsCount: 1,
+              note: 'actionable findings captured',
+            },
+          ],
+          detected: true,
+          artifactText: 'normalized ai review artifact',
+          reviewedHeadSha: 'abcdef1234567890',
+          vendors: ['coderabbit'],
+          comments: [
+            {
+              vendor: 'coderabbit',
+              channel: 'inline_review',
+              authorLogin: 'coderabbitai',
+              authorType: 'Bot',
+              body: 'Guard the null return here.',
+              threadId: 'thread_example_1',
+              threadViewerCanResolve: true,
+              kind: 'finding',
+            },
+          ],
+        }),
+        triager: () => ({
+          outcome: 'patched',
+          note: 'Patched the prudent AI review follow-up.',
+          actionSummary: 'Patched 1 finding comment.',
+          nonActionSummary: undefined,
+          vendors: ['coderabbit'],
+        }),
+        resolveThreads: () => [
           {
-            agent: 'coderabbit',
-            state: 'findings_detected',
-            findingsCount: 1,
-            note: 'actionable findings captured',
-          },
-        ],
-        detected: true,
-        artifactText: 'normalized ai review artifact',
-        reviewedHeadSha: 'abcdef1234567890',
-        vendors: ['coderabbit'],
-        comments: [
-          {
-            vendor: 'coderabbit',
-            channel: 'inline_review',
-            authorLogin: 'coderabbitai',
-            authorType: 'Bot',
-            body: 'Guard the null return here.',
+            status: 'resolved',
             threadId: 'thread_example_1',
-            threadViewerCanResolve: true,
-            kind: 'finding',
+            url: 'https://example.test/comment/1',
+            vendor: 'coderabbit',
           },
         ],
-      }),
-      triager: () => ({
-        outcome: 'patched',
-        note: 'Patched the prudent AI review follow-up.',
-        actionSummary: 'Patched 1 finding comment.',
-        nonActionSummary: undefined,
-        vendors: ['coderabbit'],
-      }),
-      resolveThreads: () => [
-        {
-          status: 'resolved',
-          threadId: 'thread_example_1',
-          url: 'https://example.test/comment/1',
-          vendor: 'coderabbit',
+        updatePullRequestBody: async (updatedState, ticket) => {
+          prBodyUpdates.push(`${updatedState.planKey}:${ticket.reviewOutcome}`);
         },
-      ],
-      updatePullRequestBody: async (updatedState, ticket) => {
-        prBodyUpdates.push(`${updatedState.planKey}:${ticket.reviewOutcome}`);
       },
-    });
+    );
 
     expect(nextState.tickets[0]).toMatchObject({
       status: 'done',
@@ -2265,26 +2305,32 @@ describe('delivery orchestrator', () => {
     };
     const sleeps: number[] = [];
 
-    const nextState = await pollReview(state, '/tmp/pirate_claw', 'P3.01', {
-      now: () => Date.parse('2026-04-01T10:00:00.000Z'),
-      sleep: async (milliseconds) => {
-        sleeps.push(milliseconds);
+    const nextState = await pollReview(
+      state,
+      '/tmp/pirate_claw',
+      testContext(),
+      'P3.01',
+      {
+        now: () => Date.parse('2026-04-01T10:00:00.000Z'),
+        sleep: async (milliseconds) => {
+          sleeps.push(milliseconds);
+        },
+        fetcher: () => ({
+          agents: [
+            {
+              agent: 'coderabbit',
+              state: 'started',
+              note: 'review still in progress',
+            },
+          ],
+          detected: true,
+          artifactText: 'started only artifact',
+          vendors: ['coderabbit'],
+          comments: [],
+        }),
+        updatePullRequestBody: async () => undefined,
       },
-      fetcher: () => ({
-        agents: [
-          {
-            agent: 'coderabbit',
-            state: 'started',
-            note: 'review still in progress',
-          },
-        ],
-        detected: true,
-        artifactText: 'started only artifact',
-        vendors: ['coderabbit'],
-        comments: [],
-      }),
-      updatePullRequestBody: async () => undefined,
-    });
+    );
 
     expect(sleeps).toEqual([360000, 720000]);
     expect(nextState.tickets[0]).toMatchObject({
@@ -2335,22 +2381,28 @@ describe('delivery orchestrator', () => {
     const sleeps: number[] = [];
     const prBodyUpdates: string[] = [];
 
-    const nextState = await pollReview(state, '/tmp/pirate_claw', 'P3.01', {
-      now: () => Date.parse('2026-04-01T10:00:00.000Z'),
-      sleep: async (milliseconds) => {
-        sleeps.push(milliseconds);
+    const nextState = await pollReview(
+      state,
+      '/tmp/pirate_claw',
+      testContext(),
+      'P3.01',
+      {
+        now: () => Date.parse('2026-04-01T10:00:00.000Z'),
+        sleep: async (milliseconds) => {
+          sleeps.push(milliseconds);
+        },
+        fetcher: () => ({
+          agents: [],
+          detected: false,
+          artifactText: '',
+          vendors: [],
+          comments: [],
+        }),
+        updatePullRequestBody: async (updatedState, ticket) => {
+          prBodyUpdates.push(`${updatedState.planKey}:${ticket.reviewOutcome}`);
+        },
       },
-      fetcher: () => ({
-        agents: [],
-        detected: false,
-        artifactText: '',
-        vendors: [],
-        comments: [],
-      }),
-      updatePullRequestBody: async (updatedState, ticket) => {
-        prBodyUpdates.push(`${updatedState.planKey}:${ticket.reviewOutcome}`);
-      },
-    });
+    );
 
     expect(sleeps).toEqual([360000, 720000]);
     expect(nextState.tickets[0]).toMatchObject({
@@ -2401,30 +2453,36 @@ describe('delivery orchestrator', () => {
       ],
     };
 
-    const nextState = await pollReview(state, '/tmp/pirate_claw', 'P3.01', {
-      now: () => Date.parse('2026-04-01T10:00:00.000Z'),
-      sleep: async () => {},
-      fetcher: () => ({
-        agents: [
-          {
-            agent: 'coderabbit',
-            state: 'completed',
-            note: 'review completed without actionable findings',
-          },
-        ],
-        detected: true,
-        artifactText: 'normalized ai review artifact',
-        reviewedHeadSha: 'abcdef1234567890',
-        vendors: ['coderabbit'],
-        comments: [],
-      }),
-      triager: () => ({
-        outcome: 'clean',
-        note: 'External AI review completed without prudent follow-up changes.',
-        vendors: ['coderabbit'],
-      }),
-      updatePullRequestBody: async () => {},
-    });
+    const nextState = await pollReview(
+      state,
+      '/tmp/pirate_claw',
+      testContext(),
+      'P3.01',
+      {
+        now: () => Date.parse('2026-04-01T10:00:00.000Z'),
+        sleep: async () => {},
+        fetcher: () => ({
+          agents: [
+            {
+              agent: 'coderabbit',
+              state: 'completed',
+              note: 'review completed without actionable findings',
+            },
+          ],
+          detected: true,
+          artifactText: 'normalized ai review artifact',
+          reviewedHeadSha: 'abcdef1234567890',
+          vendors: ['coderabbit'],
+          comments: [],
+        }),
+        triager: () => ({
+          outcome: 'clean',
+          note: 'External AI review completed without prudent follow-up changes.',
+          vendors: ['coderabbit'],
+        }),
+        updatePullRequestBody: async () => {},
+      },
+    );
 
     expect(nextState.tickets[0]).toMatchObject({
       status: 'done',
@@ -2473,18 +2531,24 @@ describe('delivery orchestrator', () => {
       ],
     };
 
-    const nextState = await pollReview(state, '/tmp/pirate_claw', 'P3.01', {
-      now: () => Date.parse('2026-04-01T10:00:00.000Z'),
-      sleep: async () => {},
-      fetcher: () => ({
-        agents: [],
-        detected: false,
-        artifactText: '',
-        vendors: [],
-        comments: [],
-      }),
-      updatePullRequestBody: async () => {},
-    });
+    const nextState = await pollReview(
+      state,
+      '/tmp/pirate_claw',
+      testContext(),
+      'P3.01',
+      {
+        now: () => Date.parse('2026-04-01T10:00:00.000Z'),
+        sleep: async () => {},
+        fetcher: () => ({
+          agents: [],
+          detected: false,
+          artifactText: '',
+          vendors: [],
+          comments: [],
+        }),
+        updatePullRequestBody: async () => {},
+      },
+    );
 
     expect(nextState.tickets[0]).toMatchObject({
       status: 'done',
@@ -2552,16 +2616,23 @@ describe('delivery orchestrator', () => {
       vendors: ['coderabbit'],
     });
 
-    const nextState = await pollReview(state, '/tmp/pirate_claw', 'P3.01', {
-      now: () => Date.parse('2026-04-01T10:00:00.000Z'),
-      sleep: async () => {},
-      fetcher,
-      triager,
-      updatePullRequestBody: async () => {},
-    });
+    const nextState = await pollReview(
+      state,
+      '/tmp/pirate_claw',
+      testContext(),
+      'P3.01',
+      {
+        now: () => Date.parse('2026-04-01T10:00:00.000Z'),
+        sleep: async () => {},
+        fetcher,
+        triager,
+        updatePullRequestBody: async () => {},
+      },
+    );
     const standaloneResult = await runStandaloneAiReview(
       '/tmp/pirate_claw',
       { kind: 'noop', enabled: false },
+      testContext(),
       undefined,
       {
         now: () => Date.parse('2026-04-01T10:00:00.000Z'),
@@ -2629,15 +2700,22 @@ describe('delivery orchestrator', () => {
       comments: [],
     });
 
-    const nextState = await pollReview(state, '/tmp/pirate_claw', 'P3.01', {
-      now: () => Date.parse('2026-04-01T10:00:00.000Z'),
-      sleep: async () => {},
-      fetcher,
-      updatePullRequestBody: async () => {},
-    });
+    const nextState = await pollReview(
+      state,
+      '/tmp/pirate_claw',
+      testContext(),
+      'P3.01',
+      {
+        now: () => Date.parse('2026-04-01T10:00:00.000Z'),
+        sleep: async () => {},
+        fetcher,
+        updatePullRequestBody: async () => {},
+      },
+    );
     const standaloneResult = await runStandaloneAiReview(
       '/tmp/pirate_claw',
       { kind: 'noop', enabled: false },
+      testContext(),
       undefined,
       {
         now: () => Date.parse('2026-04-01T10:00:00.000Z'),
@@ -2708,15 +2786,22 @@ describe('delivery orchestrator', () => {
       comments: [],
     });
 
-    const nextState = await pollReview(state, '/tmp/pirate_claw', 'P3.01', {
-      now: () => Date.parse('2026-04-01T10:00:00.000Z'),
-      sleep: async () => {},
-      fetcher,
-      updatePullRequestBody: async () => {},
-    });
+    const nextState = await pollReview(
+      state,
+      '/tmp/pirate_claw',
+      testContext(),
+      'P3.01',
+      {
+        now: () => Date.parse('2026-04-01T10:00:00.000Z'),
+        sleep: async () => {},
+        fetcher,
+        updatePullRequestBody: async () => {},
+      },
+    );
     const standaloneResult = await runStandaloneAiReview(
       '/tmp/pirate_claw',
       { kind: 'noop', enabled: false },
+      testContext(),
       undefined,
       {
         now: () => Date.parse('2026-04-01T10:00:00.000Z'),
@@ -2751,6 +2836,7 @@ describe('delivery orchestrator', () => {
     const standaloneResult = await runStandaloneAiReview(
       '/tmp/pirate_claw',
       { kind: 'noop', enabled: false },
+      testContext(),
       undefined,
       {
         now: () => Date.parse('2026-04-01T10:12:00.000Z'),
@@ -2852,6 +2938,7 @@ describe('delivery orchestrator', () => {
     const standaloneResult = await runStandaloneAiReview(
       '/tmp/pirate_claw',
       { kind: 'noop', enabled: false },
+      testContext(),
       undefined,
       {
         now: () => Date.parse('2026-04-01T10:00:00.000Z'),
@@ -2918,6 +3005,7 @@ describe('delivery orchestrator', () => {
     const standaloneResult = await runStandaloneAiReview(
       '/tmp/pirate_claw',
       { kind: 'noop', enabled: false },
+      testContext(),
       undefined,
       {
         now: () => Date.parse('2026-04-01T10:00:00.000Z'),
@@ -2984,7 +3072,7 @@ describe('delivery orchestrator', () => {
     };
     const sleeps: number[] = [];
 
-    await pollReview(state, '/tmp/pirate_claw', 'P3.01', {
+    await pollReview(state, '/tmp/pirate_claw', testContext(), 'P3.01', {
       now: () => Date.parse('2026-04-01T10:00:00.000Z'),
       sleep: async (milliseconds) => {
         sleeps.push(milliseconds);
@@ -3059,47 +3147,53 @@ describe('delivery orchestrator', () => {
     let fetchCount = 0;
 
     try {
-      const nextState = await reconcileLateReview(state, cwd, 'P3.01', {
-        now: () => Date.parse('2026-04-01T10:00:00.000Z'),
-        sleep: async (milliseconds) => {
-          sleeps.push(milliseconds);
-        },
-        fetcher: () => {
-          fetchCount += 1;
-          return {
-            agents: [
-              {
-                agent: 'coderabbit',
-                state: 'completed',
-                note: 'review completed',
-              },
-            ],
-            detected: true,
-            artifactText: 'late review artifact',
-            reviewedHeadSha: 'abcdef1234567890',
+      const nextState = await reconcileLateReview(
+        state,
+        cwd,
+        testContext(),
+        'P3.01',
+        {
+          now: () => Date.parse('2026-04-01T10:00:00.000Z'),
+          sleep: async (milliseconds) => {
+            sleeps.push(milliseconds);
+          },
+          fetcher: () => {
+            fetchCount += 1;
+            return {
+              agents: [
+                {
+                  agent: 'coderabbit',
+                  state: 'completed',
+                  note: 'review completed',
+                },
+              ],
+              detected: true,
+              artifactText: 'late review artifact',
+              reviewedHeadSha: 'abcdef1234567890',
+              vendors: ['coderabbit'],
+              comments: [
+                {
+                  vendor: 'coderabbit',
+                  channel: 'inline_review',
+                  authorLogin: 'coderabbitai',
+                  authorType: 'Bot',
+                  body: 'Late follow-up.',
+                  threadId: 'thread_late_1',
+                  threadViewerCanResolve: true,
+                  kind: 'finding',
+                },
+              ],
+            };
+          },
+          triager: () => ({
+            outcome: 'needs_patch',
+            note: 'Actionable AI review findings were detected and still need follow-up.',
+            actionSummary: 'Flagged 1 finding comment for follow-up.',
+            nonActionSummary: undefined,
             vendors: ['coderabbit'],
-            comments: [
-              {
-                vendor: 'coderabbit',
-                channel: 'inline_review',
-                authorLogin: 'coderabbitai',
-                authorType: 'Bot',
-                body: 'Late follow-up.',
-                threadId: 'thread_late_1',
-                threadViewerCanResolve: true,
-                kind: 'finding',
-              },
-            ],
-          };
+          }),
         },
-        triager: () => ({
-          outcome: 'needs_patch',
-          note: 'Actionable AI review findings were detected and still need follow-up.',
-          actionSummary: 'Flagged 1 finding comment for follow-up.',
-          nonActionSummary: undefined,
-          vendors: ['coderabbit'],
-        }),
-      });
+      );
 
       expect(sleeps).toEqual([]);
       expect(fetchCount).toBe(1);
@@ -3148,7 +3242,7 @@ describe('delivery orchestrator', () => {
     };
 
     await expect(
-      reconcileLateReview(state, '/tmp/pirate_claw', 'P3.01', {
+      reconcileLateReview(state, '/tmp/pirate_claw', testContext(), 'P3.01', {
         now: () => Date.parse('2026-04-01T10:00:00.000Z'),
         sleep: async () => {},
         fetcher: () => ({
@@ -3199,6 +3293,7 @@ describe('delivery orchestrator', () => {
     const nextState = await reconcileLateReview(
       state,
       '/tmp/pirate_claw',
+      testContext(),
       'P3.01',
       {
         now: () => Date.parse('2026-04-01T10:00:00.000Z'),
@@ -3276,6 +3371,7 @@ describe('delivery orchestrator', () => {
     const nextState = await recordReview(
       state,
       '/tmp/pirate_claw',
+      testContext(),
       'P3.01',
       'patched',
       undefined,
@@ -3346,6 +3442,7 @@ describe('delivery orchestrator', () => {
     const nextState = await recordReview(
       state,
       '/tmp/pirate_claw',
+      testContext(),
       'P3.01',
       'clean',
       'External AI review completed without prudent follow-up changes.',
@@ -3401,6 +3498,7 @@ describe('delivery orchestrator', () => {
     const nextState = await recordReview(
       state,
       '/tmp/pirate_claw',
+      testContext(),
       'P3.01',
       'clean',
       undefined,
@@ -3474,6 +3572,7 @@ describe('delivery orchestrator', () => {
     const nextState = await recordReview(
       state,
       '/tmp/pirate_claw',
+      testContext(),
       'P3.01',
       'patched',
       undefined,
@@ -3607,39 +3706,13 @@ describe('delivery orchestrator', () => {
   });
 
   it('surfaces node spawn startup errors in stderr', () => {
-    initOrchestratorConfig({
-      defaultBranch: 'main',
-      planRoot: 'docs',
+    const result = createPlatformAdapters({
+      ...baseConfig,
       runtime: 'node',
-      packageManager: 'bun',
-      ticketBoundaryMode: 'cook',
-    });
+    }).runProcessResult(process.cwd(), ['__codex_missing_binary_for_test__']);
 
-    try {
-      const result = createPlatformAdapters({
-        defaultBranch: 'main',
-        planRoot: 'docs',
-        runtime: 'node',
-        packageManager: 'bun',
-        ticketBoundaryMode: 'cook',
-        reviewPolicy: {
-          selfAudit: 'skip_doc_only',
-          codexPreflight: 'skip_doc_only',
-          externalReview: 'skip_doc_only',
-        },
-      }).runProcessResult(process.cwd(), ['__codex_missing_binary_for_test__']);
-
-      expect(result.exitCode).toBe(1);
-      expect(result.stderr).toContain('__codex_missing_binary_for_test__');
-    } finally {
-      initOrchestratorConfig({
-        defaultBranch: 'main',
-        planRoot: 'docs',
-        runtime: 'bun',
-        packageManager: 'bun',
-        ticketBoundaryMode: 'cook',
-      });
-    }
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('__codex_missing_binary_for_test__');
   });
 
   it('replies to a thread before resolving when databaseId is present', () => {
@@ -3831,11 +3904,7 @@ describe('delivery orchestrator', () => {
     };
 
     it('auto-starts the next ticket in cook mode', async () => {
-      initOrchestratorConfig({
-        defaultBranch: 'main',
-        planRoot: 'docs',
-        runtime: 'bun',
-        packageManager: 'bun',
+      const context = testContext({
         ticketBoundaryMode: 'cook',
       });
 
@@ -3854,6 +3923,7 @@ describe('delivery orchestrator', () => {
         baseState,
         advancedState,
         '/tmp',
+        context,
         {
           startTicket: async (_state, _cwd, ticketId) => {
             startedTicketId = ticketId;
@@ -3882,11 +3952,7 @@ describe('delivery orchestrator', () => {
     });
 
     it('does not auto-start the next ticket for glide fallback', async () => {
-      initOrchestratorConfig({
-        defaultBranch: 'main',
-        planRoot: 'docs',
-        runtime: 'bun',
-        packageManager: 'bun',
+      const context = testContext({
         ticketBoundaryMode: 'glide',
       });
 
@@ -3903,6 +3969,7 @@ describe('delivery orchestrator', () => {
         baseState,
         advancedState,
         '/tmp',
+        context,
         {
           startTicket: async () => {
             throw new Error('should not start');

--- a/tools/delivery/test/runtime-config.test.ts
+++ b/tools/delivery/test/runtime-config.test.ts
@@ -6,10 +6,23 @@ import { join } from 'node:path';
 import { createOptions, syncStateFromScratch } from '../orchestrator';
 import {
   inferPackageManager,
-  initOrchestratorConfig,
   loadOrchestratorConfig,
   resolveOrchestratorConfig,
+  type ResolvedOrchestratorConfig,
 } from '../runtime-config';
+
+const baseConfig: ResolvedOrchestratorConfig = {
+  defaultBranch: 'main',
+  planRoot: 'docs',
+  runtime: 'bun',
+  packageManager: 'bun',
+  ticketBoundaryMode: 'cook',
+  reviewPolicy: {
+    selfAudit: 'skip_doc_only',
+    codexPreflight: 'skip_doc_only',
+    externalReview: 'skip_doc_only',
+  },
+};
 
 describe('orchestrator config', () => {
   it('returns defaults when config file is absent', async () => {
@@ -253,41 +266,28 @@ describe('orchestrator config', () => {
   });
 
   it('syncStateFromScratch uses configured defaultBranch for first ticket baseBranch', () => {
-    initOrchestratorConfig({
+    const config: ResolvedOrchestratorConfig = {
+      ...baseConfig,
       defaultBranch: 'develop',
-      planRoot: 'docs',
-      runtime: 'bun',
-      packageManager: 'bun',
-      ticketBoundaryMode: 'cook',
+    };
+    const options = createOptions({
+      planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
     });
 
-    try {
-      const options = createOptions({
-        planPath: 'docs/02-delivery/phase-03/implementation-plan.md',
-      });
+    const synced = syncStateFromScratch(
+      [
+        {
+          id: 'P3.01',
+          title: 'First Ticket',
+          slug: 'first-ticket',
+          ticketFile: 'docs/02-delivery/phase-03/ticket-01-first-ticket.md',
+        },
+      ],
+      '/workspace/test',
+      options,
+      config,
+    );
 
-      const synced = syncStateFromScratch(
-        [
-          {
-            id: 'P3.01',
-            title: 'First Ticket',
-            slug: 'first-ticket',
-            ticketFile: 'docs/02-delivery/phase-03/ticket-01-first-ticket.md',
-          },
-        ],
-        '/workspace/test',
-        options,
-      );
-
-      expect(synced.tickets[0]?.baseBranch).toBe('develop');
-    } finally {
-      initOrchestratorConfig({
-        defaultBranch: 'main',
-        planRoot: 'docs',
-        runtime: 'bun',
-        packageManager: 'bun',
-        ticketBoundaryMode: 'cook',
-      });
-    }
+    expect(synced.tickets[0]?.baseBranch).toBe('develop');
   });
 });

--- a/tools/delivery/test/ticket-flow.test.ts
+++ b/tools/delivery/test/ticket-flow.test.ts
@@ -15,12 +15,12 @@ import {
 } from '../cli-runner';
 import { formatStatus } from '../format';
 import {
-  initOrchestratorConfig,
   loadOrchestratorConfig,
   resolveOrchestratorConfig,
   type ResolvedOrchestratorConfig,
   VALID_REVIEW_POLICY_STAGE_VALUES,
 } from '../runtime-config';
+import { createDeliveryOrchestratorContext } from '../context';
 import {
   materializeTicketContext,
   openPullRequest as openPullRequestFlow,
@@ -43,6 +43,20 @@ const baseConfig: ResolvedOrchestratorConfig = {
     externalReview: 'skip_doc_only',
   },
 };
+
+function testConfig(
+  overrides: Partial<ResolvedOrchestratorConfig> = {},
+): ResolvedOrchestratorConfig {
+  return {
+    ...baseConfig,
+    ...overrides,
+    reviewPolicy: overrides.reviewPolicy ?? baseConfig.reviewPolicy,
+  };
+}
+
+function testContext(overrides: Partial<ResolvedOrchestratorConfig> = {}) {
+  return createDeliveryOrchestratorContext(testConfig(overrides));
+}
 
 describe('ticket-flow', () => {
   it('materializes first-ticket continuation artifacts into the target worktree', async () => {
@@ -300,6 +314,7 @@ describe('EE8.01 — self-audit observability and reviewPolicy config', () => {
       baseInProgressState,
       undefined,
       'clean',
+      baseConfig,
     );
     expect(nextState.tickets[0]?.selfAuditOutcome).toBe('clean');
     expect(nextState.tickets[0]?.status).toBe(
@@ -312,6 +327,7 @@ describe('EE8.01 — self-audit observability and reviewPolicy config', () => {
       baseInProgressState,
       undefined,
       'patched',
+      baseConfig,
       {},
       [
         {
@@ -333,7 +349,12 @@ describe('EE8.01 — self-audit observability and reviewPolicy config', () => {
   });
 
   it('defaults selfAuditOutcome to clean when no outcome arg is passed', async () => {
-    const nextState = await recordPostVerifySelfAudit(baseInProgressState);
+    const nextState = await recordPostVerifySelfAudit(
+      baseInProgressState,
+      undefined,
+      undefined,
+      baseConfig,
+    );
     expect(nextState.tickets[0]?.selfAuditOutcome).toBe('clean');
     expect(nextState.tickets[0]?.status).toBe(
       'post_verify_self_audit_complete',
@@ -345,6 +366,7 @@ describe('EE8.01 — self-audit observability and reviewPolicy config', () => {
       baseInProgressState,
       undefined,
       undefined,
+      baseConfig,
       {
         isLocalBranchDocOnly: () => true,
         selfAuditPolicy: 'skip_doc_only',
@@ -358,10 +380,16 @@ describe('EE8.01 — self-audit observability and reviewPolicy config', () => {
 
   it('requires an explicit self-audit outcome for doc-only tickets when policy is required', async () => {
     await expect(
-      recordPostVerifySelfAudit(baseInProgressState, undefined, undefined, {
-        isLocalBranchDocOnly: () => true,
-        selfAuditPolicy: 'required',
-      }),
+      recordPostVerifySelfAudit(
+        baseInProgressState,
+        undefined,
+        undefined,
+        baseConfig,
+        {
+          isLocalBranchDocOnly: () => true,
+          selfAuditPolicy: 'required',
+        },
+      ),
     ).rejects.toThrow(/requires an explicit self-audit outcome/);
   });
 
@@ -370,6 +398,7 @@ describe('EE8.01 — self-audit observability and reviewPolicy config', () => {
       baseInProgressState,
       undefined,
       'patched',
+      baseConfig,
       {},
       [
         {
@@ -386,7 +415,12 @@ describe('EE8.01 — self-audit observability and reviewPolicy config', () => {
 
   it('rejects patched self-audit outcomes without recorded patch commits', async () => {
     await expect(
-      recordPostVerifySelfAudit(baseInProgressState, undefined, 'patched'),
+      recordPostVerifySelfAudit(
+        baseInProgressState,
+        undefined,
+        'patched',
+        baseConfig,
+      ),
     ).rejects.toThrow(
       /Self-audit recorded as patched requires at least one patch commit/,
     );
@@ -495,7 +529,12 @@ describe('EE8.02 — codex preflight command, status, and gate', () => {
   };
 
   it('records codexPreflightOutcome: clean and transitions to codex_preflight_complete', () => {
-    const nextState = recordCodexPreflight(basePostAuditState, 'clean');
+    const nextState = recordCodexPreflight(
+      basePostAuditState,
+      'clean',
+      false,
+      baseConfig.reviewPolicy.codexPreflight,
+    );
     expect(nextState.tickets[0]?.codexPreflightOutcome).toBe('clean');
     expect(nextState.tickets[0]?.status).toBe('codex_preflight_complete');
     expect(nextState.tickets[0]?.codexPreflightCompletedAt).toBeTruthy();
@@ -506,7 +545,7 @@ describe('EE8.02 — codex preflight command, status, and gate', () => {
       basePostAuditState,
       'patched',
       false,
-      'skip_doc_only',
+      baseConfig.reviewPolicy.codexPreflight,
       [
         {
           sha: 'bbbbbbbbbbbb2222222222222222222222222222',
@@ -537,7 +576,7 @@ describe('EE8.02 — codex preflight command, status, and gate', () => {
       docOnlyState,
       undefined,
       true,
-      'skip_doc_only',
+      baseConfig.reviewPolicy.codexPreflight,
     );
     expect(nextState.tickets[0]?.codexPreflightOutcome).toBe('skipped');
     expect(nextState.tickets[0]?.status).toBe('codex_preflight_complete');
@@ -564,21 +603,38 @@ describe('EE8.02 — codex preflight command, status, and gate', () => {
         status: 'in_progress' as const,
       })),
     };
-    expect(() => recordCodexPreflight(inProgressState, 'clean')).toThrow(
-      /No ticket at post_verify_self_audit_complete status/,
-    );
+    expect(() =>
+      recordCodexPreflight(
+        inProgressState,
+        'clean',
+        false,
+        baseConfig.reviewPolicy.codexPreflight,
+      ),
+    ).toThrow(/No ticket at post_verify_self_audit_complete status/);
   });
 
   it('rejects patched codex-preflight outcomes without recorded patch commits', () => {
-    expect(() => recordCodexPreflight(basePostAuditState, 'patched')).toThrow(
+    expect(() =>
+      recordCodexPreflight(
+        basePostAuditState,
+        'patched',
+        false,
+        baseConfig.reviewPolicy.codexPreflight,
+      ),
+    ).toThrow(
       /Codex preflight recorded as patched requires at least one patch commit/,
     );
   });
 
   it('rejects codex-preflight on a code ticket with no outcome arg', () => {
-    expect(() => recordCodexPreflight(basePostAuditState)).toThrow(
-      /requires a Codex preflight outcome/,
-    );
+    expect(() =>
+      recordCodexPreflight(
+        basePostAuditState,
+        undefined,
+        false,
+        baseConfig.reviewPolicy.codexPreflight,
+      ),
+    ).toThrow(/requires a Codex preflight outcome/);
   });
 
   it('statusRank orders: post_verify_self_audit_complete < codex_preflight_complete < in_review', () => {
@@ -617,111 +673,52 @@ describe('EE8.02 — codex preflight command, status, and gate', () => {
       existing.tickets,
       '/tmp',
       options,
+      baseConfig,
       inferred,
     );
     expect(synced.tickets[0]?.status).toBe('codex_preflight_complete');
   });
 
   it('open-pr rejects code ticket at post_verify_self_audit_complete when policy is required', async () => {
-    initOrchestratorConfig({
-      defaultBranch: 'main',
-      planRoot: 'docs',
-      runtime: 'bun',
-      packageManager: 'bun',
-      ticketBoundaryMode: 'cook',
+    const context = testContext({
       reviewPolicy: {
         selfAudit: 'required',
         codexPreflight: 'required',
         externalReview: 'required',
       },
     });
-    try {
-      await expect(
-        openPullRequest(basePostAuditState, '/tmp/pirate_claw', 'P3.01'),
-      ).rejects.toThrow(/requires Codex preflight before opening a PR/);
-    } finally {
-      initOrchestratorConfig({
-        defaultBranch: 'main',
-        planRoot: 'docs',
-        runtime: 'bun',
-        packageManager: 'bun',
-        ticketBoundaryMode: 'cook',
-        reviewPolicy: {
-          selfAudit: 'required',
-          codexPreflight: 'disabled',
-          externalReview: 'required',
-        },
-      });
-    }
+    await expect(
+      openPullRequest(basePostAuditState, '/tmp/pirate_claw', context, 'P3.01'),
+    ).rejects.toThrow(/requires Codex preflight before opening a PR/);
   });
 
   it('open-pr rejects code ticket at post_verify_self_audit_complete when policy is skip_doc_only', async () => {
-    initOrchestratorConfig({
-      defaultBranch: 'main',
-      planRoot: 'docs',
-      runtime: 'bun',
-      packageManager: 'bun',
-      ticketBoundaryMode: 'cook',
+    const context = testContext({
       reviewPolicy: {
         selfAudit: 'skip_doc_only',
         codexPreflight: 'skip_doc_only',
         externalReview: 'skip_doc_only',
       },
     });
-    try {
-      await expect(
-        openPullRequest(basePostAuditState, '/tmp/pirate_claw', 'P3.01'),
-      ).rejects.toThrow(/requires Codex preflight before opening a PR/);
-    } finally {
-      initOrchestratorConfig({
-        defaultBranch: 'main',
-        planRoot: 'docs',
-        runtime: 'bun',
-        packageManager: 'bun',
-        ticketBoundaryMode: 'cook',
-        reviewPolicy: {
-          selfAudit: 'required',
-          codexPreflight: 'disabled',
-          externalReview: 'required',
-        },
-      });
-    }
+    await expect(
+      openPullRequest(basePostAuditState, '/tmp/pirate_claw', context, 'P3.01'),
+    ).rejects.toThrow(/requires Codex preflight before opening a PR/);
   });
 
   it('open-pr error message includes codex-plugin-cc and config escape hatch', async () => {
-    initOrchestratorConfig({
-      defaultBranch: 'main',
-      planRoot: 'docs',
-      runtime: 'bun',
-      packageManager: 'bun',
-      ticketBoundaryMode: 'cook',
+    const context = testContext({
       reviewPolicy: {
         selfAudit: 'required',
         codexPreflight: 'required',
         externalReview: 'required',
       },
     });
-    try {
-      await expect(
-        openPullRequest(basePostAuditState, '/tmp/pirate_claw', 'P3.01'),
-      ).rejects.toThrow(/codex-plugin-cc/);
-      await expect(
-        openPullRequest(basePostAuditState, '/tmp/pirate_claw', 'P3.01'),
-      ).rejects.toThrow(/codexPreflight.*disabled.*orchestrator\.config\.json/);
-    } finally {
-      initOrchestratorConfig({
-        defaultBranch: 'main',
-        planRoot: 'docs',
-        runtime: 'bun',
-        packageManager: 'bun',
-        ticketBoundaryMode: 'cook',
-        reviewPolicy: {
-          selfAudit: 'required',
-          codexPreflight: 'disabled',
-          externalReview: 'required',
-        },
-      });
-    }
+    await expect(
+      openPullRequest(basePostAuditState, '/tmp/pirate_claw', context, 'P3.01'),
+    ).rejects.toThrow(/codex-plugin-cc/);
+    await expect(
+      openPullRequest(basePostAuditState, '/tmp/pirate_claw', context, 'P3.01'),
+    ).rejects.toThrow(/codexPreflight.*disabled.*orchestrator\.config\.json/);
   });
 
   it('open-pr reports publication progress for a new PR', () => {


### PR DESCRIPTION
## Summary

- delivery ticket: `EE11.05 Clean singleton removal and test isolation`
- ticket file: [docs/02-delivery/engineering-epic-11/ticket-05-clean-singleton-removal-and-test-isolation.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/engineering-epic-11/ticket-05-clean-singleton-removal-and-test-isolation.md)
- stacked base branch: `agents/ee11-04-cli-command-context-wiring-and-handler-split`
- self-audit: outcome `clean` completed at 2026-04-27 07:22 UTC
