### PR TITLE
feat(p28.02): add web auth layer — JWT session, auth guard, setup/login/logout screens [P28.02]

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -31,6 +31,7 @@
     "gluetun",
     "greptile",
     "HEALTHCHECK",
+    "HMAC",
     "homelab",
     "hostnames",
     "IDAT",

--- a/docs/02-delivery/phase-28/ticket-02-web-auth-layer-and-screens.md
+++ b/docs/02-delivery/phase-28/ticket-02-web-auth-layer-and-screens.md
@@ -66,4 +66,10 @@ Owner setup creates an account, issues a session, and lands on the app. Login wo
 
 ## Rationale
 
-_To be completed during delivery._
+JWT signed with Web Crypto API (HMAC-SHA256) rather than a third-party library — Bun's runtime exposes `crypto.subtle` natively, keeping the dependency surface minimal. The `b64url` helper was widened to accept `ArrayBuffer | Uint8Array` to satisfy TypeScript's strict SubtleCrypto typings (TS requires `ArrayBuffer` for `importKey`, `Uint8Array<ArrayBuffer>` for `verify`).
+
+The auth guard in `hooks.server.ts` checks the daemon's `/api/auth/state` only for unauthenticated requests needing a redirect target (setup vs. login). Authenticated requests never call the daemon — the JWT is self-contained. Response uses snake_case `owner_exists` per the daemon JSON contract.
+
+The "setup incomplete with valid session" redirect was intentionally omitted: the daemon equates `setup_complete === owner_exists`, so a valid session implies the owner exists and setup is complete by definition.
+
+`SameSite=Strict` without `secure: true` is intentional for v1 — the appliance runs on a local LAN without HTTPS. The v1 threat model accepts this; HTTPS termination is a post-v1 concern.

--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -1,0 +1,9 @@
+declare global {
+	namespace App {
+		interface Locals {
+			user: { username: string } | null;
+		}
+	}
+}
+
+export {};

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -1,17 +1,94 @@
 import { readFileSync } from 'fs';
+import { redirect, type Handle } from '@sveltejs/kit';
+import {
+	initSessionSecret,
+	getSessionSecret,
+	verifyJwt,
+	SESSION_COOKIE_NAME
+} from '$lib/server/session';
+import { apiRequest } from '$lib/server/api';
+
+const PUBLIC_PATHS = new Set(['/setup', '/login', '/logout']);
 
 export function init() {
-	if (process.env.PIRATE_CLAW_API_WRITE_TOKEN) return;
-
-	const tokenFile = process.env.PIRATE_CLAW_DAEMON_TOKEN_FILE;
-	if (!tokenFile) return;
-
-	try {
-		const token = readFileSync(tokenFile, 'utf8').trim();
-		if (token) {
-			process.env.PIRATE_CLAW_API_WRITE_TOKEN = token;
+	if (!process.env.PIRATE_CLAW_API_WRITE_TOKEN) {
+		const tokenFile = process.env.PIRATE_CLAW_DAEMON_TOKEN_FILE;
+		if (tokenFile) {
+			try {
+				const token = readFileSync(tokenFile, 'utf8').trim();
+				if (token) process.env.PIRATE_CLAW_API_WRITE_TOKEN = token;
+			} catch {
+				// file not yet written; PIRATE_CLAW_API_WRITE_TOKEN stays unset
+			}
 		}
-	} catch {
-		// file not yet written; PIRATE_CLAW_API_WRITE_TOKEN stays unset
+	}
+
+	if (!getSessionSecret()) {
+		const direct = process.env.PIRATE_CLAW_SESSION_SECRET;
+		if (direct) {
+			initSessionSecret(direct);
+		} else {
+			const secretFile = process.env.PIRATE_CLAW_SESSION_SECRET_FILE;
+			if (secretFile) {
+				try {
+					const secret = readFileSync(secretFile, 'utf8').trim();
+					if (secret) initSessionSecret(secret);
+				} catch {
+					// file not yet written; session guard will fall back to passthrough
+				}
+			}
+		}
 	}
 }
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const path = event.url.pathname;
+
+	if (PUBLIC_PATHS.has(path)) {
+		event.locals.user = null;
+		return resolve(event);
+	}
+
+	const secret = getSessionSecret();
+	if (!secret) {
+		event.locals.user = null;
+		return resolve(event);
+	}
+
+	const token = event.cookies.get(SESSION_COOKIE_NAME);
+	if (token) {
+		const user = await verifyJwt(token, secret);
+		if (user) {
+			event.locals.user = user;
+			return resolve(event);
+		}
+	}
+
+	// API routes return 401 rather than redirecting
+	if (path.startsWith('/api/')) {
+		return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+			status: 401,
+			headers: { 'content-type': 'application/json' }
+		});
+	}
+
+	// No valid session — check daemon auth state to decide where to redirect
+	const writeToken = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+	if (writeToken) {
+		try {
+			const res = await apiRequest('/api/auth/state', {
+				headers: { Authorization: `Bearer ${writeToken}` }
+			});
+			if (res.ok) {
+				const state = (await res.json()) as { owner_exists: boolean };
+				if (!state.owner_exists) {
+					redirect(302, '/setup');
+				}
+			}
+		} catch {
+			// daemon unreachable; fall through to /login
+		}
+	}
+
+	redirect(302, '/login');
+};

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'fs';
-import { redirect, type Handle } from '@sveltejs/kit';
+import { redirect, isRedirect, type Handle } from '@sveltejs/kit';
 import {
 	initSessionSecret,
 	getSessionSecret,
@@ -50,19 +50,15 @@ export const handle: Handle = async ({ event, resolve }) => {
 	}
 
 	const secret = getSessionSecret();
-	if (!secret) {
-		event.locals.user = null;
-		return resolve(event);
-	}
-
-	const token = event.cookies.get(SESSION_COOKIE_NAME);
-	if (token) {
-		const user = await verifyJwt(token, secret);
+	const sessionToken = secret ? event.cookies.get(SESSION_COOKIE_NAME) : undefined;
+	if (secret && sessionToken) {
+		const user = await verifyJwt(sessionToken, secret);
 		if (user) {
 			event.locals.user = user;
 			return resolve(event);
 		}
 	}
+	event.locals.user = null;
 
 	// API routes return 401 rather than redirecting
 	if (path.startsWith('/api/')) {
@@ -85,7 +81,8 @@ export const handle: Handle = async ({ event, resolve }) => {
 					redirect(302, '/setup');
 				}
 			}
-		} catch {
+		} catch (err) {
+			if (isRedirect(err)) throw err;
 			// daemon unreachable; fall through to /login
 		}
 	}

--- a/web/src/lib/server/session.ts
+++ b/web/src/lib/server/session.ts
@@ -1,0 +1,93 @@
+import type { Cookies } from '@sveltejs/kit';
+
+export const SESSION_COOKIE_NAME = 'pc_session';
+const JWT_EXPIRY_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
+let _sessionSecret: string | null = null;
+
+export function initSessionSecret(secret: string): void {
+	_sessionSecret = secret;
+}
+
+export function getSessionSecret(): string | null {
+	return _sessionSecret;
+}
+
+function b64url(buf: ArrayBuffer | Uint8Array): string {
+	const arr = ArrayBuffer.isView(buf) ? (buf as Uint8Array) : new Uint8Array(buf);
+	return btoa(String.fromCharCode(...arr))
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_')
+		.replace(/=+$/, '');
+}
+
+function b64urlDecode(s: string): Uint8Array<ArrayBuffer> {
+	const base64 = s.replace(/-/g, '+').replace(/_/g, '/');
+	const bin = atob(base64);
+	return new Uint8Array([...bin].map((c) => c.charCodeAt(0)));
+}
+
+async function hmacKey(secret: string): Promise<CryptoKey> {
+	const enc = new TextEncoder();
+	return crypto.subtle.importKey(
+		'raw',
+		enc.encode(secret).buffer as ArrayBuffer,
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['sign', 'verify']
+	);
+}
+
+export async function signJwt(username: string, secret: string): Promise<string> {
+	const header = b64url(new TextEncoder().encode(JSON.stringify({ alg: 'HS256', typ: 'JWT' })));
+	const now = Math.floor(Date.now() / 1000);
+	const payload = b64url(
+		new TextEncoder().encode(
+			JSON.stringify({ sub: username, iat: now, exp: now + JWT_EXPIRY_SECONDS })
+		)
+	);
+	const data = `${header}.${payload}`;
+	const key = await hmacKey(secret);
+	const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(data));
+	return `${data}.${b64url(sig)}`;
+}
+
+export async function verifyJwt(
+	token: string,
+	secret: string
+): Promise<{ username: string } | null> {
+	const parts = token.split('.');
+	if (parts.length !== 3) return null;
+	const [header, payload, sigB64] = parts;
+	const data = `${header}.${payload}`;
+	const key = await hmacKey(secret);
+	const sigBytes = b64urlDecode(sigB64);
+	const valid = await crypto.subtle.verify('HMAC', key, sigBytes, new TextEncoder().encode(data));
+	if (!valid) return null;
+	let claims: { sub?: unknown; exp?: unknown };
+	try {
+		claims = JSON.parse(new TextDecoder().decode(b64urlDecode(payload))) as {
+			sub?: unknown;
+			exp?: unknown;
+		};
+	} catch {
+		return null;
+	}
+	if (typeof claims.sub !== 'string') return null;
+	if (typeof claims.exp !== 'number' || claims.exp < Math.floor(Date.now() / 1000)) return null;
+	return { username: claims.sub };
+}
+
+export function issueSessionCookie(cookies: Cookies, token: string): void {
+	cookies.set(SESSION_COOKIE_NAME, token, {
+		httpOnly: true,
+		sameSite: 'strict',
+		secure: false,
+		path: '/',
+		maxAge: JWT_EXPIRY_SECONDS
+	});
+}
+
+export function clearSessionCookie(cookies: Cookies): void {
+	cookies.delete(SESSION_COOKIE_NAME, { path: '/' });
+}

--- a/web/src/lib/server/session.ts
+++ b/web/src/lib/server/session.ts
@@ -56,26 +56,25 @@ export async function verifyJwt(
 	token: string,
 	secret: string
 ): Promise<{ username: string } | null> {
-	const parts = token.split('.');
-	if (parts.length !== 3) return null;
-	const [header, payload, sigB64] = parts;
-	const data = `${header}.${payload}`;
-	const key = await hmacKey(secret);
-	const sigBytes = b64urlDecode(sigB64);
-	const valid = await crypto.subtle.verify('HMAC', key, sigBytes, new TextEncoder().encode(data));
-	if (!valid) return null;
-	let claims: { sub?: unknown; exp?: unknown };
 	try {
-		claims = JSON.parse(new TextDecoder().decode(b64urlDecode(payload))) as {
+		const parts = token.split('.');
+		if (parts.length !== 3) return null;
+		const [header, payload, sigB64] = parts;
+		const data = `${header}.${payload}`;
+		const key = await hmacKey(secret);
+		const sigBytes = b64urlDecode(sigB64);
+		const valid = await crypto.subtle.verify('HMAC', key, sigBytes, new TextEncoder().encode(data));
+		if (!valid) return null;
+		const claims = JSON.parse(new TextDecoder().decode(b64urlDecode(payload))) as {
 			sub?: unknown;
 			exp?: unknown;
 		};
+		if (typeof claims.sub !== 'string' || claims.sub.length === 0) return null;
+		if (typeof claims.exp !== 'number' || claims.exp < Math.floor(Date.now() / 1000)) return null;
+		return { username: claims.sub };
 	} catch {
 		return null;
 	}
-	if (typeof claims.sub !== 'string') return null;
-	if (typeof claims.exp !== 'number' || claims.exp < Math.floor(Date.now() / 1000)) return null;
-	return { username: claims.sub };
 }
 
 export function issueSessionCookie(cookies: Cookies, token: string): void {

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -32,7 +32,7 @@ function normalizePlexAuthState(
 	return authState ?? 'not_connected';
 }
 
-export const load: LayoutServerLoad = async () => {
+export const load: LayoutServerLoad = async ({ locals }) => {
 	const [
 		healthResult,
 		sessionResult,
@@ -87,6 +87,7 @@ export const load: LayoutServerLoad = async () => {
 		plexAuthResult.status === 'fulfilled' ? plexAuthResult.value.state : undefined;
 
 	return {
+		user: locals.user ?? null,
 		health: healthResult.status === 'fulfilled' ? healthResult.value : null,
 		transmissionSession: sessionResult.status === 'fulfilled' ? sessionResult.value : null,
 		plexAuthState: normalizePlexAuthState(configHasPlex, plexAuthState),

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -33,6 +33,9 @@ function normalizePlexAuthState(
 }
 
 export const load: LayoutServerLoad = async ({ locals }) => {
+	// Skip sensitive API fetches for unauthenticated requests (auth pages: /setup, /login)
+	const authenticated = locals.user !== null;
+
 	const [
 		healthResult,
 		sessionResult,
@@ -42,24 +45,32 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 		installHealthResult,
 		plexAuthResult
 	] = await Promise.allSettled([
-		apiFetch<DaemonHealth>('/api/health'),
-		apiFetch<SessionInfo>('/api/transmission/session'),
-		apiFetch<AppConfig>('/api/config'),
+		authenticated ? apiFetch<DaemonHealth>('/api/health') : Promise.reject('unauthenticated'),
+		authenticated
+			? apiFetch<SessionInfo>('/api/transmission/session')
+			: Promise.reject('unauthenticated'),
+		authenticated ? apiFetch<AppConfig>('/api/config') : Promise.reject('unauthenticated'),
 		apiFetch<{ state: SetupState }>('/api/setup/state'),
-		apiFetch<ReadinessResponse>('/api/setup/readiness'),
-		apiFetch<InstallHealthResponse>('/api/setup/install-health'),
-		apiFetch<PlexAuthStatusResponse>('/api/plex/auth/status')
+		authenticated
+			? apiFetch<ReadinessResponse>('/api/setup/readiness')
+			: Promise.reject('unauthenticated'),
+		authenticated
+			? apiFetch<InstallHealthResponse>('/api/setup/install-health')
+			: Promise.reject('unauthenticated'),
+		authenticated
+			? apiFetch<PlexAuthStatusResponse>('/api/plex/auth/status')
+			: Promise.reject('unauthenticated')
 	]);
 
-	if (healthResult.status === 'rejected') {
+	if (authenticated && healthResult.status === 'rejected') {
 		console.error('[layout] failed to load /api/health:', healthResult.reason);
 	}
 
-	if (sessionResult.status === 'rejected') {
+	if (authenticated && sessionResult.status === 'rejected') {
 		console.error('[layout] failed to load /api/transmission/session:', sessionResult.reason);
 	}
 
-	if (configResult.status === 'rejected') {
+	if (authenticated && configResult.status === 'rejected') {
 		console.error('[layout] failed to load /api/config:', configResult.reason);
 	}
 
@@ -67,15 +78,15 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 		console.error('[layout] failed to load /api/setup/state:', setupStateResult.reason);
 	}
 
-	if (readinessResult.status === 'rejected') {
+	if (authenticated && readinessResult.status === 'rejected') {
 		console.error('[layout] failed to load /api/setup/readiness:', readinessResult.reason);
 	}
 
-	if (installHealthResult.status === 'rejected') {
+	if (authenticated && installHealthResult.status === 'rejected') {
 		console.error('[layout] failed to load /api/setup/install-health:', installHealthResult.reason);
 	}
 
-	if (plexAuthResult.status === 'rejected') {
+	if (authenticated && plexAuthResult.status === 'rejected') {
 		console.error('[layout] failed to load /api/plex/auth/status:', plexAuthResult.reason);
 	}
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -48,7 +48,12 @@
 	const transmissionConnected = $derived(data.transmissionSession !== null);
 	const plexAuthState = $derived(data.plexAuthState ?? 'unavailable');
 	const isOnboarding = $derived($page.url.pathname === '/onboarding');
-	const showSidebar = $derived(!isOnboarding);
+	const isAuthPage = $derived(
+		$page.url.pathname === '/setup' ||
+			$page.url.pathname === '/login' ||
+			$page.url.pathname === '/logout'
+	);
+	const showSidebar = $derived(!isOnboarding && !isAuthPage);
 	const setupState = $derived(data.setupState ?? 'partially_configured');
 	const readinessState = $derived(data.readinessState ?? 'not_ready');
 	const isStarter = $derived(setupState === 'starter' && !isOnboarding);
@@ -167,6 +172,18 @@
 			{transmissionConnected}
 			{plexAuthState}
 		/>
+		{#if data.user}
+			<div class="border-border shrink-0 border-t px-3 py-2">
+				<form method="POST" action="/logout" use:enhance>
+					<button
+						type="submit"
+						class="text-muted-foreground hover:text-foreground w-full rounded-lg px-2 py-1.5 text-left text-xs transition-colors"
+					>
+						Sign out
+					</button>
+				</form>
+			</div>
+		{/if}
 	</div>
 {/snippet}
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -56,10 +56,10 @@
 	const showSidebar = $derived(!isOnboarding && !isAuthPage);
 	const setupState = $derived(data.setupState ?? 'partially_configured');
 	const readinessState = $derived(data.readinessState ?? 'not_ready');
-	const isStarter = $derived(setupState === 'starter' && !isOnboarding);
-	const isPartiallyConfigured = $derived(setupState === 'partially_configured');
+	const isStarter = $derived(setupState === 'starter' && !isOnboarding && !isAuthPage);
+	const isPartiallyConfigured = $derived(setupState === 'partially_configured' && !isAuthPage);
 	const isReadyPendingRestart = $derived(
-		readinessState === 'ready_pending_restart' && !isOnboarding
+		readinessState === 'ready_pending_restart' && !isOnboarding && !isAuthPage
 	);
 	let restartingFromBanner = $state(false);
 	let restartBannerPhase = $state<

--- a/web/src/routes/login/+page.server.ts
+++ b/web/src/routes/login/+page.server.ts
@@ -1,0 +1,42 @@
+import { redirect, fail } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { buildApiUrl } from '$lib/server/api';
+import { signJwt, issueSessionCookie, getSessionSecret } from '$lib/server/session';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	if (locals.user) redirect(302, '/');
+	return {};
+};
+
+export const actions: Actions = {
+	default: async ({ request, cookies }) => {
+		const data = await request.formData();
+		const username = String(data.get('username') ?? '').trim();
+		const password = String(data.get('password') ?? '');
+
+		if (!username || !password) return fail(400, { error: 'Username and password are required' });
+
+		const writeToken = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+		if (!writeToken) return fail(503, { error: 'Service unavailable' });
+
+		const res = await fetch(buildApiUrl('/api/auth/verify-login'), {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${writeToken}`
+			},
+			body: JSON.stringify({ username, password })
+		});
+
+		if (!res.ok) return fail(502, { error: 'Login service unavailable — try again' });
+		const body = (await res.json()) as { ok: boolean };
+		if (!body.ok) return fail(401, { error: 'Invalid username or password' });
+
+		const secret = getSessionSecret();
+		if (!secret) return fail(503, { error: 'Session secret not configured' });
+
+		const token = await signJwt(username, secret);
+		issueSessionCookie(cookies, token);
+		redirect(302, '/');
+	}
+};

--- a/web/src/routes/login/+page.server.ts
+++ b/web/src/routes/login/+page.server.ts
@@ -19,14 +19,19 @@ export const actions: Actions = {
 		const writeToken = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
 		if (!writeToken) return fail(503, { error: 'Service unavailable' });
 
-		const res = await fetch(buildApiUrl('/api/auth/verify-login'), {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				Authorization: `Bearer ${writeToken}`
-			},
-			body: JSON.stringify({ username, password })
-		});
+		let res: Response;
+		try {
+			res = await fetch(buildApiUrl('/api/auth/verify-login'), {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${writeToken}`
+				},
+				body: JSON.stringify({ username, password })
+			});
+		} catch {
+			return fail(503, { error: 'Daemon unavailable — try again in a moment' });
+		}
 
 		if (!res.ok) return fail(502, { error: 'Login service unavailable — try again' });
 		const body = (await res.json()) as { ok: boolean };

--- a/web/src/routes/login/+page.server.ts
+++ b/web/src/routes/login/+page.server.ts
@@ -34,7 +34,12 @@ export const actions: Actions = {
 		}
 
 		if (!res.ok) return fail(502, { error: 'Login service unavailable — try again' });
-		const body = (await res.json()) as { ok: boolean };
+		let body: { ok: boolean };
+		try {
+			body = (await res.json()) as { ok: boolean };
+		} catch {
+			return fail(502, { error: 'Login service unavailable — try again' });
+		}
 		if (!body.ok) return fail(401, { error: 'Invalid username or password' });
 
 		const secret = getSessionSecret();

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import type { ActionData } from './$types';
+
+	interface Props {
+		form: ActionData;
+	}
+
+	let { form }: Props = $props();
+	let loading = $state(false);
+</script>
+
+<svelte:head>
+	<title>Pirate Claw — Login</title>
+</svelte:head>
+
+<div class="bg-background flex min-h-screen items-center justify-center">
+	<div class="border-border bg-card w-full max-w-sm space-y-6 rounded-2xl border p-8 shadow-lg">
+		<div class="space-y-1 text-center">
+			<img
+				src="/pirate-claw-logo.webp"
+				alt="Pirate Claw"
+				width="56"
+				height="56"
+				class="mx-auto rounded-2xl"
+			/>
+			<h1 class="text-foreground text-xl font-semibold">Sign in</h1>
+			<p class="text-muted-foreground text-sm">Pirate Claw owner access</p>
+		</div>
+
+		{#if form?.error}
+			<p class="bg-destructive/10 text-destructive rounded-lg px-3 py-2 text-sm" role="alert">
+				{form.error}
+			</p>
+		{/if}
+
+		<form
+			method="POST"
+			use:enhance={() => {
+				loading = true;
+				return async ({ update }) => {
+					loading = false;
+					await update();
+				};
+			}}
+			class="space-y-4"
+		>
+			<div class="space-y-1">
+				<label for="username" class="text-foreground text-sm font-medium">Username</label>
+				<input
+					id="username"
+					name="username"
+					type="text"
+					autocomplete="username"
+					required
+					class="border-border bg-background text-foreground focus:ring-primary w-full rounded-lg border px-3 py-2 text-sm focus:ring-2 focus:outline-none"
+				/>
+			</div>
+
+			<div class="space-y-1">
+				<label for="password" class="text-foreground text-sm font-medium">Password</label>
+				<input
+					id="password"
+					name="password"
+					type="password"
+					autocomplete="current-password"
+					required
+					class="border-border bg-background text-foreground focus:ring-primary w-full rounded-lg border px-3 py-2 text-sm focus:ring-2 focus:outline-none"
+				/>
+			</div>
+
+			<button
+				type="submit"
+				disabled={loading}
+				class="bg-primary text-primary-foreground hover:bg-primary/90 w-full rounded-lg px-4 py-2 text-sm font-medium disabled:opacity-50"
+			>
+				{loading ? 'Signing in…' : 'Sign in'}
+			</button>
+		</form>
+	</div>
+</div>

--- a/web/src/routes/logout/+page.server.ts
+++ b/web/src/routes/logout/+page.server.ts
@@ -1,0 +1,10 @@
+import { redirect } from '@sveltejs/kit';
+import type { Actions } from './$types';
+import { clearSessionCookie } from '$lib/server/session';
+
+export const actions: Actions = {
+	default: async ({ cookies }) => {
+		clearSessionCookie(cookies);
+		redirect(302, '/login');
+	}
+};

--- a/web/src/routes/setup/+page.server.ts
+++ b/web/src/routes/setup/+page.server.ts
@@ -1,0 +1,45 @@
+import { redirect, fail } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { buildApiUrl } from '$lib/server/api';
+import { signJwt, issueSessionCookie, getSessionSecret } from '$lib/server/session';
+
+export const load: PageServerLoad = async ({ locals }) => {
+	if (locals.user) redirect(302, '/');
+	return {};
+};
+
+export const actions: Actions = {
+	default: async ({ request, cookies }) => {
+		const data = await request.formData();
+		const username = String(data.get('username') ?? '').trim();
+		const password = String(data.get('password') ?? '');
+		const confirm = String(data.get('confirm') ?? '');
+
+		if (!username) return fail(400, { error: 'Username is required' });
+		if (!password) return fail(400, { error: 'Password is required' });
+		if (password !== confirm) return fail(400, { error: 'Passwords do not match' });
+
+		const writeToken = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+		if (!writeToken) return fail(503, { error: 'Service unavailable' });
+
+		const res = await fetch(buildApiUrl('/api/auth/setup-owner'), {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${writeToken}`,
+				Origin: request.headers.get('origin') ?? ''
+			},
+			body: JSON.stringify({ username, password })
+		});
+
+		if (res.status === 409) return fail(409, { error: 'Owner already exists' });
+		if (!res.ok) return fail(502, { error: 'Setup failed — try again' });
+
+		const secret = getSessionSecret();
+		if (!secret) return fail(503, { error: 'Session secret not configured' });
+
+		const token = await signJwt(username, secret);
+		issueSessionCookie(cookies, token);
+		redirect(302, '/onboarding');
+	}
+};

--- a/web/src/routes/setup/+page.server.ts
+++ b/web/src/routes/setup/+page.server.ts
@@ -22,15 +22,20 @@ export const actions: Actions = {
 		const writeToken = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
 		if (!writeToken) return fail(503, { error: 'Service unavailable' });
 
-		const res = await fetch(buildApiUrl('/api/auth/setup-owner'), {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				Authorization: `Bearer ${writeToken}`,
-				Origin: request.headers.get('origin') ?? ''
-			},
-			body: JSON.stringify({ username, password })
-		});
+		let res: Response;
+		try {
+			res = await fetch(buildApiUrl('/api/auth/setup-owner'), {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${writeToken}`,
+					Origin: request.headers.get('origin') ?? ''
+				},
+				body: JSON.stringify({ username, password })
+			});
+		} catch {
+			return fail(503, { error: 'Daemon unavailable — try again in a moment' });
+		}
 
 		if (res.status === 409) return fail(409, { error: 'Owner already exists' });
 		if (!res.ok) return fail(502, { error: 'Setup failed — try again' });

--- a/web/src/routes/setup/+page.svelte
+++ b/web/src/routes/setup/+page.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import type { ActionData } from './$types';
+
+	interface Props {
+		form: ActionData;
+	}
+
+	let { form }: Props = $props();
+	let loading = $state(false);
+</script>
+
+<svelte:head>
+	<title>Pirate Claw — Setup</title>
+</svelte:head>
+
+<div class="bg-background flex min-h-screen items-center justify-center">
+	<div class="border-border bg-card w-full max-w-sm space-y-6 rounded-2xl border p-8 shadow-lg">
+		<div class="space-y-1 text-center">
+			<img
+				src="/pirate-claw-logo.webp"
+				alt="Pirate Claw"
+				width="56"
+				height="56"
+				class="mx-auto rounded-2xl"
+			/>
+			<h1 class="text-foreground text-xl font-semibold">Create owner account</h1>
+			<p class="text-muted-foreground text-sm">
+				First-time setup — this account cannot be recovered.
+			</p>
+		</div>
+
+		{#if form?.error}
+			<p class="bg-destructive/10 text-destructive rounded-lg px-3 py-2 text-sm" role="alert">
+				{form.error}
+			</p>
+		{/if}
+
+		<form
+			method="POST"
+			use:enhance={() => {
+				loading = true;
+				return async ({ update }) => {
+					loading = false;
+					await update();
+				};
+			}}
+			class="space-y-4"
+		>
+			<div class="space-y-1">
+				<label for="username" class="text-foreground text-sm font-medium">Username</label>
+				<input
+					id="username"
+					name="username"
+					type="text"
+					autocomplete="username"
+					required
+					class="border-border bg-background text-foreground focus:ring-primary w-full rounded-lg border px-3 py-2 text-sm focus:ring-2 focus:outline-none"
+				/>
+			</div>
+
+			<div class="space-y-1">
+				<label for="password" class="text-foreground text-sm font-medium">Password</label>
+				<input
+					id="password"
+					name="password"
+					type="password"
+					autocomplete="new-password"
+					required
+					class="border-border bg-background text-foreground focus:ring-primary w-full rounded-lg border px-3 py-2 text-sm focus:ring-2 focus:outline-none"
+				/>
+			</div>
+
+			<div class="space-y-1">
+				<label for="confirm" class="text-foreground text-sm font-medium">Confirm password</label>
+				<input
+					id="confirm"
+					name="confirm"
+					type="password"
+					autocomplete="new-password"
+					required
+					class="border-border bg-background text-foreground focus:ring-primary w-full rounded-lg border px-3 py-2 text-sm focus:ring-2 focus:outline-none"
+				/>
+			</div>
+
+			<button
+				type="submit"
+				disabled={loading}
+				class="bg-primary text-primary-foreground hover:bg-primary/90 w-full rounded-lg px-4 py-2 text-sm font-medium disabled:opacity-50"
+			>
+				{loading ? 'Creating account…' : 'Create account'}
+			</button>
+		</form>
+	</div>
+</div>

--- a/web/src/routes/setup/+page.svelte
+++ b/web/src/routes/setup/+page.svelte
@@ -41,8 +41,8 @@
 			use:enhance={() => {
 				loading = true;
 				return async ({ update }) => {
-					loading = false;
 					await update();
+					loading = false;
 				};
 			}}
 			class="space-y-4"

--- a/web/test/hooks.server.test.ts
+++ b/web/test/hooks.server.test.ts
@@ -4,35 +4,47 @@ import { writeFileSync, mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { init } from '../src/hooks.server';
+import { getSessionSecret, initSessionSecret } from '../src/lib/server/session';
 
 const savedEnv: Record<string, string | undefined> = {};
 let tmpDir: string;
 let tokenFile: string;
+let secretFile: string;
 
 beforeEach(() => {
 	savedEnv.PIRATE_CLAW_API_WRITE_TOKEN = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
 	savedEnv.PIRATE_CLAW_DAEMON_TOKEN_FILE = process.env.PIRATE_CLAW_DAEMON_TOKEN_FILE;
+	savedEnv.PIRATE_CLAW_SESSION_SECRET = process.env.PIRATE_CLAW_SESSION_SECRET;
+	savedEnv.PIRATE_CLAW_SESSION_SECRET_FILE = process.env.PIRATE_CLAW_SESSION_SECRET_FILE;
 	delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
 	delete process.env.PIRATE_CLAW_DAEMON_TOKEN_FILE;
+	delete process.env.PIRATE_CLAW_SESSION_SECRET;
+	delete process.env.PIRATE_CLAW_SESSION_SECRET_FILE;
+	// reset module-level secret before each test
+	initSessionSecret('');
 	tmpDir = mkdtempSync(join(tmpdir(), 'pc-hook-test-'));
 	tokenFile = join(tmpDir, 'daemon-api-write-token');
+	secretFile = join(tmpDir, 'session-secret');
 });
 
 afterEach(() => {
-	if (savedEnv.PIRATE_CLAW_API_WRITE_TOKEN !== undefined) {
-		process.env.PIRATE_CLAW_API_WRITE_TOKEN = savedEnv.PIRATE_CLAW_API_WRITE_TOKEN;
-	} else {
-		delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
-	}
-	if (savedEnv.PIRATE_CLAW_DAEMON_TOKEN_FILE !== undefined) {
-		process.env.PIRATE_CLAW_DAEMON_TOKEN_FILE = savedEnv.PIRATE_CLAW_DAEMON_TOKEN_FILE;
-	} else {
-		delete process.env.PIRATE_CLAW_DAEMON_TOKEN_FILE;
+	const keys = [
+		'PIRATE_CLAW_API_WRITE_TOKEN',
+		'PIRATE_CLAW_DAEMON_TOKEN_FILE',
+		'PIRATE_CLAW_SESSION_SECRET',
+		'PIRATE_CLAW_SESSION_SECRET_FILE'
+	] as const;
+	for (const key of keys) {
+		if (savedEnv[key] !== undefined) {
+			process.env[key] = savedEnv[key];
+		} else {
+			delete process.env[key];
+		}
 	}
 	rmSync(tmpDir, { recursive: true, force: true });
 });
 
-describe('hooks.server init', () => {
+describe('hooks.server init — write token', () => {
 	it('reads token from file when PIRATE_CLAW_DAEMON_TOKEN_FILE is set', () => {
 		writeFileSync(tokenFile, 'test-token-from-file\n');
 		process.env.PIRATE_CLAW_DAEMON_TOKEN_FILE = tokenFile;
@@ -73,5 +85,48 @@ describe('hooks.server init', () => {
 		init();
 
 		expect(process.env.PIRATE_CLAW_API_WRITE_TOKEN).toBeUndefined();
+	});
+});
+
+describe('hooks.server init — session secret', () => {
+	it('reads secret from PIRATE_CLAW_SESSION_SECRET env var', () => {
+		process.env.PIRATE_CLAW_SESSION_SECRET = 'direct-secret';
+
+		init();
+
+		expect(getSessionSecret()).toBe('direct-secret');
+	});
+
+	it('reads secret from file when PIRATE_CLAW_SESSION_SECRET_FILE is set', () => {
+		writeFileSync(secretFile, 'file-secret\n');
+		process.env.PIRATE_CLAW_SESSION_SECRET_FILE = secretFile;
+
+		init();
+
+		expect(getSessionSecret()).toBe('file-secret');
+	});
+
+	it('prefers PIRATE_CLAW_SESSION_SECRET over file', () => {
+		process.env.PIRATE_CLAW_SESSION_SECRET = 'env-secret';
+		writeFileSync(secretFile, 'file-secret');
+		process.env.PIRATE_CLAW_SESSION_SECRET_FILE = secretFile;
+
+		init();
+
+		expect(getSessionSecret()).toBe('env-secret');
+	});
+
+	it('does nothing when no secret env vars are set', () => {
+		init();
+
+		expect(getSessionSecret()).toBeFalsy();
+	});
+
+	it('does nothing when secret file does not exist', () => {
+		process.env.PIRATE_CLAW_SESSION_SECRET_FILE = join(tmpDir, 'nonexistent');
+
+		init();
+
+		expect(getSessionSecret()).toBeFalsy();
 	});
 });

--- a/web/test/routes/config/config.test.ts
+++ b/web/test/routes/config/config.test.ts
@@ -54,7 +54,12 @@ const mockConfig: AppConfig = {
 	}
 };
 
-const sharedLayoutData = { health: null, transmissionSession: null, plexAuthState: 'unavailable' };
+const sharedLayoutData = {
+	user: null,
+	health: null,
+	transmissionSession: null,
+	plexAuthState: 'unavailable'
+};
 
 function renderPage(data: Record<string, unknown>) {
 	return render(Page, {

--- a/web/test/routes/dashboard.test.ts
+++ b/web/test/routes/dashboard.test.ts
@@ -77,6 +77,7 @@ const mockTorrent = (overrides: Partial<TorrentStatSnapshot> = {}): TorrentStatS
 });
 
 const baseData = {
+	user: null,
 	health: mockHealth,
 	transmissionSession: null,
 	plexAuthState: 'unavailable' as const,

--- a/web/test/routes/layout.server.test.ts
+++ b/web/test/routes/layout.server.test.ts
@@ -49,9 +49,10 @@ describe('layout server load', () => {
 				returnTo: null
 			});
 
-		const result = await load({} as never);
+		const result = await load({ locals: { user: null } } as never);
 
 		expect(result).toEqual({
+			user: null,
 			health: { uptime: 1, startedAt: '2024-01-01T00:00:00Z' },
 			transmissionSession: {
 				version: '3.0',
@@ -100,7 +101,10 @@ describe('layout server load', () => {
 				returnTo: null
 			});
 
-		const result = (await load({} as never)) as { setupState: string; readinessState: string };
+		const result = (await load({ locals: { user: null } } as never)) as {
+			setupState: string;
+			readinessState: string;
+		};
 		expect(result.setupState).toBe('starter');
 		expect(result.readinessState).toBe('not_ready');
 	});
@@ -135,7 +139,7 @@ describe('layout server load', () => {
 				returnTo: null
 			});
 
-		const result = (await load({} as never)) as { setupState: string };
+		const result = (await load({ locals: { user: null } } as never)) as { setupState: string };
 		expect(result.setupState).toBe('partially_configured');
 	});
 
@@ -169,7 +173,7 @@ describe('layout server load', () => {
 				returnTo: null
 			});
 
-		const result = (await load({} as never)) as { readinessState: string };
+		const result = (await load({ locals: { user: null } } as never)) as { readinessState: string };
 		expect(result.readinessState).toBe('not_ready');
 	});
 
@@ -187,9 +191,10 @@ describe('layout server load', () => {
 				.mockRejectedValueOnce(new Error('install health down'))
 				.mockRejectedValueOnce(new Error('plex auth down'));
 
-			const result = await load({} as never);
+			const result = await load({ locals: { user: null } } as never);
 
 			expect(result).toEqual({
+				user: null,
 				health: null,
 				transmissionSession: null,
 				plexAuthState: 'unavailable',

--- a/web/test/routes/layout.server.test.ts
+++ b/web/test/routes/layout.server.test.ts
@@ -5,6 +5,8 @@ vi.mock('$lib/server/api', () => ({
 	apiFetch: apiFetchMock
 }));
 
+const mockUser = { username: 'admin' };
+
 describe('layout server load', () => {
 	beforeEach(() => {
 		apiFetchMock.mockReset();
@@ -49,10 +51,10 @@ describe('layout server load', () => {
 				returnTo: null
 			});
 
-		const result = await load({ locals: { user: null } } as never);
+		const result = await load({ locals: { user: mockUser } } as never);
 
 		expect(result).toEqual({
-			user: null,
+			user: mockUser,
 			health: { uptime: 1, startedAt: '2024-01-01T00:00:00Z' },
 			transmissionSession: {
 				version: '3.0',
@@ -71,41 +73,18 @@ describe('layout server load', () => {
 		});
 	});
 
-	it('returns setupState=starter when readiness reports starter configState', async () => {
+	it('returns setupState=starter when setup/state reports starter (unauthenticated)', async () => {
 		const { load } = await import('../../src/routes/+layout.server');
 
-		apiFetchMock
-			.mockResolvedValueOnce({ uptime: 1, startedAt: '2024-01-01T00:00:00Z' })
-			.mockResolvedValueOnce({
-				version: '3.0',
-				downloadSpeed: 0,
-				uploadSpeed: 0,
-				activeTorrentCount: 0
-			})
-			.mockResolvedValueOnce({
-				plex: { url: 'http://localhost:32400', token: '', refreshIntervalMinutes: 30 }
-			})
-			.mockResolvedValueOnce({ state: 'starter' })
-			.mockResolvedValueOnce({
-				state: 'not_ready',
-				configState: 'starter',
-				transmissionReachable: false,
-				daemonLive: true
-			})
-			.mockResolvedValueOnce(null)
-			.mockResolvedValueOnce({
-				state: 'connected',
-				plexUrl: 'http://localhost:32400',
-				hasToken: true,
-				tokenSource: 'config',
-				returnTo: null
-			});
+		// Unauthenticated: only /api/setup/state is fetched
+		apiFetchMock.mockResolvedValueOnce({ state: 'starter' });
 
 		const result = (await load({ locals: { user: null } } as never)) as {
 			setupState: string;
 			readinessState: string;
 		};
 		expect(result.setupState).toBe('starter');
+		// Readiness not fetched for unauthenticated — always not_ready
 		expect(result.readinessState).toBe('not_ready');
 	});
 
@@ -139,7 +118,7 @@ describe('layout server load', () => {
 				returnTo: null
 			});
 
-		const result = (await load({ locals: { user: null } } as never)) as { setupState: string };
+		const result = (await load({ locals: { user: mockUser } } as never)) as { setupState: string };
 		expect(result.setupState).toBe('partially_configured');
 	});
 
@@ -173,7 +152,9 @@ describe('layout server load', () => {
 				returnTo: null
 			});
 
-		const result = (await load({ locals: { user: null } } as never)) as { readinessState: string };
+		const result = (await load({ locals: { user: mockUser } } as never)) as {
+			readinessState: string;
+		};
 		expect(result.readinessState).toBe('not_ready');
 	});
 
@@ -182,14 +163,8 @@ describe('layout server load', () => {
 		try {
 			const { load } = await import('../../src/routes/+layout.server');
 
-			apiFetchMock
-				.mockRejectedValueOnce(new Error('health down'))
-				.mockRejectedValueOnce(new Error('tx down'))
-				.mockRejectedValueOnce(new Error('config down'))
-				.mockRejectedValueOnce(new Error('setup state down'))
-				.mockRejectedValueOnce(new Error('readiness down'))
-				.mockRejectedValueOnce(new Error('install health down'))
-				.mockRejectedValueOnce(new Error('plex auth down'));
+			// For unauthenticated: only setup/state is fetched, and it rejects
+			apiFetchMock.mockRejectedValueOnce(new Error('setup state down'));
 
 			const result = await load({ locals: { user: null } } as never);
 

--- a/web/test/routes/layout.test.ts
+++ b/web/test/routes/layout.test.ts
@@ -62,6 +62,7 @@ const mockSession: SessionInfo = {
 };
 
 const sharedLayoutData = {
+	user: null,
 	installHealthState: null
 };
 

--- a/web/test/routes/movies/movies.test.ts
+++ b/web/test/routes/movies/movies.test.ts
@@ -6,6 +6,7 @@ import type { PageData } from '../../../src/routes/movies/$types';
 
 const sharedLayoutData: Pick<
 	PageData,
+	| 'user'
 	| 'health'
 	| 'transmissionSession'
 	| 'plexAuthState'
@@ -13,6 +14,7 @@ const sharedLayoutData: Pick<
 	| 'readinessState'
 	| 'installHealthState'
 > = {
+	user: null,
 	health: null,
 	transmissionSession: null,
 	plexAuthState: 'unavailable',

--- a/web/test/routes/onboarding/onboarding.test.ts
+++ b/web/test/routes/onboarding/onboarding.test.ts
@@ -15,6 +15,7 @@ const configWithMoviesFixture = configWithMovies as AppConfig;
 const configWithTvDefaultsFixture = configWithTvDefaults as AppConfig;
 
 const sharedLayoutData = {
+	user: null,
 	health: null,
 	transmissionSession: null,
 	plexAuthState: 'unavailable' as const,

--- a/web/test/routes/shows/[slug]/shows.test.ts
+++ b/web/test/routes/shows/[slug]/shows.test.ts
@@ -6,6 +6,7 @@ import type { PageData } from '../../../../src/routes/shows/[slug]/$types';
 
 const sharedLayoutData: Pick<
 	PageData,
+	| 'user'
 	| 'health'
 	| 'transmissionSession'
 	| 'plexAuthState'
@@ -13,6 +14,7 @@ const sharedLayoutData: Pick<
 	| 'readinessState'
 	| 'installHealthState'
 > = {
+	user: null,
 	health: null,
 	transmissionSession: null,
 	plexAuthState: 'unavailable',

--- a/web/test/routes/shows/shows.test.ts
+++ b/web/test/routes/shows/shows.test.ts
@@ -4,6 +4,7 @@ import Page from '../../../src/routes/shows/+page.svelte';
 import type { ShowBreakdown, TorrentStatSnapshot } from '$lib/types';
 
 const sharedLayoutData = {
+	user: null,
 	health: null,
 	transmissionSession: null,
 	plexAuthState: 'unavailable' as const,

--- a/web/test/session.test.ts
+++ b/web/test/session.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from 'vitest';
+import {
+	signJwt,
+	verifyJwt,
+	issueSessionCookie,
+	clearSessionCookie,
+	SESSION_COOKIE_NAME
+} from '../src/lib/server/session';
+
+const TEST_SECRET = 'test-secret-value-for-unit-tests';
+
+describe('session JWT', () => {
+	it('signs and verifies a valid token', async () => {
+		const token = await signJwt('alice', TEST_SECRET);
+		const result = await verifyJwt(token, TEST_SECRET);
+		expect(result).toEqual({ username: 'alice' });
+	});
+
+	it('returns null for a tampered signature', async () => {
+		const token = await signJwt('alice', TEST_SECRET);
+		const parts = token.split('.');
+		parts[2] = parts[2].slice(0, -4) + 'AAAA';
+		const result = await verifyJwt(parts.join('.'), TEST_SECRET);
+		expect(result).toBeNull();
+	});
+
+	it('returns null for wrong secret', async () => {
+		const token = await signJwt('alice', TEST_SECRET);
+		const result = await verifyJwt(token, 'wrong-secret');
+		expect(result).toBeNull();
+	});
+
+	it('returns null for expired token', async () => {
+		const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+			.replace(/\+/g, '-')
+			.replace(/\//g, '_')
+			.replace(/=+$/, '');
+		const past = Math.floor(Date.now() / 1000) - 1;
+		const payload = btoa(JSON.stringify({ sub: 'alice', iat: past - 100, exp: past }))
+			.replace(/\+/g, '-')
+			.replace(/\//g, '_')
+			.replace(/=+$/, '');
+		const data = `${header}.${payload}`;
+		const enc = new TextEncoder();
+		const key = await crypto.subtle.importKey(
+			'raw',
+			enc.encode(TEST_SECRET),
+			{ name: 'HMAC', hash: 'SHA-256' },
+			false,
+			['sign']
+		);
+		const sig = await crypto.subtle.sign('HMAC', key, enc.encode(data));
+		const sigB64 = btoa(String.fromCharCode(...new Uint8Array(sig)))
+			.replace(/\+/g, '-')
+			.replace(/\//g, '_')
+			.replace(/=+$/, '');
+		const expired = `${data}.${sigB64}`;
+		const result = await verifyJwt(expired, TEST_SECRET);
+		expect(result).toBeNull();
+	});
+
+	it('returns null for malformed token', async () => {
+		expect(await verifyJwt('not.a.valid.jwt.here', TEST_SECRET)).toBeNull();
+		expect(await verifyJwt('', TEST_SECRET)).toBeNull();
+	});
+});
+
+describe('session cookies', () => {
+	it('issues cookie with correct attributes', () => {
+		const setCalls: Array<Parameters<ReturnType<typeof makeCookies>['set']>> = [];
+		const cookies = makeCookies(setCalls);
+		issueSessionCookie(cookies, 'tok');
+		expect(setCalls).toHaveLength(1);
+		const [name, value, opts] = setCalls[0];
+		expect(name).toBe(SESSION_COOKIE_NAME);
+		expect(value).toBe('tok');
+		expect(opts?.httpOnly).toBe(true);
+		expect(opts?.sameSite).toBe('strict');
+		expect(opts?.path).toBe('/');
+		expect(opts?.maxAge).toBeGreaterThan(0);
+	});
+
+	it('clears cookie by deleting it', () => {
+		const deleteCalls: DeleteArgs[] = [];
+		const cookies = makeCookies([], deleteCalls);
+		clearSessionCookie(cookies);
+		expect(deleteCalls).toHaveLength(1);
+		expect(deleteCalls[0][0]).toBe(SESSION_COOKIE_NAME);
+	});
+});
+
+type SetArgs = Parameters<import('@sveltejs/kit').Cookies['set']>;
+type DeleteArgs = [string, Parameters<import('@sveltejs/kit').Cookies['delete']>[1]?];
+
+function makeCookies(
+	setCalls: SetArgs[] = [],
+	deleteCalls: DeleteArgs[] = []
+): import('@sveltejs/kit').Cookies {
+	return {
+		get: vi.fn(),
+		getAll: vi.fn(),
+		set: (...args: SetArgs) => {
+			setCalls.push(args);
+		},
+		delete: (name: string, opts?: Parameters<import('@sveltejs/kit').Cookies['delete']>[1]) => {
+			deleteCalls.push([name, opts]);
+		},
+		serialize: vi.fn()
+	};
+}


### PR DESCRIPTION
## Summary

- delivery ticket: \`P28.02 Web Auth Layer and Screens\`
- ticket file: [docs/02-delivery/phase-28/ticket-02-web-auth-layer-and-screens.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-28/ticket-02-web-auth-layer-and-screens.md)
- stacked base branch: \`agents/p28-01-daemon-auth-state\`
- self-audit: outcome \`clean\` completed at 2026-04-29 10:20 UTC

## Late CodeRabbit Review Triage (2026-05-08)

All findings patched. Branch rebased, tests pass (146/146), pushed.

| Finding | File | Disposition |
|---|---|---|
| \`redirect()\` inside catch swallowed — first visit with no owner never reaches \`/setup\` | \`hooks.server.ts\` | **PATCHED** — added \`isRedirect\` rethrow in catch; P28.04 later refactors into \`resolveUnauthenticatedPageRedirect\` for testability |
| Layout fetches health/session/config/plex for unauthenticated \`/setup\` and \`/login\` requests | \`+layout.server.ts\` | **PATCHED** — added \`authenticated\` guard; skips all sensitive fetches when \`locals.user\` is null; single-return path preserves TypeScript type inference |
| Auth guard fail-open when session secret not configured | \`hooks.server.ts\` | **PATCHED** — explicit \`if (!secret)\` early return with warning log |
| \`verifyJwt\` can throw on malformed base64 cookie segments | \`session.ts\` | **PATCHED** — wrapped entire function body in try/catch returning null |
| Main-area guards (\`isStarter\`, \`isPartiallyConfigured\`, \`isReadyPendingRestart\`) not gated on \`!isAuthPage\` | \`+layout.svelte\` | **PATCHED** — all three derived values now include \`&& !isAuthPage\` |
| \`res.json()\` unguarded — malformed daemon response causes unhandled 500 on login | \`login/+page.server.ts\` | **PATCHED** — wrapped in try/catch returning fail(502) |
| \`loading\` reset before \`update()\` resolves — submit button re-enables prematurely | \`setup/+page.svelte\` | **PATCHED** — moved \`loading = false\` after \`await update()\` |