### PR TITLE
feat(daemon): VPN config types and file path helpers [P29.03]

### DIFF
--- a/.prettierignore.root
+++ b/.prettierignore.root
@@ -9,6 +9,9 @@ bun.lock
 .agents/delivery/
 .agents/analysis/
 .agents/ai-review/
+.son-of-anton/.agents/delivery/
+.son-of-anton/.agents/analysis/
+.son-of-anton/.agents/ai-review/
 pirate-claw.config.json
 pirate-claw.db
 .pirate-claw/

--- a/docs/product/delivery/phase-29/ticket-03-vpn-config-types-and-file-paths.md
+++ b/docs/product/delivery/phase-29/ticket-03-vpn-config-types-and-file-paths.md
@@ -94,8 +94,8 @@ export function validateDownloaderNetwork(
 
 > Append here (do not edit above) when behavior or trade-offs change during implementation.
 
-Red first: [what test failed first]
-Why this path: [why this implementation was the smallest acceptable]
-Alternative considered: [one rejected alternative and why]
-Deferred: [what was intentionally left out of this ticket]
-Contract note: record any deviation from the ticket metadata contract here, including missing/incorrect `Type:` or non-compliant `Scope:` fields, and why it happened.
+Red first: `Cannot find module '../src/vpn-state'` — module did not exist, all 10 new tests failed at typecheck before any runtime.
+Why this path: Smallest surface that satisfies the ticket contract — plain `join` helpers, Bun file I/O for manifest, `ConfigError` for validation. No HTTP, no credentials handling.
+Alternative considered: Inlining path helpers into `auth-state.ts` — rejected; VPN concerns belong in their own module consistent with how `auth-state.ts` owns auth-path helpers.
+Deferred: Credential file write (gluetun `username\npassword\n` format) — P29.04 owns that write; this ticket only defines the path helper.
+Contract note: No deviations from ticket metadata contract.

--- a/src/auth-state.ts
+++ b/src/auth-state.ts
@@ -6,7 +6,8 @@ export type NetworkPostureState =
   | 'unacknowledged'
   | 'direct_acknowledged'
   | 'already_secured_externally'
-  | 'vpn_bridge_pending';
+  | 'vpn_bridge_pending'
+  | 'vpn_bridge_active';
 
 export type AuthStateResult = {
   owner_exists: boolean;
@@ -108,7 +109,8 @@ async function readNetworkPosture(
         s === 'unacknowledged' ||
         s === 'direct_acknowledged' ||
         s === 'already_secured_externally' ||
-        s === 'vpn_bridge_pending'
+        s === 'vpn_bridge_pending' ||
+        s === 'vpn_bridge_active'
       ) {
         return s;
       }
@@ -204,7 +206,8 @@ export async function acknowledgeNetworkPosture(
   state:
     | 'direct_acknowledged'
     | 'already_secured_externally'
-    | 'vpn_bridge_pending',
+    | 'vpn_bridge_pending'
+    | 'vpn_bridge_active',
 ): Promise<void> {
   await mkdir(webSubdir(configDir), { recursive: true });
   await Bun.write(

--- a/src/config.ts
+++ b/src/config.ts
@@ -181,7 +181,7 @@ function validateOptionalDownloaderNetwork(
   input: unknown,
   path: string,
 ): DownloaderNetworkConfig | undefined {
-  if (input === undefined || input === null) return undefined;
+  if (input === undefined) return undefined;
   try {
     return validateDownloaderNetwork(input);
   } catch (err) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,10 @@
 import { dirname, join } from 'node:path';
 
 import { generatedDaemonApiWriteTokenPath } from './install-bootstrap';
+import {
+  validateDownloaderNetwork,
+  type DownloaderNetworkConfig,
+} from './vpn-state';
 
 export type FeedConfig = {
   name: string;
@@ -100,6 +104,7 @@ export type AppConfig = {
   runtime: RuntimeConfig;
   tmdb?: TmdbConfig;
   plex?: PlexConfig;
+  downloaderNetwork?: DownloaderNetworkConfig;
 };
 
 const DEFAULT_CONFIG_PATH = 'pirate-claw.config.json';
@@ -165,7 +170,26 @@ export function validateConfig(
     runtime: validateRuntime(input.runtime, path, env),
     tmdb: validateOptionalTmdb(input.tmdb, path),
     plex: validateOptionalPlex(input.plex, path, env),
+    downloaderNetwork: validateOptionalDownloaderNetwork(
+      input.downloaderNetwork,
+      path,
+    ),
   };
+}
+
+function validateOptionalDownloaderNetwork(
+  input: unknown,
+  path: string,
+): DownloaderNetworkConfig | undefined {
+  if (input === undefined || input === null) return undefined;
+  try {
+    return validateDownloaderNetwork(input);
+  } catch (err) {
+    if (err instanceof ConfigError) throw err;
+    throw new ConfigError(
+      `Config file "${path}" has an invalid downloaderNetwork block: ${String(err)}`,
+    );
+  }
 }
 
 function validateTvConfig(input: unknown, path: string): TvRule[] {

--- a/src/vpn-state.ts
+++ b/src/vpn-state.ts
@@ -1,0 +1,123 @@
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { ConfigError } from './config';
+
+export function vpnDir(configDir: string): string {
+  return join(configDir, 'vpn');
+}
+
+export function activeProfilePath(configDir: string): string {
+  return join(vpnDir(configDir), 'active-profile.ovpn');
+}
+
+export function credentialsPath(configDir: string): string {
+  return join(vpnDir(configDir), 'credentials');
+}
+
+export function vpnManifestPath(configDir: string): string {
+  return join(vpnDir(configDir), 'manifest.json');
+}
+
+export type VpnManifest = {
+  uploadedAt: string;
+  provider: string;
+  hasCredentials: boolean;
+};
+
+export async function readVpnManifest(
+  configDir: string,
+): Promise<VpnManifest | null> {
+  const file = Bun.file(vpnManifestPath(configDir));
+  if (!(await file.exists())) return null;
+  try {
+    const raw: unknown = await file.json();
+    if (
+      raw &&
+      typeof raw === 'object' &&
+      !Array.isArray(raw) &&
+      typeof (raw as Record<string, unknown>).uploadedAt === 'string' &&
+      typeof (raw as Record<string, unknown>).provider === 'string' &&
+      typeof (raw as Record<string, unknown>).hasCredentials === 'boolean'
+    ) {
+      return raw as VpnManifest;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeVpnManifest(
+  configDir: string,
+  manifest: VpnManifest,
+): Promise<void> {
+  await mkdir(vpnDir(configDir), { recursive: true });
+  await Bun.write(
+    vpnManifestPath(configDir),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  console.log(
+    `[vpn] manifest written — provider: ${manifest.provider}, hasCredentials: ${String(manifest.hasCredentials)}`,
+  );
+}
+
+export type DownloaderNetworkMode = 'passthrough' | 'vpn_bridge';
+export type DownloaderNetworkStatus =
+  | 'pending_verify'
+  | 'verified'
+  | 'unreachable';
+
+export type DownloaderNetworkConfig = {
+  mode: DownloaderNetworkMode;
+  provider?: string;
+  profile?: string;
+  status?: DownloaderNetworkStatus;
+};
+
+const VALID_MODES: DownloaderNetworkMode[] = ['passthrough', 'vpn_bridge'];
+const VALID_STATUSES: DownloaderNetworkStatus[] = [
+  'pending_verify',
+  'verified',
+  'unreachable',
+];
+
+export function validateDownloaderNetwork(
+  raw: unknown,
+): DownloaderNetworkConfig {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new ConfigError(
+      'downloaderNetwork must be an object with a "mode" field.',
+    );
+  }
+  const obj = raw as Record<string, unknown>;
+  const mode = obj.mode;
+  if (!VALID_MODES.includes(mode as DownloaderNetworkMode)) {
+    throw new ConfigError(
+      `downloaderNetwork.mode must be one of: ${VALID_MODES.join(', ')}.`,
+    );
+  }
+  const result: DownloaderNetworkConfig = {
+    mode: mode as DownloaderNetworkMode,
+  };
+  if (obj.provider !== undefined) {
+    if (typeof obj.provider !== 'string') {
+      throw new ConfigError('downloaderNetwork.provider must be a string.');
+    }
+    result.provider = obj.provider;
+  }
+  if (obj.profile !== undefined) {
+    if (typeof obj.profile !== 'string') {
+      throw new ConfigError('downloaderNetwork.profile must be a string.');
+    }
+    result.profile = obj.profile;
+  }
+  if (obj.status !== undefined) {
+    if (!VALID_STATUSES.includes(obj.status as DownloaderNetworkStatus)) {
+      throw new ConfigError(
+        `downloaderNetwork.status must be one of: ${VALID_STATUSES.join(', ')}.`,
+      );
+    }
+    result.status = obj.status as DownloaderNetworkStatus;
+  }
+  return result;
+}

--- a/src/vpn-state.ts
+++ b/src/vpn-state.ts
@@ -90,6 +90,14 @@ export function validateDownloaderNetwork(
     );
   }
   const obj = raw as Record<string, unknown>;
+  const allowedKeys = new Set(['mode', 'provider', 'profile', 'status']);
+  for (const key of Object.keys(obj)) {
+    if (!allowedKeys.has(key)) {
+      throw new ConfigError(
+        `downloaderNetwork has unknown key "${key}"; allowed keys are: mode, provider, profile, status.`,
+      );
+    }
+  }
   const mode = obj.mode;
   if (!VALID_MODES.includes(mode as DownloaderNetworkMode)) {
     throw new ConfigError(

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1051,6 +1051,34 @@ describe('validateConfig', () => {
       ),
     );
   });
+
+  it('accepts optional downloaderNetwork block', () => {
+    const config = validateConfig({
+      ...createMinimalConfig(),
+      downloaderNetwork: { mode: 'passthrough' },
+    });
+    expect(config.downloaderNetwork).toEqual({ mode: 'passthrough' });
+  });
+
+  it('omits downloaderNetwork when absent', () => {
+    const config = validateConfig(createMinimalConfig());
+    expect(config.downloaderNetwork).toBeUndefined();
+  });
+
+  it('fails when downloaderNetwork is null', () => {
+    expect(() =>
+      validateConfig({ ...createMinimalConfig(), downloaderNetwork: null }),
+    ).toThrow();
+  });
+
+  it('fails when downloaderNetwork has an unknown key', () => {
+    expect(() =>
+      validateConfig({
+        ...createMinimalConfig(),
+        downloaderNetwork: { mode: 'vpn_bridge', typo: true },
+      }),
+    ).toThrow('unknown key');
+  });
 });
 
 function createMinimalConfig() {

--- a/test/vpn-state.test.ts
+++ b/test/vpn-state.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import {
+  vpnDir,
+  activeProfilePath,
+  credentialsPath,
+  vpnManifestPath,
+  readVpnManifest,
+  writeVpnManifest,
+  validateDownloaderNetwork,
+  type VpnManifest,
+} from '../src/vpn-state';
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'pirate-claw-vpn-test-'));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('vpnDir', () => {
+  it('returns <configDir>/vpn', () => {
+    expect(vpnDir('/config')).toBe('/config/vpn');
+  });
+});
+
+describe('activeProfilePath', () => {
+  it('returns <configDir>/vpn/active-profile.ovpn', () => {
+    expect(activeProfilePath('/config')).toBe(
+      '/config/vpn/active-profile.ovpn',
+    );
+  });
+});
+
+describe('credentialsPath', () => {
+  it('returns <configDir>/vpn/credentials', () => {
+    expect(credentialsPath('/config')).toBe('/config/vpn/credentials');
+  });
+});
+
+describe('vpnManifestPath', () => {
+  it('returns <configDir>/vpn/manifest.json', () => {
+    expect(vpnManifestPath('/config')).toBe('/config/vpn/manifest.json');
+  });
+});
+
+describe('readVpnManifest', () => {
+  it('returns null when file does not exist', async () => {
+    const result = await readVpnManifest(tempDir);
+    expect(result).toBeNull();
+  });
+});
+
+describe('writeVpnManifest / readVpnManifest', () => {
+  it('writes a valid manifest and reads it back', async () => {
+    const manifest: VpnManifest = {
+      uploadedAt: '2026-05-09T00:00:00.000Z',
+      provider: 'custom_openvpn',
+      hasCredentials: true,
+    };
+    await writeVpnManifest(tempDir, manifest);
+    const result = await readVpnManifest(tempDir);
+    expect(result).toEqual(manifest);
+  });
+});
+
+describe('validateDownloaderNetwork', () => {
+  it('throws ConfigError when mode is missing', () => {
+    expect(() => validateDownloaderNetwork({})).toThrow();
+  });
+
+  it('throws ConfigError when mode is invalid', () => {
+    expect(() => validateDownloaderNetwork({ mode: 'wireguard' })).toThrow();
+  });
+
+  it('accepts mode: passthrough', () => {
+    const result = validateDownloaderNetwork({ mode: 'passthrough' });
+    expect(result).toEqual({ mode: 'passthrough' });
+  });
+
+  it('accepts mode: vpn_bridge', () => {
+    const result = validateDownloaderNetwork({ mode: 'vpn_bridge' });
+    expect(result).toEqual({ mode: 'vpn_bridge' });
+  });
+
+  it('accepts full valid downloaderNetwork block', () => {
+    const input = {
+      mode: 'vpn_bridge',
+      provider: 'custom_openvpn',
+      profile: 'active',
+      status: 'verified',
+    };
+    const result = validateDownloaderNetwork(input);
+    expect(result).toEqual(input);
+  });
+
+  it('throws when input is not an object', () => {
+    expect(() => validateDownloaderNetwork('passthrough')).toThrow();
+    expect(() => validateDownloaderNetwork(null)).toThrow();
+  });
+});

--- a/test/vpn-state.test.ts
+++ b/test/vpn-state.test.ts
@@ -103,4 +103,10 @@ describe('validateDownloaderNetwork', () => {
     expect(() => validateDownloaderNetwork('passthrough')).toThrow();
     expect(() => validateDownloaderNetwork(null)).toThrow();
   });
+
+  it('throws ConfigError on unknown keys', () => {
+    expect(() =>
+      validateDownloaderNetwork({ mode: 'passthrough', typo: true }),
+    ).toThrow('unknown key');
+  });
 });

--- a/test/vpn-state.test.ts
+++ b/test/vpn-state.test.ts
@@ -90,10 +90,10 @@ describe('validateDownloaderNetwork', () => {
 
   it('accepts full valid downloaderNetwork block', () => {
     const input = {
-      mode: 'vpn_bridge',
+      mode: 'vpn_bridge' as const,
       provider: 'custom_openvpn',
       profile: 'active',
-      status: 'verified',
+      status: 'verified' as const,
     };
     const result = validateDownloaderNetwork(input);
     expect(result).toEqual(input);


### PR DESCRIPTION
## Summary

- delivery ticket: `P29.03 VPN Config Types and File Path Helpers`
- ticket file: [docs/product/delivery/phase-29/ticket-03-vpn-config-types-and-file-paths.md](https://github.com/cesarnml/Pirate-Claw/blob/main/docs/product/delivery/phase-29/ticket-03-vpn-config-types-and-file-paths.md)
- stacked base branch: `agents/p29-02-p28-carry-over-prerequisites`

## External AI Review

- outcome: `patched`
- reviewed commit: [`c35e151dc743`](https://github.com/cesarnml/Pirate-Claw/commit/c35e151dc74355cf0456d5a7a71c8d41197d9659)
- current branch head: [`7a273e032769`](https://github.com/cesarnml/Pirate-Claw/commit/7a273e0327695b7cc7abb00720ecd4ae3826d0a8)
- the latest recorded external AI review applies to an older branch head; the prior review history is shown below for debugging.
- patch commits after `c35e151dc743` address all findings from that review.
- vendors: `coderabbit`, `qodo`

### Resolved Review Findings

- [coderabbit] Do not treat explicit `null` as “absent” for `downloaderNetwork`. (native GitHub thread resolved) `src/config.ts:186` [thread](https://github.com/cesarnml/Pirate-Claw/pull/262#discussion_r3211282166)
- [coderabbit] Reject unknown keys in `downloaderNetwork` to prevent silent misconfiguration. (native GitHub thread resolved) `src/vpn-state.ts:123` [thread](https://github.com/cesarnml/Pirate-Claw/pull/262#discussion_r3211282189)
- [qodo] <pre><b>ⓘ You've reached your Qodo monthly free-tier limit.</b> Reviews pause until next month — <a href="https://www.qodo.ai/pricing">up... (patched) [thread](https://github.com/cesarnml/Pirate-Claw/pull/262#issuecomment-4409755047)

### No-Action Rationale

- Left 1 unclear comment(s) for manual judgment.
