### PR TITLE
feat(p28.01): add daemon auth state and internal auth endpoints [P28.01]

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -107,7 +107,11 @@
     "watchlist",
     "worktree",
     "worktrees",
-    "writeability"
+    "writeability",
+    "correcthorsebatterystaple",
+    "mypassword",
+    "notadmin",
+    "wrongpassword"
   ],
   "ignoreWords": [],
   "import": []

--- a/docs/02-delivery/phase-28/ticket-01-daemon-auth-state.md
+++ b/docs/02-delivery/phase-28/ticket-01-daemon-auth-state.md
@@ -53,4 +53,4 @@ All five auth endpoints behave correctly. `session-secret` is generated on first
 
 ## Rationale
 
-_To be completed during delivery._
+Auth state lives in a new `src/auth-state.ts` module (not mixed into `install-bootstrap.ts` or `api.ts`) so the file I/O contract and bcrypt operations are testable in isolation. Session-secret generation was added to `ensureFirstStartupBootstrap` following the same create-if-absent pattern as the daemon write token; `auth/` and `web/` subdirectories are created lazily by each write function rather than added to `INSTALL_ROOT_DIRECTORIES`, matching the existing `config/generated` pattern. All five auth endpoints are behind `checkWriteAuth` (daemon write token) so the web layer remains the only caller, preventing direct unauthenticated access from LAN. Bcrypt cost 12 was chosen as the standard hardening value; the timing-safe comparison relies on bcrypt's inherent constant-time properties plus always calling `Bun.password.verify` before the username check when an owner exists.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,14 @@
 import type { Database } from 'bun:sqlite';
 import { createHash, randomUUID } from 'node:crypto';
+import { dirname } from 'node:path';
 import { getSetupState } from './bootstrap';
+import {
+  acknowledgeNetworkPosture,
+  readAuthState,
+  setupOwner,
+  trustOrigin,
+  verifyLogin,
+} from './auth-state';
 import { renameSync, writeFileSync } from 'node:fs';
 import { getInstallHealth } from './install-health';
 import {
@@ -508,6 +516,169 @@ export function createApiFetch(
             ? 'Non-standard Transmission configuration detected. Setup will proceed but verify your URL and port.'
             : undefined;
         return Response.json({ compatibility, url, reachable, advisory });
+      } catch {
+        return json500();
+      }
+    }
+
+    if (path === '/api/auth/state' && request.method === 'GET') {
+      const authError = checkWriteAuth(request, activeConfig);
+      if (authError) return authError;
+      try {
+        return Response.json(await readAuthState(dirname(configPath)));
+      } catch {
+        return json500();
+      }
+    }
+
+    if (path === '/api/auth/setup-owner' && request.method === 'POST') {
+      const authError = checkWriteAuth(request, activeConfig);
+      if (authError) return authError;
+
+      let body: unknown;
+      try {
+        body = await request.json();
+      } catch {
+        return Response.json({ error: 'invalid json body' }, { status: 400 });
+      }
+
+      const parsed = body as Record<string, unknown>;
+      if (typeof parsed?.username !== 'string' || !parsed.username.trim()) {
+        return Response.json(
+          { error: 'username is required' },
+          { status: 400 },
+        );
+      }
+      if (typeof parsed?.password !== 'string' || !parsed.password) {
+        return Response.json(
+          { error: 'password is required' },
+          { status: 400 },
+        );
+      }
+
+      try {
+        const origin = request.headers.get('origin');
+        const result = await setupOwner(
+          dirname(configPath),
+          parsed.username.trim(),
+          parsed.password,
+          origin,
+        );
+        if (!result.ok) {
+          return Response.json(
+            { error: 'owner already exists' },
+            { status: 409 },
+          );
+        }
+        return Response.json({ ok: true });
+      } catch {
+        return json500();
+      }
+    }
+
+    if (path === '/api/auth/verify-login' && request.method === 'POST') {
+      const authError = checkWriteAuth(request, activeConfig);
+      if (authError) return authError;
+
+      let body: unknown;
+      try {
+        body = await request.json();
+      } catch {
+        return Response.json({ error: 'invalid json body' }, { status: 400 });
+      }
+
+      const parsed = body as Record<string, unknown>;
+      if (typeof parsed?.username !== 'string' || !parsed.username.trim()) {
+        return Response.json(
+          { error: 'username is required' },
+          { status: 400 },
+        );
+      }
+      if (typeof parsed?.password !== 'string') {
+        return Response.json(
+          { error: 'password is required' },
+          { status: 400 },
+        );
+      }
+
+      try {
+        const result = await verifyLogin(
+          dirname(configPath),
+          parsed.username.trim(),
+          parsed.password,
+        );
+        return Response.json(result);
+      } catch {
+        return json500();
+      }
+    }
+
+    if (path === '/api/auth/trust-origin' && request.method === 'POST') {
+      const authError = checkWriteAuth(request, activeConfig);
+      if (authError) return authError;
+
+      let body: unknown;
+      try {
+        body = await request.json();
+      } catch {
+        return Response.json({ error: 'invalid json body' }, { status: 400 });
+      }
+
+      const parsed = body as Record<string, unknown>;
+      if (typeof parsed?.origin !== 'string' || !parsed.origin.trim()) {
+        return Response.json({ error: 'origin is required' }, { status: 400 });
+      }
+
+      try {
+        await trustOrigin(dirname(configPath), parsed.origin.trim());
+        return Response.json({ ok: true });
+      } catch {
+        return json500();
+      }
+    }
+
+    if (
+      path === '/api/auth/acknowledge-network-posture' &&
+      request.method === 'POST'
+    ) {
+      const authError = checkWriteAuth(request, activeConfig);
+      if (authError) return authError;
+
+      let body: unknown;
+      try {
+        body = await request.json();
+      } catch {
+        return Response.json({ error: 'invalid json body' }, { status: 400 });
+      }
+
+      const parsed = body as Record<string, unknown>;
+      const validStates = [
+        'direct_acknowledged',
+        'already_secured_externally',
+        'vpn_bridge_pending',
+      ] as const;
+      if (
+        typeof parsed?.state !== 'string' ||
+        !validStates.includes(parsed.state as (typeof validStates)[number])
+      ) {
+        return Response.json(
+          {
+            error:
+              'state must be one of: direct_acknowledged, already_secured_externally, vpn_bridge_pending',
+          },
+          { status: 400 },
+        );
+      }
+
+      try {
+        await acknowledgeNetworkPosture(
+          dirname(configPath),
+          parsed.state as
+            | 'direct_acknowledged'
+            | 'already_secured_externally'
+            | 'vpn_bridge_pending',
+        );
+        return Response.json({ ok: true });
       } catch {
         return json500();
       }

--- a/src/auth-state.ts
+++ b/src/auth-state.ts
@@ -1,0 +1,201 @@
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+
+export type NetworkPostureState =
+  | 'unacknowledged'
+  | 'direct_acknowledged'
+  | 'already_secured_externally'
+  | 'vpn_bridge_pending';
+
+export type AuthStateResult = {
+  owner_exists: boolean;
+  setup_complete: boolean;
+  trusted_origins: string[];
+  network_posture: NetworkPostureState;
+};
+
+type OwnerRecord = {
+  username: string;
+  password_hash: string;
+};
+
+function authSubdir(configDir: string): string {
+  return join(configDir, 'auth');
+}
+
+function webSubdir(configDir: string): string {
+  return join(configDir, 'web');
+}
+
+export function sessionSecretPath(configDir: string): string {
+  return join(authSubdir(configDir), 'session-secret');
+}
+
+function ownerPath(configDir: string): string {
+  return join(authSubdir(configDir), 'owner.json');
+}
+
+function trustedOriginsPath(configDir: string): string {
+  return join(webSubdir(configDir), 'trusted-origins.json');
+}
+
+function networkPosturePath(configDir: string): string {
+  return join(webSubdir(configDir), 'network-posture.json');
+}
+
+export async function ensureSessionSecret(
+  configDir: string,
+): Promise<{ created: boolean; path: string }> {
+  const path = sessionSecretPath(configDir);
+  const file = Bun.file(path);
+  if (await file.exists()) {
+    return { created: false, path };
+  }
+  await mkdir(authSubdir(configDir), { recursive: true });
+  await Bun.write(path, `${randomBytes(32).toString('hex')}\n`);
+  return { created: true, path };
+}
+
+async function readOwner(configDir: string): Promise<OwnerRecord | null> {
+  const file = Bun.file(ownerPath(configDir));
+  if (!(await file.exists())) return null;
+  try {
+    const raw: unknown = await file.json();
+    if (
+      raw &&
+      typeof raw === 'object' &&
+      !Array.isArray(raw) &&
+      typeof (raw as Record<string, unknown>).username === 'string' &&
+      typeof (raw as Record<string, unknown>).password_hash === 'string'
+    ) {
+      return raw as OwnerRecord;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function readTrustedOrigins(configDir: string): Promise<string[]> {
+  const file = Bun.file(trustedOriginsPath(configDir));
+  if (!(await file.exists())) return [];
+  try {
+    const raw: unknown = await file.json();
+    if (!Array.isArray(raw)) return [];
+    return (raw as unknown[]).filter((x): x is string => typeof x === 'string');
+  } catch {
+    return [];
+  }
+}
+
+async function readNetworkPosture(
+  configDir: string,
+): Promise<NetworkPostureState> {
+  const file = Bun.file(networkPosturePath(configDir));
+  if (!(await file.exists())) return 'unacknowledged';
+  try {
+    const raw: unknown = await file.json();
+    if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+      const s = (raw as Record<string, unknown>).state;
+      if (
+        s === 'unacknowledged' ||
+        s === 'direct_acknowledged' ||
+        s === 'already_secured_externally' ||
+        s === 'vpn_bridge_pending'
+      ) {
+        return s;
+      }
+    }
+    return 'unacknowledged';
+  } catch {
+    return 'unacknowledged';
+  }
+}
+
+async function writeTrustedOrigins(
+  configDir: string,
+  origins: string[],
+): Promise<void> {
+  await mkdir(webSubdir(configDir), { recursive: true });
+  await Bun.write(
+    trustedOriginsPath(configDir),
+    `${JSON.stringify(origins, null, 2)}\n`,
+  );
+}
+
+export async function readAuthState(
+  configDir: string,
+): Promise<AuthStateResult> {
+  const [owner, trustedOrigins, networkPosture] = await Promise.all([
+    readOwner(configDir),
+    readTrustedOrigins(configDir),
+    readNetworkPosture(configDir),
+  ]);
+  const ownerExists = owner !== null;
+  return {
+    owner_exists: ownerExists,
+    setup_complete: ownerExists,
+    trusted_origins: trustedOrigins,
+    network_posture: networkPosture,
+  };
+}
+
+export async function setupOwner(
+  configDir: string,
+  username: string,
+  password: string,
+  origin: string | null,
+): Promise<{ ok: true } | { ok: false; error: 'already_exists' }> {
+  const existing = await readOwner(configDir);
+  if (existing !== null) {
+    return { ok: false, error: 'already_exists' };
+  }
+  await mkdir(authSubdir(configDir), { recursive: true });
+  const passwordHash = await Bun.password.hash(password, {
+    algorithm: 'bcrypt',
+    cost: 12,
+  });
+  await Bun.write(
+    ownerPath(configDir),
+    `${JSON.stringify({ username, password_hash: passwordHash }, null, 2)}\n`,
+  );
+  if (origin) {
+    await writeTrustedOrigins(configDir, [origin]);
+  }
+  return { ok: true };
+}
+
+export async function verifyLogin(
+  configDir: string,
+  username: string,
+  password: string,
+): Promise<{ ok: boolean }> {
+  const owner = await readOwner(configDir);
+  if (!owner) return { ok: false };
+  const hashMatch = await Bun.password.verify(password, owner.password_hash);
+  return { ok: hashMatch && owner.username === username };
+}
+
+export async function trustOrigin(
+  configDir: string,
+  origin: string,
+): Promise<void> {
+  const existing = await readTrustedOrigins(configDir);
+  if (existing.includes(origin)) return;
+  await writeTrustedOrigins(configDir, [...existing, origin]);
+}
+
+export async function acknowledgeNetworkPosture(
+  configDir: string,
+  state:
+    | 'direct_acknowledged'
+    | 'already_secured_externally'
+    | 'vpn_bridge_pending',
+): Promise<void> {
+  await mkdir(webSubdir(configDir), { recursive: true });
+  await Bun.write(
+    networkPosturePath(configDir),
+    `${JSON.stringify({ state }, null, 2)}\n`,
+  );
+}

--- a/src/auth-state.ts
+++ b/src/auth-state.ts
@@ -1,4 +1,4 @@
-import { mkdir } from 'node:fs/promises';
+import { mkdir, writeFile, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
 
@@ -48,13 +48,19 @@ export async function ensureSessionSecret(
   configDir: string,
 ): Promise<{ created: boolean; path: string }> {
   const path = sessionSecretPath(configDir);
-  const file = Bun.file(path);
-  if (await file.exists()) {
-    return { created: false, path };
-  }
   await mkdir(authSubdir(configDir), { recursive: true });
-  await Bun.write(path, `${randomBytes(32).toString('hex')}\n`);
-  return { created: true, path };
+  try {
+    await writeFile(path, `${randomBytes(32).toString('hex')}\n`, {
+      flag: 'wx',
+      mode: 0o600,
+    });
+    return { created: true, path };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      return { created: false, path };
+    }
+    throw err;
+  }
 }
 
 async function readOwner(configDir: string): Promise<OwnerRecord | null> {
@@ -147,21 +153,28 @@ export async function setupOwner(
   password: string,
   origin: string | null,
 ): Promise<{ ok: true } | { ok: false; error: 'already_exists' }> {
-  const existing = await readOwner(configDir);
-  if (existing !== null) {
-    return { ok: false, error: 'already_exists' };
-  }
   await mkdir(authSubdir(configDir), { recursive: true });
   const passwordHash = await Bun.password.hash(password, {
     algorithm: 'bcrypt',
     cost: 12,
   });
-  await Bun.write(
-    ownerPath(configDir),
-    `${JSON.stringify({ username, password_hash: passwordHash }, null, 2)}\n`,
-  );
+  const ownerRecord = `${JSON.stringify({ username, password_hash: passwordHash }, null, 2)}\n`;
+  const path = ownerPath(configDir);
+  try {
+    await writeFile(path, ownerRecord, { flag: 'wx', mode: 0o600 });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      return { ok: false, error: 'already_exists' };
+    }
+    throw err;
+  }
   if (origin) {
-    await writeTrustedOrigins(configDir, [origin]);
+    try {
+      await writeTrustedOrigins(configDir, [origin]);
+    } catch (err) {
+      await unlink(path).catch(() => undefined);
+      throw err;
+    }
   }
   return { ok: true };
 }

--- a/src/install-bootstrap.ts
+++ b/src/install-bootstrap.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from 'node:crypto';
 import { mkdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { ensureSessionSecret } from './auth-state';
 
 export const DEFAULT_SYNOLOGY_INSTALL_ROOT = '/volume1/pirate-claw';
 
@@ -23,6 +24,8 @@ export type FirstStartupBootstrapResult = {
   configDir: string;
   daemonApiWriteTokenPath: string;
   daemonApiWriteTokenCreated: boolean;
+  sessionSecretPath: string;
+  sessionSecretCreated: boolean;
 };
 
 export async function ensureFirstStartupBootstrap(input: {
@@ -56,11 +59,15 @@ export async function ensureFirstStartupBootstrap(input: {
     await Bun.write(daemonApiWriteTokenPath, `${generateSecretToken()}\n`);
   }
 
+  const sessionSecret = await ensureSessionSecret(configDir);
+
   return {
     installRoot,
     configDir,
     daemonApiWriteTokenPath,
     daemonApiWriteTokenCreated,
+    sessionSecretPath: sessionSecret.path,
+    sessionSecretCreated: sessionSecret.created,
   };
 }
 

--- a/test/auth-state.test.ts
+++ b/test/auth-state.test.ts
@@ -1,0 +1,568 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  acknowledgeNetworkPosture,
+  ensureSessionSecret,
+  readAuthState,
+  sessionSecretPath,
+  setupOwner,
+  trustOrigin,
+  verifyLogin,
+} from '../src/auth-state';
+import { createApiFetch, createHealthState } from '../src/api';
+import type { AppConfig } from '../src/config';
+import type { Repository } from '../src/repository';
+
+// --- Helpers ---
+
+let configDir: string | undefined;
+
+afterEach(async () => {
+  if (configDir) {
+    await rm(configDir, { recursive: true, force: true });
+    configDir = undefined;
+  }
+});
+
+async function makeTmpConfigDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'pirate-claw-auth-'));
+  configDir = dir;
+  return dir;
+}
+
+// --- auth-state module tests ---
+
+describe('ensureSessionSecret', () => {
+  it('creates session-secret on first call', async () => {
+    const dir = await makeTmpConfigDir();
+    const result = await ensureSessionSecret(dir);
+
+    expect(result.created).toBe(true);
+    expect(result.path).toBe(sessionSecretPath(dir));
+
+    const content = (await Bun.file(result.path).text()).trim();
+    expect(content).toHaveLength(64); // 32 bytes as hex
+    expect(content).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('does not overwrite existing session-secret on second call', async () => {
+    const dir = await makeTmpConfigDir();
+    const first = await ensureSessionSecret(dir);
+    const firstContent = await Bun.file(first.path).text();
+
+    const second = await ensureSessionSecret(dir);
+    const secondContent = await Bun.file(second.path).text();
+
+    expect(second.created).toBe(false);
+    expect(secondContent).toBe(firstContent);
+  });
+});
+
+describe('readAuthState', () => {
+  it('returns default state before any setup', async () => {
+    const dir = await makeTmpConfigDir();
+    const state = await readAuthState(dir);
+
+    expect(state.owner_exists).toBe(false);
+    expect(state.setup_complete).toBe(false);
+    expect(state.trusted_origins).toEqual([]);
+    expect(state.network_posture).toBe('unacknowledged');
+  });
+
+  it('reflects owner existence after setupOwner', async () => {
+    const dir = await makeTmpConfigDir();
+    await setupOwner(dir, 'admin', 'secret123', null);
+
+    const state = await readAuthState(dir);
+    expect(state.owner_exists).toBe(true);
+    expect(state.setup_complete).toBe(true);
+  });
+});
+
+describe('setupOwner', () => {
+  it('creates owner.json with bcrypt hash and persists origin to trusted-origins.json', async () => {
+    const dir = await makeTmpConfigDir();
+    const result = await setupOwner(
+      dir,
+      'admin',
+      'correcthorsebatterystaple',
+      'http://192.168.1.100:3000',
+    );
+
+    expect(result.ok).toBe(true);
+
+    const ownerFile = (await Bun.file(
+      join(dir, 'auth', 'owner.json'),
+    ).json()) as { username: string; password_hash: string };
+    expect(ownerFile.username).toBe('admin');
+    expect(ownerFile.password_hash).toMatch(/^\$2b\$/);
+
+    const origins = await Bun.file(
+      join(dir, 'web', 'trusted-origins.json'),
+    ).json();
+    expect(origins).toEqual(['http://192.168.1.100:3000']);
+  });
+
+  it('creates owner.json without trusted-origins.json when origin is null', async () => {
+    const dir = await makeTmpConfigDir();
+    await setupOwner(dir, 'admin', 'secret', null);
+
+    const originsFile = Bun.file(join(dir, 'web', 'trusted-origins.json'));
+    expect(await originsFile.exists()).toBe(false);
+  });
+
+  it('returns already_exists on duplicate call', async () => {
+    const dir = await makeTmpConfigDir();
+    await setupOwner(dir, 'admin', 'secret', null);
+    const second = await setupOwner(dir, 'admin', 'other', null);
+
+    expect(second.ok).toBe(false);
+    expect((second as { ok: false; error: string }).error).toBe(
+      'already_exists',
+    );
+  });
+});
+
+describe('verifyLogin', () => {
+  it('returns ok: true for correct credentials', async () => {
+    const dir = await makeTmpConfigDir();
+    await setupOwner(dir, 'admin', 'correct-password', null);
+
+    const result = await verifyLogin(dir, 'admin', 'correct-password');
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns ok: false for wrong password', async () => {
+    const dir = await makeTmpConfigDir();
+    await setupOwner(dir, 'admin', 'correct-password', null);
+
+    const result = await verifyLogin(dir, 'admin', 'wrong-password');
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns ok: false for wrong username', async () => {
+    const dir = await makeTmpConfigDir();
+    await setupOwner(dir, 'admin', 'correct-password', null);
+
+    const result = await verifyLogin(dir, 'notadmin', 'correct-password');
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns ok: false when no owner exists', async () => {
+    const dir = await makeTmpConfigDir();
+
+    const result = await verifyLogin(dir, 'admin', 'password');
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('trustOrigin', () => {
+  it('appends a new origin', async () => {
+    const dir = await makeTmpConfigDir();
+    await trustOrigin(dir, 'http://localhost:3000');
+
+    const origins = await Bun.file(
+      join(dir, 'web', 'trusted-origins.json'),
+    ).json();
+    expect(origins).toEqual(['http://localhost:3000']);
+  });
+
+  it('is idempotent for an already-trusted origin', async () => {
+    const dir = await makeTmpConfigDir();
+    await trustOrigin(dir, 'http://localhost:3000');
+    await trustOrigin(dir, 'http://localhost:3000');
+
+    const origins = await Bun.file(
+      join(dir, 'web', 'trusted-origins.json'),
+    ).json();
+    expect(origins).toEqual(['http://localhost:3000']);
+  });
+
+  it('appends without duplicating when different origins added', async () => {
+    const dir = await makeTmpConfigDir();
+    await trustOrigin(dir, 'http://192.168.1.100:3000');
+    await trustOrigin(dir, 'http://100.64.0.1:3000');
+
+    const origins = await Bun.file(
+      join(dir, 'web', 'trusted-origins.json'),
+    ).json();
+    expect(origins).toEqual([
+      'http://192.168.1.100:3000',
+      'http://100.64.0.1:3000',
+    ]);
+  });
+});
+
+describe('acknowledgeNetworkPosture', () => {
+  it('persists direct_acknowledged', async () => {
+    const dir = await makeTmpConfigDir();
+    await acknowledgeNetworkPosture(dir, 'direct_acknowledged');
+
+    const raw = (await Bun.file(
+      join(dir, 'web', 'network-posture.json'),
+    ).json()) as { state: string };
+    expect(raw.state).toBe('direct_acknowledged');
+  });
+
+  it('persists already_secured_externally', async () => {
+    const dir = await makeTmpConfigDir();
+    await acknowledgeNetworkPosture(dir, 'already_secured_externally');
+
+    const raw = (await Bun.file(
+      join(dir, 'web', 'network-posture.json'),
+    ).json()) as { state: string };
+    expect(raw.state).toBe('already_secured_externally');
+  });
+
+  it('persists vpn_bridge_pending', async () => {
+    const dir = await makeTmpConfigDir();
+    await acknowledgeNetworkPosture(dir, 'vpn_bridge_pending');
+
+    const raw = (await Bun.file(
+      join(dir, 'web', 'network-posture.json'),
+    ).json()) as { state: string };
+    expect(raw.state).toBe('vpn_bridge_pending');
+  });
+});
+
+// --- HTTP API tests via createApiFetch ---
+
+function stubRepository(): Repository {
+  return {
+    recordRun: () => ({ id: 1, startedAt: '', status: 'running' }),
+    startRun: () => ({ id: 1, startedAt: '', status: 'running' }),
+    getRun: () => undefined,
+    completeRun: () => {},
+    failRun: () => ({}) as never,
+    recordFeedItem: () => 1,
+    recordFeedItemOutcome: () => {},
+    recordCandidateOutcome: () => ({}) as never,
+    recordCandidateReconciliation: () => ({}) as never,
+    getCandidateState: () => undefined,
+    getCandidateStateByTransmissionHash: () => undefined,
+    isCandidateQueued: () => false,
+    updateCandidateReconciliation: () => ({}) as never,
+    retryCandidate: () => ({}) as never,
+    listFeedItemOutcomes: () => [],
+    listRecentRunSummaries: () => [],
+    listCandidateStates: () => [],
+    listReconcilableCandidates: () => [],
+    listRetryableCandidates: () => [],
+    listRecentFeedItemOutcomesForReview: () => [],
+    listDistinctUnmatchedAndFailedOutcomes: () => [],
+    setPirateClawDisposition: () => {},
+    trySetPirateClawDispositionIfUnset: () => true,
+    requeueCandidate: () => {},
+  } as unknown as Repository;
+}
+
+function stubConfig(): AppConfig {
+  return {
+    feeds: [],
+    tv: [],
+    transmission: {
+      url: 'http://localhost:9091/transmission/rpc',
+      username: 'user',
+      password: 'pass',
+    },
+    runtime: {
+      runIntervalMinutes: 15,
+      reconcileIntervalSeconds: 30,
+      artifactDir: '/tmp',
+      artifactRetentionDays: 7,
+      apiWriteToken: 'test-write-token',
+    },
+  } as AppConfig;
+}
+
+const WRITE_TOKEN = 'test-write-token';
+const AUTH_HEADER = { authorization: `Bearer ${WRITE_TOKEN}` };
+
+describe('GET /api/auth/state', () => {
+  it('returns default state shape before any setup', async () => {
+    const dir = await makeTmpConfigDir();
+    const configPath = join(dir, 'pirate-claw.config.json');
+    const handler = createApiFetch({
+      repository: stubRepository(),
+      health: createHealthState(),
+      config: stubConfig(),
+      configPath,
+      pollStatePath: '/tmp/poll-state.json',
+      loadPollState: () => ({ feeds: {} }),
+    });
+
+    const res = await handler(
+      new Request('http://localhost/api/auth/state', { headers: AUTH_HEADER }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.owner_exists).toBe(false);
+    expect(body.setup_complete).toBe(false);
+    expect(body.trusted_origins).toEqual([]);
+    expect(body.network_posture).toBe('unacknowledged');
+  });
+
+  it('reflects owner_exists after setup-owner', async () => {
+    const dir = await makeTmpConfigDir();
+    const configPath = join(dir, 'pirate-claw.config.json');
+    const handler = createApiFetch({
+      repository: stubRepository(),
+      health: createHealthState(),
+      config: stubConfig(),
+      configPath,
+      pollStatePath: '/tmp/poll-state.json',
+      loadPollState: () => ({ feeds: {} }),
+    });
+
+    await handler(
+      new Request('http://localhost/api/auth/setup-owner', {
+        method: 'POST',
+        headers: { ...AUTH_HEADER, 'content-type': 'application/json' },
+        body: JSON.stringify({ username: 'admin', password: 'secret' }),
+      }),
+    );
+
+    const res = await handler(
+      new Request('http://localhost/api/auth/state', { headers: AUTH_HEADER }),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.owner_exists).toBe(true);
+    expect(body.setup_complete).toBe(true);
+  });
+
+  it('requires write token', async () => {
+    const dir = await makeTmpConfigDir();
+    const configPath = join(dir, 'pirate-claw.config.json');
+    const handler = createApiFetch({
+      repository: stubRepository(),
+      health: createHealthState(),
+      config: stubConfig(),
+      configPath,
+      pollStatePath: '/tmp/poll-state.json',
+      loadPollState: () => ({ feeds: {} }),
+    });
+
+    const res = await handler(new Request('http://localhost/api/auth/state'));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /api/auth/setup-owner', () => {
+  it('creates owner and persists origin from Origin header', async () => {
+    const dir = await makeTmpConfigDir();
+    const configPath = join(dir, 'pirate-claw.config.json');
+    const handler = createApiFetch({
+      repository: stubRepository(),
+      health: createHealthState(),
+      config: stubConfig(),
+      configPath,
+      pollStatePath: '/tmp/poll-state.json',
+      loadPollState: () => ({ feeds: {} }),
+    });
+
+    const res = await handler(
+      new Request('http://localhost/api/auth/setup-owner', {
+        method: 'POST',
+        headers: {
+          ...AUTH_HEADER,
+          'content-type': 'application/json',
+          origin: 'http://192.168.1.100:3000',
+        },
+        body: JSON.stringify({ username: 'admin', password: 'password123' }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+
+    const origins = await Bun.file(
+      join(dir, 'web', 'trusted-origins.json'),
+    ).json();
+    expect(origins).toEqual(['http://192.168.1.100:3000']);
+  });
+
+  it('returns 409 on duplicate call', async () => {
+    const dir = await makeTmpConfigDir();
+    const configPath = join(dir, 'pirate-claw.config.json');
+    const handler = createApiFetch({
+      repository: stubRepository(),
+      health: createHealthState(),
+      config: stubConfig(),
+      configPath,
+      pollStatePath: '/tmp/poll-state.json',
+      loadPollState: () => ({ feeds: {} }),
+    });
+
+    const reqBody = JSON.stringify({ username: 'admin', password: 'secret' });
+    await handler(
+      new Request('http://localhost/api/auth/setup-owner', {
+        method: 'POST',
+        headers: { ...AUTH_HEADER, 'content-type': 'application/json' },
+        body: reqBody,
+      }),
+    );
+
+    const res = await handler(
+      new Request('http://localhost/api/auth/setup-owner', {
+        method: 'POST',
+        headers: { ...AUTH_HEADER, 'content-type': 'application/json' },
+        body: reqBody,
+      }),
+    );
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('POST /api/auth/verify-login', () => {
+  it('returns ok: true for correct credentials', async () => {
+    const dir = await makeTmpConfigDir();
+    const configPath = join(dir, 'pirate-claw.config.json');
+    const handler = createApiFetch({
+      repository: stubRepository(),
+      health: createHealthState(),
+      config: stubConfig(),
+      configPath,
+      pollStatePath: '/tmp/poll-state.json',
+      loadPollState: () => ({ feeds: {} }),
+    });
+
+    await setupOwner(dir, 'admin', 'mypassword', null);
+
+    const res = await handler(
+      new Request('http://localhost/api/auth/verify-login', {
+        method: 'POST',
+        headers: { ...AUTH_HEADER, 'content-type': 'application/json' },
+        body: JSON.stringify({ username: 'admin', password: 'mypassword' }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+  });
+
+  it('returns ok: false for wrong password', async () => {
+    const dir = await makeTmpConfigDir();
+    const configPath = join(dir, 'pirate-claw.config.json');
+    const handler = createApiFetch({
+      repository: stubRepository(),
+      health: createHealthState(),
+      config: stubConfig(),
+      configPath,
+      pollStatePath: '/tmp/poll-state.json',
+      loadPollState: () => ({ feeds: {} }),
+    });
+
+    await setupOwner(dir, 'admin', 'mypassword', null);
+
+    const res = await handler(
+      new Request('http://localhost/api/auth/verify-login', {
+        method: 'POST',
+        headers: { ...AUTH_HEADER, 'content-type': 'application/json' },
+        body: JSON.stringify({ username: 'admin', password: 'wrongpassword' }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(false);
+  });
+});
+
+describe('POST /api/auth/trust-origin', () => {
+  it('appends origin and is idempotent', async () => {
+    const dir = await makeTmpConfigDir();
+    const configPath = join(dir, 'pirate-claw.config.json');
+    const handler = createApiFetch({
+      repository: stubRepository(),
+      health: createHealthState(),
+      config: stubConfig(),
+      configPath,
+      pollStatePath: '/tmp/poll-state.json',
+      loadPollState: () => ({ feeds: {} }),
+    });
+
+    await handler(
+      new Request('http://localhost/api/auth/trust-origin', {
+        method: 'POST',
+        headers: { ...AUTH_HEADER, 'content-type': 'application/json' },
+        body: JSON.stringify({ origin: 'http://100.64.0.1:3000' }),
+      }),
+    );
+    const res = await handler(
+      new Request('http://localhost/api/auth/trust-origin', {
+        method: 'POST',
+        headers: { ...AUTH_HEADER, 'content-type': 'application/json' },
+        body: JSON.stringify({ origin: 'http://100.64.0.1:3000' }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const origins = await Bun.file(
+      join(dir, 'web', 'trusted-origins.json'),
+    ).json();
+    expect(origins).toEqual(['http://100.64.0.1:3000']);
+  });
+});
+
+describe('POST /api/auth/acknowledge-network-posture', () => {
+  it('persists all three valid states', async () => {
+    const dir = await makeTmpConfigDir();
+    const configPath = join(dir, 'pirate-claw.config.json');
+    const handler = createApiFetch({
+      repository: stubRepository(),
+      health: createHealthState(),
+      config: stubConfig(),
+      configPath,
+      pollStatePath: '/tmp/poll-state.json',
+      loadPollState: () => ({ feeds: {} }),
+    });
+
+    for (const state of [
+      'direct_acknowledged',
+      'already_secured_externally',
+      'vpn_bridge_pending',
+    ] as const) {
+      const res = await handler(
+        new Request('http://localhost/api/auth/acknowledge-network-posture', {
+          method: 'POST',
+          headers: { ...AUTH_HEADER, 'content-type': 'application/json' },
+          body: JSON.stringify({ state }),
+        }),
+      );
+      expect(res.status).toBe(200);
+
+      const raw = (await Bun.file(
+        join(dir, 'web', 'network-posture.json'),
+      ).json()) as { state: string };
+      expect(raw.state).toBe(state);
+    }
+  });
+
+  it('returns 400 for invalid state', async () => {
+    const dir = await makeTmpConfigDir();
+    const configPath = join(dir, 'pirate-claw.config.json');
+    const handler = createApiFetch({
+      repository: stubRepository(),
+      health: createHealthState(),
+      config: stubConfig(),
+      configPath,
+      pollStatePath: '/tmp/poll-state.json',
+      loadPollState: () => ({ feeds: {} }),
+    });
+
+    const res = await handler(
+      new Request('http://localhost/api/auth/acknowledge-network-posture', {
+        method: 'POST',
+        headers: { ...AUTH_HEADER, 'content-type': 'application/json' },
+        body: JSON.stringify({ state: 'unacknowledged' }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/test/repository.test.ts
+++ b/test/repository.test.ts
@@ -594,12 +594,13 @@ describe('SQLite repository', () => {
   describe('listRecentFeedItemOutcomesForReview', () => {
     it('returns one row per identity_key for latest failed enqueue while candidate is still failed', async () => {
       const repository = createTestRepository(await createDatabasePath());
-      const run = repository.startRun('2026-04-01T00:00:00.000Z');
+      const baseTime = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000);
+      const run = repository.startRun(offsetIso(baseTime, 0));
       const feedItem = repository.recordFeedItem(run.id, {
         feedName: 'main-tv',
         guidOrLink: 'https://example.test/item1',
         rawTitle: 'Some.Show.S01E01.720p',
-        publishedAt: '2026-04-01T00:00:00.000Z',
+        publishedAt: offsetIso(baseTime, 0),
         downloadUrl: 'https://example.test/item1.torrent',
       });
 
@@ -607,14 +608,14 @@ describe('SQLite repository', () => {
         runId: run.id,
         feedItemId: feedItem.id,
         status: 'skipped_no_match',
-        createdAt: '2026-04-01T00:01:00.000Z',
+        createdAt: offsetIso(baseTime, 60_000),
       });
 
       const failedFeedItem = repository.recordFeedItem(run.id, {
         feedName: 'main-tv',
         guidOrLink: 'https://example.test/movie-2024-1080p-x265',
         rawTitle: 'Movie 2024 1080p x265',
-        publishedAt: '2026-04-01T00:03:00.000Z',
+        publishedAt: offsetIso(baseTime, 180_000),
         downloadUrl: 'https://example.test/movie.torrent',
       });
       const failedMatch = requireMovieMatch(failedFeedItem.rawTitle);
@@ -624,21 +625,21 @@ describe('SQLite repository', () => {
         feedItem: failedFeedItem,
         match: failedMatch,
         status: 'failed',
-        updatedAt: '2026-04-01T00:03:10.000Z',
+        updatedAt: offsetIso(baseTime, 190_000),
       });
       repository.recordFeedItemOutcome({
         runId: run.id,
         feedItemId: failedFeedItem.id,
         status: 'failed',
         identityKey: failedMatch.identityKey,
-        createdAt: '2026-04-01T00:03:00.000Z',
+        createdAt: offsetIso(baseTime, 180_000),
       });
       repository.recordFeedItemOutcome({
         runId: run.id,
         feedItemId: failedFeedItem.id,
         status: 'failed',
         identityKey: failedMatch.identityKey,
-        createdAt: '2026-04-01T00:04:00.000Z',
+        createdAt: offsetIso(baseTime, 240_000),
         message: 'later run',
       });
 
@@ -646,7 +647,7 @@ describe('SQLite repository', () => {
         feedName: 'main-movie',
         guidOrLink: 'https://example.test/dup1',
         rawTitle: 'Other Movie 2024 1080p',
-        publishedAt: '2026-04-01T00:05:00.000Z',
+        publishedAt: offsetIso(baseTime, 300_000),
         downloadUrl: 'https://example.test/other.torrent',
       });
       const dupMatch = requireMovieMatch(dupFeed.rawTitle);
@@ -656,7 +657,7 @@ describe('SQLite repository', () => {
         status: 'skipped_duplicate',
         identityKey: dupMatch.identityKey,
         ruleName: dupMatch.ruleName,
-        createdAt: '2026-04-01T00:05:30.000Z',
+        createdAt: offsetIso(baseTime, 330_000),
       });
 
       const results = repository.listRecentFeedItemOutcomesForReview(30);
@@ -664,7 +665,7 @@ describe('SQLite repository', () => {
       expect(results).toHaveLength(1);
       expect(results[0].status).toBe('failed');
       expect(results[0].identityKey).toBe(failedMatch.identityKey);
-      expect(results[0].recordedAt).toBe('2026-04-01T00:04:00.000Z');
+      expect(results[0].recordedAt).toBe(offsetIso(baseTime, 240_000));
 
       repository.requeueCandidate(failedMatch.identityKey, {});
       const afterRequeue = repository.listRecentFeedItemOutcomesForReview(30);
@@ -673,12 +674,13 @@ describe('SQLite repository', () => {
 
     it('returns null title and feedName when the latest failed outcome row has no feed item', async () => {
       const repository = createTestRepository(await createDatabasePath());
-      const run = repository.startRun('2026-04-01T00:00:00.000Z');
+      const baseTime = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000);
+      const run = repository.startRun(offsetIso(baseTime, 0));
       const failedFeedItem = repository.recordFeedItem(run.id, {
         feedName: 'main-tv',
         guidOrLink: 'https://example.test/movie-2024-1080p-x265',
         rawTitle: 'Movie 2024 1080p x265',
-        publishedAt: '2026-04-01T00:03:00.000Z',
+        publishedAt: offsetIso(baseTime, 180_000),
         downloadUrl: 'https://example.test/movie.torrent',
       });
       const failedMatch = requireMovieMatch(failedFeedItem.rawTitle);
@@ -688,21 +690,21 @@ describe('SQLite repository', () => {
         feedItem: failedFeedItem,
         match: failedMatch,
         status: 'failed',
-        updatedAt: '2026-04-01T00:03:10.000Z',
+        updatedAt: offsetIso(baseTime, 190_000),
       });
       repository.recordFeedItemOutcome({
         runId: run.id,
         feedItemId: failedFeedItem.id,
         status: 'failed',
         identityKey: failedMatch.identityKey,
-        createdAt: '2026-04-01T00:03:00.000Z',
+        createdAt: offsetIso(baseTime, 180_000),
       });
       repository.recordFeedItemOutcome({
         runId: run.id,
         feedItemId: undefined,
         status: 'failed',
         identityKey: failedMatch.identityKey,
-        createdAt: '2026-04-01T00:04:00.000Z',
+        createdAt: offsetIso(baseTime, 240_000),
       });
 
       const results = repository.listRecentFeedItemOutcomesForReview(30);
@@ -813,6 +815,10 @@ async function createDatabasePath(): Promise<string> {
 
   tempDirs.push(directory);
   return join(directory, 'pirate-claw.db');
+}
+
+function offsetIso(base: Date, offsetMs: number): string {
+  return new Date(base.getTime() + offsetMs).toISOString();
 }
 
 function requireMovieMatch(rawTitle: string) {


### PR DESCRIPTION
## Summary

- delivery ticket: \`P28.01 Daemon Auth State\`
- ticket file: [docs/02-delivery/phase-28/ticket-01-daemon-auth-state.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-28/ticket-01-daemon-auth-state.md)
- stacked base branch: \`main\`
- self-audit: outcome \`clean\` completed at 2026-04-29 07:11 UTC

## External AI Review

- outcome: \`clean\`
- current branch head: [\`b9429554f27f\`](https://github.com/cesarnml/Pirate-Claw/commit/b9429554f27f8b3ffcbf299b80d64ef0ce1175ef)
- no prudent follow-up changes were required.

## Late CodeRabbit Review Triage (2026-05-08)

| Finding | File | Disposition | Notes |
|---|---|---|---|
| \`trustOrigin\` read/append/write race — two concurrent requests could drop one origin | \`src/auth-state.ts\` | **REJECTED** | Single-owner LAN appliance; truly concurrent trust-origin writes from two browser sessions on the same user account are impossible in practice. The atomic \`writeFile({ flag: 'wx' })\` pattern applied elsewhere in this file addresses TOCTOU for the initial writes; concurrent appends are a non-issue for a single-user deployment. |