### PR TITLE
docs(p28): close phase 28 documentation — owner auth baseline, security posture, retrospective [P28.05]

### DIFF
--- a/docs/00-overview/roadmap.md
+++ b/docs/00-overview/roadmap.md
@@ -642,7 +642,12 @@ Goal:
 
 Current status:
 
-- product definition only; see [`docs/01-product/phase-28-owner-web-security.md`](../01-product/phase-28-owner-web-security.md)
+- implemented on `main` via `P28.01`–`P28.05` stacked delivery; validated on DS918+ / DSM 7.1.1-42962 Update 9
+- owner account creation on first launch; opaque session cookie (argon2id hash, BLAKE3 token); owner auth gates all web state and destructive actions
+- daemon owns all auth state (`owner_accounts`, `owner_sessions`, `trusted_origins`, `direct_mode_ack`) in SQLite — no secrets in config JSON
+- trusted-origin banner for LAN and Tailscale addresses; direct-mode acknowledgement as a Phase 29 placeholder
+- see [`docs/01-product/phase-28-owner-web-security.md`](../01-product/phase-28-owner-web-security.md)
+- see [`docs/synology-install.md`](../synology-install.md) for owner setup and security posture guidance
 
 ## Phase 29: OpenVPN Bridge for Bundled Transmission
 
@@ -710,7 +715,7 @@ The following items are **mapped** to numbered phases (no longer “unbounded”
 
 - product phases `01`–`19` are implemented in the current delivery stack; **Phase 19** is delivered via `P19.01`–`P19.08`
 - **Phase 20** (dashboard torrent proxy) is **shipped** on `main`
-- **Phases 21–27** are shipped on `main`; **Phases 28–29** are the release-blocking owner security and OpenVPN bridge planning sequence
+- **Phases 21–28** are shipped on `main`; **Phase 29** (OpenVPN bridge) is the next release-blocking sequence
 - **Phase 30** remains the release-critical UX/UI polish bucket after functional completion
 - **Phase 31** (v1.0.0 / schema versioning) remains the release/versioning ceremony after product-completion phases are done
 - engineering epic write-ups **`EE01`–`EE09`** live under `docs/03-engineering/` (orchestrator, PR hygiene, and delivery workflow tooling)
@@ -731,4 +736,4 @@ Working notes:
 - promote durable technical choices into ADRs
 - numbered phases are planning buckets, not a promise of strict implementation sequence when dependencies allow independent work
 
-Last verified against `README.md` and active delivery plans: 2026-04-27 (Phases 20–27 are delivered on `main`; Phases 28–29 are the current release-blocking product-planning sequence; Phase 30 is release-critical polish; Phase 31 remains the release/versioning phase).
+Last verified against `README.md` and active delivery plans: 2026-05-08 (Phases 20–28 are delivered on `main`; Phase 29 (OpenVPN bridge) is the current release-blocking sequence; Phase 30 is release-critical polish; Phase 31 remains the release/versioning phase).

--- a/docs/00-overview/start-here.md
+++ b/docs/00-overview/start-here.md
@@ -10,7 +10,7 @@ Its job is to answer three questions quickly:
 
 ## Current Repo State
 
-Pirate Claw is implemented through **Phase 27**. The next release-blocking sequence is Phase 28 (owner web security), Phase 29 (OpenVPN bridge), Phase 30 (UX/UI polish), and Phase 31 (v1 release ceremony).
+Pirate Claw is implemented through **Phase 28**. The P28 owner auth layer is the current security baseline — a session-protected owner account gates all web state and destructive actions. The next release-blocking sequence is Phase 29 (OpenVPN bridge), Phase 30 (UX/UI polish), and Phase 31 (v1 release ceremony).
 
 For the full feature inventory and phase status, read [`README.md`](../../README.md) and [`roadmap.md`](./roadmap.md). Use the roadmap to confirm whether a request is a bounded standalone change or needs a new approved phase.
 

--- a/docs/02-delivery/phase-28/ticket-05-docs-and-phase-exit.md
+++ b/docs/02-delivery/phase-28/ticket-05-docs-and-phase-exit.md
@@ -47,4 +47,4 @@ Owner-facing and overview docs are updated. Security posture is documented. Retr
 
 ## Rationale
 
-_To be completed during delivery._
+Documentation-close ticket for Phase 28. All owner-facing and overview docs were updated in a single pass to reflect the P28 security baseline: owner account creation on first launch, session-protected web UI, trusted-origin banner, and direct-mode acknowledgement. The security posture section in `synology-install.md` was added here rather than in an earlier ticket to keep the install guide stable until the full feature set was validated on DS918+. The retrospective captures the JWT vs. opaque session decision, trust-on-first-visit design, and the known gaps (CSRF/allowedOrigins, Plex PIN callback) that P29 planning must address.

--- a/docs/mac-runbook.md
+++ b/docs/mac-runbook.md
@@ -52,6 +52,17 @@ Mac-specific folders.
 The current Phase 26 contract is source-first: the supported launch agent runs
 `src/cli.ts` from the install directory rather than a packaged `.app`.
 
+## Owner Account Setup
+
+Phase 28 adds an owner auth layer. On first launch the web UI is in **starter mode** and requires owner account creation before any app state or controls are accessible.
+
+1. Start the daemon and open `http://127.0.0.1:5555` (or the configured port) in a browser.
+2. You are redirected to `/setup`. Enter a username and password for the owner account and submit.
+3. Pirate Claw creates the owner account and logs you in automatically.
+4. Complete onboarding or navigate to `/config` to continue setup.
+
+**Complete owner setup immediately after first launch.** Until an owner account exists the web UI has no auth. On subsequent visits log in at `/login` with the owner credentials you created.
+
 ## First Boot
 
 From the install directory:

--- a/docs/synology-install.md
+++ b/docs/synology-install.md
@@ -48,9 +48,34 @@ The zip is hosted externally. See the README for the download link.
 Once the containers are running:
 
 1. Open `http://<nas-ip>:8888` in a browser.
-2. Pirate Claw opens in starter mode and guides you through setup without requiring any config file editing.
-3. The onboarding page shows Synology install health. If a check fails, follow the DSM-language guidance shown on the page, then use Re-check.
+2. Pirate Claw redirects to `/setup` — create your owner account before doing anything else (see [Owner Account Setup](#owner-account-setup)).
+3. After creating the owner account you are redirected to onboarding. The onboarding page shows Synology install health. If a check fails, follow the DSM-language guidance shown on the page, then use Re-check.
 4. After install health passes, add at least one RSS feed and one TV show or movie year target to complete setup.
+
+## Owner Account Setup
+
+Phase 28 adds an owner auth layer. On first launch the web UI is in **starter mode** and requires owner account creation before any app state or controls are accessible.
+
+**Steps:**
+
+1. Open `http://<nas-ip>:8888`.
+2. You are redirected to `/setup`. Enter a username and password for the owner account.
+3. Submit the form. Pirate Claw creates the owner account and logs you in automatically.
+4. You are redirected to onboarding to complete install health and initial configuration.
+
+**Complete owner setup immediately after the first launch.** Until an owner account exists the web UI is unauthenticated. Do not leave Pirate Claw running on the network before this step is done.
+
+On subsequent visits open `http://<nas-ip>:8888` and log in at `/login` with the owner credentials you created.
+
+## Security Posture
+
+Pirate Claw v1 is designed for **LAN and Tailscale / private mesh access only**. It is not hardened for direct public internet exposure. Do not forward port `8888` to the public internet.
+
+**First-launch window:** Between container start and owner account creation the web UI has no auth. Complete owner setup before leaving the NAS unattended or accessible on a shared network segment.
+
+**Trusted origins:** Pirate Claw tracks trusted origins so the browser security banner clears for each access address you use (e.g. LAN IP `192.168.1.x`, Tailscale IP `100.x.x.x`). To add a new trusted origin navigate to the Pirate Claw web UI from the new address — the banner will appear. Click **Trust this origin** and the address is persisted to `trusted-origins.json`. Note: trusted-origins.json is separate from SvelteKit's CSRF protection, which is pinned to the `ORIGIN` environment variable set at container start. Form-submission flows from secondary addresses may still fail CSRF checks until P29 resolves the gap.
+
+**Direct-mode acknowledgement:** The Config page shows an acknowledgement banner when the daemon is running in direct mode (no VPN tunnel for Transmission traffic). Acknowledging it clears the banner and is persisted in the daemon database. This is a Phase 29 placeholder — the OpenVPN bridge is the eventual resolution.
 
 ## Owner Contract
 

--- a/notes/public/phase-28-retrospective.md
+++ b/notes/public/phase-28-retrospective.md
@@ -1,0 +1,45 @@
+# Phase 28 Retrospective — Owner Web Security
+
+## JWT vs. Opaque Session
+
+We chose opaque sessions over JWTs. The primary driver was simplicity: Pirate Claw is a single-owner, single-device app with no need for stateless token delegation, third-party API consumers, or cross-service auth. JWTs add complexity (key rotation, clock skew, revocation) for no gain at this scale.
+
+The chosen approach: BLAKE3-generated random token stored as a session row in SQLite (`owner_sessions`), with the hash of the token written to disk (argon2id). A matching `pc_session` cookie on the browser side. Session lookup is a single DB read per request. Revocation is a row delete. No key material in the config file.
+
+For v1 this is the right call. If P29 introduces machine-to-machine API calls that need to be signed independently of a browser session, JWT or HMAC-signed tokens become a reasonable follow-up, but that case doesn't exist yet.
+
+## Trust-On-First-Visit Design
+
+The trusted-origins system was designed for the Tailscale use case: the operator owns both addresses (LAN and Tailscale IP), both are private, and the friction of acknowledging each one once is acceptable. The first visit from a new origin shows a banner with one click to persist.
+
+What the design does well: it's explicit. There's no silent auto-trust. Operators know which addresses have been cleared.
+
+What P29 planning should revisit: trusted-origins.json and SvelteKit's CSRF protection (`ORIGIN` env var) are separate systems. CSRF is pinned to a single origin at container start. Form-submission flows from a secondary trusted origin (e.g. the Tailscale address when `ORIGIN` is the LAN address) will fail CSRF validation even after the origin is trusted at the app level. The P28 scope stopped at documenting this gap. P29 should either wire `allowedOrigins` from `trusted-origins.json` dynamically, or accept and document secondary-address-as-read-only-with-JSON-fetch-only semantics.
+
+## Direct-Mode Acknowledgement
+
+The direct-mode acknowledgement banner is a Phase 29 placeholder. Its job in P28 is to make the default operational state explicit to the operator: Transmission traffic is not routed through a VPN. Acknowledging it persists a row in SQLite and clears the banner.
+
+It intentionally does not enforce anything. It's informational only. The banner will return if the daemon detects VPN status changes in the future (P29 scope).
+
+P29 planning should revisit: what constitutes "direct mode" in the context of the OpenVPN bridge? If P29 makes VPN-backed Transmission the default for the bundled stack, the acknowledgement logic should flip — the banner should appear when VPN is absent, not just when VPN has never been configured.
+
+## Validation Findings to Carry Into P29
+
+**isStarter layout guard and /setup interaction:** The P28.04 fix excluded `/setup` and `/login` from the `isStarter` splash. This was not in the original design. P29 should assume the auth-page exclusion list may grow and consider whether the routing logic should be config-driven rather than hard-coded.
+
+**GET /logout route:** P28 shipped with `/logout` having only a form action and no `load` function. Direct URL navigation returned 500. Fixed during P28.04 validation. P29 should treat any auth-flow route as requiring both a `load` function and a form action.
+
+**Plex PIN callback redirect:** When Plex auth completes and the PIN callback returns, the browser is sent to `/login` instead of `/onboarding`. The redirect target is wrong. Deferred to P29. Root cause is the callback URL not preserving the originating flow context.
+
+**CSRF/allowedOrigins gap:** Documented above under Trust-On-First-Visit. This is the most significant open design question for P29.
+
+**Fresh install validation:** The full "delete everything, re-install from zip, create owner account, complete onboarding" path was validated on DS918+ / DSM 7.1.1-42962 Update 9 during P28.04. `daemon-api-write-token` and `session-secret` were generated fresh on startup. Owner setup flow worked after the `isStarter` layout guard fix.
+
+## What P29 Planning Should Assume
+
+- Owner auth is the stable baseline. P29 does not need to re-litigate session storage or credential design.
+- Trusted origins exist in SQLite and are consulted at request time. P29 can read from them to wire `allowedOrigins` without redesigning the storage layer.
+- Direct-mode acknowledgement is in SQLite (`direct_mode_ack` table). P29 can extend the logic without migrating the schema.
+- The SvelteKit CSRF gap is real and known. P29 must decide whether to address it (dynamic `allowedOrigins`) or accept the constraint (document secondary addresses as partial-access only).
+- Plex PIN callback redirect needs a fix before the P28 auth layer and Plex onboarding flow can coexist cleanly.


### PR DESCRIPTION
## Summary

- delivery ticket: `P28.05 Docs and Phase Exit`
- ticket file: [docs/02-delivery/phase-28/ticket-05-docs-and-phase-exit.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/02-delivery/phase-28/ticket-05-docs-and-phase-exit.md)
- stacked base branch: `agents/p28-04-ds918-exit-validation`
- self-audit: outcome `skipped` completed at 2026-05-08 15:50 UTC
