### PR TITLE
docs: close delivery context epic [EE11.06]

### DIFF
--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -67,7 +67,7 @@ Current planning focus:
 - see [`roadmap.md`](./roadmap.md) for numbered phases and what is implemented on `main`
 - use the roadmap to confirm whether the request is a bounded standalone change or needs a new approved phase/epic planning pass
 - treat the current Phase 07 config surface and the current extracted delivery-orchestrator module boundaries as the baseline for future work
-- for delivery-tooling architecture work, EE11 is the approved follow-up plan to replace the orchestrator `_config` singleton with an explicit context object and platform adapter factory; see [`engineering-epic-11/implementation-plan.md`](../02-delivery/engineering-epic-11/implementation-plan.md)
+- for delivery-tooling architecture work, EE11 completed the replacement of the orchestrator `_config` singleton with an explicit context object and platform adapter factory; see [`delivery-orchestrator.md`](../03-engineering/delivery-orchestrator.md)
 - the next product-completion planning buckets are Phase 27 (Synology DSM-first stack and cold start), Phase 28 (owner web security), and Phase 29 (OpenVPN bridge for bundled Transmission)
 - treat the shipped Phase 25 browser proof as a follow-on to the Phase 24 restart contract, not as a replacement for the persisted Plex auth/device boundary
 - treat the shipped Phase 26 Mac `launchd` path as a parallel supported deployment contract alongside the reviewed Synology runbook, not as a reason to merge those operator runbooks together

--- a/docs/02-delivery/engineering-epic-11/ticket-06-docs-issue-tracking-and-retrospective.md
+++ b/docs/02-delivery/engineering-epic-11/ticket-06-docs-issue-tracking-and-retrospective.md
@@ -48,9 +48,24 @@ and Markdown changed.
 ## Rationale
 
 Red first:
+The active delivery-orchestrator doc still described the EE10-era singleton as
+current architecture, and issue tracking still listed EE11 as planned even
+though the stacked implementation had landed through EE11.05.
 
 Why this path:
+The closeout docs now update the durable workflow map rather than repeating
+ticket details: delivery-orchestrator owns the final context/adapter/formatter
+model, issue tracking marks the epic closed, Start Here points future delivery
+tooling work at the new architecture, and the retrospective captures the lessons
+for future agents.
 
 Alternative considered:
+Leaving Start Here unchanged would keep the ticket inside its narrow change
+surface, but that document is the first place future delivery-tooling agents look
+for current repo state. A one-line status update avoids sending them to EE11 as
+future work after EE11 has closed.
 
 Deferred:
+No new follow-up epic is opened for the context boundary. Future cleanup should
+be proposed from concrete friction in later delivery-tooling work, not from this
+closeout ticket.

--- a/docs/02-delivery/issue-tracking.md
+++ b/docs/02-delivery/issue-tracking.md
@@ -68,14 +68,15 @@ Each ticket or PR should include a short rationale section with these prompts:
 
 ## Epic Status
 
-| Epic                                         | Status      | Notes                                                                                                                                                                                                 |
-| -------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| EE10 — Delivery Tooling Module Decomposition | **closed**  | `orchestrator.ts` reduced to a pure re-export barrel; 6 focused modules extracted; `bun test` green throughout                                                                                        |
-| EE11 — Delivery Tooling Context Object       | **planned** | Approved ticket stack in `docs/02-delivery/engineering-epic-11/implementation-plan.md`; cleanly removes `_config`, adds explicit context, adapter factory, formatter config, and command helper split |
+| Epic                                         | Status     | Notes                                                                                                                                                                                            |
+| -------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| EE10 — Delivery Tooling Module Decomposition | **closed** | `orchestrator.ts` reduced to a pure re-export barrel; 6 focused modules extracted; `bun test` green throughout                                                                                   |
+| EE11 — Delivery Tooling Context Object       | **closed** | `_config`, `initOrchestratorConfig`, and `getOrchestratorConfig` removed; delivery runtime config now flows through explicit context/config parameters, adapter factory, and local test fixtures |
 
-EE11 is the direct follow-up to EE10. It is an architectural improvement, not a
-structural refactor. The ticket stack is approved; implementation should run
-through the delivery orchestrator after the plan docs land on `main`.
+EE11 closed the direct follow-up from EE10. No follow-up epic is required for
+the context-object boundary itself; any future delivery-tooling work should start
+from the explicit context and adapter-factory model documented in
+`docs/03-engineering/delivery-orchestrator.md`.
 
 ## Source Of Truth
 

--- a/docs/03-engineering/delivery-orchestrator.md
+++ b/docs/03-engineering/delivery-orchestrator.md
@@ -16,30 +16,58 @@ This keeps the product boundary honest. `src/` remains the Pirate Claw applicati
 
 ## Module Structure
 
-After EE10, `tools/delivery/` is decomposed into focused single-concern modules.
+After EE11, `tools/delivery/` is decomposed into focused single-concern modules.
 `orchestrator.ts` is a pure re-export barrel with no logic — it exists only so
 external callers can import from one stable path.
 
-| Module                 | Concern                                                                                     |
-| ---------------------- | ------------------------------------------------------------------------------------------- |
-| `types.ts`             | All shared TypeScript types and interfaces                                                  |
-| `env.ts`               | `.env` parsing (`parseDotEnv`)                                                              |
-| `runtime-config.ts`    | `OrchestratorConfig` loading, `_config` singleton, `resolveOrchestratorConfig`              |
-| `format.ts`            | Human-readable status formatting (`formatStatus`, `formatCurrentTicketStatus`, etc.)        |
-| `platform.ts`          | Raw platform primitives: `spawnSync`, git worktree parsing, shell helpers                   |
-| `platform-adapters.ts` | Thin wrappers that inject `_config.runtime` into `platform.ts` calls                        |
-| `planning.ts`          | Branch and worktree naming (`deriveBranchName`, `deriveWorktreePath`, `findExistingBranch`) |
-| `state.ts`             | State persistence (`loadState`, `saveState`, `normalizeDeliveryStateFromPersisted`)         |
-| `ticket-flow.ts`       | Ticket lifecycle transitions, handoff artifact writing, `materializeTicketContext`          |
-| `notifications.ts`     | Telegram notification events and formatting                                                 |
-| `pr-metadata.ts`       | PR title/body construction and AI-review section builders                                   |
-| `review.ts`            | Review polling lifecycle, fetcher/triager adapters, artifact parsing                        |
-| `cli-runner.ts`        | `runDeliveryOrchestrator` dispatch switch and private CLI helpers                           |
-| `cli.ts`               | Argument parsing (`parseCliArgs`, `getUsage`)                                               |
-| `orchestrator.ts`      | Pure re-export barrel — no logic                                                            |
+| Module                 | Concern                                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| `types.ts`             | All shared TypeScript types and interfaces                                                             |
+| `env.ts`               | `.env` parsing (`parseDotEnv`) and environment readiness helpers                                       |
+| `runtime-config.ts`    | `OrchestratorConfig` loading, resolution, package-manager inference, and invocation formatting         |
+| `context.ts`           | Plain `DeliveryOrchestratorContext` construction from resolved config and platform adapters            |
+| `format.ts`            | Human-readable status formatting (`formatStatus`, `formatCurrentTicketStatus`, etc.) with config input |
+| `platform.ts`          | Raw platform primitives: `spawnSync`, git worktree parsing, shell helpers                              |
+| `platform-adapters.ts` | `createPlatformAdapters(config)` factory that binds runtime/config to platform primitives              |
+| `planning.ts`          | Branch and worktree naming (`deriveBranchName`, `deriveWorktreePath`, `findExistingBranch`)            |
+| `state.ts`             | State persistence (`loadState`, `saveState`, `normalizeDeliveryStateFromPersisted`)                    |
+| `ticket-flow.ts`       | Ticket lifecycle transitions, handoff artifact writing, `materializeTicketContext`                     |
+| `notifications.ts`     | Telegram notification events and formatting                                                            |
+| `pr-metadata.ts`       | PR title/body construction and AI-review section builders                                              |
+| `review.ts`            | Review polling lifecycle, fetcher/triager adapters, artifact parsing                                   |
+| `cli-runner.ts`        | `runDeliveryOrchestrator` dispatch switch and explicit command-helper wiring                           |
+| `cli.ts`               | Argument parsing (`parseCliArgs`, `getUsage`)                                                          |
+| `orchestrator.ts`      | Pure re-export barrel — no logic                                                                       |
 
 Each source module has a corresponding test file under `tools/delivery/test/`.
 Import from source modules in tests, not from the barrel.
+
+## Runtime Context Boundary
+
+Runtime config is not stored in a module-level singleton. The CLI loads
+`orchestrator.config.json`, resolves defaults once, builds a
+`DeliveryOrchestratorContext`, and passes that context or its `config` field into
+helpers that need runtime values.
+
+The context is intentionally small:
+
+- `config`: resolved branch, plan-root, runtime, package-manager, boundary-mode,
+  and review-policy values
+- `platform`: platform adapters created by `createPlatformAdapters(config)`
+- `invocation`: the package-manager-specific deliver command string used in
+  user-facing errors
+
+This keeps dependency direction visible at call sites. Helpers that need branch
+or runtime behavior accept `ResolvedOrchestratorConfig`; helpers that need git,
+GitHub, filesystem, or process adapters accept `DeliveryOrchestratorContext`.
+Tests use local config/context fixtures instead of mutating global module state.
+
+`runtime-config.ts` still owns config loading and validation, but it does not
+export `_config`, `initOrchestratorConfig`, or `getOrchestratorConfig`.
+`platform-adapters.ts` no longer reads runtime config directly; all adapter
+methods close over the config passed to `createPlatformAdapters(config)`.
+Formatters receive config explicitly so status rendering and boundary guidance
+do not depend on hidden process state.
 
 ## Configurable Core
 

--- a/notes/public/ee11-retrospective.md
+++ b/notes/public/ee11-retrospective.md
@@ -1,0 +1,106 @@
+# EE11 Retrospective
+
+_Engineering Epic 11: Delivery Tooling Context Object — stacked PRs #245, #246, #248, #249, #251, and the EE11.06 docs closeout PR._
+
+---
+
+## Scope delivered
+
+EE11 replaced the delivery orchestrator's mutable config singleton with an
+explicit context/config boundary. The stack added `DeliveryOrchestratorContext`,
+introduced `createPlatformAdapters(config)`, made formatter config explicit,
+wired CLI command paths through a resolved context, deleted `_config`,
+`initOrchestratorConfig`, and `getOrchestratorConfig`, migrated tests to local
+config/context fixtures, and closed with updated delivery docs and issue
+tracking.
+
+## What went well
+
+The ticket order held. Adding `context.ts` before changing consumers kept the
+first PR additive, and moving platform adapters before command wiring meant the
+CLI could depend on a real adapter factory instead of guessing at its eventual
+shape. The formatter ticket also paid off because status rendering became a
+small explicit-config migration before the broader CLI helper changes.
+
+The context boundary stayed appropriately small. Restricting it to `config`,
+`platform`, and `invocation` avoided turning the refactor into a command
+framework or dependency injection container. That made the final singleton
+removal mostly a call-site cleanup instead of an architectural rewrite.
+
+The adapter factory improved testability in the right way. Tests can now create
+adapters from a local `ResolvedOrchestratorConfig`, so runtime choices like
+`bun` vs `node` are exercised without mutating shared module state. That is
+especially important for tests that run in one process and previously depended
+on cleanup calls to reset singleton state.
+
+## Pain points
+
+The command-helper split carried expected cost. `cli-runner.ts` owns many small
+mode-specific edges, so removing the default singleton context required touching
+more exported helper signatures than the earlier tickets touched. The work was
+not conceptually hard, but it was broad enough that TypeScript caught required
+parameter ordering and call-site drift only after the first cleanup pass.
+
+The tests still have some historical coupling to `cli-runner` helpers. EE11
+removed singleton mutation, but several tests still exercise CLI helper exports
+directly rather than narrower source modules. That is acceptable for now because
+the helpers are repo tooling, but future CLI work should watch for tests that
+make helper signatures harder to simplify.
+
+Running full verification in parallel exposed local web bootstrap contention:
+two concurrent gates tried to link web dependencies and failed with file-exists
+errors. Sequential reruns passed. This is avoidable workflow friction, not an
+EE11 code issue.
+
+## Surprises
+
+The final cleanup ticket was where the real dependency graph became visible.
+Earlier tickets deliberately preserved compatibility surfaces to keep their
+diffs small; deleting the singleton showed exactly which helpers still depended
+on default branch, plan root, runtime, or review policy. That confirmed the
+cleanup-gate placement was correct.
+
+The PR contract change in the adapter ticket was smaller than expected. Returning
+both PR URL and number from `createPullRequest` looked like it might ripple
+through PR metadata code, but the adapter boundary kept the change localized to
+PR creation and state recording.
+
+The stale delivery-orchestrator doc was more misleading than the plan doc. The
+plan already described EE11's desired end state, while the durable engineering
+workflow doc still named `_config` as current architecture. Future closeout
+tickets should prioritize docs that future agents read for live behavior, not
+only the implementation plan.
+
+## What we'd do differently
+
+If starting again, EE11.04 would be slightly narrower: wire the live CLI command
+paths through context, but leave exported test helper signature changes entirely
+to EE11.05. The original split mostly did this, but a few compatibility choices
+made the final cleanup look larger than it actually was. Making that boundary
+explicit in the ticket text would have reduced ambiguity.
+
+The docs ticket would include Start Here in the declared change surface. The
+ticket already required reading Start Here, and that document contained a stale
+"EE11 is the approved follow-up" note. Updating it was the right closeout move,
+but the ticket should have named it directly.
+
+## Net assessment
+
+EE11 achieved its architecture hypothesis. Delivery runtime dependencies now
+flow through explicit config/context values, platform adapters are created by a
+factory, formatter behavior is config-driven at the call site, command helpers
+avoid hidden singleton state, and tests no longer mutate module-level runtime
+config. The command split stayed plain and local; it did not turn into a command
+bus, class hierarchy, or framework-style abstraction.
+
+## Follow-up
+
+- Keep future delivery-tooling changes on the explicit context and adapter
+  factory path; do not reintroduce process-global runtime config for test
+  convenience.
+- If `cli-runner.ts` grows again, extract narrower command modules only around
+  concrete repeated behavior. Do not add a command framework preemptively.
+- Avoid running `verify:quiet` and `ci:quiet` concurrently in this repo unless
+  web bootstrap linking becomes concurrency-safe.
+
+_Created: 2026-04-27. EE11 stacked PRs open for final developer review._


### PR DESCRIPTION
## Summary

- delivery ticket: `EE11.06 Docs, issue tracking, and retrospective`
- ticket file: [docs/02-delivery/engineering-epic-11/ticket-06-docs-issue-tracking-and-retrospective.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/engineering-epic-11/ticket-06-docs-issue-tracking-and-retrospective.md)
- stacked base branch: `agents/ee11-05-clean-singleton-removal-and-test-isolation`
- self-audit: outcome `skipped` completed at 2026-04-27 07:27 UTC
