### PR TITLE
feat: p28 carry-over prerequisites [P29.02]

### DIFF
--- a/docs/product/delivery/phase-29/ticket-02-p28-carry-over-prerequisites.md
+++ b/docs/product/delivery/phase-29/ticket-02-p28-carry-over-prerequisites.md
@@ -64,8 +64,12 @@ Scope: web-daemon
 
 > Append here (do not edit above) when behavior or trade-offs change during implementation.
 
-Red first: [what test failed first]
-Why this path: [why this implementation was the smallest acceptable]
-Alternative considered: [one rejected alternative and why]
-Deferred: [what was intentionally left out of this ticket]
-Contract note: record any deviation from the ticket metadata contract here, including missing/incorrect `Type:` or non-compliant `Scope:` fields, and why it happened.
+Red first: CSRF handle test failed (got 200, expected 403) because the old `handle` had no origin check. Plex connect test failed because `forwardUrl` had no `returnTo` query param.
+
+Why this path: Disabled SvelteKit's built-in CSRF (`csrf: { checkOrigin: false }`) and implemented a custom check in `handle`. This is the only approach that is unit-testable without running a full SvelteKit server. Setting `process.env.ALLOWED_ORIGINS` in `init()` would be too late — the adapter-node reads it at import time, before `init()` runs.
+
+Alternative considered: Setting `process.env.ALLOWED_ORIGINS` at `init()` time. Rejected because `@sveltejs/adapter-node` parses ALLOWED_ORIGINS at module load time, not per-request, so the env var is read before the init hook fires.
+
+Deferred: Daemon-side structured logging (startup config load, API request receipt) is not included here — the ticket scope was the web/SvelteKit side. The `PIRATE_CLAW_TRUSTED_ORIGINS_FILE` env var must be wired into the compose artifacts in P29.04 for deployed instances.
+
+Contract note: No deviations from ticket metadata.

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -7,6 +7,7 @@ import {
 	SESSION_COOKIE_NAME
 } from '$lib/server/session';
 import { apiRequest } from '$lib/server/api';
+import { log } from '$lib/server/log';
 
 const PUBLIC_PATHS = new Set(['/setup', '/login', '/logout']);
 
@@ -15,21 +16,6 @@ const FORM_CONTENT_TYPES = new Set([
 	'multipart/form-data',
 	'text/plain'
 ]);
-
-type LogLevel = 'debug' | 'info' | 'silent';
-
-function logLevel(): LogLevel {
-	const level = process.env.PIRATE_CLAW_LOG_LEVEL;
-	if (level === 'debug' || level === 'info' || level === 'silent') return level;
-	return 'info';
-}
-
-function log(level: LogLevel, data: Record<string, unknown>): void {
-	const current = logLevel();
-	if (current === 'silent') return;
-	if (level === 'debug' && current !== 'debug') return;
-	console.log(data);
-}
 
 let trustedOrigins: string[] = [];
 
@@ -63,6 +49,7 @@ export function init() {
 		}
 	}
 
+	trustedOrigins = [];
 	const originsFile = process.env.PIRATE_CLAW_TRUSTED_ORIGINS_FILE;
 	if (originsFile) {
 		try {
@@ -70,10 +57,18 @@ export function init() {
 			if (Array.isArray(raw)) {
 				trustedOrigins = (raw as unknown[]).filter((x): x is string => typeof x === 'string');
 				log('info', { event: 'csrf_origins_loaded', count: trustedOrigins.length });
+			} else {
+				log('warn', { event: 'csrf_origins_invalid', file: originsFile });
 			}
-		} catch {
-			// file not yet written; trustedOrigins stays [] (same as pre-P29 behavior)
+		} catch (error) {
+			log('warn', {
+				event: 'csrf_origins_load_failed',
+				file: originsFile,
+				error: error instanceof Error ? error.message : String(error)
+			});
 		}
+	} else {
+		log('debug', { event: 'csrf_origins_not_configured' });
 	}
 }
 
@@ -96,7 +91,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 		const origin = event.request.headers.get('origin');
 		const serverOrigin = process.env.ORIGIN ?? event.url.origin;
 		if (!isAllowedOrigin(origin, serverOrigin)) {
-			log('info', { event: 'csrf_rejected', origin, serverOrigin });
+			log('warn', { event: 'csrf_rejected', origin, serverOrigin });
 			return new Response('Cross-site form submissions are not allowed.', { status: 403 });
 		}
 		log('debug', { event: 'csrf_allowed', origin, serverOrigin });

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -10,6 +10,29 @@ import { apiRequest } from '$lib/server/api';
 
 const PUBLIC_PATHS = new Set(['/setup', '/login', '/logout']);
 
+const FORM_CONTENT_TYPES = new Set([
+	'application/x-www-form-urlencoded',
+	'multipart/form-data',
+	'text/plain'
+]);
+
+type LogLevel = 'debug' | 'info' | 'silent';
+
+function logLevel(): LogLevel {
+	const level = process.env.PIRATE_CLAW_LOG_LEVEL;
+	if (level === 'debug' || level === 'info' || level === 'silent') return level;
+	return 'info';
+}
+
+function log(level: LogLevel, data: Record<string, unknown>): void {
+	const current = logLevel();
+	if (current === 'silent') return;
+	if (level === 'debug' && current !== 'debug') return;
+	console.log(data);
+}
+
+let trustedOrigins: string[] = [];
+
 export function init() {
 	if (!process.env.PIRATE_CLAW_API_WRITE_TOKEN) {
 		const tokenFile = process.env.PIRATE_CLAW_DAEMON_TOKEN_FILE;
@@ -39,9 +62,46 @@ export function init() {
 			}
 		}
 	}
+
+	const originsFile = process.env.PIRATE_CLAW_TRUSTED_ORIGINS_FILE;
+	if (originsFile) {
+		try {
+			const raw: unknown = JSON.parse(readFileSync(originsFile, 'utf8'));
+			if (Array.isArray(raw)) {
+				trustedOrigins = (raw as unknown[]).filter((x): x is string => typeof x === 'string');
+				log('info', { event: 'csrf_origins_loaded', count: trustedOrigins.length });
+			}
+		} catch {
+			// file not yet written; trustedOrigins stays [] (same as pre-P29 behavior)
+		}
+	}
+}
+
+function isAllowedOrigin(origin: string | null, serverOrigin: string): boolean {
+	if (!origin) return true;
+	if (origin === serverOrigin) return true;
+	return trustedOrigins.includes(origin);
+}
+
+function isMutatingFormRequest(request: Request): boolean {
+	const method = request.method.toUpperCase();
+	if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') return false;
+	const ct = (request.headers.get('content-type') ?? '').split(';')[0].trim();
+	return FORM_CONTENT_TYPES.has(ct);
 }
 
 export const handle: Handle = async ({ event, resolve }) => {
+	// Custom CSRF check — built-in SvelteKit CSRF is disabled in svelte.config.js
+	if (isMutatingFormRequest(event.request)) {
+		const origin = event.request.headers.get('origin');
+		const serverOrigin = process.env.ORIGIN ?? event.url.origin;
+		if (!isAllowedOrigin(origin, serverOrigin)) {
+			log('info', { event: 'csrf_rejected', origin, serverOrigin });
+			return new Response('Cross-site form submissions are not allowed.', { status: 403 });
+		}
+		log('debug', { event: 'csrf_allowed', origin, serverOrigin });
+	}
+
 	const path = event.url.pathname;
 
 	if (PUBLIC_PATHS.has(path)) {
@@ -52,6 +112,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 	const secret = getSessionSecret();
 	if (!secret) {
 		event.locals.user = null;
+		log('debug', { event: 'session_no_secret', path });
 		return resolve(event);
 	}
 
@@ -60,6 +121,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 		const user = await verifyJwt(token, secret);
 		if (user) {
 			event.locals.user = user;
+			log('debug', { event: 'session_valid', username: user.username, path });
 			return resolve(event);
 		}
 	}
@@ -67,6 +129,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 
 	// API routes return 401 rather than redirecting
 	if (path.startsWith('/api/')) {
+		log('debug', { event: 'api_unauthorized', path });
 		return new Response(JSON.stringify({ error: 'Unauthorized' }), {
 			status: 401,
 			headers: { 'content-type': 'application/json' }
@@ -76,6 +139,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 	const destination = await resolveUnauthenticatedPageRedirect(
 		process.env.PIRATE_CLAW_API_WRITE_TOKEN
 	);
+	log('info', { event: 'auth_redirect', path, destination });
 	redirect(302, destination);
 };
 

--- a/web/src/lib/server/log.ts
+++ b/web/src/lib/server/log.ts
@@ -1,0 +1,28 @@
+type LogLevel = 'debug' | 'info' | 'warn' | 'silent';
+
+const LOG_PRIORITY: Record<Exclude<LogLevel, 'silent'>, number> = {
+	debug: 10,
+	info: 20,
+	warn: 30
+};
+
+function currentLogLevel(): LogLevel {
+	const level = process.env.PIRATE_CLAW_LOG_LEVEL;
+	if (level === 'debug' || level === 'info' || level === 'warn' || level === 'silent') {
+		return level;
+	}
+	return 'info';
+}
+
+export function log(level: Exclude<LogLevel, 'silent'>, data: Record<string, unknown>): void {
+	const current = currentLogLevel();
+	if (current === 'silent') return;
+	if (LOG_PRIORITY[level] < LOG_PRIORITY[current]) return;
+
+	if (level === 'warn') {
+		console.warn(data);
+		return;
+	}
+
+	console.log(data);
+}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -49,10 +49,13 @@
 	const transmissionConnected = $derived(data.transmissionSession !== null);
 	const plexAuthState = $derived(data.plexAuthState ?? 'unavailable');
 	const isOnboarding = $derived($page.url.pathname === '/onboarding');
+	// Any new auth-flow route must be added here — absence causes visible test failure
 	const isAuthPage = $derived(
 		$page.url.pathname === '/setup' ||
 			$page.url.pathname === '/login' ||
-			$page.url.pathname === '/logout'
+			$page.url.pathname === '/logout' ||
+			$page.url.pathname === '/plex/connect' ||
+			$page.url.pathname === '/plex/connect/callback'
 	);
 	const showSidebar = $derived(!isOnboarding && !isAuthPage);
 	const setupState = $derived(data.setupState ?? 'partially_configured');

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -49,7 +49,7 @@
 	const transmissionConnected = $derived(data.transmissionSession !== null);
 	const plexAuthState = $derived(data.plexAuthState ?? 'unavailable');
 	const isOnboarding = $derived($page.url.pathname === '/onboarding');
-	// Any new auth-flow route must be added here — absence causes visible test failure
+	// Auth-flow routes render transient redirects/callbacks; keep the app shell hidden there.
 	const isAuthPage = $derived(
 		$page.url.pathname === '/setup' ||
 			$page.url.pathname === '/login' ||

--- a/web/src/routes/plex/connect/+server.ts
+++ b/web/src/routes/plex/connect/+server.ts
@@ -9,8 +9,10 @@ export const GET: RequestHandler = async ({ url }) => {
 		throw redirect(303, '/config?plexAuthError=Config+writes+are+disabled.');
 	}
 
-	const forwardUrl = `${url.origin}/plex/connect/callback`;
 	const returnTo = url.searchParams.get('returnTo') ?? '/config';
+	const callbackUrl = new URL(`${url.origin}/plex/connect/callback`);
+	callbackUrl.searchParams.set('returnTo', returnTo);
+	const forwardUrl = callbackUrl.toString();
 
 	const response = await apiRequest('/api/plex/auth/start', {
 		method: 'POST',

--- a/web/src/routes/plex/connect/callback/+page.server.ts
+++ b/web/src/routes/plex/connect/callback/+page.server.ts
@@ -5,13 +5,15 @@ import type { PageServerLoad } from './$types';
 export const load: PageServerLoad = async ({ url }) => {
 	const writeToken = env.PIRATE_CLAW_API_WRITE_TOKEN;
 	const sessionId = url.searchParams.get('session');
+	// URL param is authoritative — it survives Plex's redirect round-trip
+	const returnToFromUrl = url.searchParams.get('returnTo') ?? '/config';
 
 	if (!writeToken || !sessionId) {
 		return {
 			ok: false,
 			pending: false,
 			message: 'Missing Plex auth session. Start the connect flow again.',
-			returnTo: '/config',
+			returnTo: returnToFromUrl,
 			expiresAt: null
 		};
 	}
@@ -37,7 +39,7 @@ export const load: PageServerLoad = async ({ url }) => {
 				ok: false,
 				pending: true,
 				message: body.error ?? 'Plex sign-in is still completing.',
-				returnTo: body.returnTo ?? '/config',
+				returnTo: returnToFromUrl,
 				expiresAt: body.expiresAt ?? null
 			};
 		}
@@ -45,17 +47,18 @@ export const load: PageServerLoad = async ({ url }) => {
 			ok: false,
 			pending: false,
 			message: body.error ?? 'Could not complete Plex auth.',
-			returnTo: '/config',
+			returnTo: returnToFromUrl,
 			expiresAt: null
 		};
 	}
 
-	const body = (await response.json()) as { returnTo?: string | null };
+	await response.json();
+	console.log({ event: 'plex_callback_redirect', returnTo: returnToFromUrl });
 	return {
 		ok: true,
 		pending: false,
 		message: 'Plex connected successfully.',
-		returnTo: body.returnTo ?? '/config',
+		returnTo: returnToFromUrl,
 		expiresAt: null
 	};
 };

--- a/web/src/routes/plex/connect/callback/+page.server.ts
+++ b/web/src/routes/plex/connect/callback/+page.server.ts
@@ -1,5 +1,6 @@
 import { env } from '$env/dynamic/private';
 import { apiRequest } from '$lib/server/api';
+import { log } from '$lib/server/log';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ url }) => {
@@ -53,7 +54,7 @@ export const load: PageServerLoad = async ({ url }) => {
 	}
 
 	await response.json();
-	console.log({ event: 'plex_callback_redirect', returnTo: returnToFromUrl });
+	log('info', { event: 'plex_callback_redirect', returnTo: returnToFromUrl });
 	return {
 		ok: true,
 		pending: false,

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -9,7 +9,8 @@ const config = {
 		defaultHandler(warning);
 	},
 	kit: {
-		adapter: adapter()
+		adapter: adapter(),
+		csrf: { checkOrigin: false }
 	},
 	vitePlugin: {
 		inspector: {

--- a/web/test/hooks.server.test.ts
+++ b/web/test/hooks.server.test.ts
@@ -21,10 +21,16 @@ beforeEach(() => {
 	savedEnv.PIRATE_CLAW_DAEMON_TOKEN_FILE = process.env.PIRATE_CLAW_DAEMON_TOKEN_FILE;
 	savedEnv.PIRATE_CLAW_SESSION_SECRET = process.env.PIRATE_CLAW_SESSION_SECRET;
 	savedEnv.PIRATE_CLAW_SESSION_SECRET_FILE = process.env.PIRATE_CLAW_SESSION_SECRET_FILE;
+	savedEnv.PIRATE_CLAW_TRUSTED_ORIGINS_FILE = process.env.PIRATE_CLAW_TRUSTED_ORIGINS_FILE;
+	savedEnv.PIRATE_CLAW_LOG_LEVEL = process.env.PIRATE_CLAW_LOG_LEVEL;
+	savedEnv.ORIGIN = process.env.ORIGIN;
 	delete process.env.PIRATE_CLAW_API_WRITE_TOKEN;
 	delete process.env.PIRATE_CLAW_DAEMON_TOKEN_FILE;
 	delete process.env.PIRATE_CLAW_SESSION_SECRET;
 	delete process.env.PIRATE_CLAW_SESSION_SECRET_FILE;
+	delete process.env.PIRATE_CLAW_TRUSTED_ORIGINS_FILE;
+	process.env.PIRATE_CLAW_LOG_LEVEL = 'silent';
+	delete process.env.ORIGIN;
 	vi.mocked(apiRequest).mockReset();
 	// reset module-level secret before each test
 	initSessionSecret('');
@@ -38,7 +44,10 @@ afterEach(() => {
 		'PIRATE_CLAW_API_WRITE_TOKEN',
 		'PIRATE_CLAW_DAEMON_TOKEN_FILE',
 		'PIRATE_CLAW_SESSION_SECRET',
-		'PIRATE_CLAW_SESSION_SECRET_FILE'
+		'PIRATE_CLAW_SESSION_SECRET_FILE',
+		'PIRATE_CLAW_TRUSTED_ORIGINS_FILE',
+		'PIRATE_CLAW_LOG_LEVEL',
+		'ORIGIN'
 	] as const;
 	for (const key of keys) {
 		if (savedEnv[key] !== undefined) {
@@ -162,7 +171,6 @@ describe('resolveUnauthenticatedPageRedirect', () => {
 });
 
 describe('handle — CSRF validation', () => {
-	const savedOrigin = process.env.ORIGIN;
 	let trustedOriginsFile: string;
 
 	beforeEach(() => {
@@ -174,11 +182,6 @@ describe('handle — CSRF validation', () => {
 	});
 
 	afterEach(() => {
-		if (savedOrigin !== undefined) {
-			process.env.ORIGIN = savedOrigin;
-		} else {
-			delete process.env.ORIGIN;
-		}
 		delete process.env.PIRATE_CLAW_TRUSTED_ORIGINS_FILE;
 	});
 
@@ -220,6 +223,35 @@ describe('handle — CSRF validation', () => {
 		expect(response.status).not.toBe(403);
 	});
 
+	it('does not reread trusted-origins at request time', async () => {
+		writeFileSync(trustedOriginsFile, JSON.stringify(['http://100.64.0.1']));
+		process.env.PIRATE_CLAW_TRUSTED_ORIGINS_FILE = trustedOriginsFile;
+		init();
+		writeFileSync(trustedOriginsFile, JSON.stringify([]));
+
+		const event = makeFormEvent('http://100.64.0.1');
+		const resolve = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+
+		const response = await handle({ event: event as never, resolve });
+
+		expect(response.status).not.toBe(403);
+	});
+
+	it('resets trusted-origins to safe defaults when startup read fails', async () => {
+		writeFileSync(trustedOriginsFile, JSON.stringify(['http://100.64.0.1']));
+		process.env.PIRATE_CLAW_TRUSTED_ORIGINS_FILE = trustedOriginsFile;
+		init();
+		process.env.PIRATE_CLAW_TRUSTED_ORIGINS_FILE = join(tmpDir, 'missing-trusted-origins.json');
+		init();
+
+		const event = makeFormEvent('http://100.64.0.1');
+		const resolve = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+
+		const response = await handle({ event: event as never, resolve });
+
+		expect(response.status).toBe(403);
+	});
+
 	it('allows form POST from same-origin (ORIGIN env)', async () => {
 		const event = makeFormEvent('http://localhost');
 		const resolve = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
@@ -244,5 +276,34 @@ describe('handle — CSRF validation', () => {
 		const response = await handle({ event: event as never, resolve });
 
 		expect(response.status).not.toBe(403);
+	});
+
+	it('suppresses CSRF logs when PIRATE_CLAW_LOG_LEVEL is silent', async () => {
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		process.env.PIRATE_CLAW_LOG_LEVEL = 'silent';
+		process.env.PIRATE_CLAW_TRUSTED_ORIGINS_FILE = join(tmpDir, 'missing-trusted-origins.json');
+
+		init();
+		const event = makeFormEvent('http://100.64.0.1');
+		const resolve = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+		await handle({ event: event as never, resolve });
+
+		expect(logSpy).not.toHaveBeenCalled();
+		expect(warnSpy).not.toHaveBeenCalled();
+		logSpy.mockRestore();
+		warnSpy.mockRestore();
+	});
+
+	it('does not emit debug logs by default', async () => {
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		delete process.env.PIRATE_CLAW_LOG_LEVEL;
+
+		const event = makeFormEvent('http://localhost');
+		const resolve = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+		await handle({ event: event as never, resolve });
+
+		expect(logSpy).not.toHaveBeenCalled();
+		logSpy.mockRestore();
 	});
 });

--- a/web/test/hooks.server.test.ts
+++ b/web/test/hooks.server.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { writeFileSync, mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { init, resolveUnauthenticatedPageRedirect } from '../src/hooks.server';
+import { init, resolveUnauthenticatedPageRedirect, handle } from '../src/hooks.server';
 import { getSessionSecret, initSessionSecret } from '../src/lib/server/session';
 import { apiRequest } from '../src/lib/server/api';
 
@@ -158,5 +158,91 @@ describe('resolveUnauthenticatedPageRedirect', () => {
 		vi.mocked(apiRequest).mockRejectedValue(new Error('offline'));
 
 		await expect(resolveUnauthenticatedPageRedirect('write-token')).resolves.toBe('/login');
+	});
+});
+
+describe('handle — CSRF validation', () => {
+	const savedOrigin = process.env.ORIGIN;
+	let trustedOriginsFile: string;
+
+	beforeEach(() => {
+		process.env.ORIGIN = 'http://localhost';
+		trustedOriginsFile = join(tmpDir, 'trusted-origins.json');
+		delete process.env.PIRATE_CLAW_TRUSTED_ORIGINS_FILE;
+		initSessionSecret('');
+		vi.mocked(apiRequest).mockReset();
+	});
+
+	afterEach(() => {
+		if (savedOrigin !== undefined) {
+			process.env.ORIGIN = savedOrigin;
+		} else {
+			delete process.env.ORIGIN;
+		}
+		delete process.env.PIRATE_CLAW_TRUSTED_ORIGINS_FILE;
+	});
+
+	function makeFormEvent(origin: string, pathname = '/setup') {
+		return {
+			request: new Request(`http://localhost${pathname}`, {
+				method: 'POST',
+				headers: {
+					'content-type': 'application/x-www-form-urlencoded',
+					origin
+				},
+				body: 'field=value'
+			}),
+			url: new URL(`http://localhost${pathname}`),
+			cookies: { get: vi.fn().mockReturnValue(undefined) },
+			locals: {} as App.Locals
+		};
+	}
+
+	it('rejects form POST from unknown secondary origin (current broken state — CSRF not enforced)', async () => {
+		const event = makeFormEvent('http://100.64.0.1');
+		const resolve = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+
+		const response = await handle({ event: event as never, resolve });
+
+		expect(response.status).toBe(403);
+	});
+
+	it('allows form POST from secondary origin when it is in trusted-origins', async () => {
+		writeFileSync(trustedOriginsFile, JSON.stringify(['http://100.64.0.1']));
+		process.env.PIRATE_CLAW_TRUSTED_ORIGINS_FILE = trustedOriginsFile;
+		init();
+
+		const event = makeFormEvent('http://100.64.0.1');
+		const resolve = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+
+		const response = await handle({ event: event as never, resolve });
+
+		expect(response.status).not.toBe(403);
+	});
+
+	it('allows form POST from same-origin (ORIGIN env)', async () => {
+		const event = makeFormEvent('http://localhost');
+		const resolve = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+
+		const response = await handle({ event: event as never, resolve });
+
+		expect(response.status).not.toBe(403);
+	});
+
+	it('allows GET requests from any origin without CSRF check', async () => {
+		const event = {
+			request: new Request('http://localhost/', {
+				method: 'GET',
+				headers: { origin: 'http://100.64.0.1' }
+			}),
+			url: new URL('http://localhost/'),
+			cookies: { get: vi.fn().mockReturnValue(undefined) },
+			locals: {} as App.Locals
+		};
+		const resolve = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+
+		const response = await handle({ event: event as never, resolve });
+
+		expect(response.status).not.toBe(403);
 	});
 });

--- a/web/test/hooks.server.test.ts
+++ b/web/test/hooks.server.test.ts
@@ -194,7 +194,7 @@ describe('handle — CSRF validation', () => {
 			}),
 			url: new URL(`http://localhost${pathname}`),
 			cookies: { get: vi.fn().mockReturnValue(undefined) },
-			locals: {} as App.Locals
+			locals: {} as never
 		};
 	}
 
@@ -237,7 +237,7 @@ describe('handle — CSRF validation', () => {
 			}),
 			url: new URL('http://localhost/'),
 			cookies: { get: vi.fn().mockReturnValue(undefined) },
-			locals: {} as App.Locals
+			locals: {} as never
 		};
 		const resolve = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
 

--- a/web/test/routes/layout.test.ts
+++ b/web/test/routes/layout.test.ts
@@ -265,4 +265,27 @@ describe('+layout.svelte', () => {
 		expect(screen.queryByTestId('partial-config-banner')).not.toBeInTheDocument();
 		expect(screen.queryByTestId('ready-pending-restart-banner')).not.toBeInTheDocument();
 	});
+
+	it.each(['/plex/connect', '/plex/connect/callback'])(
+		'does not show starter splash on auth-flow route %s',
+		(pathname) => {
+			setPathname(pathname);
+
+			render(Layout, {
+				props: {
+					children: childSnippet,
+					data: {
+						...sharedLayoutData,
+						health: null,
+						transmissionSession: null,
+						plexAuthState: 'unavailable' as const,
+						setupState: 'starter' as const,
+						readinessState: 'not_ready' as const
+					}
+				}
+			});
+
+			expect(screen.queryByTestId('starter-mode-splash')).not.toBeInTheDocument();
+		}
+	);
 });

--- a/web/test/routes/plex/connect/callback.server.test.ts
+++ b/web/test/routes/plex/connect/callback.server.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const apiRequestMock = vi.fn();
+vi.mock('$lib/server/api', () => ({
+	apiRequest: apiRequestMock
+}));
+
+describe('GET /plex/connect/callback load', () => {
+	const savedLogLevel = process.env.PIRATE_CLAW_LOG_LEVEL;
+
+	beforeEach(() => {
+		apiRequestMock.mockReset();
+		vi.resetModules();
+		process.env.PIRATE_CLAW_LOG_LEVEL = 'silent';
+	});
+
+	afterEach(() => {
+		if (savedLogLevel !== undefined) {
+			process.env.PIRATE_CLAW_LOG_LEVEL = savedLogLevel;
+		} else {
+			delete process.env.PIRATE_CLAW_LOG_LEVEL;
+		}
+	});
+
+	it('uses returnTo from the callback URL instead of the daemon response body', async () => {
+		vi.doMock('$env/dynamic/private', () => ({
+			env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+		}));
+		apiRequestMock.mockResolvedValue(
+			new Response(JSON.stringify({ returnTo: '/config' }), { status: 200 })
+		);
+
+		const { load } = await import('../../../../src/routes/plex/connect/callback/+page.server');
+
+		const result = (await load({
+			url: new URL('http://localhost/plex/connect/callback?session=abc&returnTo=%2Fonboarding')
+		} as never)) as { returnTo: string };
+
+		expect(result.returnTo).toBe('/onboarding');
+		expect(apiRequestMock).toHaveBeenCalledWith(
+			'/api/plex/auth/finalize',
+			expect.objectContaining({
+				body: JSON.stringify({ sessionId: 'abc' })
+			})
+		);
+	});
+
+	it('honors PIRATE_CLAW_LOG_LEVEL=silent on successful callback logging', async () => {
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		vi.doMock('$env/dynamic/private', () => ({
+			env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+		}));
+		apiRequestMock.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+		const { load } = await import('../../../../src/routes/plex/connect/callback/+page.server');
+
+		await load({
+			url: new URL('http://localhost/plex/connect/callback?session=abc&returnTo=%2Fconfig')
+		} as never);
+
+		expect(logSpy).not.toHaveBeenCalled();
+		expect(warnSpy).not.toHaveBeenCalled();
+		logSpy.mockRestore();
+		warnSpy.mockRestore();
+	});
+});

--- a/web/test/routes/plex/connect/connect.server.test.ts
+++ b/web/test/routes/plex/connect/connect.server.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const apiRequestMock = vi.fn();
+vi.mock('$lib/server/api', () => ({
+	apiRequest: apiRequestMock
+}));
+
+describe('GET /plex/connect', () => {
+	beforeEach(() => {
+		apiRequestMock.mockReset();
+		vi.resetModules();
+	});
+
+	it('includes returnTo as query param in forwardUrl when returnTo is in search params', async () => {
+		vi.doMock('$env/dynamic/private', () => ({
+			env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+		}));
+
+		apiRequestMock.mockResolvedValue(
+			new Response(JSON.stringify({ redirectUrl: 'https://plex.tv/auth' }), { status: 200 })
+		);
+
+		const { GET } = await import('../../../../src/routes/plex/connect/+server');
+
+		const url = new URL('http://localhost/plex/connect?returnTo=%2Fonboarding');
+		const event = {
+			url,
+			request: new Request(url),
+			locals: {} as App.Locals,
+			cookies: { get: vi.fn() }
+		};
+
+		await GET(event as never).catch(() => {});
+
+		expect(apiRequestMock).toHaveBeenCalledWith(
+			'/api/plex/auth/start',
+			expect.objectContaining({
+				body: expect.stringContaining('"returnTo":"/onboarding"')
+			})
+		);
+
+		const callBody = JSON.parse(apiRequestMock.mock.calls[0][1].body as string) as {
+			forwardUrl: string;
+			returnTo: string;
+		};
+		const forwardUrl = new URL(callBody.forwardUrl);
+		expect(forwardUrl.searchParams.get('returnTo')).toBe('/onboarding');
+	});
+
+	it('uses /config as fallback returnTo when returnTo param is absent', async () => {
+		vi.doMock('$env/dynamic/private', () => ({
+			env: { PIRATE_CLAW_API_WRITE_TOKEN: 'write-token' }
+		}));
+
+		apiRequestMock.mockResolvedValue(
+			new Response(JSON.stringify({ redirectUrl: 'https://plex.tv/auth' }), { status: 200 })
+		);
+
+		const { GET } = await import('../../../../src/routes/plex/connect/+server');
+
+		const url = new URL('http://localhost/plex/connect');
+		const event = {
+			url,
+			request: new Request(url),
+			locals: {} as App.Locals,
+			cookies: { get: vi.fn() }
+		};
+
+		await GET(event as never).catch(() => {});
+
+		const callBody = JSON.parse(apiRequestMock.mock.calls[0][1].body as string) as {
+			forwardUrl: string;
+			returnTo: string;
+		};
+		const forwardUrl = new URL(callBody.forwardUrl);
+		expect(forwardUrl.searchParams.get('returnTo')).toBe('/config');
+	});
+});

--- a/web/test/routes/plex/connect/connect.server.test.ts
+++ b/web/test/routes/plex/connect/connect.server.test.ts
@@ -27,11 +27,11 @@ describe('GET /plex/connect', () => {
 		const event = {
 			url,
 			request: new Request(url),
-			locals: {} as App.Locals,
+			locals: {} as never,
 			cookies: { get: vi.fn() }
 		};
 
-		await GET(event as never).catch(() => {});
+		await Promise.resolve(GET(event as never)).catch(() => {});
 
 		expect(apiRequestMock).toHaveBeenCalledWith(
 			'/api/plex/auth/start',
@@ -63,11 +63,11 @@ describe('GET /plex/connect', () => {
 		const event = {
 			url,
 			request: new Request(url),
-			locals: {} as App.Locals,
+			locals: {} as never,
 			cookies: { get: vi.fn() }
 		};
 
-		await GET(event as never).catch(() => {});
+		await Promise.resolve(GET(event as never)).catch(() => {});
 
 		const callBody = JSON.parse(apiRequestMock.mock.calls[0][1].body as string) as {
 			forwardUrl: string;


### PR DESCRIPTION
## Summary

- delivery ticket: `P29.02 P28 Carry-Over Prerequisites`
- ticket file: [docs/product/delivery/phase-29/ticket-02-p28-carry-over-prerequisites.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/product/delivery/phase-29/ticket-02-p28-carry-over-prerequisites.md)
- stacked base branch: `agents/p29-01-dsm-7-1-vpn-apply-spike`
- post-verify: outcome `clean` completed at 2026-05-08 20:08 UTC
- subagentReview: outcome `patched` completed at 2026-05-08 20:18 UTC

### Subagent Review Patch Commits

- [`4c53685acf2a`](https://github.com/cesarnml/Pirate-Claw/commit/4c53685acf2a59c9ae04dd4a6db6dead0ab8bd21) fix(web): harden csrf origin loading and callback logging [subagent-review]

## External AI Review

- outcome: `clean`
- reviewed commit: [`4c53685acf2a`](https://github.com/cesarnml/Pirate-Claw/commit/4c53685acf2a59c9ae04dd4a6db6dead0ab8bd21)
- current branch head: [`4c53685acf2a`](https://github.com/cesarnml/Pirate-Claw/commit/4c53685acf2a59c9ae04dd4a6db6dead0ab8bd21)
- vendors: `coderabbit`, `qodo`
