### PR TITLE
feat: add TMDB config panel

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -23,6 +23,7 @@ import {
   validateConfig,
   validateFeed,
   validateMoviePolicy,
+  validateTmdbConfig,
   loadConfigEnv,
 } from './config';
 import type { MovieBreakdown } from './movie-api-types';
@@ -1113,6 +1114,77 @@ export function createApiFetch(
             resolutions: movies.resolutions,
             codecs: movies.codecs,
             codecPolicy: movies.codecPolicy,
+          },
+        };
+
+        const validated = validateConfig(
+          merged,
+          'config',
+          await loadConfigEnv(configPath),
+        );
+        writeConfigAtomically(configPath, merged);
+        activeConfig = validated;
+        if (configHolder) {
+          configHolder.current = validated;
+        }
+
+        const redacted = redactConfig(activeConfig);
+        return Response.json(redacted, {
+          headers: { ETag: buildConfigEtag(redacted) },
+        });
+      } catch (error) {
+        if (error instanceof ConfigError) {
+          return Response.json({ error: error.message }, { status: 400 });
+        }
+        if (error instanceof ConfigWriteError) {
+          return jsonConfigWriteFailure();
+        }
+        return json500();
+      }
+    }
+
+    if (path === '/api/config/tmdb' && request.method === 'PUT') {
+      const authError = checkWriteAuth(request, activeConfig);
+      if (authError) return authError;
+
+      const etagError = checkEtag(request, activeConfig);
+      if (etagError) return etagError;
+
+      let body: unknown;
+      try {
+        body = await request.json();
+      } catch {
+        return Response.json({ error: 'invalid json body' }, { status: 400 });
+      }
+
+      try {
+        const patch = expectRecord(body, 'request body');
+        const baseOnDisk = await readConfigFileRecord(configPath);
+        const currentTmdb = isRecord(baseOnDisk.tmdb) ? baseOnDisk.tmdb : {};
+        const apiKey =
+          typeof patch.apiKey === 'string' && patch.apiKey.trim().length > 0
+            ? patch.apiKey.trim()
+            : currentTmdb.apiKey;
+        const tmdbPatch = validateTmdbConfig(
+          {
+            ...patch,
+            ...(apiKey === undefined ? {} : { apiKey }),
+          },
+          'request body',
+        );
+
+        const merged = {
+          ...baseOnDisk,
+          tmdb: {
+            ...(tmdbPatch.apiKey === undefined
+              ? {}
+              : { apiKey: tmdbPatch.apiKey }),
+            ...(tmdbPatch.cacheTtlDays === undefined
+              ? {}
+              : { cacheTtlDays: tmdbPatch.cacheTtlDays }),
+            ...(tmdbPatch.negativeCacheTtlDays === undefined
+              ? {}
+              : { negativeCacheTtlDays: tmdbPatch.negativeCacheTtlDays }),
           },
         };
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1165,17 +1165,17 @@ export function createApiFetch(
           typeof patch.apiKey === 'string' && patch.apiKey.trim().length > 0
             ? patch.apiKey.trim()
             : currentTmdb.apiKey;
-        const tmdbPatch = validateTmdbConfig(
-          {
-            ...patch,
-            ...(apiKey === undefined ? {} : { apiKey }),
-          },
-          'request body',
-        );
+        const nextTmdbInput = {
+          ...currentTmdb,
+          ...patch,
+          ...(apiKey === undefined ? {} : { apiKey }),
+        };
+        const tmdbPatch = validateTmdbConfig(nextTmdbInput, 'request body');
 
         const merged = {
           ...baseOnDisk,
           tmdb: {
+            ...currentTmdb,
             ...(tmdbPatch.apiKey === undefined
               ? {}
               : { apiKey: tmdbPatch.apiKey }),

--- a/src/config.ts
+++ b/src/config.ts
@@ -651,15 +651,21 @@ function expectString(input: unknown, path: string): string {
   return input;
 }
 
-function validateOptionalTmdb(
-  input: unknown,
+export function validateTmdbConfig(
+  tmdb: Record<string, unknown>,
   path: string,
-): TmdbConfig | undefined {
-  if (input === undefined) {
-    return undefined;
+): TmdbConfig {
+  for (const key of Object.keys(tmdb)) {
+    if (
+      key !== 'apiKey' &&
+      key !== 'cacheTtlDays' &&
+      key !== 'negativeCacheTtlDays'
+    ) {
+      throw new ConfigError(
+        `Config file "${path} tmdb" has unknown key "${key}"; expected only "apiKey", "cacheTtlDays", and "negativeCacheTtlDays".`,
+      );
+    }
   }
-
-  const tmdb = expectRecord(input, `${path} tmdb`);
 
   const apiKey =
     tmdb.apiKey === undefined
@@ -686,6 +692,17 @@ function validateOptionalTmdb(
     cacheTtlDays,
     negativeCacheTtlDays,
   };
+}
+
+function validateOptionalTmdb(
+  input: unknown,
+  path: string,
+): TmdbConfig | undefined {
+  if (input === undefined) {
+    return undefined;
+  }
+
+  return validateTmdbConfig(expectRecord(input, `${path} tmdb`), path);
 }
 
 function validateOptionalTmdbDayCount(

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -2490,6 +2490,132 @@ describe('PUT /api/config/movies', () => {
   });
 });
 
+describe('PUT /api/config/tmdb', () => {
+  it('persists TMDB settings and redacts the response key', async () => {
+    const prevWrite = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    try {
+      const directory = await mkdtemp(
+        join(tmpdir(), 'pirate-claw-api-config-tmdb-'),
+      );
+      const configPath = join(directory, 'pirate-claw.config.json');
+      await writeCompactTvConfigFile(configPath);
+      const loaded = await loadConfig(configPath);
+      const holder = { current: loaded };
+      const deps = createDeps();
+      deps.config = loaded;
+      deps.configHolder = holder;
+      deps.configPath = configPath;
+
+      const handler = createApiFetch(deps);
+      const get = await handler(new Request('http://localhost/api/config'));
+      const etag = get.headers.get('etag')!;
+
+      const put = await handler(
+        new Request('http://localhost/api/config/tmdb', {
+          method: 'PUT',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer write-token',
+            'if-match': etag,
+          },
+          body: JSON.stringify({
+            apiKey: 'tmdb-api-key',
+            cacheTtlDays: 7,
+            negativeCacheTtlDays: 1,
+          }),
+        }),
+      );
+
+      expect(put.status).toBe(200);
+      expect(await put.json()).toMatchObject({
+        tmdb: {
+          apiKey: '[redacted]',
+          cacheTtlDays: 7,
+          negativeCacheTtlDays: 1,
+        },
+      });
+      expect(holder.current.tmdb).toEqual({
+        apiKey: 'tmdb-api-key',
+        cacheTtlDays: 7,
+        negativeCacheTtlDays: 1,
+      });
+
+      const disk = await Bun.file(configPath).json();
+      expect(disk.tmdb).toEqual({
+        apiKey: 'tmdb-api-key',
+        cacheTtlDays: 7,
+        negativeCacheTtlDays: 1,
+      });
+    } finally {
+      if (prevWrite !== undefined) {
+        process.env.PIRATE_CLAW_API_WRITE_TOKEN = prevWrite;
+      } else {
+        delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+      }
+    }
+  });
+
+  it('preserves the existing TMDB API key when only TTL values change', async () => {
+    const prevWrite = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+    try {
+      const directory = await mkdtemp(
+        join(tmpdir(), 'pirate-claw-api-config-tmdb-preserve-'),
+      );
+      const configPath = join(directory, 'pirate-claw.config.json');
+      await writeCompactTvConfigFile(configPath);
+      const doc = (await Bun.file(configPath).json()) as Record<
+        string,
+        unknown
+      >;
+      doc.tmdb = {
+        apiKey: 'existing-api-key',
+        cacheTtlDays: 7,
+        negativeCacheTtlDays: 1,
+      };
+      await Bun.write(configPath, `${JSON.stringify(doc, null, 2)}\n`);
+      const loaded = await loadConfig(configPath);
+      const deps = createDeps();
+      deps.config = loaded;
+      deps.configPath = configPath;
+
+      const handler = createApiFetch(deps);
+      const get = await handler(new Request('http://localhost/api/config'));
+      const etag = get.headers.get('etag')!;
+
+      const put = await handler(
+        new Request('http://localhost/api/config/tmdb', {
+          method: 'PUT',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer write-token',
+            'if-match': etag,
+          },
+          body: JSON.stringify({
+            cacheTtlDays: 14,
+            negativeCacheTtlDays: 2,
+          }),
+        }),
+      );
+
+      expect(put.status).toBe(200);
+      const disk = await Bun.file(configPath).json();
+      expect(disk.tmdb).toEqual({
+        apiKey: 'existing-api-key',
+        cacheTtlDays: 14,
+        negativeCacheTtlDays: 2,
+      });
+    } finally {
+      if (prevWrite !== undefined) {
+        process.env.PIRATE_CLAW_API_WRITE_TOKEN = prevWrite;
+      } else {
+        delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+      }
+    }
+  });
+});
+
 describe('PUT /api/config/transmission/download-dirs', () => {
   async function makeDownloadDirsHandler() {
     const prevWrite = process.env.PIRATE_CLAW_API_WRITE_TOKEN;

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -2556,7 +2556,7 @@ describe('PUT /api/config/tmdb', () => {
     }
   });
 
-  it('preserves the existing TMDB API key when only TTL values change', async () => {
+  it('preserves existing TMDB fields when a partial update omits them', async () => {
     const prevWrite = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
     delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
     try {
@@ -2594,7 +2594,6 @@ describe('PUT /api/config/tmdb', () => {
           },
           body: JSON.stringify({
             cacheTtlDays: 14,
-            negativeCacheTtlDays: 2,
           }),
         }),
       );
@@ -2604,7 +2603,7 @@ describe('PUT /api/config/tmdb', () => {
       expect(disk.tmdb).toEqual({
         apiKey: 'existing-api-key',
         cacheTtlDays: 14,
-        negativeCacheTtlDays: 2,
+        negativeCacheTtlDays: 1,
       });
     } finally {
       if (prevWrite !== undefined) {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -173,6 +173,12 @@ export type PlexConfig = {
 	refreshIntervalMinutes: number;
 };
 
+export type TmdbConfig = {
+	apiKey?: string;
+	cacheTtlDays?: number;
+	negativeCacheTtlDays?: number;
+};
+
 export type PlexAuthState =
 	| 'not_connected'
 	| 'connecting'
@@ -197,6 +203,7 @@ export type AppConfig = {
 	movies?: MoviePolicy;
 	transmission: TransmissionConfig;
 	runtime: RuntimeConfig;
+	tmdb?: TmdbConfig;
 	plex?: PlexConfig;
 };
 

--- a/web/src/routes/config/+page.server.ts
+++ b/web/src/routes/config/+page.server.ts
@@ -104,6 +104,20 @@ function validateRuntimeBounds(
 	return { ok: true };
 }
 
+function validateTmdbDays(
+	field: string,
+	value: number | undefined
+): { ok: true } | { ok: false; message: string } {
+	if (value === undefined) return { ok: false, message: `Field "${field}" is required.` };
+	if (!Number.isInteger(value) || value <= 0 || value > 3650) {
+		return {
+			ok: false,
+			message: `Field "${field}" must be a whole number between 1 and 3650.`
+		};
+	}
+	return { ok: true };
+}
+
 export const actions: Actions = {
 	savePlex: async ({ request }) => {
 		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
@@ -476,6 +490,75 @@ export const actions: Actions = {
 		} catch (error) {
 			console.error('[config] saveMovies failed:', error);
 			return fail(500, { moviesMessage: 'Could not save movies policy.' });
+		}
+	},
+
+	saveTmdb: async ({ request }) => {
+		const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
+		if (!writeToken) {
+			return fail(403, { tmdbMessage: 'Config writes are disabled.' });
+		}
+
+		const formData = await request.formData();
+		const ifMatch = String(formData.get('tmdbIfMatch') ?? '').trim();
+		if (!ifMatch) {
+			return fail(400, { tmdbMessage: 'Missing config revision. Reload and try again.' });
+		}
+
+		const apiKey = String(formData.get('tmdbApiKey') ?? '').trim();
+		const cacheTtlDays = parseOptionalInt(formData.get('tmdbCacheTtlDays'));
+		const negativeCacheTtlDays = parseOptionalInt(formData.get('tmdbNegativeCacheTtlDays'));
+		if (Number.isNaN(cacheTtlDays) || Number.isNaN(negativeCacheTtlDays)) {
+			return fail(400, { tmdbMessage: 'TMDB cache TTLs must be whole numbers.' });
+		}
+
+		for (const [field, value] of [
+			['cacheTtlDays', cacheTtlDays],
+			['negativeCacheTtlDays', negativeCacheTtlDays]
+		] as const) {
+			const result = validateTmdbDays(field, value);
+			if (!result.ok) {
+				return fail(400, { tmdbMessage: result.message });
+			}
+		}
+
+		try {
+			const response = await apiRequest('/api/config/tmdb', {
+				method: 'PUT',
+				headers: {
+					'content-type': 'application/json',
+					authorization: `Bearer ${writeToken}`,
+					'if-match': ifMatch
+				},
+				body: JSON.stringify({
+					...(apiKey ? { apiKey } : {}),
+					cacheTtlDays,
+					negativeCacheTtlDays
+				})
+			});
+
+			if (!response.ok) {
+				let tmdbMessage = `Save failed (${response.status}).`;
+				try {
+					const body = (await response.json()) as { error?: string };
+					if (body.error) tmdbMessage = body.error;
+				} catch {
+					// keep fallback message
+				}
+				return fail(response.status, {
+					tmdbMessage,
+					tmdbEtag: response.headers.get('etag')
+				});
+			}
+
+			return {
+				tmdbSuccess: true,
+				tmdbMessage: 'TMDB settings saved.',
+				tmdbEtag: response.headers.get('etag')
+			};
+		} catch (error) {
+			console.error('[config] saveTmdb failed:', error);
+			return fail(500, { tmdbMessage: 'Could not save TMDB settings.' });
 		}
 	},
 

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -16,6 +16,7 @@
 	import MoviePolicyCard from './components/MoviePolicyCard.svelte';
 	import RemoveMovieYearModal from './components/RemoveMovieYearModal.svelte';
 	import ShowWatchlistEditor from './components/ShowWatchlistEditor.svelte';
+	import TmdbPanel from './components/TmdbPanel.svelte';
 	import TransmissionCard from './components/TransmissionCard.svelte';
 	import TvConfigCard from './components/TvConfigCard.svelte';
 
@@ -31,6 +32,7 @@
 	const { data, form }: { data: PageData; form?: ActionData } = $props();
 	const currentEtag = $derived(
 		form?.feedsEtag ??
+			form?.tmdbEtag ??
 			form?.moviesEtag ??
 			form?.tvDefaultsEtag ??
 			form?.showsEtag ??
@@ -488,6 +490,23 @@
 		};
 	};
 
+	const enhanceSaveTmdb: SubmitFunction = () => {
+		return async ({ result, update }) => {
+			if (result.type === 'success') {
+				toast('Saved', 'success');
+			} else if (result.type === 'failure') {
+				if (result.status === 409) {
+					toast('Config changed elsewhere — reload and try again', 'error');
+				} else {
+					const detail =
+						typeof result.data?.tmdbMessage === 'string' ? result.data.tmdbMessage : undefined;
+					toast('Save failed — see errors above', 'error', detail);
+				}
+			}
+			await update({ reset: false });
+		};
+	};
+
 	const enhanceRestartDaemon: SubmitFunction = () => {
 		restarting = true;
 		return async ({ result, update }) => {
@@ -591,6 +610,15 @@
 				onNewFeedNameChange={(value) => (newFeedName = value)}
 				onNewFeedUrlChange={(value) => (newFeedUrl = value)}
 				onNewFeedMediaTypeChange={(value) => (newFeedMediaType = value)}
+			/>
+
+			<TmdbPanel
+				tmdb={data.config.tmdb}
+				{canWrite}
+				{currentEtag}
+				writeDisabledTooltip={WRITE_DISABLED_TOOLTIP}
+				tmdbMessage={form?.tmdbMessage}
+				{enhanceSaveTmdb}
 			/>
 
 			<div class="space-y-5">

--- a/web/src/routes/config/components/TmdbPanel.svelte
+++ b/web/src/routes/config/components/TmdbPanel.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { Button } from '$lib/components/ui/button';
+	import { Card, CardContent, CardHeader } from '$lib/components/ui/card';
+	import type { TmdbConfig } from '$lib/types';
+	import type { SubmitFunction } from '@sveltejs/kit';
+	import DatabaseIcon from '@lucide/svelte/icons/database';
+	import KeyRoundIcon from '@lucide/svelte/icons/key-round';
+
+	interface Props {
+		tmdb?: TmdbConfig;
+		canWrite: boolean;
+		currentEtag: string | null;
+		writeDisabledTooltip: string;
+		tmdbMessage?: string;
+		enhanceSaveTmdb: SubmitFunction;
+	}
+
+	const { tmdb, canWrite, currentEtag, writeDisabledTooltip, tmdbMessage, enhanceSaveTmdb }: Props =
+		$props();
+
+	const apiKeyConfigured = $derived(!!tmdb?.apiKey);
+</script>
+
+<Card class="bg-card/75 rounded-[30px] border-white/10">
+	<CardHeader class="space-y-4">
+		<div class="flex items-start justify-between gap-3">
+			<div class="space-y-1">
+				<p class="text-primary font-mono text-xs font-semibold tracking-[0.2em] uppercase">
+					03 · Metadata
+				</p>
+				<h2 class="text-2xl font-semibold tracking-[-0.03em]">TMDB Metadata</h2>
+			</div>
+			<div class="text-muted-foreground inline-flex items-center gap-2 text-xs uppercase">
+				<span
+					class={`inline-block size-2 rounded-full ${apiKeyConfigured ? 'bg-emerald-400' : 'bg-amber-400'}`}
+					aria-label={apiKeyConfigured ? 'configured' : 'not configured'}
+				></span>
+				{apiKeyConfigured ? 'Configured' : 'No API Key'}
+			</div>
+		</div>
+	</CardHeader>
+	<CardContent>
+		<form method="POST" action="?/saveTmdb" class="space-y-5" use:enhance={enhanceSaveTmdb}>
+			<input type="hidden" name="tmdbIfMatch" value={currentEtag ?? ''} />
+
+			<div class="grid gap-3 sm:grid-cols-2">
+				<label class="grid gap-1 text-sm sm:col-span-2">
+					<span class="text-muted-foreground">API key</span>
+					<div class="relative">
+						<KeyRoundIcon class="text-muted-foreground absolute top-3 left-3 size-4" />
+						<input
+							name="tmdbApiKey"
+							type="password"
+							autocomplete="off"
+							placeholder={apiKeyConfigured
+								? 'Configured; enter a new key to replace'
+								: 'TMDB API key'}
+							disabled={!canWrite}
+							title={!canWrite ? writeDisabledTooltip : undefined}
+							class="border-input bg-background ring-offset-background focus-visible:ring-ring h-10 w-full rounded-2xl border pr-3 pl-10 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+						/>
+					</div>
+				</label>
+
+				<label class="grid gap-1 text-sm">
+					<span class="text-muted-foreground">Cache TTL (days)</span>
+					<input
+						name="tmdbCacheTtlDays"
+						type="number"
+						min="1"
+						max="3650"
+						step="1"
+						value={tmdb?.cacheTtlDays ?? 7}
+						disabled={!canWrite}
+						title={!canWrite ? writeDisabledTooltip : undefined}
+						class="border-input bg-background ring-offset-background focus-visible:ring-ring h-10 rounded-2xl border px-3 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+					/>
+				</label>
+
+				<label class="grid gap-1 text-sm">
+					<span class="text-muted-foreground">Negative cache TTL (days)</span>
+					<input
+						name="tmdbNegativeCacheTtlDays"
+						type="number"
+						min="1"
+						max="3650"
+						step="1"
+						value={tmdb?.negativeCacheTtlDays ?? 1}
+						disabled={!canWrite}
+						title={!canWrite ? writeDisabledTooltip : undefined}
+						class="border-input bg-background ring-offset-background focus-visible:ring-ring h-10 rounded-2xl border px-3 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
+					/>
+				</label>
+			</div>
+
+			{#if tmdbMessage}
+				<p class="text-destructive text-xs">{tmdbMessage}</p>
+			{/if}
+
+			<Button
+				type="submit"
+				class="rounded-full px-5"
+				disabled={!canWrite || !currentEtag}
+				title={!canWrite ? writeDisabledTooltip : undefined}
+			>
+				<DatabaseIcon class="size-4" />
+				Save TMDB
+			</Button>
+		</form>
+	</CardContent>
+</Card>

--- a/web/test/routes/config/config.test.ts
+++ b/web/test/routes/config/config.test.ts
@@ -46,6 +46,11 @@ const mockConfig: AppConfig = {
 		reconcileIntervalSeconds: 30,
 		artifactDir: '.pirate-claw/runtime',
 		artifactRetentionDays: 7
+	},
+	tmdb: {
+		apiKey: '[redacted]',
+		cacheTtlDays: 7,
+		negativeCacheTtlDays: 1
 	}
 };
 
@@ -81,6 +86,7 @@ describe('/config', () => {
 		expect(screen.getByRole('heading', { name: 'TV Configuration' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Movie Policy' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Transmission Protocol' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'TMDB Metadata' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Plex Connection' })).toBeInTheDocument();
 		expect(screen.getByLabelText('Plex Media Server URL')).toHaveValue('http://localhost:32400');
 		expect(screen.getByRole('link', { name: 'Connect in browser' })).toBeInTheDocument();
@@ -92,6 +98,7 @@ describe('/config', () => {
 		expect(screen.queryByRole('button', { name: 'Save shows' })).not.toBeInTheDocument();
 		expect(screen.queryByRole('button', { name: 'Save TV defaults' })).not.toBeInTheDocument();
 		expect(screen.queryByRole('button', { name: 'Save movies policy' })).not.toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Save TMDB' })).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Save runtime' })).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Restart Daemon' })).toBeDisabled();
 		expect(screen.queryByText('Storage Pool')).not.toBeInTheDocument();
@@ -323,6 +330,7 @@ describe('/config', () => {
 
 		expect(screen.getByRole('heading', { name: 'Transmission Protocol' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'RSS Feeds' })).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'TMDB Metadata' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'TV Configuration' })).toBeInTheDocument();
 		expect(screen.getByRole('heading', { name: 'Movie Policy' })).toBeInTheDocument();
 	});
@@ -342,6 +350,7 @@ describe('/config', () => {
 		expect(screen.queryByRole('button', { name: 'Save movies policy' })).not.toBeInTheDocument();
 		expect(screen.queryByRole('button', { name: 'Save shows' })).not.toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Save runtime' })).toBeDisabled();
+		expect(screen.getByRole('button', { name: 'Save TMDB' })).toBeDisabled();
 		expect(screen.getByRole('button', { name: 'Restart Daemon' })).toBeDisabled();
 		expect(screen.getByRole('button', { name: 'Add show' })).toBeDisabled();
 		expect(screen.getByRole('button', { name: 'Add year' })).toBeDisabled();

--- a/web/test/routes/config/page.server.test.ts
+++ b/web/test/routes/config/page.server.test.ts
@@ -449,6 +449,97 @@ describe('config page server actions', () => {
 		});
 	});
 
+	describe('saveTmdb', () => {
+		it('returns fail(400) when tmdbIfMatch is missing', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('../../../src/routes/config/+page.server');
+
+			const body = new URLSearchParams();
+			body.set('tmdbCacheTtlDays', '7');
+			body.set('tmdbNegativeCacheTtlDays', '1');
+
+			const result = await actions.saveTmdb({
+				request: new Request('http://localhost/config', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(400);
+			expect((result as { data?: { tmdbMessage?: string } }).data?.tmdbMessage).toContain(
+				'Missing config revision'
+			);
+			expect(apiRequestMock).not.toHaveBeenCalled();
+		});
+
+		it('returns fail(400) when TTLs are invalid', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('../../../src/routes/config/+page.server');
+
+			const body = new URLSearchParams();
+			body.set('tmdbIfMatch', '"rev-1"');
+			body.set('tmdbCacheTtlDays', '0');
+			body.set('tmdbNegativeCacheTtlDays', '1');
+
+			const result = await actions.saveTmdb({
+				request: new Request('http://localhost/config', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { status?: number }).status).toBe(400);
+			expect((result as { data?: { tmdbMessage?: string } }).data?.tmdbMessage).toContain(
+				'cacheTtlDays'
+			);
+			expect(apiRequestMock).not.toHaveBeenCalled();
+		});
+
+		it('saves TMDB settings and sends the API key only when provided', async () => {
+			vi.doMock('$env/dynamic/private', () => ({
+				env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+			}));
+			const { actions } = await import('../../../src/routes/config/+page.server');
+			apiRequestMock.mockResolvedValue(
+				new Response(null, { status: 200, headers: { etag: '"rev-2"' } })
+			);
+
+			const body = new URLSearchParams();
+			body.set('tmdbIfMatch', '"rev-1"');
+			body.set('tmdbApiKey', 'new-key');
+			body.set('tmdbCacheTtlDays', '7');
+			body.set('tmdbNegativeCacheTtlDays', '1');
+
+			const result = await actions.saveTmdb({
+				request: new Request('http://localhost/config', {
+					method: 'POST',
+					headers: { 'content-type': 'application/x-www-form-urlencoded' },
+					body
+				})
+			} as never);
+
+			expect((result as { tmdbSuccess?: boolean }).tmdbSuccess).toBe(true);
+			expect((result as { tmdbEtag?: string }).tmdbEtag).toBe('"rev-2"');
+			expect(apiRequestMock).toHaveBeenCalledWith(
+				'/api/config/tmdb',
+				expect.objectContaining({
+					method: 'PUT',
+					body: JSON.stringify({
+						apiKey: 'new-key',
+						cacheTtlDays: 7,
+						negativeCacheTtlDays: 1
+					})
+				})
+			);
+		});
+	});
+
 	describe('restartDaemon', () => {
 		it('returns 401 when write token is not configured', async () => {
 			vi.doMock('$env/dynamic/private', () => ({


### PR DESCRIPTION
## Summary
- add a dedicated TMDB Metadata panel on /config
- add a guarded /api/config/tmdb write endpoint with ETag protection and response redaction
- cover API persistence, form action validation, and config page rendering

<!-- ai-review:start -->
## External AI Review

- outcome: `operator_input_needed`
- reviewed commit: [`18dd4c2ba24a`](https://github.com/cesarnml/Pirate-Claw/commit/18dd4c2ba24a71a8e40445db57e8bd6c28d12198)
- current branch head: [`18dd4c2ba24a`](https://github.com/cesarnml/Pirate-Claw/commit/18dd4c2ba24a71a8e40445db57e8bd6c28d12198)
- vendors: `coderabbit`

### Resolved Review Findings

- [coderabbit] Partial TMDB updates can erase existing TTL values. `src/api.ts:1189` [thread](https://github.com/cesarnml/Pirate-Claw/pull/253#discussion_r3147237245)
<!-- ai-review:end -->
