### PR TITLE
feat(p28.03): add trust-on-first-visit banner and direct-mode acknowledgement

### DIFF
--- a/docs/02-delivery/phase-28/ticket-03-origin-trust-and-direct-mode-banner.md
+++ b/docs/02-delivery/phase-28/ticket-03-origin-trust-and-direct-mode-banner.md
@@ -46,4 +46,8 @@ Tailscale access from a new origin shows the trust banner; one click adds the or
 
 ## Rationale
 
-_To be completed during delivery._
+`untrustedOrigin` is computed from `url.origin` (scheme+host+port of the request), not the HTTP `Origin` header. Direct browser navigation doesn't send an `Origin` header; `url.origin` is always present and correctly represents the access origin (LAN IP, Tailscale IP, etc.).
+
+The auth state fetch (`GET /api/auth/state`) runs on every authenticated page load inside `+layout.server.ts`. This adds one daemon round-trip per navigation but keeps trust-origin and network-posture state always fresh without client-side caching. For a local NAS appliance, this latency is acceptable.
+
+The `apiRequest` mock in layout tests required an explicit `.mockRejectedValue(...)` default to prevent `undefined.then()` errors when `PIRATE_CLAW_API_WRITE_TOKEN` is set in the `.env` file. The layout tests only care about `apiFetch` calls; auth state is intentionally absent from the layout test fixtures (always null).

--- a/web/src/lib/components/NetworkPostureBanner.svelte
+++ b/web/src/lib/components/NetworkPostureBanner.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import { invalidateAll } from '$app/navigation';
+	import type { NetworkPostureState } from '$lib/types';
+
+	let dismissed = $state(false);
+	let loading = $state<NetworkPostureState | null>(null);
+	let errorMsg = $state<string | null>(null);
+
+	async function acknowledge(state: NetworkPostureState) {
+		loading = state;
+		errorMsg = null;
+		try {
+			const res = await fetch('/api/auth/acknowledge-network-posture', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ state })
+			});
+			if (res.ok) {
+				dismissed = true;
+				await invalidateAll();
+			} else {
+				errorMsg = 'Could not save — try again.';
+			}
+		} catch {
+			errorMsg = 'Could not save — try again.';
+		} finally {
+			loading = null;
+		}
+	}
+</script>
+
+{#if !dismissed}
+	<div role="alert" class="border-border bg-card space-y-3 rounded-xl border p-4 text-sm shadow-sm">
+		<p class="text-foreground">
+			Transmission connects directly through your NAS network. Pirate Claw recommends a VPN bridge
+			for most torrent use.
+		</p>
+		{#if errorMsg}
+			<p class="text-destructive text-xs">{errorMsg}</p>
+		{/if}
+		<div class="flex flex-wrap gap-2">
+			<button
+				onclick={() => acknowledge('direct_acknowledged')}
+				disabled={loading !== null}
+				class="border-border text-foreground hover:bg-muted rounded-lg border px-3 py-1.5 text-xs disabled:opacity-50"
+			>
+				{loading === 'direct_acknowledged' ? 'Saving…' : 'Understood, using direct'}
+			</button>
+			<button
+				onclick={() => acknowledge('already_secured_externally')}
+				disabled={loading !== null}
+				class="border-border text-foreground hover:bg-muted rounded-lg border px-3 py-1.5 text-xs disabled:opacity-50"
+			>
+				{loading === 'already_secured_externally' ? 'Saving…' : 'I have external routing'}
+			</button>
+			<button
+				onclick={() => acknowledge('vpn_bridge_pending')}
+				disabled={loading !== null}
+				class="border-border text-foreground hover:bg-muted rounded-lg border px-3 py-1.5 text-xs disabled:opacity-50"
+			>
+				{loading === 'vpn_bridge_pending' ? 'Saving…' : "I'll set up a VPN bridge"}
+			</button>
+		</div>
+	</div>
+{/if}

--- a/web/src/lib/components/TrustOriginBanner.svelte
+++ b/web/src/lib/components/TrustOriginBanner.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import { invalidateAll } from '$app/navigation';
+
+	interface Props {
+		origin: string;
+	}
+
+	let { origin }: Props = $props();
+	let dismissed = $state(false);
+	let loading = $state(false);
+	let errorMsg = $state<string | null>(null);
+
+	async function trustOrigin() {
+		loading = true;
+		errorMsg = null;
+		try {
+			const res = await fetch('/api/auth/trust-origin', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ origin })
+			});
+			if (res.ok) {
+				dismissed = true;
+				await invalidateAll();
+			} else {
+				errorMsg = 'Could not add trusted origin — try again.';
+			}
+		} catch {
+			errorMsg = 'Could not add trusted origin — try again.';
+		} finally {
+			loading = false;
+		}
+	}
+</script>
+
+{#if !dismissed}
+	<div
+		role="alert"
+		class="bg-warning/10 border-warning/30 text-warning-foreground flex items-center gap-3 rounded-xl border px-4 py-3 text-sm"
+	>
+		<span class="min-w-0 flex-1">
+			You're accessing Pirate Claw from an untrusted origin (<code class="font-mono">{origin}</code
+			>).
+			{#if errorMsg}
+				<span class="text-destructive ml-1">{errorMsg}</span>
+			{/if}
+		</span>
+		<button
+			onclick={trustOrigin}
+			disabled={loading}
+			class="bg-warning text-warning-foreground hover:bg-warning/90 shrink-0 rounded-lg px-3 py-1.5 text-xs font-medium disabled:opacity-50"
+		>
+			{loading ? 'Trusting…' : 'Trust this origin'}
+		</button>
+	</div>
+{/if}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -324,3 +324,16 @@ export type TransmissionStatusResponse = {
 	reachable: boolean;
 	advisory?: string;
 };
+
+export type NetworkPostureState =
+	| 'unacknowledged'
+	| 'direct_acknowledged'
+	| 'already_secured_externally'
+	| 'vpn_bridge_pending';
+
+export type AuthStateResult = {
+	owner_exists: boolean;
+	setup_complete: boolean;
+	trusted_origins: string[];
+	network_posture: NetworkPostureState;
+};

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -1,8 +1,10 @@
-import { apiFetch } from '$lib/server/api';
+import { apiRequest, apiFetch } from '$lib/server/api';
 import type {
 	AppConfig,
+	AuthStateResult,
 	DaemonHealth,
 	InstallHealthResponse,
+	NetworkPostureState,
 	PlexAuthState,
 	PlexAuthStatusResponse,
 	ReadinessResponse,
@@ -32,9 +34,19 @@ function normalizePlexAuthState(
 	return authState ?? 'not_connected';
 }
 
-export const load: LayoutServerLoad = async ({ locals }) => {
+export const load: LayoutServerLoad = async ({ locals, url }) => {
 	// Skip sensitive API fetches for unauthenticated requests (auth pages: /setup, /login)
 	const authenticated = locals.user !== null;
+	const writeToken = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+	const authStateFetch: Promise<AuthStateResult> =
+		authenticated && writeToken
+			? apiRequest('/api/auth/state', {
+					headers: { Authorization: `Bearer ${writeToken}` }
+				}).then(async (res) => {
+					if (!res.ok) throw new Error(`auth/state ${res.status}`);
+					return res.json() as Promise<AuthStateResult>;
+				})
+			: Promise.reject(new Error('unauthenticated'));
 
 	const [
 		healthResult,
@@ -43,7 +55,8 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 		setupStateResult,
 		readinessResult,
 		installHealthResult,
-		plexAuthResult
+		plexAuthResult,
+		authStateResult
 	] = await Promise.allSettled([
 		authenticated ? apiFetch<DaemonHealth>('/api/health') : Promise.reject('unauthenticated'),
 		authenticated
@@ -59,7 +72,8 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 			: Promise.reject('unauthenticated'),
 		authenticated
 			? apiFetch<PlexAuthStatusResponse>('/api/plex/auth/status')
-			: Promise.reject('unauthenticated')
+			: Promise.reject('unauthenticated'),
+		authStateFetch
 	]);
 
 	if (authenticated && healthResult.status === 'rejected') {
@@ -96,6 +110,12 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 		configResult.status === 'fulfilled' && configResult.value.plex !== undefined;
 	const plexAuthState =
 		plexAuthResult.status === 'fulfilled' ? plexAuthResult.value.state : undefined;
+	const authState = authStateResult.status === 'fulfilled' ? authStateResult.value : null;
+	const trustedOrigins = authState?.trusted_origins ?? [];
+	const requestOrigin = url.origin;
+	const untrustedOrigin: string | null =
+		locals.user && !trustedOrigins.includes(requestOrigin) ? requestOrigin : null;
+	const networkPosture: NetworkPostureState | null = authState?.network_posture ?? null;
 
 	return {
 		user: locals.user ?? null,
@@ -105,6 +125,8 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 		setupState: normalizeSetupState(setupState),
 		readinessState: normalizeReadinessState(readiness?.state),
 		installHealthState:
-			installHealthResult.status === 'fulfilled' ? installHealthResult.value : null
+			installHealthResult.status === 'fulfilled' ? installHealthResult.value : null,
+		untrustedOrigin,
+		networkPosture
 	};
 };

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -15,6 +15,7 @@
 	import SidebarNav from './components/SidebarNav.svelte';
 	import SidebarStatusFooter from './components/SidebarStatusFooter.svelte';
 	import MobileNav from './components/MobileNav.svelte';
+	import TrustOriginBanner from '$lib/components/TrustOriginBanner.svelte';
 	import type { NavLink } from './components/SidebarNav.svelte';
 	import { page } from '$app/stores';
 	import { toast } from '$lib/toast';
@@ -308,6 +309,11 @@
 							</button>
 						</div>
 					</form>
+				{/if}
+				{#if data.untrustedOrigin}
+					<div class="mb-6">
+						<TrustOriginBanner origin={data.untrustedOrigin} />
+					</div>
 				{/if}
 				{@render children()}
 			{/if}

--- a/web/src/routes/api/auth/acknowledge-network-posture/+server.ts
+++ b/web/src/routes/api/auth/acknowledge-network-posture/+server.ts
@@ -1,0 +1,32 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import type { NetworkPostureState } from '$lib/types';
+import { apiRequest } from '$lib/server/api';
+
+const VALID_STATES: NetworkPostureState[] = [
+	'direct_acknowledged',
+	'already_secured_externally',
+	'vpn_bridge_pending'
+];
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	if (!locals.user) error(401, 'Unauthorized');
+
+	const writeToken = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+	if (!writeToken) error(503, 'Service unavailable');
+
+	const { state } = (await request.json()) as { state: NetworkPostureState };
+	if (!VALID_STATES.includes(state)) error(400, 'Invalid state');
+
+	const res = await apiRequest('/api/auth/acknowledge-network-posture', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${writeToken}`
+		},
+		body: JSON.stringify({ state })
+	});
+
+	if (!res.ok) error(res.status as 400 | 500, 'Failed to acknowledge network posture');
+	return json({ ok: true });
+};

--- a/web/src/routes/api/auth/trust-origin/+server.ts
+++ b/web/src/routes/api/auth/trust-origin/+server.ts
@@ -1,0 +1,24 @@
+import { error, json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { apiRequest } from '$lib/server/api';
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	if (!locals.user) error(401, 'Unauthorized');
+
+	const writeToken = process.env.PIRATE_CLAW_API_WRITE_TOKEN;
+	if (!writeToken) error(503, 'Service unavailable');
+
+	const { origin } = (await request.json()) as { origin: string };
+
+	const res = await apiRequest('/api/auth/trust-origin', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${writeToken}`
+		},
+		body: JSON.stringify({ origin })
+	});
+
+	if (!res.ok) error(res.status as 400 | 500, 'Failed to trust origin');
+	return json({ ok: true });
+};

--- a/web/src/routes/config/+page.svelte
+++ b/web/src/routes/config/+page.svelte
@@ -10,6 +10,7 @@
 	import { toast } from '$lib/toast';
 	import type { FeedConfig, RestartStatus } from '$lib/types';
 	import type { ActionData, PageData } from './$types';
+	import NetworkPostureBanner from '$lib/components/NetworkPostureBanner.svelte';
 	import ConfigPageHeader from './components/ConfigPageHeader.svelte';
 	import DeleteShowModal from './components/DeleteShowModal.svelte';
 	import FeedsCard from './components/FeedsCard.svelte';
@@ -543,6 +544,10 @@
 
 <section class="space-y-6">
 	<ConfigPageHeader {canWrite} onboarding={data.onboarding} />
+
+	{#if data.networkPosture === 'unacknowledged'}
+		<NetworkPostureBanner />
+	{/if}
 
 	{#if data.error}
 		<ApiUnavailableAlert message={data.error} />

--- a/web/test/routes/config/config.test.ts
+++ b/web/test/routes/config/config.test.ts
@@ -56,6 +56,8 @@ const mockConfig: AppConfig = {
 
 const sharedLayoutData = {
 	user: null,
+	untrustedOrigin: null,
+	networkPosture: null,
 	health: null,
 	transmissionSession: null,
 	plexAuthState: 'unavailable'

--- a/web/test/routes/dashboard.test.ts
+++ b/web/test/routes/dashboard.test.ts
@@ -78,6 +78,8 @@ const mockTorrent = (overrides: Partial<TorrentStatSnapshot> = {}): TorrentStatS
 
 const baseData = {
 	user: null,
+	untrustedOrigin: null,
+	networkPosture: null,
 	health: mockHealth,
 	transmissionSession: null,
 	plexAuthState: 'unavailable' as const,

--- a/web/test/routes/layout.server.test.ts
+++ b/web/test/routes/layout.server.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const apiFetchMock = vi.fn();
 vi.mock('$lib/server/api', () => ({
-	apiFetch: apiFetchMock
+	apiFetch: apiFetchMock,
+	apiRequest: vi.fn().mockRejectedValue(new Error('auth state not available in layout tests'))
 }));
 
 const mockUser = { username: 'admin' };
@@ -51,10 +52,16 @@ describe('layout server load', () => {
 				returnTo: null
 			});
 
-		const result = await load({ locals: { user: mockUser } } as never);
+		const result = await load({
+			locals: { user: mockUser },
+			url: new URL('http://localhost:5173/')
+		} as never);
 
 		expect(result).toEqual({
 			user: mockUser,
+			// auth/state not fetched in test env (no write token) — origin flagged as untrusted
+			untrustedOrigin: 'http://localhost:5173',
+			networkPosture: null,
 			health: { uptime: 1, startedAt: '2024-01-01T00:00:00Z' },
 			transmissionSession: {
 				version: '3.0',
@@ -79,7 +86,10 @@ describe('layout server load', () => {
 		// Unauthenticated: only /api/setup/state is fetched
 		apiFetchMock.mockResolvedValueOnce({ state: 'starter' });
 
-		const result = (await load({ locals: { user: null } } as never)) as {
+		const result = (await load({
+			locals: { user: null },
+			url: new URL('http://localhost:5173/')
+		} as never)) as {
 			setupState: string;
 			readinessState: string;
 		};
@@ -118,7 +128,10 @@ describe('layout server load', () => {
 				returnTo: null
 			});
 
-		const result = (await load({ locals: { user: mockUser } } as never)) as { setupState: string };
+		const result = (await load({
+			locals: { user: mockUser },
+			url: new URL('http://localhost:5173/')
+		} as never)) as { setupState: string };
 		expect(result.setupState).toBe('partially_configured');
 	});
 
@@ -152,7 +165,10 @@ describe('layout server load', () => {
 				returnTo: null
 			});
 
-		const result = (await load({ locals: { user: mockUser } } as never)) as {
+		const result = (await load({
+			locals: { user: mockUser },
+			url: new URL('http://localhost:5173/')
+		} as never)) as {
 			readinessState: string;
 		};
 		expect(result.readinessState).toBe('not_ready');
@@ -166,10 +182,15 @@ describe('layout server load', () => {
 			// For unauthenticated: only setup/state is fetched, and it rejects
 			apiFetchMock.mockRejectedValueOnce(new Error('setup state down'));
 
-			const result = await load({ locals: { user: null } } as never);
+			const result = await load({
+				locals: { user: null },
+				url: new URL('http://localhost:5173/')
+			} as never);
 
 			expect(result).toEqual({
 				user: null,
+				untrustedOrigin: null,
+				networkPosture: null,
 				health: null,
 				transmissionSession: null,
 				plexAuthState: 'unavailable',

--- a/web/test/routes/layout.test.ts
+++ b/web/test/routes/layout.test.ts
@@ -63,6 +63,8 @@ const mockSession: SessionInfo = {
 
 const sharedLayoutData = {
 	user: null,
+	untrustedOrigin: null,
+	networkPosture: null,
 	installHealthState: null
 };
 

--- a/web/test/routes/movies/movies.test.ts
+++ b/web/test/routes/movies/movies.test.ts
@@ -7,6 +7,8 @@ import type { PageData } from '../../../src/routes/movies/$types';
 const sharedLayoutData: Pick<
 	PageData,
 	| 'user'
+	| 'untrustedOrigin'
+	| 'networkPosture'
 	| 'health'
 	| 'transmissionSession'
 	| 'plexAuthState'
@@ -15,6 +17,8 @@ const sharedLayoutData: Pick<
 	| 'installHealthState'
 > = {
 	user: null,
+	untrustedOrigin: null,
+	networkPosture: null,
 	health: null,
 	transmissionSession: null,
 	plexAuthState: 'unavailable',

--- a/web/test/routes/onboarding/onboarding.test.ts
+++ b/web/test/routes/onboarding/onboarding.test.ts
@@ -16,6 +16,8 @@ const configWithTvDefaultsFixture = configWithTvDefaults as AppConfig;
 
 const sharedLayoutData = {
 	user: null,
+	untrustedOrigin: null,
+	networkPosture: null,
 	health: null,
 	transmissionSession: null,
 	plexAuthState: 'unavailable' as const,

--- a/web/test/routes/shows/[slug]/shows.test.ts
+++ b/web/test/routes/shows/[slug]/shows.test.ts
@@ -7,6 +7,8 @@ import type { PageData } from '../../../../src/routes/shows/[slug]/$types';
 const sharedLayoutData: Pick<
 	PageData,
 	| 'user'
+	| 'untrustedOrigin'
+	| 'networkPosture'
 	| 'health'
 	| 'transmissionSession'
 	| 'plexAuthState'
@@ -15,6 +17,8 @@ const sharedLayoutData: Pick<
 	| 'installHealthState'
 > = {
 	user: null,
+	untrustedOrigin: null,
+	networkPosture: null,
 	health: null,
 	transmissionSession: null,
 	plexAuthState: 'unavailable',

--- a/web/test/routes/shows/shows.test.ts
+++ b/web/test/routes/shows/shows.test.ts
@@ -5,6 +5,8 @@ import type { ShowBreakdown, TorrentStatSnapshot } from '$lib/types';
 
 const sharedLayoutData = {
 	user: null,
+	untrustedOrigin: null,
+	networkPosture: null,
 	health: null,
 	transmissionSession: null,
 	plexAuthState: 'unavailable' as const,


### PR DESCRIPTION
## Summary

- delivery ticket: \`P28.03 Origin Trust and Direct-Mode Banner\`
- ticket file: [docs/02-delivery/phase-28/ticket-03-origin-trust-and-direct-mode-banner.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-28/ticket-03-origin-trust-and-direct-mode-banner.md)
- stacked base branch: \`agents/p28-02-web-auth-layer-and-screens\`
- self-audit: outcome \`clean\` completed at 2026-04-29 10:40 UTC

## Late CodeRabbit Review Triage (2026-05-08)

| Finding | File | Disposition |
|---|---|---|
| \`authStateFetch\` (\`/api/auth/state\`) runs even when \`locals.user\` is null — returns \`networkPosture\` in unauthenticated layout payload | \`+layout.server.ts\` | **PATCHED** — gated behind \`authenticated && writeToken\` (same pattern as all other sensitive fetches in this file) |